### PR TITLE
Fixed a couple of incorrect queries from a previous optimisation

### DIFF
--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -203,8 +203,8 @@ internal extension LibSession {
             .filter(SessionThread.Columns.variant == SessionThread.Variant.contact)
             .filter(
                 /// Only want to include include standard contact conversations (not blinded conversations)
-                ClosedGroup.Columns.threadId > SessionId.Prefix.standard.rawValue &&
-                ClosedGroup.Columns.threadId < SessionId.Prefix.standard.endOfRangeString
+                SessionThread.Columns.id > SessionId.Prefix.standard.rawValue &&
+                SessionThread.Columns.id < SessionId.Prefix.standard.endOfRangeString
             )
             .select(.id)
             .asRequest(of: String.self)

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
@@ -60,12 +60,12 @@ extension MessageReceiver {
             .filter(SessionThread.Columns.variant == SessionThread.Variant.contact)
             .filter(
                 (
-                    ClosedGroup.Columns.threadId > SessionId.Prefix.blinded15.rawValue &&
-                    ClosedGroup.Columns.threadId < SessionId.Prefix.blinded15.endOfRangeString
+                    SessionThread.Columns.id > SessionId.Prefix.blinded15.rawValue &&
+                    SessionThread.Columns.id < SessionId.Prefix.blinded15.endOfRangeString
                 ) ||
                 (
-                    ClosedGroup.Columns.threadId > SessionId.Prefix.blinded25.rawValue &&
-                    ClosedGroup.Columns.threadId < SessionId.Prefix.blinded25.endOfRangeString
+                    SessionThread.Columns.id > SessionId.Prefix.blinded25.rawValue &&
+                    SessionThread.Columns.id < SessionId.Prefix.blinded25.endOfRangeString
                 )
             )
             .asRequest(of: String.self)


### PR DESCRIPTION
Both of these process will currently fail due to the column having an incorrect name in the query (`threadId` instead of `id`)