### PR TITLE
Updated NTS & 1-1 conversation deletion to be consistent with other platforms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "LibSession-Util"]
 	path = LibSession-Util
-	url = https://github.com/oxen-io/libsession-util.git
+	url = https://github.com/session-foundation/libsession-util.git

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 		FD716E7128505E5200C96BF4 /* MessageRequestsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD716E7028505E5100C96BF4 /* MessageRequestsCell.swift */; };
 		FD716E722850647600C96BF4 /* Data+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD859EF127BF6BA200510D0C /* Data+Utilities.swift */; };
 		FD72BD9A2BDF5EEA00CF6CF6 /* Message+Origin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD72BD992BDF5EEA00CF6CF6 /* Message+Origin.swift */; };
+		FD756BEB2D0181D700BD7199 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = FD756BEA2D0181D700BD7199 /* GRDB */; };
 		FD7692F72A53A2ED000E4B70 /* SessionThreadViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7692F62A53A2ED000E4B70 /* SessionThreadViewModelSpec.swift */; };
 		FD7728962849E7E90018502F /* String+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7728952849E7E90018502F /* String+Utilities.swift */; };
 		FD7728982849E8110018502F /* UITableView+ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7728972849E8110018502F /* UITableView+ReusableView.swift */; };
@@ -845,7 +846,6 @@
 		FDC1BD662CFD6C4F002CDC71 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC1BD652CFD6C4E002CDC71 /* Config.swift */; };
 		FDC1BD682CFE6EEB002CDC71 /* DeveloperSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC1BD672CFE6EEA002CDC71 /* DeveloperSettingsViewModel.swift */; };
 		FDC1BD6A2CFE7B6B002CDC71 /* DirectoryArchiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC1BD692CFE7B67002CDC71 /* DirectoryArchiver.swift */; };
-		FDC289422C86AB5800020BC2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = FDC289412C86AB5800020BC2 /* GRDB */; };
 		FDC289472C881A3800020BC2 /* MutableIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC289462C881A3800020BC2 /* MutableIdentifiable.swift */; };
 		FDC2908727D7047F005DAE71 /* RoomSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC2908627D7047F005DAE71 /* RoomSpec.swift */; };
 		FDC2908927D70656005DAE71 /* RoomPollInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC2908827D70656005DAE71 /* RoomPollInfoSpec.swift */; };
@@ -2208,7 +2208,7 @@
 				FD6A38EC2C2A63B500762359 /* KeychainSwift in Frameworks */,
 				FD6A38EF2C2A641200762359 /* DifferenceKit in Frameworks */,
 				FD6A396D2C2D284B00762359 /* YYImage in Frameworks */,
-				FDC289422C86AB5800020BC2 /* GRDB in Frameworks */,
+				FD756BEB2D0181D700BD7199 /* GRDB in Frameworks */,
 				FD6A38E92C2A630E00762359 /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4762,7 +4762,7 @@
 				FD6A38EE2C2A641200762359 /* DifferenceKit */,
 				FD6A39652C2D21E400762359 /* libwebp */,
 				FD6A396C2C2D284B00762359 /* YYImage */,
-				FDC289412C86AB5800020BC2 /* GRDB */,
+				FD756BEA2D0181D700BD7199 /* GRDB */,
 			);
 			productName = SessionUtilities;
 			productReference = C3C2A679255388CC00C340D1 /* SessionUtilitiesKit.framework */;
@@ -5071,7 +5071,7 @@
 				FD6A39392C2AD3A300762359 /* XCRemoteSwiftPackageReference "Nimble" */,
 				FD6A39642C2D21E400762359 /* XCRemoteSwiftPackageReference "libwebp-Xcode" */,
 				FD6A39672C2D283A00762359 /* XCRemoteSwiftPackageReference "session-ios-yyimage" */,
-				FDC289402C86AB5800020BC2 /* XCRemoteSwiftPackageReference "session-grdb-swift" */,
+				FD6DA9D52D017F480092085A /* XCRemoteSwiftPackageReference "session-grdb-swift" */,
 			);
 			productRefGroup = D221A08A169C9E5E00537ABF /* Products */;
 			projectDirPath = "";
@@ -8654,18 +8654,18 @@
 		};
 		FD6A39672C2D283A00762359 /* XCRemoteSwiftPackageReference "session-ios-yyimage" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/oxen-io/session-ios-yyimage.git";
+			repositoryURL = "https://github.com/session-foundation/session-ios-yyimage";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.1.0;
 			};
 		};
-		FDC289402C86AB5800020BC2 /* XCRemoteSwiftPackageReference "session-grdb-swift" */ = {
+		FD6DA9D52D017F480092085A /* XCRemoteSwiftPackageReference "session-grdb-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/oxen-io/session-grdb-swift.git";
+			repositoryURL = "https://github.com/session-foundation/session-grdb-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 106.29.2;
+				minimumVersion = 106.29.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -8799,9 +8799,9 @@
 			package = FD6A39672C2D283A00762359 /* XCRemoteSwiftPackageReference "session-ios-yyimage" */;
 			productName = YYImage;
 		};
-		FDC289412C86AB5800020BC2 /* GRDB */ = {
+		FD756BEA2D0181D700BD7199 /* GRDB */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = FDC289402C86AB5800020BC2 /* XCRemoteSwiftPackageReference "session-grdb-swift" */;
+			package = FD6DA9D52D017F480092085A /* XCRemoteSwiftPackageReference "session-grdb-swift" */;
 			productName = GRDB;
 		};
 		FDEF57292C3CF50B00131302 /* WebRTC */ = {

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -685,6 +685,8 @@
 		FD6A7A692818BE7300035AC1 /* RetrieveDefaultOpenGroupRoomsJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6A7A682818BE7300035AC1 /* RetrieveDefaultOpenGroupRoomsJob.swift */; };
 		FD6A7A6B2818C17C00035AC1 /* UpdateProfilePictureJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6A7A6A2818C17C00035AC1 /* UpdateProfilePictureJob.swift */; };
 		FD6A7A6D2818C61500035AC1 /* _002_SetupStandardJobs.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6A7A6C2818C61500035AC1 /* _002_SetupStandardJobs.swift */; };
+		FD6C67242CF6E72E00B350A7 /* NoopSessionCallManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6C67232CF6E72900B350A7 /* NoopSessionCallManager.swift */; };
+		FD6C67262CF6EA2300B350A7 /* PushRegistrationManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6C67252CF6EA1E00B350A7 /* PushRegistrationManagerType.swift */; };
 		FD6DF00B2ACFE40D0084BA4C /* _005_AddSnodeReveivedMessageInfoPrimaryKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6DF00A2ACFE40D0084BA4C /* _005_AddSnodeReveivedMessageInfoPrimaryKey.swift */; };
 		FD6E4C8A2A1AEE4700C7C243 /* LegacyUnsubscribeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6E4C892A1AEE4700C7C243 /* LegacyUnsubscribeRequest.swift */; };
 		FD705A92278D051200F16121 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD705A91278D051200F16121 /* ReusableView.swift */; };
@@ -1832,6 +1834,8 @@
 		FD6A7A682818BE7300035AC1 /* RetrieveDefaultOpenGroupRoomsJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveDefaultOpenGroupRoomsJob.swift; sourceTree = "<group>"; };
 		FD6A7A6A2818C17C00035AC1 /* UpdateProfilePictureJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProfilePictureJob.swift; sourceTree = "<group>"; };
 		FD6A7A6C2818C61500035AC1 /* _002_SetupStandardJobs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _002_SetupStandardJobs.swift; sourceTree = "<group>"; };
+		FD6C67232CF6E72900B350A7 /* NoopSessionCallManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopSessionCallManager.swift; sourceTree = "<group>"; };
+		FD6C67252CF6EA1E00B350A7 /* PushRegistrationManagerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationManagerType.swift; sourceTree = "<group>"; };
 		FD6DF00A2ACFE40D0084BA4C /* _005_AddSnodeReveivedMessageInfoPrimaryKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _005_AddSnodeReveivedMessageInfoPrimaryKey.swift; sourceTree = "<group>"; };
 		FD6E4C892A1AEE4700C7C243 /* LegacyUnsubscribeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyUnsubscribeRequest.swift; sourceTree = "<group>"; };
 		FD705A91278D051200F16121 /* ReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
@@ -2783,6 +2787,7 @@
 				FD716E692850327900C96BF4 /* EndCallMode.swift */,
 				FD716E6528502EE200C96BF4 /* CurrentCallProtocol.swift */,
 				FD716E6328502DDD00C96BF4 /* CallManagerProtocol.swift */,
+				FD6C67232CF6E72900B350A7 /* NoopSessionCallManager.swift */,
 			);
 			path = Calls;
 			sourceTree = "<group>";
@@ -3177,6 +3182,7 @@
 			children = (
 				FDC498B52AC15F6D00EDD897 /* Types */,
 				4539B5851F79348F007141FF /* PushRegistrationManager.swift */,
+				FD6C67252CF6EA1E00B350A7 /* PushRegistrationManagerType.swift */,
 				45CD81EE1DC030E7004C9430 /* SyncPushTokensJob.swift */,
 				451A13B01E13DED2000A50FD /* AppNotifications.swift */,
 				450DF2081E0DD2C6003D14BE /* UserNotificationsAdaptee.swift */,
@@ -5929,6 +5935,7 @@
 				FDC438A427BB107F00C60D73 /* UserBanRequest.swift in Sources */,
 				FD4C53AF2CC1D62E003B10F4 /* _021_ReworkRecipientState.swift in Sources */,
 				C379DCF4256735770002D4EB /* VisibleMessage+Attachment.swift in Sources */,
+				FD6C67242CF6E72E00B350A7 /* NoopSessionCallManager.swift in Sources */,
 				FDB4BBC72838B91E00B7C95D /* LinkPreviewError.swift in Sources */,
 				FD09798327FD1A1500936362 /* ClosedGroup.swift in Sources */,
 				FDC13D542A16FF29007267C7 /* LegacyGroupRequest.swift in Sources */,
@@ -6226,6 +6233,7 @@
 				FDEF57242C3CF04700131302 /* WebRTC+Utilities.swift in Sources */,
 				34BECE2E1F7ABCE000D7438D /* GifPickerViewController.swift in Sources */,
 				9422568C2C23F8C800C0FDBF /* DisplayNameScreen.swift in Sources */,
+				FD6C67262CF6EA2300B350A7 /* PushRegistrationManagerType.swift in Sources */,
 				B84664F5235022F30083A1CD /* MentionUtilities.swift in Sources */,
 				7B9F71D72853100A006DFE7B /* Emoji+Available.swift in Sources */,
 				FD09C5E628260FF9000CE219 /* MediaGalleryViewModel.swift in Sources */,

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -842,6 +842,7 @@
 		FDC13D562A171FE4007267C7 /* UnsubscribeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC13D552A171FE4007267C7 /* UnsubscribeRequest.swift */; };
 		FDC13D582A17207D007267C7 /* UnsubscribeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC13D572A17207D007267C7 /* UnsubscribeResponse.swift */; };
 		FDC13D5A2A1721C5007267C7 /* LegacyNotifyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC13D592A1721C5007267C7 /* LegacyNotifyRequest.swift */; };
+		FDC1BD662CFD6C4F002CDC71 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC1BD652CFD6C4E002CDC71 /* Config.swift */; };
 		FDC289422C86AB5800020BC2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = FDC289412C86AB5800020BC2 /* GRDB */; };
 		FDC289472C881A3800020BC2 /* MutableIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC289462C881A3800020BC2 /* MutableIdentifiable.swift */; };
 		FDC2908727D7047F005DAE71 /* RoomSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC2908627D7047F005DAE71 /* RoomSpec.swift */; };
@@ -1966,6 +1967,7 @@
 		FDC13D552A171FE4007267C7 /* UnsubscribeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsubscribeRequest.swift; sourceTree = "<group>"; };
 		FDC13D572A17207D007267C7 /* UnsubscribeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsubscribeResponse.swift; sourceTree = "<group>"; };
 		FDC13D592A1721C5007267C7 /* LegacyNotifyRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNotifyRequest.swift; sourceTree = "<group>"; };
+		FDC1BD652CFD6C4E002CDC71 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		FDC289462C881A3800020BC2 /* MutableIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutableIdentifiable.swift; sourceTree = "<group>"; };
 		FDC2908627D7047F005DAE71 /* RoomSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSpec.swift; sourceTree = "<group>"; };
 		FDC2908827D70656005DAE71 /* RoomPollInfoSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPollInfoSpec.swift; sourceTree = "<group>"; };
@@ -4168,8 +4170,9 @@
 		FD8ECF7529340F4800C0D1BB /* LibSession */ = {
 			isa = PBXGroup;
 			children = (
-				FD2B4B022949886900AB4848 /* Database */,
 				FD8ECF8E29381FB200C0D1BB /* Config Handling */,
+				FD2B4B022949886900AB4848 /* Database */,
+				FDC1BD642CFD6C44002CDC71 /* Types */,
 				FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */,
 			);
 			path = LibSession;
@@ -4250,6 +4253,14 @@
 				FDD82C3E2A205D0A00425F05 /* ProcessResult.swift */,
 				FDC13D4F2A16EE50007267C7 /* PushNotificationAPIEndpoint.swift */,
 				FD7F74872BB2929B006DDFD8 /* Request+PushNotificationAPI.swift */,
+			);
+			path = Types;
+			sourceTree = "<group>";
+		};
+		FDC1BD642CFD6C44002CDC71 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				FDC1BD652CFD6C4E002CDC71 /* Config.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -5997,6 +6008,7 @@
 				FD5C72FD284F0EC90029977D /* MessageReceiver+ExpirationTimers.swift in Sources */,
 				C32C5A88256DBCF9003C73A2 /* MessageReceiver+ClosedGroups.swift in Sources */,
 				B8D0A25925E367AC00C1835E /* Notification+MessageReceiver.swift in Sources */,
+				FDC1BD662CFD6C4F002CDC71 /* Config.swift in Sources */,
 				FD245C53285065DB00B966DD /* ProximityMonitoringManager.swift in Sources */,
 				FD245C55285065E500B966DD /* OpenGroupManager.swift in Sources */,
 				C32C599E256DB02B003C73A2 /* TypingIndicators.swift in Sources */,

--- a/Session.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Session.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "53c1182a7d64df9a13a5c0ec4420b2c8da9c4d81d97b2b79b6e8f2946978471b",
+  "originHash" : "702124fa8d79aa2cee4d496d60bf6b3ad2053e234bcb84c4df5b8f43e95fd8df",
   "pins" : [
     {
       "identity" : "cocoalumberjack",
@@ -85,16 +85,16 @@
     {
       "identity" : "session-grdb-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/oxen-io/session-grdb-swift.git",
+      "location" : "https://github.com/session-foundation/session-grdb-swift.git",
       "state" : {
-        "revision" : "04f480b95263b7c517085100ceb249f879c021d8",
+        "revision" : "b3643613f1e0f392fa41072ee499da93b4c06b67",
         "version" : "106.29.3"
       }
     },
     {
       "identity" : "session-ios-yyimage",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/oxen-io/session-ios-yyimage.git",
+      "location" : "https://github.com/session-foundation/session-ios-yyimage",
       "state" : {
         "revision" : "14786afd2523f80be304b377f9dbab6b7904bf02",
         "version" : "1.1.0"

--- a/Session/Calls/Call Management/SessionCallManager+CXCallController.swift
+++ b/Session/Calls/Call Management/SessionCallManager+CXCallController.swift
@@ -2,12 +2,16 @@
 
 import Foundation
 import CallKit
+import SessionMessagingKit
 import SessionUtilitiesKit
 
 extension SessionCallManager {
-    public func startCall(_ call: SessionCall, completion: ((Error?) -> Void)?) {
-        guard case .offer = call.mode else { return }
-        guard !call.hasConnected else { return }
+    public func startCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?) {
+        guard
+            let call: SessionCall = call as? SessionCall,
+            case .offer = call.mode,
+            !call.hasConnected
+        else { return }
         
         reportOutgoingCall(call)
         
@@ -28,9 +32,9 @@ extension SessionCallManager {
         }
     }
     
-    public func answerCall(_ call: SessionCall, completion: ((Error?) -> Void)?) {
-        if callController != nil {
-            let answerCallAction = CXAnswerCallAction(call: call.callId)
+    public func answerCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?) {
+        if callController != nil, let callId: UUID = call?.callId {
+            let answerCallAction = CXAnswerCallAction(call: callId)
             let transaction = CXTransaction()
             transaction.addAction(answerCallAction)
 
@@ -42,9 +46,9 @@ extension SessionCallManager {
         }
     }
     
-    public func endCall(_ call: SessionCall, completion: ((Error?) -> Void)?) {
-        if callController != nil {
-            let endCallAction = CXEndCallAction(call: call.callId)
+    public func endCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?) {
+        if callController != nil, let callId: UUID = call?.callId {
+            let endCallAction = CXEndCallAction(call: callId)
             let transaction = CXTransaction()
             transaction.addAction(endCallAction)
 

--- a/Session/Calls/Call Management/SessionCallManager.swift
+++ b/Session/Calls/Call Management/SessionCallManager.swift
@@ -9,7 +9,21 @@ import SessionMessagingKit
 import SignalUtilitiesKit
 import SessionUtilitiesKit
 
+// MARK: - Cache
+
+public extension Cache {
+    static let callManager: CacheInfo.Config<CallManagerCacheType, CallManagerImmutableCacheType> = CacheInfo.create(
+        createInstance: { SessionCallManager.Cache() },
+        mutableInstance: { $0 },
+        immutableInstance: { $0 }
+    )
+}
+
+// MARK: - SessionCallManager
+
 public final class SessionCallManager: NSObject, CallManagerProtocol {
+    let dependencies: Dependencies
+    
     let provider: CXProvider?
     let callController: CXCallController?
     
@@ -27,40 +41,15 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
         }
     }
     
-    private static var _sharedProvider: CXProvider?
-    static func sharedProvider(useSystemCallLog: Bool) -> CXProvider {
-        let configuration = buildProviderConfiguration(useSystemCallLog: useSystemCallLog)
-
-        if let sharedProvider = self._sharedProvider {
-            sharedProvider.configuration = configuration
-            return sharedProvider
-        }
-        else {
-            SwiftSingletons.register(self)
-            let provider = CXProvider(configuration: configuration)
-            _sharedProvider = provider
-            return provider
-        }
-    }
-    
-    static func buildProviderConfiguration(useSystemCallLog: Bool) -> CXProviderConfiguration {
-        let providerConfiguration = CXProviderConfiguration()
-        providerConfiguration.supportsVideo = true
-        providerConfiguration.maximumCallGroups = 1
-        providerConfiguration.maximumCallsPerCallGroup = 1
-        providerConfiguration.supportedHandleTypes = [.generic]
-        let iconMaskImage = #imageLiteral(resourceName: "SessionGreen32")
-        providerConfiguration.iconTemplateImageData = iconMaskImage.pngData()
-        providerConfiguration.includesCallsInRecents = useSystemCallLog
-
-        return providerConfiguration
-    }
-    
     // MARK: - Initialization
     
-    init(useSystemCallLog: Bool = false) {
+    init(useSystemCallLog: Bool = false, using dependencies: Dependencies) {
+        self.dependencies = dependencies
+        
         if Preferences.isCallKitSupported {
-            self.provider = SessionCallManager.sharedProvider(useSystemCallLog: useSystemCallLog)
+            self.provider = dependencies.caches.mutate(cache: .callManager) {
+                $0.getOrCreateProvider(useSystemCallLog: useSystemCallLog)
+            }
             self.callController = CXCallController()
         }
         else {
@@ -76,9 +65,11 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
     
     // MARK: - Report calls
     
-    public static func reportFakeCall(info: String) {
+    public static func reportFakeCall(info: String, using dependencies: Dependencies) {
         let callId = UUID()
-        let provider = SessionCallManager.sharedProvider(useSystemCallLog: false)
+        let provider: CXProvider = dependencies.caches.mutate(cache: .callManager) {
+            $0.getOrCreateProvider(useSystemCallLog: false)
+        }
         provider.reportNewIncomingCall(
             with: callId,
             update: CXCallUpdate()
@@ -90,6 +81,10 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
             endedAt: nil,
             reason: .failed
         )
+    }
+    
+    public func setCurrentCall(_ call: CurrentCallProtocol?) {
+        self.currentCall = call
     }
     
     public func reportOutgoingCall(_ call: SessionCall) {
@@ -108,8 +103,10 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
         }
     }
     
-    public func reportIncomingCall(_ call: SessionCall, callerName: String, completion: @escaping (Error?) -> Void) {
-        let provider = provider ?? Self.sharedProvider(useSystemCallLog: false)
+    public func reportIncomingCall(_ call: CurrentCallProtocol, callerName: String, completion: @escaping (Error?) -> Void) {
+        let provider: CXProvider = dependencies.caches.mutate(cache: .callManager) {
+            $0.getOrCreateProvider(useSystemCallLog: false)
+        }
         // Construct a CXCallUpdate describing the incoming call, including the caller.
         let update = CXCallUpdate()
         update.localizedCallerName = callerName
@@ -152,7 +149,7 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
         
         guard let call = currentCall else {
             handleCallEnded()
-            Self.suspendDatabaseIfCallEndedInBackground()
+            suspendDatabaseIfCallEndedInBackground()
             return
         }
         
@@ -160,14 +157,14 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
             self.provider?.reportCall(with: call.callId, endedAt: nil, reason: reason)
             
             switch (reason) {
-                case .answeredElsewhere: call.updateCallMessage(mode: .answeredElsewhere)
-                case .unanswered: call.updateCallMessage(mode: .unanswered)
-                case .declinedElsewhere: call.updateCallMessage(mode: .local)
-                default: call.updateCallMessage(mode: .remote)
+                case .answeredElsewhere: call.updateCallMessage(mode: .answeredElsewhere, using: dependencies)
+                case .unanswered: call.updateCallMessage(mode: .unanswered, using: dependencies)
+                case .declinedElsewhere: call.updateCallMessage(mode: .local, using: dependencies)
+                default: call.updateCallMessage(mode: .remote, using: dependencies)
             }
         }
         else {
-            call.updateCallMessage(mode: .local)
+            call.updateCallMessage(mode: .local, using: dependencies)
         }
         
         (call as? SessionCall)?.webRTCSession.dropConnection()
@@ -197,7 +194,7 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
         callUpdate.supportsDTMF = false
     }
     
-    public static func suspendDatabaseIfCallEndedInBackground() {
+    public func suspendDatabaseIfCallEndedInBackground() {
         if Singleton.hasAppContext && Singleton.appContext.isInBackground {
             // FIXME: Initialise the `SessionCallManager` with a dependencies instance
             let dependencies: Dependencies = Dependencies()
@@ -214,9 +211,11 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
     // MARK: - UI
     
     public func showCallUIForCall(caller: String, uuid: String, mode: CallMode, interactionId: Int64?) {
-        guard let call: SessionCall = Storage.shared.read({ db in SessionCall(db, for: caller, uuid: uuid, mode: mode) }) else {
-            return
-        }
+        guard
+            let call: SessionCall = Storage.shared.read({ [dependencies] db in
+                SessionCall(db, for: caller, uuid: uuid, mode: mode, using: dependencies)
+            })
+        else { return }
         
         call.callInteractionId = interactionId
         call.reportIncomingCallIfNeeded { error in
@@ -295,3 +294,38 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
     }
 }
 
+// MARK: - SessionCallManager Cache
+
+public extension SessionCallManager {
+    class Cache: CallManagerCacheType {
+        public var provider: CXProvider?
+        
+        public func getOrCreateProvider(useSystemCallLog: Bool) -> CXProvider {
+            if let provider: CXProvider = self.provider {
+                return provider
+            }
+            
+            let iconMaskImage: UIImage = #imageLiteral(resourceName: "SessionGreen32")
+            let configuration = CXProviderConfiguration()
+            configuration.supportsVideo = true
+            configuration.maximumCallGroups = 1
+            configuration.maximumCallsPerCallGroup = 1
+            configuration.supportedHandleTypes = [.generic]
+            configuration.iconTemplateImageData = iconMaskImage.pngData()
+            configuration.includesCallsInRecents = useSystemCallLog
+            
+            let provider: CXProvider = CXProvider(configuration: configuration)
+            self.provider = provider
+            return provider
+        }
+    }
+}
+
+// MARK: - OGMCacheType
+
+/// This is a read-only version of the Cache designed to avoid unintentionally mutating the instance in a non-thread-safe way
+public protocol CallManagerImmutableCacheType: ImmutableCacheType {}
+
+public protocol CallManagerCacheType: CallManagerImmutableCacheType, MutableCacheType {
+    func getOrCreateProvider(useSystemCallLog: Bool) -> CXProvider
+}

--- a/Session/Calls/CallVC.swift
+++ b/Session/Calls/CallVC.swift
@@ -429,7 +429,7 @@ final class CallVC: UIViewController, VideoPreviewDelegate {
         
         _ = call.videoCapturer // Force the lazy var to instantiate
         titleLabel.text = self.call.contactName
-        AppEnvironment.shared.callManager.startCall(call) { [weak self] error in
+        Singleton.callManager.startCall(call) { [weak self] error in
             DispatchQueue.main.async {
                 if let _ = error {
                     self?.callInfoLabel.text = "callsErrorStart".localized()
@@ -606,7 +606,7 @@ final class CallVC: UIViewController, VideoPreviewDelegate {
     }
     
     @objc private func answerCall() {
-        AppEnvironment.shared.callManager.answerCall(call) { [weak self] error in
+        Singleton.callManager.answerCall(call) { [weak self] error in
             DispatchQueue.main.async {
                 if let _ = error {
                     self?.callInfoLabel.text = "callsErrorAnswer".localized()
@@ -617,10 +617,10 @@ final class CallVC: UIViewController, VideoPreviewDelegate {
     }
     
     @objc private func endCall() {
-        AppEnvironment.shared.callManager.endCall(call) { [weak self] error in
+        Singleton.callManager.endCall(call) { [weak self] error in
             if let _ = error {
                 self?.call.endSessionCall()
-                AppEnvironment.shared.callManager.reportCurrentCallEnded(reason: nil)
+                Singleton.callManager.reportCurrentCallEnded(reason: nil)
             }
             
             DispatchQueue.main.async {

--- a/Session/Calls/Views & Modals/IncomingCallBanner.swift
+++ b/Session/Calls/Views & Modals/IncomingCallBanner.swift
@@ -184,10 +184,10 @@ final class IncomingCallBanner: UIView, UIGestureRecognizerDelegate {
     }
     
     @objc private func endCall() {
-        AppEnvironment.shared.callManager.endCall(call) { error in
+        Singleton.callManager.endCall(call) { error in
             if let _ = error {
                 self.call.endSessionCall()
-                AppEnvironment.shared.callManager.reportCurrentCallEnded(reason: nil)
+                Singleton.callManager.reportCurrentCallEnded(reason: nil)
             }
             
             self.dismiss()

--- a/Session/Closed Groups/NewClosedGroupVC.swift
+++ b/Session/Closed Groups/NewClosedGroupVC.swift
@@ -28,13 +28,27 @@ final class NewClosedGroupVC: BaseVC, UITableViewDataSource, UITableViewDelegate
         case contacts
     }
     
-    private let contactProfiles: [Profile] = Profile.fetchAllContactProfiles(excludeCurrentUser: true)
+    private let dependencies: Dependencies
+    private let contactProfiles: [Profile]
     private lazy var data: [ArraySection<Section, Profile>] = [
         ArraySection(model: .contacts, elements: contactProfiles)
     ]
     private var selectedContacts: Set<String> = []
     private var searchText: String = ""
-
+    
+    // MARK: - Initialization
+    
+    init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+        self.contactProfiles = Profile.fetchAllContactProfiles(excludeCurrentUser: true)
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     // MARK: - Components
     
     private static let textFieldHeight: CGFloat = 50
@@ -329,7 +343,7 @@ final class NewClosedGroupVC: BaseVC, UITableViewDataSource, UITableViewDelegate
         }
         let selectedContacts = self.selectedContacts
         let message: String? = (selectedContacts.count > 20 ? "deleteAfterLegacyGroupsGroupCreation".localized() : nil)
-        ModalActivityIndicatorViewController.present(fromViewController: navigationController!, message: message) { [weak self] _ in
+        ModalActivityIndicatorViewController.present(fromViewController: navigationController!, message: message) { [weak self, dependencies] _ in
             MessageSender
                 .createClosedGroup(name: name, members: selectedContacts)
                 .subscribe(on: DispatchQueue.global(qos: .userInitiated))
@@ -358,7 +372,8 @@ final class NewClosedGroupVC: BaseVC, UITableViewDataSource, UITableViewDelegate
                             for: thread.id,
                             variant: thread.variant,
                             dismissing: self?.presentingViewController,
-                            animated: false
+                            animated: false,
+                            using: dependencies
                         )
                     }
                 )

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -1273,7 +1273,7 @@ extension ConversationVC:
                     id: sessionId,
                     variant: .contact,
                     values: .existingOrDefault,
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
             }
@@ -1309,7 +1309,7 @@ extension ConversationVC:
                 id: (lookup.sessionId ?? lookup.blindedId),
                 variant: .contact,
                 values: .existingOrDefault,
-                calledFromConfig: false,
+                calledFromConfig: nil,
                 using: dependencies
             ).id
         }
@@ -1766,7 +1766,7 @@ extension ConversationVC:
                                 roomToken: room,
                                 server: server,
                                 publicKey: publicKey,
-                                calledFromConfigHandling: false
+                                calledFromConfig: nil
                             )
                         }
                         .flatMap { successfullyAddedGroup in

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -782,18 +782,18 @@ public class ConversationViewModel: OWSAudioPlayerDelegate, NavigatableStateHold
             markAsReadPublisher = markAsReadTrigger
                 .throttle(for: .milliseconds(100), scheduler: DispatchQueue.global(qos: .userInitiated), latest: true)
                 .handleEvents(
-                    receiveOutput: { [weak self] target, timestampMs in
+                    receiveOutput: { [weak self, dependencies] target, timestampMs in
                         let threadData: SessionThreadViewModel? = self?._threadData.wrappedValue
                         
                         switch target {
-                            case .thread: threadData?.markAsRead(target: target)
+                            case .thread: threadData?.markAsRead(target: target, using: dependencies)
                             case .threadAndInteractions(let interactionId):
                                 guard
                                     timestampMs == nil ||
                                     (self?.lastInteractionTimestampMsMarkedAsRead ?? 0) < (timestampMs ?? 0) ||
                                     (self?.lastInteractionIdMarkedAsRead ?? 0) < (interactionId ?? 0)
                                 else {
-                                    threadData?.markAsRead(target: .thread)
+                                    threadData?.markAsRead(target: .thread, using: dependencies)
                                     return
                                 }
                                 
@@ -804,7 +804,7 @@ public class ConversationViewModel: OWSAudioPlayerDelegate, NavigatableStateHold
                                 }
                                 
                                 self?.lastInteractionIdMarkedAsRead = (interactionId ?? threadData?.interactionId)
-                                threadData?.markAsRead(target: target)
+                                threadData?.markAsRead(target: target, using: dependencies)
                         }
                     }
                 )
@@ -872,10 +872,14 @@ public class ConversationViewModel: OWSAudioPlayerDelegate, NavigatableStateHold
         let threadId: String = self.threadId
         let displayName: String = self._threadData.wrappedValue.displayName
         
-        Storage.shared.writeAsync { db in
+        Storage.shared.writeAsync { [dependencies] db in
             try Contact
                 .filter(id: threadId)
-                .updateAllAndConfig(db, Contact.Columns.isBlocked.set(to: false))
+                .updateAllAndConfig(
+                    db,
+                    Contact.Columns.isBlocked.set(to: false),
+                    using: dependencies
+                )
         }
     }
     

--- a/Session/Conversations/Settings/ThreadDisappearingMessagesSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadDisappearingMessagesSettingsViewModel.swift
@@ -375,23 +375,23 @@ class ThreadDisappearingMessagesSettingsViewModel: SessionTableViewModel, Naviga
         }
         
         // Contacts & legacy closed groups need to update the LibSession
-        dependencies.storage.writeAsync(using: dependencies) { [threadId, threadVariant] db in
+        dependencies.storage.writeAsync(using: dependencies) { [threadId, threadVariant, dependencies] db in
             switch threadVariant {
                 case .contact:
-                    try LibSession
-                        .update(
-                            db,
-                            sessionId: threadId,
-                            disappearingMessagesConfig: updatedConfig
-                        )
+                    try LibSession.update(
+                        db,
+                        sessionId: threadId,
+                        disappearingMessagesConfig: updatedConfig,
+                        using: dependencies
+                    )
                 
                 case .legacyGroup:
-                    try LibSession
-                        .update(
-                            db,
-                            groupPublicKey: threadId,
-                            disappearingConfig: updatedConfig
-                        )
+                    try LibSession.update(
+                        db,
+                        groupPublicKey: threadId,
+                        disappearingConfig: updatedConfig,
+                        using: dependencies
+                    )
                     
                 default: break
             }

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -774,8 +774,14 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigationItemSource, Navi
         dependencies.storage.writeAsync { [dependencies] db in
             let currentUserSessionId: String = getUserHexEncodedPublicKey(db, using: dependencies)
             try selectedUsers.forEach { userId in
-                let thread: SessionThread = try SessionThread
-                    .fetchOrCreate(db, id: userId, variant: .contact, shouldBeVisible: nil)
+                let thread: SessionThread = try SessionThread.upsert(
+                    db,
+                    id: userId,
+                    variant: .contact,
+                    values: .existingOrDefault,
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 
                 try LinkPreview(
                     url: communityUrl,

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -781,7 +781,7 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigationItemSource, Navi
                     id: userId,
                     variant: .contact,
                     values: .existingOrDefault,
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -157,7 +157,8 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigationItemSource, Navi
                                     .updateAllAndConfig(
                                         db,
                                         Profile.Columns.nickname
-                                            .set(to: (updatedNickname.isEmpty ? nil : editedDisplayName))
+                                            .set(to: (updatedNickname.isEmpty ? nil : editedDisplayName)),
+                                        using: dependencies
                                     )
                             }
                         }
@@ -537,7 +538,8 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigationItemSource, Navi
                                         db,
                                         type: .leaveGroupAsync,
                                         threadId: threadViewModel.threadId,
-                                        calledFromConfigHandling: false
+                                        calledFromConfigHandling: false,
+                                        using: dependencies
                                     )
                                 }
                             }
@@ -837,12 +839,13 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigationItemSource, Navi
     ) {
         guard oldBlockedState != isBlocked else { return }
         
-        dependencies.storage.writeAsync { db in
+        dependencies.storage.writeAsync { [dependencies] db in
             try Contact
                 .filter(id: threadId)
                 .updateAllAndConfig(
                     db,
-                    Contact.Columns.isBlocked.set(to: isBlocked)
+                    Contact.Columns.isBlocked.set(to: isBlocked),
+                    using: dependencies
                 )
         }
     }

--- a/Session/Home/GlobalSearch/GlobalSearchViewController.swift
+++ b/Session/Home/GlobalSearch/GlobalSearchViewController.swift
@@ -393,12 +393,14 @@ extension GlobalSearchViewController {
         // If it's a one-to-one thread then make sure the thread exists before pushing to it (in case the
         // contact has been hidden)
         if threadVariant == .contact {
-            Storage.shared.write { db in
-                try SessionThread.fetchOrCreate(
+            Storage.shared.write { [dependencies] db in
+                try SessionThread.upsert(
                     db,
                     id: threadId,
                     variant: threadVariant,
-                    shouldBeVisible: nil    // Don't change current state
+                    values: .existingOrDefault,
+                    calledFromConfig: false,
+                    using: dependencies
                 )
             }
         }

--- a/Session/Home/GlobalSearch/GlobalSearchViewController.swift
+++ b/Session/Home/GlobalSearch/GlobalSearchViewController.swift
@@ -399,7 +399,7 @@ extension GlobalSearchViewController {
                     id: threadId,
                     variant: threadVariant,
                     values: .existingOrDefault,
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
             }

--- a/Session/Home/HomeVC.swift
+++ b/Session/Home/HomeVC.swift
@@ -802,7 +802,7 @@ final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableViewDataS
                 }()
                 let destructiveAction: UIContextualAction.SwipeAction = {
                     switch (threadViewModel.threadVariant, threadViewModel.threadIsNoteToSelf, threadViewModel.currentUserIsClosedGroupMember) {
-                        case (.contact, true, _): return .clear
+                        case (.contact, true, _): return .hide
                         case (.legacyGroup, _, true), (.group, _, true), (.community, _, _): return .leave
                         default: return .delete
                     }
@@ -897,7 +897,7 @@ final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableViewDataS
     
     @objc func createNewConversation() {
         let viewController = SessionHostingViewController(
-            rootView: StartConversationScreen(),
+            rootView: StartConversationScreen(using: viewModel.dependencies),
             customizedNavigationBackground: .backgroundSecondary
         )
         viewController.setNavBarTitle("conversationsStart".localized())
@@ -912,7 +912,7 @@ final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableViewDataS
     }
     
     func createNewDMFromDeepLink(sessionId: String) {
-        let viewController: SessionHostingViewController = SessionHostingViewController(rootView: NewMessageScreen(accountId: sessionId))
+        let viewController: SessionHostingViewController = SessionHostingViewController(rootView: NewMessageScreen(accountId: sessionId, using: viewModel.dependencies))
         viewController.setNavBarTitle(
             "messageNew"
                 .putNumber(1)

--- a/Session/Home/HomeVC.swift
+++ b/Session/Home/HomeVC.swift
@@ -751,7 +751,8 @@ final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableViewDataS
                         tableView: tableView,
                         threadViewModel: threadViewModel,
                         viewController: self,
-                        navigatableStateHolder: viewModel
+                        navigatableStateHolder: viewModel,
+                        using: viewModel.dependencies
                     )
                 )
             
@@ -773,7 +774,8 @@ final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableViewDataS
                         tableView: tableView,
                         threadViewModel: threadViewModel,
                         viewController: self,
-                        navigatableStateHolder: viewModel
+                        navigatableStateHolder: viewModel,
+                        using: viewModel.dependencies
                     )
                 )
                 
@@ -820,7 +822,8 @@ final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableViewDataS
                         tableView: tableView,
                         threadViewModel: threadViewModel,
                         viewController: self,
-                        navigatableStateHolder: viewModel
+                        navigatableStateHolder: viewModel,
+                        using: viewModel.dependencies
                     )
                 )
                 

--- a/Session/Home/Message Requests/MessageRequestsViewModel.swift
+++ b/Session/Home/Message Requests/MessageRequestsViewModel.swift
@@ -208,7 +208,8 @@ class MessageRequestsViewModel: SessionTableViewModel, NavigatableStateHolder, O
                                         threadIds: threadInfo
                                             .filter { _, variant in variant == .contact }
                                             .map { id, _ in id },
-                                        calledFromConfigHandling: false
+                                        calledFromConfigHandling: false,
+                                        using: dependencies
                                     )
                                     
                                     // Remove the group requests
@@ -218,7 +219,8 @@ class MessageRequestsViewModel: SessionTableViewModel, NavigatableStateHolder, O
                                         threadIds: threadInfo
                                             .filter { _, variant in variant == .legacyGroup || variant == .group }
                                             .map { id, _ in id },
-                                        calledFromConfigHandling: false
+                                        calledFromConfigHandling: false,
+                                        using: dependencies
                                     )
                                 }
                             }
@@ -257,7 +259,8 @@ class MessageRequestsViewModel: SessionTableViewModel, NavigatableStateHolder, O
                         tableView: tableView,
                         threadViewModel: threadViewModel,
                         viewController: viewController,
-                        navigatableStateHolder: nil
+                        navigatableStateHolder: nil,
+                        using: dependencies
                     )
                 )
                 

--- a/Session/Home/Message Requests/MessageRequestsViewModel.swift
+++ b/Session/Home/Message Requests/MessageRequestsViewModel.swift
@@ -204,7 +204,7 @@ class MessageRequestsViewModel: SessionTableViewModel, NavigatableStateHolder, O
                                     // Remove the one-to-one requests
                                     try SessionThread.deleteOrLeave(
                                         db,
-                                        type: .hideContactConversationAndDeleteContent,
+                                        type: .deleteContactConversationAndMarkHidden,
                                         threadIds: threadInfo
                                             .filter { _, variant in variant == .contact }
                                             .map { id, _ in id },

--- a/Session/Home/New Conversation/NewMessageScreen.swift
+++ b/Session/Home/New Conversation/NewMessageScreen.swift
@@ -9,12 +9,14 @@ import SessionSnodeKit
 
 struct NewMessageScreen: View {
     @EnvironmentObject var host: HostWrapper
+    private let dependencies: Dependencies
     
     @State var tabIndex = 0
     @State private var accountIdOrONS: String
     @State private var errorString: String? = nil
     
-    init(accountId: String = "") {
+    init(accountId: String = "", using dependencies: Dependencies) {
+        self.dependencies = dependencies
         self.accountIdOrONS = accountId
     }
     
@@ -122,7 +124,8 @@ struct NewMessageScreen: View {
             variant: .contact,
             action: .compose,
             dismissing: self.host.controller,
-            animated: false
+            animated: false,
+            using: dependencies
         )
     }
 }
@@ -202,5 +205,5 @@ struct EnterAccountIdScreen: View {
 }
 
 #Preview {
-    NewMessageScreen()
+    NewMessageScreen(using: Dependencies())
 }

--- a/Session/Home/New Conversation/StartConversationScreen.swift
+++ b/Session/Home/New Conversation/StartConversationScreen.swift
@@ -7,6 +7,11 @@ import SessionUtilitiesKit
 
 struct StartConversationScreen: View {
     @EnvironmentObject var host: HostWrapper
+    private let dependencies: Dependencies
+    
+    init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
     
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -26,7 +31,9 @@ struct StartConversationScreen: View {
                             image: "Message",
                             title: title
                         ) {
-                            let viewController: SessionHostingViewController = SessionHostingViewController(rootView: NewMessageScreen())
+                            let viewController: SessionHostingViewController = SessionHostingViewController(
+                                rootView: NewMessageScreen(using: dependencies)
+                            )
                             viewController.setNavBarTitle(title)
                             viewController.setUpDismissingButton(on: .right)
                             self.host.controller?.navigationController?.pushViewController(viewController, animated: true)
@@ -46,7 +53,7 @@ struct StartConversationScreen: View {
                             image: "Group",
                             title: "groupCreate".localized()
                         ) {
-                            let viewController = NewClosedGroupVC()
+                            let viewController = NewClosedGroupVC(using: dependencies)
                             self.host.controller?.navigationController?.pushViewController(viewController, animated: true)
                         }
                         .accessibility(
@@ -64,7 +71,7 @@ struct StartConversationScreen: View {
                             image: "Globe", // stringlint:ignore
                             title: "communityJoin".localized()
                         ) {
-                            let viewController = JoinOpenGroupVC()
+                            let viewController = JoinOpenGroupVC(using: dependencies)
                             self.host.controller?.navigationController?.pushViewController(viewController, animated: true)
                         }
                         .accessibility(
@@ -155,5 +162,5 @@ fileprivate struct NewConversationCell: View {
 }
 
 #Preview {
-    StartConversationScreen()
+    StartConversationScreen(using: Dependencies())
 }

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -38,7 +38,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         verifyDBKeysAvailableBeforeBackgroundLaunch()
 
         _ = AppVersion.shared
-        AppEnvironment.shared.pushRegistrationManager.createVoipRegistryIfNecessary()
+        Singleton.setPushRegistrationManager(PushRegistrationManager(using: dependencies))
+        Singleton.pushRegistrationManager.createVoipRegistryIfNecessary()
 
         // Prevent the device from sleeping during database view async registration
         // (e.g. long database upgrades).
@@ -50,9 +51,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         self.loadingViewController = LoadingViewController()
         
         AppSetup.setupEnvironment(
-            appSpecificBlock: {
+            appSpecificBlock: { [dependencies] in
                 Log.setup(with: Logger(primaryPrefix: "Session", level: .info))
                 Log.info("[AppDelegate] Setting up environment.")
+                
+                /// Create a proper `SessionCallManager` for the main app (defaults to a no-op version)
+                Singleton.setCallManager(SessionCallManager(using: dependencies))
                 
                 // Setup LibSession
                 LibSession.addLogger()
@@ -97,7 +101,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             using: dependencies
         )
         
-        if SessionEnvironment.shared?.callManager.wrappedValue?.currentCall == nil {
+        if Singleton.callManager.currentCall == nil {
             UserDefaults.sharedLokiProject?[.isCallOngoing] = false
             UserDefaults.sharedLokiProject?[.lastCallPreOffer] = nil
         }
@@ -687,7 +691,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - Notifications
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        PushRegistrationManager.shared.didReceiveVanillaPushToken(deviceToken)
+        Singleton.pushRegistrationManager.didReceiveVanillaPushToken(deviceToken)
         Log.info("Registering for push notifications.")
     }
     
@@ -696,9 +700,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         #if DEBUG
         Log.warn("We're in debug mode. Faking success for remote registration with a fake push identifier.")
-        PushRegistrationManager.shared.didReceiveVanillaPushToken(Data(count: 32))
+        Singleton.pushRegistrationManager.didReceiveVanillaPushToken(Data(count: 32))
         #else
-        PushRegistrationManager.shared.didFailToReceiveVanillaPushToken(error: error)
+        Singleton.pushRegistrationManager.didFailToReceiveVanillaPushToken(error: error)
         #endif
     }
     
@@ -858,20 +862,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - Call handling
         
     func hasIncomingCallWaiting() -> Bool {
-        guard let call = AppEnvironment.shared.callManager.currentCall else { return false }
+        guard let call = Singleton.callManager.currentCall else { return false }
         
         return !call.hasStartedConnecting
     }
     
     func hasCallOngoing() -> Bool {
-        guard let call = AppEnvironment.shared.callManager.currentCall else { return false }
+        guard let call = Singleton.callManager.currentCall else { return false }
         
         return !call.hasEnded
     }
     
     func handleAppActivatedWithOngoingCallIfNeeded() {
         guard
-            let call: SessionCall = (AppEnvironment.shared.callManager.currentCall as? SessionCall),
+            let call: SessionCall = (Singleton.callManager.currentCall as? SessionCall),
             MiniCallView.current == nil,
             Singleton.hasAppContext
         else { return }

--- a/Session/Meta/AppEnvironment.swift
+++ b/Session/Meta/AppEnvironment.swift
@@ -23,9 +23,7 @@ public class AppEnvironment {
         }
     }
 
-    public var callManager: SessionCallManager
     public var notificationPresenter: NotificationPresenter
-    public var pushRegistrationManager: PushRegistrationManager
 
     // Stored properties cannot be marked as `@available`, only classes and functions.
     // Instead, store a private `Any` and wrap it with a public `@available` getter
@@ -36,9 +34,7 @@ public class AppEnvironment {
     }
 
     private init() {
-        self.callManager = SessionCallManager()
         self.notificationPresenter = NotificationPresenter()
-        self.pushRegistrationManager = PushRegistrationManager()
         self._userNotificationActionHandler = UserNotificationActionHandler()
         
         SwiftSingletons.register(self)
@@ -46,9 +42,6 @@ public class AppEnvironment {
 
     public func setup() {
         // Hang certain singletons on Environment too.
-        SessionEnvironment.shared?.callManager.mutate {
-            $0 = callManager
-        }
         SessionEnvironment.shared?.notificationsManager.mutate {
             $0 = notificationPresenter
         }

--- a/Session/Meta/SessionApp.swift
+++ b/Session/Meta/SessionApp.swift
@@ -90,7 +90,7 @@ public struct SessionApp {
                         id: threadId,
                         variant: variant,
                         values: .existingOrDefault,
-                        calledFromConfig: false,
+                        calledFromConfig: nil,
                         using: dependencies
                     )
                 }

--- a/Session/Meta/SessionApp.swift
+++ b/Session/Meta/SessionApp.swift
@@ -37,7 +37,8 @@ public struct SessionApp {
         variant: SessionThread.Variant,
         action: ConversationViewModel.Action = .none,
         dismissing presentingViewController: UIViewController?,
-        animated: Bool
+        animated: Bool,
+        using dependencies: Dependencies
     ) {
         let threadInfo: (threadExists: Bool, isMessageRequest: Bool)? = Storage.shared.read { db in
             let isMessageRequest: Bool = {
@@ -84,7 +85,14 @@ public struct SessionApp {
         guard threadInfo?.threadExists == true else {
             DispatchQueue.global(qos: .userInitiated).async {
                 Storage.shared.write { db in
-                    try SessionThread.fetchOrCreate(db, id: threadId, variant: variant, shouldBeVisible: nil)
+                    try SessionThread.upsert(
+                        db,
+                        id: threadId,
+                        variant: variant,
+                        values: .existingOrDefault,
+                        calledFromConfig: false,
+                        using: dependencies
+                    )
                 }
 
                 // Send back to main thread for UI transitions

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -576,7 +576,8 @@ class NotificationActionHandler {
             for: threadId,
             variant: threadVariant,
             dismissing: nil,
-            animated: (UIApplication.shared.applicationState == .active)
+            animated: (UIApplication.shared.applicationState == .active),
+            using: dependencies
         )
         
         return Just(())

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -480,7 +480,7 @@ class NotificationActionHandler {
 
     // MARK: -
 
-    func markAsRead(userInfo: [AnyHashable: Any]) -> AnyPublisher<Void, Error> {
+    func markAsRead(userInfo: [AnyHashable: Any], using dependencies: Dependencies) -> AnyPublisher<Void, Error> {
         guard let threadId: String = userInfo[AppNotificationUserInfoKey.threadId] as? String else {
             return Fail(error: NotificationError.failDebug("threadId was unexpectedly nil"))
                 .eraseToAnyPublisher()
@@ -491,7 +491,7 @@ class NotificationActionHandler {
                 .eraseToAnyPublisher()
         }
 
-        return markAsRead(threadId: threadId)
+        return markAsRead(threadId: threadId, using: dependencies)
     }
 
     func reply(
@@ -532,7 +532,8 @@ class NotificationActionHandler {
                         db,
                         threadId: threadId,
                         threadVariant: thread.variant
-                    )
+                    ),
+                    using: dependencies
                 )
                 
                 return try MessageSender.preparedSendData(
@@ -590,7 +591,7 @@ class NotificationActionHandler {
             .eraseToAnyPublisher()
     }
     
-    private func markAsRead(threadId: String) -> AnyPublisher<Void, Error> {
+    private func markAsRead(threadId: String, using dependencies: Dependencies) -> AnyPublisher<Void, Error> {
         return Storage.shared
             .writePublisher { db in
                 guard
@@ -617,7 +618,8 @@ class NotificationActionHandler {
                         db,
                         threadId: threadId,
                         threadVariant: threadVariant
-                    )
+                    ),
+                    using: dependencies
                 )
             }
             .eraseToAnyPublisher()

--- a/Session/Notifications/PushRegistrationManager.swift
+++ b/Session/Notifications/PushRegistrationManager.swift
@@ -318,7 +318,7 @@ public class PushRegistrationManager: NSObject, PKPushRegistryDelegate, PushRegi
                 id: caller,
                 variant: .contact,
                 values: .existingOrDefault,
-                calledFromConfig: false,
+                calledFromConfig: nil,
                 using: dependencies
             )
             

--- a/Session/Notifications/PushRegistrationManager.swift
+++ b/Session/Notifications/PushRegistrationManager.swift
@@ -8,37 +8,27 @@ import SessionMessagingKit
 import SignalUtilitiesKit
 import SessionUtilitiesKit
 
-public enum PushRegistrationError: Error {
-    case assertionError(description: String)
-    case pushNotSupported(description: String)
-    case timeout
-    case publisherNoLongerExists
+// MARK: - Singleton
+
+public extension Singleton {
+    // FIXME: This will be reworked to be part of dependencies in the Groups Rebuild branch
+    fileprivate static var _pushRegistrationManager: Atomic<PushRegistrationManagerType> = Atomic(NoopPushRegistrationManager())
+    static var pushRegistrationManager: PushRegistrationManagerType { _pushRegistrationManager.wrappedValue }
+    
+    static func setPushRegistrationManager(_ pushRegistrationManager: PushRegistrationManagerType) {
+        _pushRegistrationManager = Atomic(pushRegistrationManager)
+    }
 }
 
-/**
- * Singleton used to integrate with push notification services - registration and routing received remote notifications.
- */
-@objc public class PushRegistrationManager: NSObject, PKPushRegistryDelegate {
+// MARK: - PushRegistrationManager
+
+public class PushRegistrationManager: NSObject, PKPushRegistryDelegate, PushRegistrationManagerType {
+    private let dependencies: Dependencies
 
     // MARK: - Dependencies
 
     private var notificationPresenter: NotificationPresenter {
         return AppEnvironment.shared.notificationPresenter
-    }
-
-    // MARK: - Singleton class
-
-    @objc
-    public static var shared: PushRegistrationManager {
-        get {
-            return AppEnvironment.shared.pushRegistrationManager
-        }
-    }
-
-    override init() {
-        super.init()
-
-        SwiftSingletons.register(self)
     }
 
     private var vanillaTokenPublisher: AnyPublisher<Data, Error>?
@@ -47,6 +37,14 @@ public enum PushRegistrationError: Error {
     private var voipRegistry: PKPushRegistry?
     private var voipTokenPublisher: AnyPublisher<Data?, Error>?
     private var voipTokenResolver: ((Result<Data?, Error>) -> ())?
+    
+    // MARK: - Initialization
+
+    public init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+        
+        super.init()
+    }
 
     // MARK: - Public interface
 
@@ -72,7 +70,7 @@ public enum PushRegistrationError: Error {
     // MARK: Vanilla push token
 
     // Vanilla push token is obtained from the system via AppDelegate
-    public func didReceiveVanillaPushToken(_ tokenData: Data, using dependencies: Dependencies = Dependencies()) {
+    public func didReceiveVanillaPushToken(_ tokenData: Data) {
         guard let vanillaTokenResolver = self.vanillaTokenResolver else {
             Log.error("[PushRegistrationManager] Publisher completion in \(#function) unexpectedly nil")
             return
@@ -83,8 +81,8 @@ public enum PushRegistrationError: Error {
         }
     }
 
-    // Vanilla push token is obtained from the system via AppDelegate    
-    public func didFailToReceiveVanillaPushToken(error: Error, using dependencies: Dependencies = Dependencies()) {
+    // Vanilla push token is obtained from the system via AppDelegate
+    public func didFailToReceiveVanillaPushToken(error: Error) {
         guard let vanillaTokenResolver = self.vanillaTokenResolver else {
             Log.error("[PushRegistrationManager] Publisher completion in \(#function) unexpectedly nil")
             return
@@ -286,7 +284,7 @@ public enum PushRegistrationError: Error {
             let caller: String = payload["caller"] as? String,
             let timestampMs: Int64 = payload["timestamp"] as? Int64
         else {
-            SessionCallManager.reportFakeCall(info: "Missing payload data") // stringlint:ignore
+            SessionCallManager.reportFakeCall(info: "Missing payload data", using: dependencies) // stringlint:ignore
             return
         }
         
@@ -314,7 +312,7 @@ public enum PushRegistrationError: Error {
                 }
             }()
             
-            let call: SessionCall = SessionCall(db, for: caller, uuid: uuid, mode: .answer)
+            let call: SessionCall = SessionCall(db, for: caller, uuid: uuid, mode: .answer, using: dependencies)
             let thread: SessionThread = try SessionThread.upsert(
                 db,
                 id: caller,
@@ -342,7 +340,7 @@ public enum PushRegistrationError: Error {
         }
         
         guard let call: SessionCall = maybeCall else {
-            SessionCallManager.reportFakeCall(info: "Could not retrieve call from database") // stringlint:ignore
+            SessionCallManager.reportFakeCall(info: "Could not retrieve call from database", using: dependencies) // stringlint:ignore
             return
         }
         
@@ -362,4 +360,13 @@ fileprivate extension Data {
     var hexEncodedString: String {
         return map { String(format: "%02hhx", $0) }.joined() // stringlint:ignore
     }
+}
+
+// MARK: - PushRegistrationError
+
+public enum PushRegistrationError: Error {
+    case assertionError(description: String)
+    case pushNotSupported(description: String)
+    case timeout
+    case publisherNoLongerExists
 }

--- a/Session/Notifications/PushRegistrationManager.swift
+++ b/Session/Notifications/PushRegistrationManager.swift
@@ -315,8 +315,14 @@ public enum PushRegistrationError: Error {
             }()
             
             let call: SessionCall = SessionCall(db, for: caller, uuid: uuid, mode: .answer)
-            let thread: SessionThread = try SessionThread
-                .fetchOrCreate(db, id: caller, variant: .contact, shouldBeVisible: nil)
+            let thread: SessionThread = try SessionThread.upsert(
+                db,
+                id: caller,
+                variant: .contact,
+                values: .existingOrDefault,
+                calledFromConfig: false,
+                using: dependencies
+            )
             
             let interaction: Interaction = try Interaction(
                 messageUuid: uuid,

--- a/Session/Notifications/PushRegistrationManagerType.swift
+++ b/Session/Notifications/PushRegistrationManagerType.swift
@@ -1,0 +1,29 @@
+// Copyright © 2024 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import Combine
+
+// FIXME: Remove this in Groups Rebuild (redundant with the updated dependency management)
+public protocol PushRegistrationManagerType {
+    func createVoipRegistryIfNecessary()
+    func didReceiveVanillaPushToken(_ tokenData: Data)
+    func didFailToReceiveVanillaPushToken(error: Error)
+    
+    func requestPushTokens() -> AnyPublisher<(pushToken: String, voipToken: String), Error>
+}
+
+// MARK: - NoopPushRegistrationManager
+
+public class NoopPushRegistrationManager: PushRegistrationManagerType {
+    public func createVoipRegistryIfNecessary() {}
+    public func didReceiveVanillaPushToken(_ tokenData: Data) {}
+    public func didFailToReceiveVanillaPushToken(error: Error) {}
+    
+    public func requestPushTokens() -> AnyPublisher<(pushToken: String, voipToken: String), Error> {
+        return Fail(
+            error: PushRegistrationError.assertionError(
+                description: "Attempted to register with NoopPushRegistrationManager"   // stringlint:ignore
+            )
+        ).eraseToAnyPublisher()
+    }
+}

--- a/Session/Notifications/SyncPushTokensJob.swift
+++ b/Session/Notifications/SyncPushTokensJob.swift
@@ -104,7 +104,7 @@ public enum SyncPushTokensJob: JobExecutor {
         /// **Note:** Apple's documentation states that we should re-register for notifications on every launch:
         /// https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/HandlingRemoteNotifications.html#//apple_ref/doc/uid/TP40008194-CH6-SW1
         Log.info("[SyncPushTokensJob] Re-registering for remote notifications")
-        PushRegistrationManager.shared.requestPushTokens()
+        Singleton.pushRegistrationManager.requestPushTokens()
             .flatMap { (pushToken: String, voipToken: String) -> AnyPublisher<(String, String)?, Error> in
                 Deferred {
                     Future<(String, String)?, Error> { resolver in

--- a/Session/Notifications/UserNotificationsAdaptee.swift
+++ b/Session/Notifications/UserNotificationsAdaptee.swift
@@ -294,7 +294,7 @@ public class UserNotificationActionHandler: NSObject {
 
         switch action {
             case .markAsRead:
-                return actionHandler.markAsRead(userInfo: userInfo)
+                return actionHandler.markAsRead(userInfo: userInfo, using: dependencies)
                 
             case .reply:
                 guard let textInputResponse = response as? UNTextInputNotificationResponse else {

--- a/Session/Onboarding/DisplayNameScreen.swift
+++ b/Session/Onboarding/DisplayNameScreen.swift
@@ -119,7 +119,7 @@ struct DisplayNameScreen: View {
         // If we are not in the registration flow then we are finished and should go straight
         // to the home screen
         guard self.flow == .register else {
-            self.flow.completeRegistration()
+            self.flow.completeRegistration(using: dependencies)
             
             let homeVC: HomeVC = HomeVC(flow: self.flow, using: dependencies)
             self.host.controller?.navigationController?.setViewControllers([ homeVC ], animated: true)

--- a/Session/Onboarding/LoadingScreen.swift
+++ b/Session/Onboarding/LoadingScreen.swift
@@ -108,7 +108,7 @@ struct LoadingScreen: View {
             self.percentage = 1
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [dependencies] in
-            self.flow.completeRegistration()
+            self.flow.completeRegistration(using: dependencies)
             
             let homeVC: HomeVC = HomeVC(flow: self.flow, using: dependencies)
             self.host.controller?.navigationController?.setViewControllers([ homeVC ], animated: true)

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -169,8 +169,14 @@ enum Onboarding {
                 ///
                 /// **Note:** We need to explicitly `updateAllAndConfig` the `shouldBeVisible` value to `false`
                 /// otherwise it won't actually get synced correctly
-                try SessionThread
-                    .fetchOrCreate(db, id: x25519PublicKey, variant: .contact, shouldBeVisible: false)
+                try SessionThread.upsert(
+                    db,
+                    id: x25519PublicKey,
+                    variant: .contact,
+                    values: SessionThread.TargetValues(shouldBeVisible: .setTo(false)),
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 
                 try SessionThread
                     .filter(id: x25519PublicKey)

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -175,7 +175,7 @@ enum Onboarding {
                     id: x25519PublicKey,
                     variant: .contact,
                     values: SessionThread.TargetValues(shouldBeVisible: .setTo(false)),
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -162,7 +162,8 @@ enum Onboarding {
                         db,
                         Contact.Columns.isTrusted.set(to: true),    // Always trust the current user
                         Contact.Columns.isApproved.set(to: true),
-                        Contact.Columns.didApproveMe.set(to: true)
+                        Contact.Columns.didApproveMe.set(to: true),
+                        using: dependencies
                     )
 
                 /// Create the 'Note to Self' thread (not visible by default)
@@ -182,7 +183,8 @@ enum Onboarding {
                     .filter(id: x25519PublicKey)
                     .updateAllAndConfig(
                         db,
-                        SessionThread.Columns.shouldBeVisible.set(to: false)
+                        SessionThread.Columns.shouldBeVisible.set(to: false),
+                        using: dependencies
                     )
             }
             
@@ -201,7 +203,7 @@ enum Onboarding {
                 .sinkUntilComplete()
         }
         
-        func completeRegistration() {
+        func completeRegistration(using dependencies: Dependencies) {
             // Set the `lastNameUpdate` to the current date, so that we don't overwrite
             // what the user set in the display name step with whatever we find in their
             // swarm (otherwise the user could enter a display name and have it immediately
@@ -211,7 +213,8 @@ enum Onboarding {
                     .filter(id: getUserHexEncodedPublicKey(db))
                     .updateAllAndConfig(
                         db,
-                        Profile.Columns.lastNameUpdate.set(to: Date().timeIntervalSince1970)
+                        Profile.Columns.lastNameUpdate.set(to: Date().timeIntervalSince1970),
+                        using: dependencies
                     )
             }
             

--- a/Session/Onboarding/PNModeScreen.swift
+++ b/Session/Onboarding/PNModeScreen.swift
@@ -160,7 +160,7 @@ struct PNModeScreen: View {
     }
     
     private func finishRegister() {
-        self.flow.completeRegistration()
+        self.flow.completeRegistration(using: dependencies)
         
         let homeVC: HomeVC = HomeVC(flow: self.flow, using: dependencies)
         self.host.controller?.navigationController?.setViewControllers([ homeVC ], animated: true)

--- a/Session/Open Groups/JoinOpenGroupVC.swift
+++ b/Session/Open Groups/JoinOpenGroupVC.swift
@@ -206,7 +206,7 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
                         roomToken: roomToken,
                         server: server,
                         publicKey: publicKey,
-                        calledFromConfigHandling: false
+                        calledFromConfig: nil
                     )
                 }
                 .flatMap { successfullyAddedGroup in

--- a/Session/Open Groups/JoinOpenGroupVC.swift
+++ b/Session/Open Groups/JoinOpenGroupVC.swift
@@ -10,6 +10,7 @@ import SessionUtilitiesKit
 import SignalUtilitiesKit
 
 final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewControllerDelegate, QRScannerDelegate, NavigatableStateHolder {
+    private let dependencies: Dependencies
     public let navigatableState: NavigatableState = NavigatableState()
     private var disposables: Set<AnyCancellable> = Set()
     
@@ -55,6 +56,18 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
         
         return result
     }()
+    
+    // MARK: - Initialization
+    
+    init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     // MARK: - Lifecycle
     
@@ -185,7 +198,7 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
         
         isJoining = true
         
-        ModalActivityIndicatorViewController.present(fromViewController: navigationController, canCancel: false) { [weak self] _ in
+        ModalActivityIndicatorViewController.present(fromViewController: navigationController, canCancel: false) { [weak self, dependencies] _ in
             Storage.shared
                 .writePublisher { db in
                     OpenGroupManager.shared.add(
@@ -240,7 +253,8 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
                                         for: OpenGroup.idFor(roomToken: roomToken, server: server),
                                         variant: .community,
                                         dismissing: nil,
-                                        animated: false
+                                        animated: false,
+                                        using: dependencies
                                     )
                                 }
                         }

--- a/Session/Settings/BlockedContactsViewModel.swift
+++ b/Session/Settings/BlockedContactsViewModel.swift
@@ -205,12 +205,16 @@ public class BlockedContactsViewModel: SessionTableViewModel, NavigatableStateHo
                 confirmTitle: "blockUnblock".localized(),
                 confirmStyle: .danger,
                 cancelStyle: .alert_text
-            ) { [weak self] _ in
+            ) { [weak self, dependencies] _ in
                 // Unblock the contacts
                 Storage.shared.write { db in
                     _ = try Contact
                         .filter(ids: contactIds)
-                        .updateAllAndConfig(db, Contact.Columns.isBlocked.set(to: false))
+                        .updateAllAndConfig(
+                            db,
+                            Contact.Columns.isBlocked.set(to: false),
+                            using: dependencies
+                        )
                 }
                 
                 self?.selectedContactIdsSubject.send([])

--- a/Session/Settings/PrivacySettingsViewModel.swift
+++ b/Session/Settings/PrivacySettingsViewModel.swift
@@ -139,7 +139,11 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                                 }
                                 
                                 Storage.shared.write { db in
-                                    try db.setAndUpdateConfig(.isScreenLockEnabled, to: !db[.isScreenLockEnabled])
+                                    try db.setAndUpdateConfig(
+                                        .isScreenLockEnabled,
+                                        to: !db[.isScreenLockEnabled],
+                                        using: dependencies
+                                    )
                                 }
                             }
                         )
@@ -166,7 +170,8 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                                 Storage.shared.write { db in
                                     try db.setAndUpdateConfig(
                                         .checkForCommunityMessageRequests,
-                                        to: !db[.checkForCommunityMessageRequests]
+                                        to: !db[.checkForCommunityMessageRequests],
+                                        using: dependencies
                                     )
                                 }
                             }
@@ -192,7 +197,11 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                             ),
                             onTap: {
                                 Storage.shared.write { db in
-                                    try db.setAndUpdateConfig(.areReadReceiptsEnabled, to: !db[.areReadReceiptsEnabled])
+                                    try db.setAndUpdateConfig(
+                                        .areReadReceiptsEnabled,
+                                        to: !db[.areReadReceiptsEnabled],
+                                        using: dependencies
+                                    )
                                 }
                             }
                         )
@@ -252,7 +261,11 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                             ),
                             onTap: {
                                 Storage.shared.write { db in
-                                    try db.setAndUpdateConfig(.typingIndicatorsEnabled, to: !db[.typingIndicatorsEnabled])
+                                    try db.setAndUpdateConfig(
+                                        .typingIndicatorsEnabled,
+                                        to: !db[.typingIndicatorsEnabled],
+                                        using: dependencies
+                                    )
                                 }
                             }
                         )
@@ -277,7 +290,11 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                             ),
                             onTap: {
                                 Storage.shared.write { db in
-                                    try db.setAndUpdateConfig(.areLinkPreviewsEnabled, to: !db[.areLinkPreviewsEnabled])
+                                    try db.setAndUpdateConfig(
+                                        .areLinkPreviewsEnabled,
+                                        to: !db[.areLinkPreviewsEnabled],
+                                        using: dependencies
+                                    )
                                 }
                             }
                         )
@@ -314,7 +331,11 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                             ),
                             onTap: {
                                 Storage.shared.write { db in
-                                    try db.setAndUpdateConfig(.areCallsEnabled, to: !db[.areCallsEnabled])
+                                    try db.setAndUpdateConfig(
+                                        .areCallsEnabled,
+                                        to: !db[.areCallsEnabled],
+                                        using: dependencies
+                                    )
                                 }
                             }
                         )

--- a/Session/Settings/QRCodeScreen.swift
+++ b/Session/Settings/QRCodeScreen.swift
@@ -8,10 +8,15 @@ import AVFoundation
 
 struct QRCodeScreen: View {
     @EnvironmentObject var host: HostWrapper
+    let dependencies: Dependencies
     
     @State var tabIndex = 0
     @State private var accountId: String = ""
     @State private var errorString: String? = nil
+    
+    init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
     
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -51,7 +56,8 @@ struct QRCodeScreen: View {
                 variant: .contact,
                 action: .compose,
                 dismissing: self.host.controller,
-                animated: false
+                animated: false,
+                using: dependencies
             )
         }
     }
@@ -94,5 +100,5 @@ struct MyQRCodeScreen: View {
 }
 
 #Preview {
-    QRCodeScreen()
+    QRCodeScreen(using: Dependencies())
 }

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -145,7 +145,7 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
         .eraseToAnyPublisher()
     
     lazy var rightNavItems: AnyPublisher<[SessionNavItem<NavItem>], Never> = navState
-        .map { [weak self] navState -> [SessionNavItem<NavItem>] in
+        .map { [weak self, dependencies] navState -> [SessionNavItem<NavItem>] in
             switch navState {
                 case .standard:
                     return [
@@ -156,7 +156,9 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
                             style: .plain,
                             accessibilityIdentifier: "View QR code",
                             action: { [weak self] in
-                                let viewController: SessionHostingViewController = SessionHostingViewController(rootView: QRCodeScreen())
+                                let viewController: SessionHostingViewController = SessionHostingViewController(
+                                    rootView: QRCodeScreen(using: dependencies)
+                                )
                                 viewController.setNavBarTitle("qrCode".localized())
                                 self?.transitionToScreen(viewController)
                             }

--- a/Session/Utilities/MockDataGenerator.swift
+++ b/Session/Utilities/MockDataGenerator.swift
@@ -49,8 +49,14 @@ enum MockDataGenerator {
         logProgress("", "Start")
         
         // First create the thread used to indicate that the mock data has been generated
-        _ = try? SessionThread
-            .fetchOrCreate(db, id: "MockDatabaseThread", variant: .contact, shouldBeVisible: false)
+        _ = try? SessionThread.upsert(
+            db,
+            id: "MockDatabaseThread",
+            variant: .contact,
+            values: SessionThread.TargetValues(shouldBeVisible: .setTo(false)),
+            calledFromConfig: false,
+            using: dependencies
+        )
         
         // MARK: - -- DM Thread
         
@@ -74,13 +80,14 @@ enum MockDataGenerator {
                     .randomElement(using: &dmThreadRandomGenerator) ?? 0)
                 
                 // Generate the thread
-                let thread: SessionThread = try! SessionThread
-                    .fetchOrCreate(
-                        db,
-                        id: randomSessionId,
-                        variant: .contact,
-                        shouldBeVisible: true
-                    )
+                let thread: SessionThread = try! SessionThread.upsert(
+                    db,
+                    id: randomSessionId,
+                    variant: .contact,
+                    values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 
                 // Generate the contact
                 let contact: Contact = try! Contact(
@@ -186,13 +193,14 @@ enum MockDataGenerator {
                     members.append(randomSessionId)
                 }
                 
-                let thread: SessionThread = try! SessionThread
-                    .fetchOrCreate(
-                        db,
-                        id: randomGroupPublicKey,
-                        variant: .legacyGroup,
-                        shouldBeVisible: true
-                    )
+                let thread: SessionThread = try! SessionThread.upsert(
+                    db,
+                    id: randomGroupPublicKey,
+                    variant: .legacyGroup,
+                    values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 _ = try! ClosedGroup(
                     threadId: randomGroupPublicKey,
                     name: groupName,
@@ -316,13 +324,14 @@ enum MockDataGenerator {
                 }
                 
                 // Create the open group model and the thread
-                let thread: SessionThread = try! SessionThread
-                    .fetchOrCreate(
-                        db,
-                        id: randomGroupPublicKey,
-                        variant: .community,
-                        shouldBeVisible: true
-                    )
+                let thread: SessionThread = try! SessionThread.upsert(
+                    db,
+                    id: randomGroupPublicKey,
+                    variant: .community,
+                    values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 _ = try! OpenGroup(
                     server: serverName,
                     roomToken: roomName,

--- a/Session/Utilities/MockDataGenerator.swift
+++ b/Session/Utilities/MockDataGenerator.swift
@@ -54,7 +54,7 @@ enum MockDataGenerator {
             id: "MockDatabaseThread",
             variant: .contact,
             values: SessionThread.TargetValues(shouldBeVisible: .setTo(false)),
-            calledFromConfig: false,
+            calledFromConfig: nil,
             using: dependencies
         )
         
@@ -85,7 +85,7 @@ enum MockDataGenerator {
                     id: randomSessionId,
                     variant: .contact,
                     values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 
@@ -198,7 +198,7 @@ enum MockDataGenerator {
                     id: randomGroupPublicKey,
                     variant: .legacyGroup,
                     values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 _ = try! ClosedGroup(
@@ -329,7 +329,7 @@ enum MockDataGenerator {
                     id: randomGroupPublicKey,
                     variant: .community,
                     values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 _ = try! OpenGroup(

--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -140,7 +140,7 @@ public extension UIContextualAction {
                                         Storage.shared.writeAsync { db in
                                             try SessionThread.deleteOrLeave(
                                                 db,
-                                                type: .hideContactConversationAndDeleteContent,
+                                                type: .deleteContactConversationAndMarkHidden,
                                                 threadId: threadViewModel.threadId,
                                                 calledFromConfigHandling: false
                                             )
@@ -186,7 +186,7 @@ public extension UIContextualAction {
                                                 Storage.shared.writeAsync { db in
                                                     try SessionThread.deleteOrLeave(
                                                         db,
-                                                        type: .hideContactConversationAndDeleteContent,
+                                                        type: .hideContactConversation,
                                                         threadId: threadViewModel.threadId,
                                                         calledFromConfigHandling: false
                                                     )
@@ -343,7 +343,7 @@ public extension UIContextualAction {
                                             if threadIsMessageRequest {
                                                 try SessionThread.deleteOrLeave(
                                                     db,
-                                                    type: .hideContactConversationAndDeleteContent,
+                                                    type: .deleteContactConversationAndMarkHidden,
                                                     threadId: threadViewModel.threadId,
                                                     calledFromConfigHandling: false
                                                 )
@@ -542,8 +542,7 @@ public extension UIContextualAction {
                                                 case (.group, _), (.legacyGroup, _):
                                                     return .leaveGroupAsync
                                                 
-                                                case (.contact, _):
-                                                    return .hideContactConversationAndDeleteContent
+                                                case (.contact, _): return .deleteContactConversationAndMarkHidden
                                             }
                                         }()
                                         

--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -50,7 +50,8 @@ public extension UIContextualAction {
         tableView: UITableView,
         threadViewModel: SessionThreadViewModel,
         viewController: UIViewController?,
-        navigatableStateHolder: NavigatableStateHolder?
+        navigatableStateHolder: NavigatableStateHolder?,
+        using dependencies: Dependencies
     ) -> [UIContextualAction]? {
         guard !actions.isEmpty else { return nil }
         
@@ -106,10 +107,11 @@ public extension UIContextualAction {
                                     case true: threadViewModel.markAsRead(
                                         target: .threadAndInteractions(
                                             interactionsBeforeInclusive: threadViewModel.interactionId
-                                        )
+                                        ),
+                                        using: dependencies
                                     )
                                         
-                                    case false: threadViewModel.markAsUnread()
+                                    case false: threadViewModel.markAsUnread(using: dependencies)
                                 }
                             }
                             completionHandler(true)
@@ -142,7 +144,8 @@ public extension UIContextualAction {
                                                 db,
                                                 type: .deleteContactConversationAndMarkHidden,
                                                 threadId: threadViewModel.threadId,
-                                                calledFromConfigHandling: false
+                                                calledFromConfigHandling: false,
+                                                using: dependencies
                                             )
                                         }
                                         
@@ -188,7 +191,8 @@ public extension UIContextualAction {
                                                         db,
                                                         type: .hideContactConversation,
                                                         threadId: threadViewModel.threadId,
-                                                        calledFromConfigHandling: false
+                                                        calledFromConfigHandling: false,
+                                                        using: dependencies
                                                     )
                                                 }
                                                 
@@ -235,7 +239,8 @@ public extension UIContextualAction {
                                         .updateAllAndConfig(
                                             db,
                                             SessionThread.Columns.pinnedPriority
-                                                .set(to: (threadViewModel.threadPinnedPriority == 0 ? 1 : 0))
+                                                .set(to: (threadViewModel.threadPinnedPriority == 0 ? 1 : 0)),
+                                            using: dependencies
                                         )
                                 }
                             }
@@ -337,7 +342,11 @@ public extension UIContextualAction {
                                                 .save(db)
                                             try Contact
                                                 .filter(id: threadViewModel.threadId)
-                                                .updateAllAndConfig(db, contactChanges)
+                                                .updateAllAndConfig(
+                                                    db,
+                                                    contactChanges,
+                                                    using: dependencies
+                                                )
                                             
                                             // Blocked message requests should be deleted
                                             if threadIsMessageRequest {
@@ -345,7 +354,8 @@ public extension UIContextualAction {
                                                     db,
                                                     type: .deleteContactConversationAndMarkHidden,
                                                     threadId: threadViewModel.threadId,
-                                                    calledFromConfigHandling: false
+                                                    calledFromConfigHandling: false,
+                                                    using: dependencies
                                                 )
                                             }
                                         }
@@ -439,7 +449,8 @@ public extension UIContextualAction {
                                                     db,
                                                     type: deletionType,
                                                     threadId: threadViewModel.threadId,
-                                                    calledFromConfigHandling: false
+                                                    calledFromConfigHandling: false,
+                                                    using: dependencies
                                                 )
                                             } catch {
                                                 DispatchQueue.main.async {
@@ -551,7 +562,8 @@ public extension UIContextualAction {
                                                 db,
                                                 type: deletionType,
                                                 threadId: threadViewModel.threadId,
-                                                calledFromConfigHandling: false
+                                                calledFromConfigHandling: false,
+                                                using: dependencies
                                             )
                                         }
                                         

--- a/SessionMessagingKit/Calls/CallManagerProtocol.swift
+++ b/SessionMessagingKit/Calls/CallManagerProtocol.swift
@@ -2,11 +2,33 @@
 
 import Foundation
 import CallKit
+import SessionUtilitiesKit
+
+// MARK: - Singleton
+
+public extension Singleton {
+    // FIXME: This will be reworked to be part of dependencies in the Groups Rebuild branch
+    fileprivate static var _callManager: Atomic<CallManagerProtocol> = Atomic(NoopSessionCallManager())
+    static var callManager: CallManagerProtocol { _callManager.wrappedValue }
+    
+    static func setCallManager(_ callManager: CallManagerProtocol) {
+        _callManager = Atomic(callManager)
+    }
+}
+
+// MARK: - CallManagerProtocol
 
 public protocol CallManagerProtocol {
     var currentCall: CurrentCallProtocol? { get set }
     
+    func setCurrentCall(_ call: CurrentCallProtocol?)
+    func reportIncomingCall(_ call: CurrentCallProtocol, callerName: String, completion: @escaping (Error?) -> Void)
     func reportCurrentCallEnded(reason: CXCallEndedReason?)
+    func suspendDatabaseIfCallEndedInBackground()
+    
+    func startCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?)
+    func answerCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?)
+    func endCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?)
     
     func showCallUIForCall(caller: String, uuid: String, mode: CallMode, interactionId: Int64?)
     func handleICECandidates(message: CallMessage, sdpMLineIndexes: [UInt32], sdpMids: [String])

--- a/SessionMessagingKit/Calls/CurrentCallProtocol.swift
+++ b/SessionMessagingKit/Calls/CurrentCallProtocol.swift
@@ -3,6 +3,7 @@
 import Foundation
 import GRDB
 import WebRTC
+import SessionUtilitiesKit
 
 public protocol CurrentCallProtocol {
     var uuid: String { get }
@@ -10,7 +11,7 @@ public protocol CurrentCallProtocol {
     var hasStartedConnecting: Bool { get set }
     var hasEnded: Bool { get set }
     
-    func updateCallMessage(mode: EndCallMode)
+    func updateCallMessage(mode: EndCallMode, using dependencies: Dependencies)
     func didReceiveRemoteSDP(sdp: RTCSessionDescription)
     func startSessionCall(_ db: Database)
 }

--- a/SessionMessagingKit/Calls/NoopSessionCallManager.swift
+++ b/SessionMessagingKit/Calls/NoopSessionCallManager.swift
@@ -1,0 +1,25 @@
+// Copyright © 2024 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import CallKit
+
+internal struct NoopSessionCallManager: CallManagerProtocol {
+    var currentCall: CurrentCallProtocol?
+
+    func setCurrentCall(_ call: CurrentCallProtocol?) {}
+    func reportIncomingCall(_ call: CurrentCallProtocol, callerName: String, completion: @escaping (Error?) -> Void) {}
+    func reportCurrentCallEnded(reason: CXCallEndedReason?) {}
+    func suspendDatabaseIfCallEndedInBackground() {}
+
+    func startCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?) {}
+    func answerCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?) {}
+    func endCall(_ call: CurrentCallProtocol?, completion: ((Error?) -> Void)?) {}
+
+    func showCallUIForCall(caller: String, uuid: String, mode: CallMode, interactionId: Int64?) {}
+    func handleICECandidates(message: CallMessage, sdpMLineIndexes: [UInt32], sdpMids: [String]) {}
+    func handleAnswerMessage(_ message: CallMessage) {}
+    
+    func currentWebRTCSessionMatches(callId: String) -> Bool { return false }
+    
+    func dismissAllCallUI() {}
+}

--- a/SessionMessagingKit/Database/Migrations/_013_SessionUtilChanges.swift
+++ b/SessionMessagingKit/Database/Migrations/_013_SessionUtilChanges.swift
@@ -243,8 +243,14 @@ enum _013_SessionUtilChanges: Migration {
         /// counts so don't do this when running tests (this logic is the same as in `MainAppContext.isRunningTests`
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
             if (try SessionThread.exists(db, id: userPublicKey)) == false {
-                try SessionThread
-                    .fetchOrCreate(db, id: userPublicKey, variant: .contact, shouldBeVisible: false)
+                try SessionThread.upsert(
+                    db,
+                    id: userPublicKey,
+                    variant: .contact,
+                    values: SessionThread.TargetValues(shouldBeVisible: .setTo(false)),
+                    calledFromConfig: false,
+                    using: dependencies
+                )
             }
         }
         

--- a/SessionMessagingKit/Database/Migrations/_013_SessionUtilChanges.swift
+++ b/SessionMessagingKit/Database/Migrations/_013_SessionUtilChanges.swift
@@ -248,7 +248,7 @@ enum _013_SessionUtilChanges: Migration {
                     id: userPublicKey,
                     variant: .contact,
                     values: SessionThread.TargetValues(shouldBeVisible: .setTo(false)),
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
             }

--- a/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
+++ b/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
@@ -197,7 +197,7 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
                 
         // MARK: - Threads
         
-        try LibSession.updatingThreads(db, Array(allThreads.values))
+        try LibSession.updatingThreads(db, Array(allThreads.values), using: dependencies)
         
         // MARK: - Syncing
         

--- a/SessionMessagingKit/Database/Migrations/_018_DisappearingMessagesConfiguration.swift
+++ b/SessionMessagingKit/Database/Migrations/_018_DisappearingMessagesConfiguration.swift
@@ -80,7 +80,7 @@ enum _018_DisappearingMessagesConfiguration: Migration {
             }
         
         // Update the configs so the settings are synced
-        _ = try LibSession.updatingDisappearingConfigs(db, contactUpdate)
+        _ = try LibSession.updatingDisappearingConfigs(db, contactUpdate, using: dependencies)
         _ = try LibSession.batchUpdate(db, disappearingConfigs: legacyGroupUpdate, using: dependencies)
         
         Storage.update(progress: 1, for: self, in: target) // In case this is the last migration

--- a/SessionMessagingKit/Database/Models/BlindedIdLookup.swift
+++ b/SessionMessagingKit/Database/Models/BlindedIdLookup.swift
@@ -137,7 +137,11 @@ public extension BlindedIdLookup {
             if isCheckingForOutbox && !contact.isApproved {
                 try Contact
                     .filter(id: contact.id)
-                    .updateAllAndConfig(db, Contact.Columns.isApproved.set(to: true))
+                    .updateAllAndConfig(
+                        db,
+                        Contact.Columns.isApproved.set(to: true),
+                        using: dependencies
+                    )
             }
             
             break

--- a/SessionMessagingKit/Database/Models/ClosedGroup.swift
+++ b/SessionMessagingKit/Database/Models/ClosedGroup.swift
@@ -115,13 +115,15 @@ public extension ClosedGroup {
         _ db: Database? = nil,
         threadId: String,
         removeGroupData: Bool,
-        calledFromConfigHandling: Bool
+        calledFromConfigHandling: Bool,
+        using dependencies: Dependencies
     ) throws {
         try removeKeysAndUnsubscribe(
             db,
             threadIds: [threadId],
             removeGroupData: removeGroupData,
-            calledFromConfigHandling: calledFromConfigHandling
+            calledFromConfigHandling: calledFromConfigHandling,
+            using: dependencies
         )
     }
     
@@ -129,16 +131,18 @@ public extension ClosedGroup {
         _ db: Database? = nil,
         threadIds: [String],
         removeGroupData: Bool,
-        calledFromConfigHandling: Bool
+        calledFromConfigHandling: Bool,
+        using dependencies: Dependencies
     ) throws {
         guard !threadIds.isEmpty else { return }
         guard let db: Database = db else {
-            Storage.shared.write { db in
+            dependencies.storage.write { db in
                 try ClosedGroup.removeKeysAndUnsubscribe(
                     db,
                     threadIds: threadIds,
                     removeGroupData: removeGroupData,
-                    calledFromConfigHandling: calledFromConfigHandling
+                    calledFromConfigHandling: calledFromConfigHandling,
+                    using: dependencies
                 )
             }
             return
@@ -196,7 +200,8 @@ public extension ClosedGroup {
                 db,
                 legacyGroupIds: threadVariants
                     .filter { $0.variant == .legacyGroup }
-                    .map { $0.id }
+                    .map { $0.id },
+                using: dependencies
             )
             
             try LibSession.remove(

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -491,7 +491,8 @@ public extension Interaction {
         threadId: String,
         threadVariant: SessionThread.Variant,
         includingOlder: Bool,
-        trySendReadReceipt: Bool
+        trySendReadReceipt: Bool,
+        using dependencies: Dependencies
     ) throws {
         guard let interactionId: Int64 = interactionId else { return }
         
@@ -535,7 +536,8 @@ public extension Interaction {
                 ],
                 lastReadTimestampMs: timestampMs,
                 trySendReadReceipt: trySendReadReceipt,
-                calledFromConfigHandling: false
+                calledFromConfigHandling: false,
+                using: dependencies
             )
             return
         }
@@ -560,7 +562,8 @@ public extension Interaction {
                 interactionInfo: [interactionInfo],
                 lastReadTimestampMs: interactionInfo.timestampMs,
                 trySendReadReceipt: trySendReadReceipt,
-                calledFromConfigHandling: false
+                calledFromConfigHandling: false,
+                using: dependencies
             )
             return
         }
@@ -576,7 +579,8 @@ public extension Interaction {
             interactionInfo: interactionInfoToMarkAsRead,
             lastReadTimestampMs: interactionInfo.timestampMs,
             trySendReadReceipt: trySendReadReceipt,
-            calledFromConfigHandling: false
+            calledFromConfigHandling: false,
+            using: dependencies
         )
     }
     
@@ -647,7 +651,8 @@ public extension Interaction {
         interactionInfo: [Interaction.ReadInfo],
         lastReadTimestampMs: Int64,
         trySendReadReceipt: Bool,
-        calledFromConfigHandling: Bool
+        calledFromConfigHandling: Bool,
+        using dependencies: Dependencies
     ) throws {
         guard !interactionInfo.isEmpty else { return }
         
@@ -657,7 +662,8 @@ public extension Interaction {
                 db,
                 threadId: threadId,
                 threadVariant: threadVariant,
-                lastReadTimestampMs: lastReadTimestampMs
+                lastReadTimestampMs: lastReadTimestampMs,
+                using: dependencies
             )
             
             // Add the 'DisappearingMessagesJob' if needed - this will update any expiring

--- a/SessionMessagingKit/Database/Models/SessionThread.swift
+++ b/SessionMessagingKit/Database/Models/SessionThread.swift
@@ -485,7 +485,7 @@ public extension SessionThread {
                 if threadIds.contains(currentUserPublicKey) {
                     // Clear any interactions for the deleted thread
                     _ = try Interaction
-                        .filter(threadIds.contains(Interaction.Columns.threadId))
+                        .filter(Interaction.Columns.threadId == currentUserPublicKey)
                         .deleteAll(db)
                     
                     _ = try SessionThread

--- a/SessionMessagingKit/Database/Models/SessionThread.swift
+++ b/SessionMessagingKit/Database/Models/SessionThread.swift
@@ -202,7 +202,7 @@ public extension SessionThread {
         id: ID,
         variant: Variant,
         values: TargetValues,
-        calledFromConfig: Bool,
+        calledFromConfig configTriggeringChange: LibSession.Config.Variant?,
         using dependencies: Dependencies
     ) throws -> SessionThread {
         var result: SessionThread
@@ -215,6 +215,7 @@ public extension SessionThread {
                     db,
                     threadId: id,
                     threadVariant: variant,
+                    conf: configTriggeringChange?.conf,
                     using: dependencies
                 )
                 
@@ -239,13 +240,14 @@ public extension SessionThread {
                     )
             
             case (_, .useLibSession):                           // Create and save the config from libSession
-                guard !calledFromConfig else { throw LibSessionError.invalidConfigAccess }
+                guard configTriggeringChange == nil else { throw LibSessionError.invalidConfigAccess }
                 
                 try LibSession
                     .disappearingMessagesConfig(
                         db,
                         threadId: id,
                         threadVariant: variant,
+                        conf: configTriggeringChange?.conf,
                         using: dependencies
                     )?
                     .upserted(db)
@@ -268,6 +270,7 @@ public extension SessionThread {
                     db,
                     threadId: id,
                     threadVariant: variant,
+                    conf: configTriggeringChange?.conf,
                     using: dependencies
                 )
                 let libSessionShouldBeVisible: Bool = LibSession.shouldBeVisible(priority: targetPriority)
@@ -305,7 +308,7 @@ public extension SessionThread {
             .updateAllAndConfig(
                 db,
                 requiredChanges,
-                calledFromConfig: calledFromConfig,
+                calledFromConfig: (configTriggeringChange != nil),
                 using: dependencies
             )
         

--- a/SessionMessagingKit/Database/Models/SessionThread.swift
+++ b/SessionMessagingKit/Database/Models/SessionThread.swift
@@ -448,22 +448,8 @@ public extension SessionThread {
         
         switch type {
             case .hideContactConversation:
-                // We need to custom handle the 'Note to Self' conversation
-                if threadIds.contains(currentUserPublicKey) {
-                    _ = try SessionThread
-                        .filter(id: currentUserPublicKey)
-                        .updateAllAndConfig(
-                            db,
-                            SessionThread.Columns.pinnedPriority.set(to: LibSession.hiddenPriority),
-                            SessionThread.Columns.shouldBeVisible.set(to: false),
-                            calledFromConfig: calledFromConfigHandling,
-                            using: dependencies
-                        )
-                }
-                
-                // Update any other threads to be hidden
                 _ = try SessionThread
-                    .filter(ids: remainingThreadIds)
+                    .filter(ids: threadIds)
                     .updateAllAndConfig(
                         db,
                         SessionThread.Columns.pinnedPriority.set(to: LibSession.hiddenPriority),
@@ -478,24 +464,9 @@ public extension SessionThread {
                     .filter(threadIds.contains(Interaction.Columns.threadId))
                     .deleteAll(db)
                 
-                // We need to custom handle the 'Note to Self' conversation (it should just be
-                // hidden rather than deleted)
-                if threadIds.contains(currentUserPublicKey) {
-                    _ = try SessionThread
-                        .filter(id: currentUserPublicKey)
-                        .updateAllAndConfig(
-                            db,
-                            SessionThread.Columns.pinnedPriority.set(to: LibSession.hiddenPriority),
-                            SessionThread.Columns.shouldBeVisible.set(to: false),
-                            calledFromConfig: calledFromConfigHandling,
-                            using: dependencies
-                        )
-                }
-                
-                // Update any other threads to be hidden (don't want to actually delete the thread
-                // record in case it's settings get changed while it's not visible)
+                // Hide the threads
                 _ = try SessionThread
-                    .filter(ids: remainingThreadIds)
+                    .filter(ids: threadIds)
                     .updateAllAndConfig(
                         db,
                         SessionThread.Columns.pinnedPriority.set(to: LibSession.hiddenPriority),

--- a/SessionMessagingKit/Jobs/Types/GroupLeavingJob.swift
+++ b/SessionMessagingKit/Jobs/Types/GroupLeavingJob.swift
@@ -127,7 +127,8 @@ public enum GroupLeavingJob: JobExecutor {
                             db,
                             threadId: threadId,
                             removeGroupData: details.deleteThread,
-                            calledFromConfigHandling: false
+                            calledFromConfigHandling: false,
+                            using: dependencies
                         )
                     }
                     

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -39,7 +39,7 @@ internal extension LibSession {
         using dependencies: Dependencies
     ) throws {
         guard mergeNeedsDump else { return }
-        guard conf != nil else { throw LibSessionError.nilConfigObject }
+        guard let conf: UnsafeMutablePointer<config_object> = conf else { throw LibSessionError.nilConfigObject }
         
         // The current users contact data is handled separately so exclude it if it's present (as that's
         // actually a bug)
@@ -178,7 +178,7 @@ internal extension LibSession {
                                     .useExisting
                                 )
                             ),
-                            calledFromConfig: true,
+                            calledFromConfig: .contacts(conf),
                             using: dependencies
                         )
                     

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
@@ -17,7 +17,8 @@ internal extension LibSession {
     static func handleConvoInfoVolatileUpdate(
         _ db: Database,
         in conf: UnsafeMutablePointer<config_object>?,
-        mergeNeedsDump: Bool
+        mergeNeedsDump: Bool,
+        using dependencies: Dependencies
     ) throws {
         guard mergeNeedsDump else { return }
         guard conf != nil else { throw LibSessionError.nilConfigObject }
@@ -97,7 +98,8 @@ internal extension LibSession {
                     interactionInfo: interactionInfoToMarkAsRead,
                     lastReadTimestampMs: lastReadTimestampMs,
                     trySendReadReceipt: false,  // Interactions already read, no need to send
-                    calledFromConfigHandling: true
+                    calledFromConfigHandling: true,
+                    using: dependencies
                 )
                 return nil
             }
@@ -226,7 +228,8 @@ internal extension LibSession {
     
     static func updateMarkedAsUnreadState(
         _ db: Database,
-        threads: [SessionThread]
+        threads: [SessionThread],
+        using dependencies: Dependencies
     ) throws {
         // If we have no updated threads then no need to continue
         guard !threads.isEmpty else { return }
@@ -245,7 +248,8 @@ internal extension LibSession {
         try LibSession.performAndPushChange(
             db,
             for: .convoInfoVolatile,
-            publicKey: getUserHexEncodedPublicKey(db)
+            publicKey: getUserHexEncodedPublicKey(db),
+            using: dependencies
         ) { conf in
             try upsert(
                 convoInfoVolatileChanges: changes,
@@ -254,11 +258,16 @@ internal extension LibSession {
         }
     }
     
-    static func remove(_ db: Database, volatileContactIds: [String]) throws {
+    static func remove(
+        _ db: Database,
+        volatileContactIds: [String],
+        using dependencies: Dependencies
+    ) throws {
         try LibSession.performAndPushChange(
             db,
             for: .convoInfoVolatile,
-            publicKey: getUserHexEncodedPublicKey(db)
+            publicKey: getUserHexEncodedPublicKey(db, using: dependencies),
+            using: dependencies
         ) { conf in
             try volatileContactIds.forEach { contactId in
                 var cSessionId: [CChar] = try contactId.cString(using: .utf8) ?? { throw LibSessionError.invalidCConversion }()
@@ -269,11 +278,16 @@ internal extension LibSession {
         }
     }
     
-    static func remove(_ db: Database, volatileLegacyGroupIds: [String]) throws {
+    static func remove(
+        _ db: Database,
+        volatileLegacyGroupIds: [String],
+        using dependencies: Dependencies
+    ) throws {
         try LibSession.performAndPushChange(
             db,
             for: .convoInfoVolatile,
-            publicKey: getUserHexEncodedPublicKey(db)
+            publicKey: getUserHexEncodedPublicKey(db, using: dependencies),
+            using: dependencies
         ) { conf in
             try volatileLegacyGroupIds.forEach { legacyGroupId in
                 var cLegacyGroupId: [CChar] = try legacyGroupId.cString(using: .utf8) ?? { throw LibSessionError.invalidCConversion }()
@@ -284,11 +298,16 @@ internal extension LibSession {
         }
     }
     
-    static func remove(_ db: Database, volatileCommunityInfo: [OpenGroupUrlInfo]) throws {
+    static func remove(
+        _ db: Database,
+        volatileCommunityInfo: [OpenGroupUrlInfo],
+        using dependencies: Dependencies
+    ) throws {
         try LibSession.performAndPushChange(
             db,
             for: .convoInfoVolatile,
-            publicKey: getUserHexEncodedPublicKey(db)
+            publicKey: getUserHexEncodedPublicKey(db, using: dependencies),
+            using: dependencies
         ) { conf in
             try volatileCommunityInfo.forEach { urlInfo in
                 var cBaseUrl: [CChar] = try urlInfo.server.cString(using: .utf8) ?? { throw LibSessionError.invalidCConversion }()
@@ -308,12 +327,14 @@ public extension LibSession {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        lastReadTimestampMs: Int64
+        lastReadTimestampMs: Int64,
+        using dependencies: Dependencies
     ) throws {
         try LibSession.performAndPushChange(
             db,
             for: .convoInfoVolatile,
-            publicKey: getUserHexEncodedPublicKey(db)
+            publicKey: getUserHexEncodedPublicKey(db, using: dependencies),
+            using: dependencies
         ) { conf in
             try upsert(
                 convoInfoVolatileChanges: [

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
@@ -410,6 +410,7 @@ public extension LibSession {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
+        conf: UnsafeMutablePointer<config_object>?,
         using dependencies: Dependencies
     ) -> Int32 {
         let userPublicKey: String = getUserHexEncodedPublicKey(db)
@@ -420,70 +421,81 @@ public extension LibSession {
             }
         }()
         
-        return dependencies.caches[.libSession]
-            .config(for: configVariant, publicKey: userPublicKey)
-            .wrappedValue
-            .map { conf in
-                guard var cThreadId: [CChar] = threadId.cString(using: .utf8) else {
+        guard let conf: UnsafeMutablePointer<config_object> = conf else {
+            return dependencies.caches[.libSession]
+                .config(for: configVariant, publicKey: userPublicKey)
+                .wrappedValue
+                .map { conf in
+                    LibSession.pinnedPriority(
+                        db,
+                        threadId: threadId,
+                        threadVariant: threadVariant,
+                        conf: conf,
+                        using: dependencies
+                    )
+                }
+                .defaulting(to: LibSession.defaultNewThreadPriority)
+        }
+        
+        guard var cThreadId: [CChar] = threadId.cString(using: .utf8) else {
+            return LibSession.defaultNewThreadPriority
+        }
+        
+        switch threadVariant {
+            case .contact where threadId == userPublicKey:
+                return user_profile_get_nts_priority(conf)
+                
+            case .contact:
+                var contact: contacts_contact = contacts_contact()
+                
+                guard contacts_get(conf, &contact, &cThreadId) else {
+                    LibSessionError.clear(conf)
                     return LibSession.defaultNewThreadPriority
                 }
                 
-                switch threadVariant {
-                    case .contact where threadId == userPublicKey:
-                        return user_profile_get_nts_priority(conf)
-                        
-                    case .contact:
-                        var contact: contacts_contact = contacts_contact()
-                        
-                        guard contacts_get(conf, &contact, &cThreadId) else {
-                            LibSessionError.clear(conf)
-                            return LibSession.defaultNewThreadPriority
-                        }
-                        
-                        return contact.priority
-                        
-                    case .community:
-                        let maybeUrlInfo: OpenGroupUrlInfo? = Storage.shared
-                            .read { db in try OpenGroupUrlInfo.fetchAll(db, ids: [threadId]) }?
-                            .first
-                        
-                        guard
-                            let urlInfo: OpenGroupUrlInfo = maybeUrlInfo,
-                            var cBaseUrl: [CChar] = urlInfo.server.cString(using: .utf8),
-                            var cRoom: [CChar] = urlInfo.roomToken.cString(using: .utf8)
-                        else { return LibSession.defaultNewThreadPriority }
-                        
-                        var community: ugroups_community_info = ugroups_community_info()
-                        let result: Bool = user_groups_get_community(conf, &community, &cBaseUrl, &cRoom)
-                        LibSessionError.clear(conf)
-                        
-                        return community.priority
-                        
-                    case .legacyGroup:
-                        let groupInfo: UnsafeMutablePointer<ugroups_legacy_group_info>? = user_groups_get_legacy_group(conf, &cThreadId)
-                        LibSessionError.clear(conf)
-                        
-                        defer {
-                            if groupInfo != nil {
-                                ugroups_legacy_group_free(groupInfo)
-                            }
-                        }
-                        
-                        return (groupInfo?.pointee.priority ?? LibSession.defaultNewThreadPriority)
-                        
-                    case .group:
-                        return LibSession.defaultNewThreadPriority // FIXME: Add in groups rebuild
+                return contact.priority
+                
+            case .community:
+                let maybeUrlInfo: OpenGroupUrlInfo? = Storage.shared
+                    .read { db in try OpenGroupUrlInfo.fetchAll(db, ids: [threadId]) }?
+                    .first
+                
+                guard
+                    let urlInfo: OpenGroupUrlInfo = maybeUrlInfo,
+                    var cBaseUrl: [CChar] = urlInfo.server.cString(using: .utf8),
+                    var cRoom: [CChar] = urlInfo.roomToken.cString(using: .utf8)
+                else { return LibSession.defaultNewThreadPriority }
+                
+                var community: ugroups_community_info = ugroups_community_info()
+                let result: Bool = user_groups_get_community(conf, &community, &cBaseUrl, &cRoom)
+                LibSessionError.clear(conf)
+                
+                return community.priority
+                
+            case .legacyGroup:
+                let groupInfo: UnsafeMutablePointer<ugroups_legacy_group_info>? = user_groups_get_legacy_group(conf, &cThreadId)
+                LibSessionError.clear(conf)
+                
+                defer {
+                    if groupInfo != nil {
+                        ugroups_legacy_group_free(groupInfo)
+                    }
                 }
-            }
-            .defaulting(to: LibSession.defaultNewThreadPriority)
+                
+                return (groupInfo?.pointee.priority ?? LibSession.defaultNewThreadPriority)
+                
+            case .group:
+                return LibSession.defaultNewThreadPriority // FIXME: Add in groups rebuild
+        }
     }
     
     static func disappearingMessagesConfig(
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
+        conf: UnsafeMutablePointer<config_object>?,
         using dependencies: Dependencies
-    ) throws -> DisappearingMessagesConfiguration? {
+    ) -> DisappearingMessagesConfiguration? {
         switch threadVariant {
             case .community: return nil
             default: break
@@ -497,65 +509,75 @@ public extension LibSession {
             }
         }()
         
-        return dependencies.caches[.libSession]
-            .config(for: configVariant, publicKey: userPublicKey)
-            .wrappedValue
-            .map { conf -> DisappearingMessagesConfiguration? in
-                guard var cThreadId: [CChar] = threadId.cString(using: .utf8) else { return nil }
-                
-                switch threadVariant {
-                    case .community: return nil
-                    case .contact where threadId == userPublicKey:
-                        let targetExpiry: Int32 = user_profile_get_nts_expiry(conf)
-                        let targetIsEnabled: Bool = (targetExpiry > 0)
-                        
-                        return DisappearingMessagesConfiguration(
-                            threadId: threadId,
-                            isEnabled: targetIsEnabled,
-                            durationSeconds: TimeInterval(targetExpiry),
-                            type: targetIsEnabled ? .disappearAfterSend : .unknown
-                        )
-                        
-                    case .contact:
-                        var contact: contacts_contact = contacts_contact()
-                        
-                        guard contacts_get(conf, &contact, &cThreadId) else {
-                            LibSessionError.clear(conf)
-                            return nil
-                        }
-                        
-                        return DisappearingMessagesConfiguration(
-                            threadId: threadId,
-                            isEnabled: contact.exp_seconds > 0,
-                            durationSeconds: TimeInterval(contact.exp_seconds),
-                            type: DisappearingMessagesConfiguration.DisappearingMessageType(
-                                libSessionType: contact.exp_mode
-                            )
-                        )
-                        
-                    case .legacyGroup:
-                        let groupInfo: UnsafeMutablePointer<ugroups_legacy_group_info>? = user_groups_get_legacy_group(conf, &cThreadId)
-                        LibSessionError.clear(conf)
-                        
-                        defer {
-                            if groupInfo != nil {
-                                ugroups_legacy_group_free(groupInfo)
-                            }
-                        }
-                        
-                        return groupInfo.map { info in
-                            DisappearingMessagesConfiguration(
-                                threadId: userPublicKey,
-                                isEnabled: (info.pointee.disappearing_timer > 0),
-                                durationSeconds: TimeInterval(info.pointee.disappearing_timer),
-                                type: .disappearAfterSend
-                            )
-                        }
-                        
-                    case .group:
-                        return nil // FIXME: Add in groups rebuild
+        guard let conf: UnsafeMutablePointer<config_object> = conf else {
+            return dependencies.caches[.libSession]
+                .config(for: configVariant, publicKey: userPublicKey)
+                .wrappedValue
+                .map { conf in
+                    LibSession.disappearingMessagesConfig(
+                        db,
+                        threadId: threadId,
+                        threadVariant: threadVariant,
+                        conf: conf,
+                        using: dependencies
+                    )
                 }
-            }
+        }
+        
+        guard var cThreadId: [CChar] = threadId.cString(using: .utf8) else { return nil }
+        
+        switch threadVariant {
+            case .community: return nil
+            case .contact where threadId == userPublicKey:
+                let targetExpiry: Int32 = user_profile_get_nts_expiry(conf)
+                let targetIsEnabled: Bool = (targetExpiry > 0)
+                
+                return DisappearingMessagesConfiguration(
+                    threadId: threadId,
+                    isEnabled: targetIsEnabled,
+                    durationSeconds: TimeInterval(targetExpiry),
+                    type: targetIsEnabled ? .disappearAfterSend : .unknown
+                )
+                
+            case .contact:
+                var contact: contacts_contact = contacts_contact()
+                
+                guard contacts_get(conf, &contact, &cThreadId) else {
+                    LibSessionError.clear(conf)
+                    return nil
+                }
+                
+                return DisappearingMessagesConfiguration(
+                    threadId: threadId,
+                    isEnabled: contact.exp_seconds > 0,
+                    durationSeconds: TimeInterval(contact.exp_seconds),
+                    type: DisappearingMessagesConfiguration.DisappearingMessageType(
+                        libSessionType: contact.exp_mode
+                    )
+                )
+                
+            case .legacyGroup:
+                let groupInfo: UnsafeMutablePointer<ugroups_legacy_group_info>? = user_groups_get_legacy_group(conf, &cThreadId)
+                LibSessionError.clear(conf)
+                
+                defer {
+                    if groupInfo != nil {
+                        ugroups_legacy_group_free(groupInfo)
+                    }
+                }
+                
+                return groupInfo.map { info in
+                    DisappearingMessagesConfiguration(
+                        threadId: userPublicKey,
+                        isEnabled: (info.pointee.disappearing_timer > 0),
+                        durationSeconds: TimeInterval(info.pointee.disappearing_timer),
+                        type: .disappearAfterSend
+                    )
+                }
+                
+            case .group:
+                return nil // FIXME: Add in groups rebuild
+        }
     }
     
     static func conversationInConfig(
@@ -565,8 +587,8 @@ public extension LibSession {
         visibleOnly: Bool,
         using dependencies: Dependencies
     ) -> Bool {
-        // Currently blinded conversations cannot be contained in the config, so there is no point checking (it'll always be
-        // false)
+        // Currently blinded conversations cannot be contained in the config, so there is no
+        // point checking (it'll always be false)
         guard
             threadVariant == .community || (
                 (try? SessionId(from: threadId))?.prefix != .blinded15 &&

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
@@ -13,6 +13,9 @@ public extension LibSession {
     enum Crypto {
         public typealias Domain = String
     }
+    
+    /// The default priority for newly created threads
+    static var defaultNewThreadPriority: Int32 { return visiblePriority }
 
     /// A `0` `priority` value indicates visible, but not pinned
     static let visiblePriority: Int32 = 0
@@ -389,6 +392,158 @@ internal extension LibSession {
 // MARK: - External Outgoing Changes
 
 public extension LibSession {
+    static func pinnedPriority(
+        _ db: Database,
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        using dependencies: Dependencies
+    ) -> Int32 {
+        let userPublicKey: String = getUserHexEncodedPublicKey(db)
+        let configVariant: ConfigDump.Variant = {
+            switch threadVariant {
+                case .contact: return (threadId == userPublicKey ? .userProfile : .contacts)
+                case .legacyGroup, .group, .community: return .userGroups
+            }
+        }()
+        
+        return dependencies.caches[.libSession]
+            .config(for: configVariant, publicKey: userPublicKey)
+            .wrappedValue
+            .map { conf in
+                guard var cThreadId: [CChar] = threadId.cString(using: .utf8) else {
+                    return LibSession.defaultNewThreadPriority
+                }
+                
+                switch threadVariant {
+                    case .contact where threadId == userPublicKey:
+                        return user_profile_get_nts_priority(conf)
+                        
+                    case .contact:
+                        var contact: contacts_contact = contacts_contact()
+                        
+                        guard contacts_get(conf, &contact, &cThreadId) else {
+                            LibSessionError.clear(conf)
+                            return LibSession.defaultNewThreadPriority
+                        }
+                        
+                        return contact.priority
+                        
+                    case .community:
+                        let maybeUrlInfo: OpenGroupUrlInfo? = Storage.shared
+                            .read { db in try OpenGroupUrlInfo.fetchAll(db, ids: [threadId]) }?
+                            .first
+                        
+                        guard
+                            let urlInfo: OpenGroupUrlInfo = maybeUrlInfo,
+                            var cBaseUrl: [CChar] = urlInfo.server.cString(using: .utf8),
+                            var cRoom: [CChar] = urlInfo.roomToken.cString(using: .utf8)
+                        else { return LibSession.defaultNewThreadPriority }
+                        
+                        var community: ugroups_community_info = ugroups_community_info()
+                        let result: Bool = user_groups_get_community(conf, &community, &cBaseUrl, &cRoom)
+                        LibSessionError.clear(conf)
+                        
+                        return community.priority
+                        
+                    case .legacyGroup:
+                        let groupInfo: UnsafeMutablePointer<ugroups_legacy_group_info>? = user_groups_get_legacy_group(conf, &cThreadId)
+                        LibSessionError.clear(conf)
+                        
+                        defer {
+                            if groupInfo != nil {
+                                ugroups_legacy_group_free(groupInfo)
+                            }
+                        }
+                        
+                        return (groupInfo?.pointee.priority ?? LibSession.defaultNewThreadPriority)
+                        
+                    case .group:
+                        return LibSession.defaultNewThreadPriority // FIXME: Add in groups rebuild
+                }
+            }
+            .defaulting(to: LibSession.defaultNewThreadPriority)
+    }
+    
+    static func disappearingMessagesConfig(
+        _ db: Database,
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        using dependencies: Dependencies
+    ) throws -> DisappearingMessagesConfiguration? {
+        switch threadVariant {
+            case .community: return nil
+            default: break
+        }
+        
+        let userPublicKey: String = getUserHexEncodedPublicKey(db)
+        let configVariant: ConfigDump.Variant = {
+            switch threadVariant {
+                case .contact: return (threadId == userPublicKey ? .userProfile : .contacts)
+                case .legacyGroup, .group, .community: return .userGroups
+            }
+        }()
+        
+        return dependencies.caches[.libSession]
+            .config(for: configVariant, publicKey: userPublicKey)
+            .wrappedValue
+            .map { conf -> DisappearingMessagesConfiguration? in
+                guard var cThreadId: [CChar] = threadId.cString(using: .utf8) else { return nil }
+                
+                switch threadVariant {
+                    case .community: return nil
+                    case .contact where threadId == userPublicKey:
+                        let targetExpiry: Int32 = user_profile_get_nts_expiry(conf)
+                        let targetIsEnabled: Bool = (targetExpiry > 0)
+                        
+                        return DisappearingMessagesConfiguration(
+                            threadId: threadId,
+                            isEnabled: targetIsEnabled,
+                            durationSeconds: TimeInterval(targetExpiry),
+                            type: targetIsEnabled ? .disappearAfterSend : .unknown
+                        )
+                        
+                    case .contact:
+                        var contact: contacts_contact = contacts_contact()
+                        
+                        guard contacts_get(conf, &contact, &cThreadId) else {
+                            LibSessionError.clear(conf)
+                            return nil
+                        }
+                        
+                        return DisappearingMessagesConfiguration(
+                            threadId: threadId,
+                            isEnabled: contact.exp_seconds > 0,
+                            durationSeconds: TimeInterval(contact.exp_seconds),
+                            type: DisappearingMessagesConfiguration.DisappearingMessageType(
+                                libSessionType: contact.exp_mode
+                            )
+                        )
+                        
+                    case .legacyGroup:
+                        let groupInfo: UnsafeMutablePointer<ugroups_legacy_group_info>? = user_groups_get_legacy_group(conf, &cThreadId)
+                        LibSessionError.clear(conf)
+                        
+                        defer {
+                            if groupInfo != nil {
+                                ugroups_legacy_group_free(groupInfo)
+                            }
+                        }
+                        
+                        return groupInfo.map { info in
+                            DisappearingMessagesConfiguration(
+                                threadId: userPublicKey,
+                                isEnabled: (info.pointee.disappearing_timer > 0),
+                                durationSeconds: TimeInterval(info.pointee.disappearing_timer),
+                                type: .disappearAfterSend
+                            )
+                        }
+                        
+                    case .group:
+                        return nil // FIXME: Add in groups rebuild
+                }
+            }
+    }
+    
     static func conversationInConfig(
         _ db: Database? = nil,
         threadId: String,

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
@@ -93,7 +93,8 @@ internal extension LibSession {
                     db,
                     type: .hideContactConversation,
                     threadId: userPublicKey,
-                    calledFromConfigHandling: true
+                    calledFromConfigHandling: true,
+                    using: dependencies
                 )
             }
             else {
@@ -216,12 +217,14 @@ public extension LibSession {
     static func updateNoteToSelf(
         _ db: Database,
         priority: Int32? = nil,
-        disappearingMessagesConfig: DisappearingMessagesConfiguration? = nil
+        disappearingMessagesConfig: DisappearingMessagesConfiguration? = nil,
+        using dependencies: Dependencies
     ) throws {
         try LibSession.performAndPushChange(
             db,
             for: .userProfile,
-            publicKey: getUserHexEncodedPublicKey(db)
+            publicKey: getUserHexEncodedPublicKey(db),
+            using: dependencies
         ) { conf in
             try LibSession.updateNoteToSelf(
                 priority: priority,

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
@@ -28,7 +28,7 @@ internal extension LibSession {
         typealias ProfileData = (profileName: String, profilePictureUrl: String?, profilePictureKey: Data?)
         
         guard mergeNeedsDump else { return }
-        guard conf != nil else { throw LibSessionError.nilConfigObject }
+        guard let conf: UnsafeMutablePointer<config_object> = conf else { throw LibSessionError.nilConfigObject }
         
         // A profile must have a name so if this is null then it's invalid and can be ignored
         guard let profileNamePtr: UnsafePointer<CChar> = user_profile_get_name(conf) else { return }
@@ -106,7 +106,7 @@ internal extension LibSession {
                         shouldBeVisible: .setTo(LibSession.shouldBeVisible(priority: targetPriority)),
                         pinnedPriority: .setTo(targetPriority)
                     ),
-                    calledFromConfig: true,
+                    calledFromConfig: .userProfile(conf),
                     using: dependencies
                 )
             }

--- a/SessionMessagingKit/LibSession/Database/QueryInterfaceRequest+Utilities.swift
+++ b/SessionMessagingKit/LibSession/Database/QueryInterfaceRequest+Utilities.swift
@@ -52,17 +52,24 @@ public extension QueryInterfaceRequest where RowDecoder: FetchableRecord & Table
     @discardableResult
     func updateAllAndConfig(
         _ db: Database,
+        _ assignments: ConfigColumnAssignment...,
         calledFromConfig: Bool = false,
-        _ assignments: ConfigColumnAssignment...
+        using dependencies: Dependencies
     ) throws -> Int {
-        return try updateAllAndConfig(db, calledFromConfig: calledFromConfig, assignments)
+        return try updateAllAndConfig(
+            db,
+            assignments,
+            calledFromConfig: calledFromConfig,
+            using: dependencies
+        )
     }
     
     @discardableResult
     func updateAllAndConfig(
         _ db: Database,
+        _ assignments: [ConfigColumnAssignment],
         calledFromConfig: Bool = false,
-        _ assignments: [ConfigColumnAssignment]
+        using dependencies: Dependencies
     ) throws -> Int {
         let targetAssignments: [ColumnAssignment] = assignments.map { $0.assignment }
         
@@ -71,7 +78,12 @@ public extension QueryInterfaceRequest where RowDecoder: FetchableRecord & Table
             return try self.updateAll(db, targetAssignments)
         }
         
-        return try self.updateAndFetchAllAndUpdateConfig(db, calledFromConfig: calledFromConfig, assignments).count
+        return try self.updateAndFetchAllAndUpdateConfig(
+            db,
+            assignments,
+            calledFromConfig: calledFromConfig,
+            using: dependencies
+        ).count
     }
     
     // MARK: -- updateAndFetchAll
@@ -79,17 +91,24 @@ public extension QueryInterfaceRequest where RowDecoder: FetchableRecord & Table
     @discardableResult
     func updateAndFetchAllAndUpdateConfig(
         _ db: Database,
+        _ assignments: ConfigColumnAssignment...,
         calledFromConfig: Bool = false,
-        _ assignments: ConfigColumnAssignment...
+        using dependencies: Dependencies
     ) throws -> [RowDecoder] {
-        return try updateAndFetchAllAndUpdateConfig(db, calledFromConfig: calledFromConfig, assignments)
+        return try updateAndFetchAllAndUpdateConfig(
+            db,
+            assignments,
+            calledFromConfig: calledFromConfig,
+            using: dependencies
+        )
     }
     
     @discardableResult
     func updateAndFetchAllAndUpdateConfig(
         _ db: Database,
+        _ assignments: [ConfigColumnAssignment],
         calledFromConfig: Bool = false,
-        _ assignments: [ConfigColumnAssignment]
+        using dependencies: Dependencies
     ) throws -> [RowDecoder] {
         // First perform the actual updates
         let updatedData: [RowDecoder] = try self.updateAndFetchAll(db, assignments.map { $0.assignment })
@@ -114,13 +133,13 @@ public extension QueryInterfaceRequest where RowDecoder: FetchableRecord & Table
         // Update the config dump state where needed
         switch self {
             case is QueryInterfaceRequest<Contact>:
-                return try LibSession.updatingContacts(db, updatedData)
+                return try LibSession.updatingContacts(db, updatedData, using: dependencies)
                 
             case is QueryInterfaceRequest<Profile>:
-                return try LibSession.updatingProfiles(db, updatedData)
+                return try LibSession.updatingProfiles(db, updatedData, using: dependencies)
                 
             case is QueryInterfaceRequest<SessionThread>:
-                return try LibSession.updatingThreads(db, updatedData)
+                return try LibSession.updatingThreads(db, updatedData, using: dependencies)
                 
             default: return updatedData
         }

--- a/SessionMessagingKit/LibSession/Database/QueryInterfaceRequest+Utilities.swift
+++ b/SessionMessagingKit/LibSession/Database/QueryInterfaceRequest+Utilities.swift
@@ -97,7 +97,7 @@ public extension QueryInterfaceRequest where RowDecoder: FetchableRecord & Table
         // Then check if any of the changes could affect the config
         guard
             !calledFromConfig &&
-                LibSession.assignmentsRequireConfigUpdate(assignments)
+            LibSession.assignmentsRequireConfigUpdate(assignments)
         else { return updatedData }
         
         defer {

--- a/SessionMessagingKit/LibSession/Database/Setting+Utilities.swift
+++ b/SessionMessagingKit/LibSession/Database/Setting+Utilities.swift
@@ -5,39 +5,103 @@ import GRDB
 import SessionUtilitiesKit
 
 public extension Database {
-    func setAndUpdateConfig(_ key: Setting.BoolKey, to newValue: Bool) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig(
+        _ key: Setting.BoolKey,
+        to newValue: Bool,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
 
-    func setAndUpdateConfig(_ key: Setting.DoubleKey, to newValue: Double?) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig(
+        _ key: Setting.DoubleKey,
+        to newValue: Double?,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
 
-    func setAndUpdateConfig(_ key: Setting.IntKey, to newValue: Int?) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig(
+        _ key: Setting.IntKey,
+        to newValue: Int?,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
 
-    func setAndUpdateConfig(_ key: Setting.StringKey, to newValue: String?) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig(
+        _ key: Setting.StringKey,
+        to newValue: String?,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
 
-    func setAndUpdateConfig<T: EnumIntSetting>(_ key: Setting.EnumKey, to newValue: T?) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig<T: EnumIntSetting>(
+        _ key: Setting.EnumKey,
+        to newValue: T?,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
 
-    func setAndUpdateConfig<T: EnumStringSetting>(_ key: Setting.EnumKey, to newValue: T?) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig<T: EnumStringSetting>(
+        _ key: Setting.EnumKey,
+        to newValue: T?,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
 
     /// Value will be stored as a timestamp in seconds since 1970
-    func setAndUpdateConfig(_ key: Setting.DateKey, to newValue: Date?) throws {
-        try updateConfigIfNeeded(self, key: key.rawValue, updatedSetting: self.setting(key: key, to: newValue))
+    func setAndUpdateConfig(
+        _ key: Setting.DateKey,
+        to newValue: Date?,
+        using dependencies: Dependencies
+    ) throws {
+        try updateConfigIfNeeded(
+            self,
+            key: key.rawValue,
+            updatedSetting: self.setting(key: key, to: newValue),
+            using: dependencies
+        )
     }
     
     private func updateConfigIfNeeded(
         _ db: Database,
         key: String,
-        updatedSetting: Setting?
+        updatedSetting: Setting?,
+        using dependencies: Dependencies
     ) throws {
         // Before we do anything custom make sure the setting should trigger a change
         guard LibSession.syncedSettings.contains(key) else { return }
@@ -53,6 +117,6 @@ public extension Database {
             }
         }
         
-        try LibSession.updatingSetting(db, updatedSetting)
+        try LibSession.updatingSetting(db, updatedSetting, using: dependencies)
     }
 }

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -79,7 +79,7 @@ public extension LibSession {
         
         // If we weren't given a database instance then get one
         guard let db: Database = db else {
-            Storage.shared.read { db in
+            dependencies.storage.read { db in
                 LibSession.loadState(db, userPublicKey: userPublicKey, ed25519SecretKey: secretKey, using: dependencies)
             }
             return
@@ -465,7 +465,8 @@ public extension LibSession {
                                     try LibSession.handleConvoInfoVolatileUpdate(
                                         db,
                                         in: conf,
-                                        mergeNeedsDump: config_needs_dump(conf)
+                                        mergeNeedsDump: config_needs_dump(conf),
+                                        using: dependencies
                                     )
                                     
                                 case .userGroups:

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -457,7 +457,8 @@ public extension LibSession {
                                         db,
                                         in: conf,
                                         mergeNeedsDump: config_needs_dump(conf),
-                                        latestConfigSentTimestampMs: latestConfigSentTimestampMs
+                                        latestConfigSentTimestampMs: latestConfigSentTimestampMs,
+                                        using: dependencies
                                     )
                                     
                                 case .convoInfoVolatile:

--- a/SessionMessagingKit/LibSession/Types/Config.swift
+++ b/SessionMessagingKit/LibSession/Types/Config.swift
@@ -1,0 +1,28 @@
+// Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
+
+import Foundation
+import SessionUtil
+import SessionUtilitiesKit
+
+public extension LibSession {
+    // MARK: - Config
+    
+    enum Config {
+        public enum Variant {
+            case userProfile(UnsafeMutablePointer<config_object>)
+            case contacts(UnsafeMutablePointer<config_object>)
+            case convoInfoVolatile(UnsafeMutablePointer<config_object>)
+            case userGroups(UnsafeMutablePointer<config_object>)
+            
+            var conf: UnsafeMutablePointer<config_object> {
+                switch self {
+                    case .userProfile(let value), .contacts(let value),
+                        .convoInfoVolatile(let value), .userGroups(let value):
+                        return value
+                }
+            }
+        }
+    }
+}

--- a/SessionMessagingKit/Open Groups/OpenGroupManager.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupManager.swift
@@ -240,7 +240,8 @@ public final class OpenGroupManager {
                 .updateAllAndConfig(
                     db,
                     OpenGroup.Columns.isActive.set(to: true),
-                    OpenGroup.Columns.sequenceNumber.set(to: 0)
+                    OpenGroup.Columns.sequenceNumber.set(to: 0),
+                    using: dependencies
                 )
         }
         
@@ -290,7 +291,8 @@ public final class OpenGroupManager {
                                 db,
                                 server: server,
                                 rootToken: roomToken,
-                                publicKey: publicKey
+                                publicKey: publicKey,
+                                using: dependencies
                             )
                         }
                         
@@ -395,11 +397,15 @@ public final class OpenGroupManager {
             // If it's a session-run room then just set it to inactive
             _ = try? OpenGroup
                 .filter(id: openGroupId)
-                .updateAllAndConfig(db, OpenGroup.Columns.isActive.set(to: false))
+                .updateAllAndConfig(
+                    db,
+                    OpenGroup.Columns.isActive.set(to: false),
+                    using: dependencies
+                )
         }
         
         if !calledFromConfigHandling, let server: String = server, let roomToken: String = roomToken {
-            try? LibSession.remove(db, server: server, roomToken: roomToken)
+            try? LibSession.remove(db, server: server, roomToken: roomToken, using: dependencies)
         }
     }
     
@@ -478,7 +484,7 @@ public final class OpenGroupManager {
         
         try OpenGroup
             .filter(id: openGroup.id)
-            .updateAllAndConfig(db, changes)
+            .updateAllAndConfig(db, changes, using: dependencies)
         
         // Update the admin/moderator group members
         if let roomDetails: OpenGroupAPI.Room = pollInfo.details {
@@ -764,7 +770,7 @@ public final class OpenGroupManager {
                 
                 switch processedMessage {
                     case .config, .none: break
-                    case .standard(let threadId, _, let proto, let messageInfo):
+                    case .standard(_, _, let proto, let messageInfo):
                         // We want to update the BlindedIdLookup cache with the message info so we can avoid using the
                         // "expensive" lookup when possible
                         let lookup: BlindedIdLookup = try {

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Calls.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Calls.swift
@@ -65,7 +65,7 @@ extension MessageReceiver {
                     id: sender,
                     variant: .contact,
                     values: .existingOrDefault,
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 
@@ -92,7 +92,7 @@ extension MessageReceiver {
                     id: sender,
                     variant: .contact,
                     values: .existingOrDefault,
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Calls.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Calls.swift
@@ -60,8 +60,14 @@ extension MessageReceiver {
         guard let timestamp = message.sentTimestamp, TimestampUtils.isWithinOneMinute(timestampMs: timestamp) else {
             // Add missed call message for call offer messages from more than one minute
             if let interaction: Interaction = try MessageReceiver.insertCallInfoMessage(db, for: message, state: .missed, using: dependencies) {
-                let thread: SessionThread = try SessionThread
-                    .fetchOrCreate(db, id: sender, variant: .contact, shouldBeVisible: nil)
+                let thread: SessionThread = try SessionThread.upsert(
+                    db,
+                    id: sender,
+                    variant: .contact,
+                    values: .existingOrDefault,
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 
                 if !interaction.wasRead {
                     SessionEnvironment.shared?.notificationsManager.wrappedValue?
@@ -81,8 +87,14 @@ extension MessageReceiver {
             let state: CallMessage.MessageInfo.State = (db[.areCallsEnabled] ? .permissionDeniedMicrophone : .permissionDenied)
             
             if let interaction: Interaction = try MessageReceiver.insertCallInfoMessage(db, for: message, state: state, using: dependencies) {
-                let thread: SessionThread = try SessionThread
-                    .fetchOrCreate(db, id: sender, variant: .contact, shouldBeVisible: nil)
+                let thread: SessionThread = try SessionThread.upsert(
+                    db,
+                    id: sender,
+                    variant: .contact,
+                    values: .existingOrDefault,
+                    calledFromConfig: false,
+                    using: dependencies
+                )
                 
                 if !interaction.wasRead {
                     SessionEnvironment.shared?.notificationsManager.wrappedValue?

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
@@ -164,7 +164,7 @@ extension MessageReceiver {
                 creationDateTimestamp: (TimeInterval(formationTimestampMs) / 1000),
                 shouldBeVisible: .setTo(true)
             ),
-            calledFromConfig: false,
+            calledFromConfig: calledFromConfigHandling,
             using: dependencies
         )
         let closedGroup: ClosedGroup = try ClosedGroup(

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
@@ -152,14 +152,17 @@ extension MessageReceiver {
         guard hasApprovedAdmin || calledFromConfigHandling else { return }
         
         // Create the group
-        let thread: SessionThread = try SessionThread
-            .fetchOrCreate(
-                db,
-                id: groupPublicKey,
-                variant: .legacyGroup,
+        let thread: SessionThread = try SessionThread.upsert(
+            db,
+            id: groupPublicKey,
+            variant: .legacyGroup,
+            values: SessionThread.TargetValues(
                 creationDateTimestamp: (TimeInterval(formationTimestampMs) / 1000),
-                shouldBeVisible: true
-            )
+                shouldBeVisible: .setTo(true)
+            ),
+            calledFromConfig: false,
+            using: dependencies
+        )
         let closedGroup: ClosedGroup = try ClosedGroup(
             threadId: groupPublicKey,
             name: name,

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
@@ -31,7 +31,8 @@ extension MessageReceiver {
                     db,
                     threadId: threadId,
                     threadVariant: threadVariant,
-                    message: message
+                    message: message,
+                    using: dependencies
                 )
                 
             case .membersAdded:
@@ -39,7 +40,8 @@ extension MessageReceiver {
                     db,
                     threadId: threadId,
                     threadVariant: threadVariant,
-                    message: message
+                    message: message,
+                    using: dependencies
                 )
                 
             case .membersRemoved:
@@ -47,7 +49,8 @@ extension MessageReceiver {
                     db,
                     threadId: threadId,
                     threadVariant: threadVariant,
-                    message: message
+                    message: message,
+                    using: dependencies
                 )
                 
             case .memberLeft:
@@ -55,7 +58,8 @@ extension MessageReceiver {
                     db,
                     threadId: threadId,
                     threadVariant: threadVariant,
-                    message: message
+                    message: message,
+                    using: dependencies
                 )
                 
             case .encryptionKeyPairRequest: break // Currently not used
@@ -234,7 +238,8 @@ extension MessageReceiver {
                 latestKeyPairReceivedTimestamp: receivedTimestamp,
                 disappearingConfig: disappearingConfig,
                 members: members.asSet(),
-                admins: admins.asSet()
+                admins: admins.asSet(),
+                using: dependencies
             )
         }
         
@@ -336,7 +341,8 @@ extension MessageReceiver {
             try? LibSession.update(
                 db,
                 groupPublicKey: groupPublicKey,
-                latestKeyPair: keyPair
+                latestKeyPair: keyPair,
+                using: dependencies
             )
         }
         catch {
@@ -354,7 +360,8 @@ extension MessageReceiver {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        message: ClosedGroupControlMessage
+        message: ClosedGroupControlMessage,
+        using dependencies: Dependencies
     ) throws {
         guard
             let messageKind: ClosedGroupControlMessage.Kind = message.kind,
@@ -373,7 +380,8 @@ extension MessageReceiver {
                 try? LibSession.update(
                     db,
                     groupPublicKey: threadId,
-                    name: name
+                    name: name,
+                    using: dependencies
                 )
                 
                 _ = try ClosedGroup
@@ -390,7 +398,8 @@ extension MessageReceiver {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        message: ClosedGroupControlMessage
+        message: ClosedGroupControlMessage,
+        using dependencies: Dependencies
     ) throws {
         guard
             let messageKind: ClosedGroupControlMessage.Kind = message.kind,
@@ -424,7 +433,8 @@ extension MessageReceiver {
                     admins: allMembers
                         .filter { $0.role == .admin }
                         .map { $0.profileId }
-                        .asSet()
+                        .asSet(),
+                    using: dependencies
                 )
                 
                 // Create records for any new members
@@ -479,7 +489,8 @@ extension MessageReceiver {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        message: ClosedGroupControlMessage
+        message: ClosedGroupControlMessage,
+        using dependencies: Dependencies
     ) throws {
         guard
             let messageKind: ClosedGroupControlMessage.Kind = message.kind,
@@ -531,7 +542,8 @@ extension MessageReceiver {
                     admins: allMembers
                         .filter { $0.role == .admin }
                         .map { $0.profileId }
-                        .asSet()
+                        .asSet(),
+                    using: dependencies
                 )
                 
                 // Delete the removed members
@@ -552,7 +564,8 @@ extension MessageReceiver {
                         db,
                         threadId: threadId,
                         removeGroupData: true,
-                        calledFromConfigHandling: false
+                        calledFromConfigHandling: false,
+                        using: dependencies
                     )
                 }
             }
@@ -567,7 +580,8 @@ extension MessageReceiver {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        message: ClosedGroupControlMessage
+        message: ClosedGroupControlMessage,
+        using dependencies: Dependencies
     ) throws {
         guard
             let messageKind: ClosedGroupControlMessage.Kind = message.kind,
@@ -606,7 +620,8 @@ extension MessageReceiver {
                     admins: allMembers
                         .filter { $0.role == .admin }
                         .map { $0.profileId }
-                        .asSet()
+                        .asSet(),
+                    using: dependencies
                 )
                 
                 // Delete the members to remove
@@ -620,7 +635,8 @@ extension MessageReceiver {
                         db,
                         threadId: threadId,
                         removeGroupData: (sender == userPublicKey),
-                        calledFromConfigHandling: false
+                        calledFromConfigHandling: false,
+                        using: dependencies
                     )
                 }
                 

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ExpirationTimers.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ExpirationTimers.swift
@@ -12,7 +12,8 @@ extension MessageReceiver {
         threadVariant: SessionThread.Variant,
         message: ExpirationTimerUpdate,
         serverExpirationTimestamp: TimeInterval?,
-        proto: SNProtoContent
+        proto: SNProtoContent,
+        using dependencies: Dependencies
     ) throws {
         guard proto.hasExpirationType || proto.hasExpirationTimer else { return }
         guard
@@ -52,7 +53,8 @@ extension MessageReceiver {
                         .update(
                             db,
                             groupPublicKey: threadId,
-                            disappearingConfig: updatedConfig
+                            disappearingConfig: updatedConfig,
+                            using: dependencies
                         )
                 }
                 fallthrough
@@ -81,7 +83,8 @@ extension MessageReceiver {
         _ db: Database,
         messageVariant: Message.Variant?,
         contactId: String?,
-        version: FeatureVersion?
+        version: FeatureVersion?,
+        using dependencies: Dependencies
     ) {
         guard
             let messageVariant: Message.Variant = messageVariant,
@@ -97,7 +100,8 @@ extension MessageReceiver {
             .filter(id: contactId)
             .updateAllAndConfig(
                 db,
-                Contact.Columns.lastKnownClientVersion.set(to: version)
+                Contact.Columns.lastKnownClientVersion.set(to: version),
+                using: dependencies
             )
     }
 }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
@@ -55,7 +55,7 @@ extension MessageReceiver {
             id: senderId,
             variant: .contact,
             values: .existingOrDefault,
-            calledFromConfig: false,
+            calledFromConfig: nil,
             using: dependencies
         )
         

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
@@ -118,7 +118,8 @@ extension MessageReceiver {
                     db,
                     type: .deleteContactConversationAndContact, // Blinded contact isn't synced anyway
                     threadId: blindedIdLookup.blindedId,
-                    calledFromConfigHandling: false
+                    calledFromConfigHandling: false,
+                    using: dependencies
                 )
         }
         
@@ -126,7 +127,8 @@ extension MessageReceiver {
         try updateContactApprovalStatusIfNeeded(
             db,
             senderSessionId: senderId,
-            threadId: nil
+            threadId: nil,
+            using: dependencies
         )
         
         // If there were blinded contacts which have now been resolved to this contact then we should remove
@@ -140,7 +142,8 @@ extension MessageReceiver {
             try updateContactApprovalStatusIfNeeded(
                 db,
                 senderSessionId: userPublicKey,
-                threadId: unblindedThread.id
+                threadId: unblindedThread.id,
+                using: dependencies
             )
         }
         
@@ -165,7 +168,8 @@ extension MessageReceiver {
     internal static func updateContactApprovalStatusIfNeeded(
         _ db: Database,
         senderSessionId: String,
-        threadId: String?
+        threadId: String?,
+        using dependencies: Dependencies
     ) throws {
         let userPublicKey: String = getUserHexEncodedPublicKey(db)
         
@@ -188,7 +192,11 @@ extension MessageReceiver {
             try? contact.save(db)
             _ = try? Contact
                 .filter(id: threadId)
-                .updateAllAndConfig(db, Contact.Columns.isApproved.set(to: true))
+                .updateAllAndConfig(
+                    db,
+                    Contact.Columns.isApproved.set(to: true),
+                    using: dependencies
+                )
         }
         else {
             // The message was sent to the current user so flag their 'didApproveMe' as true (can't send a message to
@@ -200,7 +208,11 @@ extension MessageReceiver {
             try? contact.save(db)
             _ = try? Contact
                 .filter(id: senderSessionId)
-                .updateAllAndConfig(db, Contact.Columns.didApproveMe.set(to: true))
+                .updateAllAndConfig(
+                    db,
+                    Contact.Columns.didApproveMe.set(to: true),
+                    using: dependencies
+                )
         }
     }
 }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
@@ -50,8 +50,14 @@ extension MessageReceiver {
         }
         
         // Prep the unblinded thread
-        let unblindedThread: SessionThread = try SessionThread
-            .fetchOrCreate(db, id: senderId, variant: .contact, shouldBeVisible: nil)
+        let unblindedThread: SessionThread = try SessionThread.upsert(
+            db,
+            id: senderId,
+            variant: .contact,
+            values: .existingOrDefault,
+            calledFromConfig: false,
+            using: dependencies
+        )
         
         // Need to handle a `MessageRequestResponse` sent to a blinded thread (ie. check if the sender matches
         // the blinded ids of any threads)

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+UnsendRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+UnsendRequests.swift
@@ -10,7 +10,8 @@ extension MessageReceiver {
         _ db: Database,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        message: UnsendRequest
+        message: UnsendRequest,
+        using dependencies: Dependencies
     ) throws {
         let userPublicKey: String = getUserHexEncodedPublicKey(db)
         
@@ -35,7 +36,8 @@ extension MessageReceiver {
                 threadId: interaction.threadId,
                 threadVariant: threadVariant,
                 includingOlder: false,
-                trySendReadReceipt: false
+                trySendReadReceipt: false,
+                using: dependencies
             )
             
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: interaction.notificationIdentifiers)

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -72,7 +72,7 @@ extension MessageReceiver {
             id: threadId,
             variant: threadVariant,
             values: .existingOrDefault,
-            calledFromConfig: false,
+            calledFromConfig: nil,
             using: dependencies
         )
         let maybeOpenGroup: OpenGroup? = {

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -13,7 +13,7 @@ extension MessageReceiver {
         message: VisibleMessage,
         serverExpirationTimestamp: TimeInterval?,
         associatedWithProto proto: SNProtoContent,
-        using dependencies: Dependencies = Dependencies()
+        using dependencies: Dependencies
     ) throws -> Int64 {
         guard let sender: String = message.sender, let dataMessage = proto.dataMessage else {
             throw MessageReceiverError.invalidMessage
@@ -212,7 +212,8 @@ extension MessageReceiver {
                         interactionId: existingInteractionId,
                         messageSentTimestamp: messageSentTimestamp,
                         variant: variant,
-                        syncTarget: message.syncTarget
+                        syncTarget: message.syncTarget,
+                        using: dependencies
                     )
                     
                     Message.getExpirationForOutgoingDisappearingMessages(
@@ -239,7 +240,8 @@ extension MessageReceiver {
             interactionId: interactionId,
             messageSentTimestamp: messageSentTimestamp,
             variant: variant,
-            syncTarget: message.syncTarget
+            syncTarget: message.syncTarget,
+            using: dependencies
         )
         
         if messageExpirationInfo.shouldUpdateExpiry {
@@ -356,7 +358,8 @@ extension MessageReceiver {
             try MessageReceiver.updateContactApprovalStatusIfNeeded(
                 db,
                 senderSessionId: sender,
-                threadId: thread.id
+                threadId: thread.id,
+                using: dependencies
             )
         }
         
@@ -463,7 +466,8 @@ extension MessageReceiver {
         interactionId: Int64,
         messageSentTimestamp: TimeInterval,
         variant: Interaction.Variant,
-        syncTarget: String?
+        syncTarget: String?,
+        using dependencies: Dependencies
     ) throws {
         guard variant == .standardOutgoing else { return }
         
@@ -487,7 +491,8 @@ extension MessageReceiver {
             threadId: thread.id,
             threadVariant: thread.variant,
             includingOlder: true,
-            trySendReadReceipt: false
+            trySendReadReceipt: false,
+            using: dependencies
         )
         
         // Process any PendingReadReceipt values

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -67,8 +67,14 @@ extension MessageReceiver {
         
         // Store the message variant so we can run variant-specific behaviours
         let currentUserPublicKey: String = getUserHexEncodedPublicKey(db, using: dependencies)
-        let thread: SessionThread = try SessionThread
-            .fetchOrCreate(db, id: threadId, variant: threadVariant, shouldBeVisible: nil)
+        let thread: SessionThread = try SessionThread.upsert(
+            db,
+            id: threadId,
+            variant: threadVariant,
+            values: .existingOrDefault,
+            calledFromConfig: false,
+            using: dependencies
+        )
         let maybeOpenGroup: OpenGroup? = {
             guard threadVariant == .community else { return nil }
             

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
@@ -93,7 +93,8 @@ extension MessageSender {
                     latestKeyPairReceivedTimestamp: latestKeyPairReceivedTimestamp,
                     disappearingConfig: DisappearingMessagesConfiguration.defaultWith(groupPublicKey),
                     members: members,
-                    admins: admins
+                    admins: admins,
+                    using: dependencies
                 )
                 
                 let memberSendData: [MessageSender.PreparedSendData] = try members
@@ -274,7 +275,8 @@ extension MessageSender {
                             admins: allGroupMembers
                                 .filter { $0.role == .admin }
                                 .map { $0.profileId }
-                                .asSet()
+                                .asSet(),
+                            using: dependencies
                         )
                     }
                     
@@ -344,7 +346,8 @@ extension MessageSender {
                     try? LibSession.update(
                         db,
                         groupPublicKey: closedGroup.threadId,
-                        name: name
+                        name: name,
+                        using: dependencies
                     )
                 }
                 
@@ -457,7 +460,8 @@ extension MessageSender {
             admins: allGroupMembers
                 .filter { $0.role == .admin }
                 .map { $0.profileId }
-                .asSet()
+                .asSet(),
+            using: dependencies
         )
         
         // Send the update to the group

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
@@ -45,7 +45,7 @@ extension MessageSender {
                     id: groupPublicKey,
                     variant: .legacyGroup,
                     values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
-                    calledFromConfig: false,
+                    calledFromConfig: nil,
                     using: dependencies
                 )
                 try ClosedGroup(
@@ -483,7 +483,7 @@ extension MessageSender {
                 id: member,
                 variant: .contact,
                 values: .existingOrDefault,
-                calledFromConfig: false,
+                calledFromConfig: nil,
                 using: dependencies
             )
             
@@ -697,7 +697,7 @@ extension MessageSender {
                 id: publicKey,
                 variant: .contact,
                 values: .existingOrDefault,
-                calledFromConfig: false,
+                calledFromConfig: nil,
                 using: dependencies
             )
             let ciphertext = try dependencies.crypto.tryGenerate(

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
@@ -340,7 +340,8 @@ public enum PushNotificationAPI {
                 receiveCompletion: { result in
                     switch result {
                         case .finished: break
-                        case .failure: Log.error("[PushNotificationAPI] Couldn't subscribe for legacy groups.")
+                        case .failure(let error):
+                            Log.error("[PushNotificationAPI] Couldn't subscribe for legacy groups due to error: \(error).")
                     }
                 }
             )

--- a/SessionMessagingKit/Shared Models/SessionThreadViewModel.swift
+++ b/SessionMessagingKit/Shared Models/SessionThreadViewModel.swift
@@ -272,7 +272,7 @@ public struct SessionThreadViewModel: FetchableRecordWithRowId, Decodable, Equat
     }
     
     /// This method marks a thread as read and depending on the target may also update the interactions within a thread as read
-    public func markAsRead(target: ReadTarget) {
+    public func markAsRead(target: ReadTarget, using dependencies: Dependencies) {
         // Store the logic to mark a thread as read (to paths need to run this)
         let threadId: String = self.threadId
         let threadWasMarkedUnread: Bool? = self.threadWasMarkedUnread
@@ -286,7 +286,8 @@ public struct SessionThreadViewModel: FetchableRecordWithRowId, Decodable, Equat
                     .filter(id: threadId)
                     .updateAllAndConfig(
                         db,
-                        SessionThread.Columns.markedAsUnread.set(to: false)
+                        SessionThread.Columns.markedAsUnread.set(to: false),
+                        using: dependencies
                     )
             }
         }
@@ -327,14 +328,15 @@ public struct SessionThreadViewModel: FetchableRecordWithRowId, Decodable, Equat
                             threadVariant: threadVariant,
                             isBlocked: threadIsBlocked,
                             isMessageRequest: threadIsMessageRequest
-                        )
+                        ),
+                        using: dependencies
                     )
                 }
         }
     }
     
     /// This method will mark a thread as read
-    public func markAsUnread() {
+    public func markAsUnread(using dependencies: Dependencies) {
         guard self.threadWasMarkedUnread != true else { return }
         
         let threadId: String = self.threadId
@@ -344,7 +346,8 @@ public struct SessionThreadViewModel: FetchableRecordWithRowId, Decodable, Equat
                 .filter(id: threadId)
                 .updateAllAndConfig(
                     db,
-                    SessionThread.Columns.markedAsUnread.set(to: true)
+                    SessionThread.Columns.markedAsUnread.set(to: true),
+                    using: dependencies
                 )
         }
     }

--- a/SessionMessagingKit/Utilities/ProfileManager.swift
+++ b/SessionMessagingKit/Utilities/ProfileManager.swift
@@ -605,7 +605,7 @@ public struct ProfileManager {
             else {
                 try Profile
                     .filter(id: publicKey)
-                    .updateAllAndConfig(db, profileChanges)
+                    .updateAllAndConfig(db, profileChanges, using: dependencies)
             }
         }
         

--- a/SessionMessagingKit/Utilities/SessionEnvironment.swift
+++ b/SessionMessagingKit/Utilities/SessionEnvironment.swift
@@ -12,9 +12,6 @@ public class SessionEnvironment {
     public var isRequestingPermission: Bool
     
     // Note: This property is configured after Environment is created.
-    public let callManager: Atomic<CallManagerProtocol?> = Atomic(nil)
-    
-    // Note: This property is configured after Environment is created.
     public let notificationsManager: Atomic<NotificationsProtocol?> = Atomic(nil)
     
     public var isComplete: Bool {

--- a/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
@@ -63,11 +63,13 @@ class MessageSendJobSpec: QuickSpec {
                     SNMessagingKit.self
                 ],
                 initialData: { db in
-                    try SessionThread.fetchOrCreate(
+                    try SessionThread.upsert(
                         db,
                         id: "Test1",
                         variant: .contact,
-                        shouldBeVisible: true
+                        values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                        calledFromConfig: false,
+                        using: dependencies
                     )
                 },
                 using: dependencies

--- a/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
@@ -71,7 +71,7 @@ class MessageSendJobSpec: QuickSpec {
                             // False is the default and will mean we don't need libSession loaded
                             shouldBeVisible: .setTo(false)
                         ),
-                        calledFromConfig: false,
+                        calledFromConfig: nil,
                         using: dependencies
                     )
                 },

--- a/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
@@ -9,7 +9,7 @@ import Nimble
 @testable import SessionMessagingKit
 @testable import SessionUtilitiesKit
 
-extension Job: MutableIdentifiable {
+extension Job: @retroactive MutableIdentifiable {
     public mutating func setId(_ id: Int64?) { self.id = id }
 }
 
@@ -67,7 +67,10 @@ class MessageSendJobSpec: QuickSpec {
                         db,
                         id: "Test1",
                         variant: .contact,
-                        values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                        values: SessionThread.TargetValues(
+                            // False is the default and will mean we don't need libSession loaded
+                            shouldBeVisible: .setTo(false)
+                        ),
                         calledFromConfig: false,
                         using: dependencies
                     )

--- a/SessionMessagingKitTests/Open Groups/OpenGroupManagerSpec.swift
+++ b/SessionMessagingKitTests/Open Groups/OpenGroupManagerSpec.swift
@@ -764,7 +764,11 @@ class OpenGroupManagerSpec: QuickSpec {
                                     roomToken: "testRoom",
                                     server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
-                                    calledFromConfigHandling: true, // Don't trigger LibSession logic
+                                    calledFromConfig: .userGroups( // Don't trigger LibSession logic
+                                        dependencies.caches[.libSession]
+                                            .config(for: .userGroups, publicKey: "05\(TestConstants.publicKey)")
+                                            .wrappedValue!
+                                    ),
                                     using: dependencies
                                 )
                         }
@@ -802,7 +806,11 @@ class OpenGroupManagerSpec: QuickSpec {
                                     roomToken: "testRoom",
                                     server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
-                                    calledFromConfigHandling: true, // Don't trigger LibSession logic
+                                    calledFromConfig: .userGroups( // Don't trigger LibSession logic
+                                        dependencies.caches[.libSession]
+                                            .config(for: .userGroups, publicKey: "05\(TestConstants.publicKey)")
+                                            .wrappedValue!
+                                    ),
                                     using: dependencies
                                 )
                         }
@@ -849,7 +857,11 @@ class OpenGroupManagerSpec: QuickSpec {
                                         publicKey: TestConstants.serverPublicKey
                                             .replacingOccurrences(of: "c3", with: "00")
                                             .replacingOccurrences(of: "b3", with: "00"),
-                                        calledFromConfigHandling: true, // Don't trigger LibSession logic
+                                        calledFromConfig: .userGroups( // Don't trigger LibSession logic
+                                            dependencies.caches[.libSession]
+                                                .config(for: .userGroups, publicKey: "05\(TestConstants.publicKey)")
+                                                .wrappedValue!
+                                        ),
                                         using: dependencies
                                     )
                             }
@@ -914,7 +926,11 @@ class OpenGroupManagerSpec: QuickSpec {
                                         roomToken: "testRoom",
                                         server: "http://127.0.0.1",
                                         publicKey: TestConstants.serverPublicKey,
-                                        calledFromConfigHandling: true, // Don't trigger LibSession logic
+                                        calledFromConfig: .userGroups( // Don't trigger LibSession logic
+                                            dependencies.caches[.libSession]
+                                                .config(for: .userGroups, publicKey: "05\(TestConstants.publicKey)")
+                                                .wrappedValue!
+                                        ),
                                         using: dependencies
                                     )
                             }

--- a/SessionMessagingKitTests/Open Groups/OpenGroupManagerSpec.swift
+++ b/SessionMessagingKitTests/Open Groups/OpenGroupManagerSpec.swift
@@ -19,7 +19,7 @@ class OpenGroupManagerSpec: QuickSpec {
             id: 234,
             serverHash: "TestServerHash",
             messageUuid: nil,
-            threadId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+            threadId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
             authorId: "TestAuthorId",
             variant: .standardOutgoing,
             body: "Test",
@@ -39,12 +39,12 @@ class OpenGroupManagerSpec: QuickSpec {
             mostRecentFailureText: nil
         )
         @TestState var testGroupThread: SessionThread! = SessionThread(
-            id: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+            id: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
             variant: .community,
             creationDateTimestamp: 0
         )
         @TestState var testOpenGroup: OpenGroup! = OpenGroup(
-            server: "testServer",
+            server: "http://127.0.0.1",
             roomToken: "testRoom",
             publicKey: TestConstants.publicKey,
             isActive: true,
@@ -210,6 +210,14 @@ class OpenGroupManagerSpec: QuickSpec {
         
         // MARK: - an OpenGroupManager
         describe("an OpenGroupManager") {
+            beforeEach {
+                LibSession.loadState(
+                    userPublicKey: "05\(TestConstants.publicKey)",
+                    ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)),
+                    using: dependencies
+                )
+            }
+            
             // MARK: -- cache data
             context("cache data") {
                 // MARK: ---- defaults the time since last open to greatestFiniteMagnitude
@@ -301,7 +309,7 @@ class OpenGroupManagerSpec: QuickSpec {
                     
                     expect(mockOGMCache)
                         .to(call(matchingParameters: true) {
-                            $0.getOrCreatePoller(for: "testserver")
+                            $0.getOrCreatePoller(for: "http://127.0.0.1")
                         })
                     expect(mockOGMCache)
                         .to(call(matchingParameters: true) {
@@ -437,7 +445,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 // MARK: ---- when there is a thread for the room and the cache has a poller
                 context("when there is a thread for the room and the cache has a poller") {
                     beforeEach {
-                        mockOGMCache.when { $0.serversBeingPolled }.thenReturn(["testserver"])
+                        mockOGMCache.when { $0.serversBeingPolled }.thenReturn(["http://127.0.0.1"])
                     }
                     
                     // MARK: ------ for the no-scheme variant
@@ -450,7 +458,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -466,7 +474,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "http://testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -482,7 +490,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "https://testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -501,7 +509,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -517,7 +525,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "http://testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -533,7 +541,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "https://testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -552,7 +560,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -568,7 +576,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "http://testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -584,7 +592,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                         .hasExistingOpenGroup(
                                             db,
                                             roomToken: "testRoom",
-                                            server: "https://testServer",
+                                            server: "http://127.0.0.1",
                                             publicKey: TestConstants.serverPublicKey,
                                             using: dependencies
                                         )
@@ -688,7 +696,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 .hasExistingOpenGroup(
                                     db,
                                     roomToken: "testRoom",
-                                    server: "testServer",
+                                    server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
                                     using: dependencies
                                 )
@@ -708,7 +716,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 .hasExistingOpenGroup(
                                     db,
                                     roomToken: "testRoom",
-                                    server: "testServer",
+                                    server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
                                     using: dependencies
                                 )
@@ -720,6 +728,14 @@ class OpenGroupManagerSpec: QuickSpec {
         
         // MARK: - an OpenGroupManager
         describe("an OpenGroupManager") {
+            beforeEach {
+                LibSession.loadState(
+                    userPublicKey: "05\(TestConstants.publicKey)",
+                    ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)),
+                    using: dependencies
+                )
+            }
+            
             // MARK: -- when adding
             context("when adding") {
                 beforeEach {
@@ -746,7 +762,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 .add(
                                     db,
                                     roomToken: "testRoom",
-                                    server: "testServer",
+                                    server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
                                     calledFromConfigHandling: true, // Don't trigger LibSession logic
                                     using: dependencies
@@ -756,7 +772,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             openGroupManager.performInitialRequestsAfterAdd(
                                 successfullyAddedGroup: successfullyAddedGroup,
                                 roomToken: "testRoom",
-                                server: "testServer",
+                                server: "http://127.0.0.1",
                                 publicKey: TestConstants.serverPublicKey,
                                 calledFromConfigHandling: true, // Don't trigger LibSession logic
                                 using: dependencies
@@ -773,7 +789,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     .fetchOne(db)
                             }
                     )
-                    .to(equal(OpenGroup.idFor(roomToken: "testRoom", server: "testServer")))
+                    .to(equal(OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1")))
                 }
                 
                 // MARK: ---- adds a poller
@@ -784,7 +800,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 .add(
                                     db,
                                     roomToken: "testRoom",
-                                    server: "testServer",
+                                    server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
                                     calledFromConfigHandling: true, // Don't trigger LibSession logic
                                     using: dependencies
@@ -794,7 +810,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             openGroupManager.performInitialRequestsAfterAdd(
                                 successfullyAddedGroup: successfullyAddedGroup,
                                 roomToken: "testRoom",
-                                server: "testServer",
+                                server: "http://127.0.0.1",
                                 publicKey: TestConstants.serverPublicKey,
                                 calledFromConfigHandling: true, // Don't trigger LibSession logic
                                 using: dependencies
@@ -804,7 +820,7 @@ class OpenGroupManagerSpec: QuickSpec {
                     
                     expect(mockOGMCache)
                         .to(call(matchingParameters: true) {
-                            $0.getOrCreatePoller(for: "testserver")
+                            $0.getOrCreatePoller(for: "http://127.0.0.1")
                         })
                     expect(mockPoller)
                         .to(call(matchingParameters: true) { [dependencies = dependencies!] in
@@ -815,7 +831,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 // MARK: ---- an existing room
                 context("an existing room") {
                     beforeEach {
-                        mockOGMCache.when { $0.serversBeingPolled }.thenReturn(["testserver"])
+                        mockOGMCache.when { $0.serversBeingPolled }.thenReturn(["http://127.0.0.1"])
                         mockStorage.write { db in
                             try testOpenGroup.insert(db)
                         }
@@ -829,7 +845,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     .add(
                                         db,
                                         roomToken: "testRoom",
-                                        server: "testServer",
+                                        server: "http://127.0.0.1",
                                         publicKey: TestConstants.serverPublicKey
                                             .replacingOccurrences(of: "c3", with: "00")
                                             .replacingOccurrences(of: "b3", with: "00"),
@@ -841,7 +857,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 openGroupManager.performInitialRequestsAfterAdd(
                                     successfullyAddedGroup: successfullyAddedGroup,
                                     roomToken: "testRoom",
-                                    server: "testServer",
+                                    server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey
                                         .replacingOccurrences(of: "c3", with: "00")
                                         .replacingOccurrences(of: "b3", with: "00"),
@@ -896,7 +912,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     .add(
                                         db,
                                         roomToken: "testRoom",
-                                        server: "testServer",
+                                        server: "http://127.0.0.1",
                                         publicKey: TestConstants.serverPublicKey,
                                         calledFromConfigHandling: true, // Don't trigger LibSession logic
                                         using: dependencies
@@ -906,7 +922,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 openGroupManager.performInitialRequestsAfterAdd(
                                     successfullyAddedGroup: successfullyAddedGroup,
                                     roomToken: "testRoom",
-                                    server: "testServer",
+                                    server: "http://127.0.0.1",
                                     publicKey: TestConstants.serverPublicKey,
                                     calledFromConfigHandling: true, // Don't trigger LibSession logic
                                     using: dependencies
@@ -934,7 +950,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             .updateAll(
                                 db,
                                 Interaction.Columns.threadId
-                                    .set(to: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"))
+                                    .set(to: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"))
                             )
                     }
                 }
@@ -945,7 +961,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         openGroupManager
                             .delete(
                                 db,
-                                openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 calledFromConfigHandling: true, // Don't trigger LibSession logic
                                 using: dependencies
                             )
@@ -961,7 +977,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         openGroupManager
                             .delete(
                                 db,
-                                openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 calledFromConfigHandling: true, // Don't trigger LibSession logic
                                 using: dependencies
                             )
@@ -979,13 +995,13 @@ class OpenGroupManagerSpec: QuickSpec {
                             openGroupManager
                                 .delete(
                                     db,
-                                    openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                    openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                     calledFromConfigHandling: true, // Don't trigger LibSession logic
                                     using: dependencies
                                 )
                         }
                         
-                        expect(mockOGMCache).to(call(matchingParameters: true) { $0.stopAndRemovePoller(for: "testserver") })
+                        expect(mockOGMCache).to(call(matchingParameters: true) { $0.stopAndRemovePoller(for: "http://127.0.0.1") })
                     }
                     
                     // MARK: ------ removes the open group
@@ -994,7 +1010,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             openGroupManager
                                 .delete(
                                     db,
-                                    openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                    openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                     calledFromConfigHandling: true, // Don't trigger LibSession logic
                                     using: dependencies
                                 )
@@ -1012,7 +1028,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             try OpenGroup.deleteAll(db)
                             try testOpenGroup.insert(db)
                             try OpenGroup(
-                                server: "testServer",
+                                server: "http://127.0.0.1",
                                 roomToken: "testRoom1",
                                 publicKey: TestConstants.publicKey,
                                 isActive: true,
@@ -1035,7 +1051,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             openGroupManager
                                 .delete(
                                     db,
-                                    openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                    openGroupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                     calledFromConfigHandling: true, // Don't trigger LibSession logic
                                     using: dependencies
                                 )
@@ -1133,7 +1149,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             .handleCapabilities(
                                 db,
                                 capabilities: OpenGroupAPI.Capabilities(capabilities: [.sogs], missing: []),
-                                on: "testserver"
+                                on: "http://127.0.0.1"
                             )
                     }
                 }
@@ -1148,6 +1164,14 @@ class OpenGroupManagerSpec: QuickSpec {
         
         // MARK: - an OpenGroupManager
         describe("an OpenGroupManager") {
+            beforeEach {
+                LibSession.loadState(
+                    userPublicKey: "05\(TestConstants.publicKey)",
+                    ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)),
+                    using: dependencies
+                )
+            }
+            
             // MARK: -- when handling room poll info
             context("when handling room poll info") {
                 beforeEach {
@@ -1181,7 +1205,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             pollInfo: testPollInfo,
                             publicKey: TestConstants.publicKey,
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )// { didComplete = true }
                     }
@@ -1206,7 +1230,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             pollInfo: testPollInfo,
                             publicKey: TestConstants.publicKey,
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         ) { didCallComplete = true }
                     }
@@ -1224,7 +1248,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             pollInfo: testPollInfo,
                             publicKey: TestConstants.publicKey,
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             waitForImageToComplete: true,
                             using: dependencies
                         ) { didCallComplete = true }
@@ -1240,7 +1264,7 @@ class OpenGroupManagerSpec: QuickSpec {
                     mockStorage.write { db in
                         try OpenGroup.deleteAll(db)
                         try OpenGroup(
-                            server: "testServer",
+                            server: "http://127.0.0.1",
                             roomToken: "testRoom",
                             publicKey: TestConstants.publicKey,
                             isActive: true,
@@ -1254,7 +1278,7 @@ class OpenGroupManagerSpec: QuickSpec {
                     
                     mockOGMCache.when { $0.groupImagePublishers }
                         .thenReturn([
-                            OpenGroup.idFor(roomToken: "testRoom", server: "testServer"): Just(Data()).setFailureType(to: Error.self).eraseToAnyPublisher()
+                            OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"): Just(Data()).setFailureType(to: Error.self).eraseToAnyPublisher()
                         ])
                     
                     mockStorage.write { db in
@@ -1263,7 +1287,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             pollInfo: testPollInfo,
                             publicKey: TestConstants.publicKey,
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             waitForImageToComplete: true,
                             using: dependencies
                         ) { didCallComplete = true }
@@ -1293,7 +1317,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1303,7 +1327,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 try GroupMember
                                     .filter(GroupMember.Columns.groupId == OpenGroup.idFor(
                                         roomToken: "testRoom",
-                                        server: "testServer"
+                                        server: "http://127.0.0.1"
                                     ))
                                     .fetchOne(db)
                             }
@@ -1311,7 +1335,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             GroupMember(
                                 groupId: OpenGroup.idFor(
                                     roomToken: "testRoom",
-                                    server: "testServer"
+                                    server: "http://127.0.0.1"
                                 ),
                                 profileId: "TestMod",
                                 role: .moderator,
@@ -1339,7 +1363,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1349,7 +1373,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 try GroupMember
                                     .filter(GroupMember.Columns.groupId == OpenGroup.idFor(
                                         roomToken: "testRoom",
-                                        server: "testServer"
+                                        server: "http://127.0.0.1"
                                     ))
                                     .fetchOne(db)
                             }
@@ -1357,7 +1381,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             GroupMember(
                                 groupId: OpenGroup.idFor(
                                     roomToken: "testRoom",
-                                    server: "testServer"
+                                    server: "http://127.0.0.1"
                                 ),
                                 profileId: "TestMod2",
                                 role: .moderator,
@@ -1379,7 +1403,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1410,7 +1434,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1420,7 +1444,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 try GroupMember
                                     .filter(GroupMember.Columns.groupId == OpenGroup.idFor(
                                         roomToken: "testRoom",
-                                        server: "testServer"
+                                        server: "http://127.0.0.1"
                                     ))
                                     .fetchOne(db)
                             }
@@ -1428,7 +1452,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             GroupMember(
                                 groupId: OpenGroup.idFor(
                                     roomToken: "testRoom",
-                                    server: "testServer"
+                                    server: "http://127.0.0.1"
                                 ),
                                 profileId: "TestAdmin",
                                 role: .admin,
@@ -1456,7 +1480,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1466,7 +1490,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 try GroupMember
                                     .filter(GroupMember.Columns.groupId == OpenGroup.idFor(
                                         roomToken: "testRoom",
-                                        server: "testServer"
+                                        server: "http://127.0.0.1"
                                     ))
                                     .fetchOne(db)
                             }
@@ -1474,7 +1498,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             GroupMember(
                                 groupId: OpenGroup.idFor(
                                     roomToken: "testRoom",
-                                    server: "testServer"
+                                    server: "http://127.0.0.1"
                                 ),
                                 profileId: "TestAdmin2",
                                 role: .admin,
@@ -1497,7 +1521,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1521,7 +1545,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1540,7 +1564,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: nil,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -1573,7 +1597,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         
                         mockOGMCache.when { $0.groupImagePublishers }
                             .thenReturn([
-                                OpenGroup.idFor(roomToken: "testRoom", server: "testServer"): Just(imageData).setFailureType(to: Error.self).eraseToAnyPublisher()
+                                OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"): Just(imageData).setFailureType(to: Error.self).eraseToAnyPublisher()
                             ])
                     }
                     
@@ -1595,7 +1619,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 waitForImageToComplete: true,
                                 using: dependencies
                             )
@@ -1624,7 +1648,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         mockStorage.write { db in
                             try OpenGroup.deleteAll(db)
                             try OpenGroup(
-                                server: "testServer",
+                                server: "http://127.0.0.1",
                                 roomToken: "testRoom",
                                 publicKey: TestConstants.publicKey,
                                 isActive: true,
@@ -1648,7 +1672,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 waitForImageToComplete: true,
                                 using: dependencies
                             )
@@ -1677,7 +1701,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         mockStorage.write { db in
                             try OpenGroup.deleteAll(db)
                             try OpenGroup(
-                                server: "testServer",
+                                server: "http://127.0.0.1",
                                 roomToken: "testRoom",
                                 publicKey: TestConstants.publicKey,
                                 isActive: true,
@@ -1713,7 +1737,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 waitForImageToComplete: true,
                                 using: dependencies
                             )
@@ -1746,7 +1770,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 waitForImageToComplete: true,
                                 using: dependencies
                             )
@@ -1766,7 +1790,7 @@ class OpenGroupManagerSpec: QuickSpec {
                     it("does nothing if it fails to retrieve the room image") {
                         mockOGMCache.when { $0.groupImagePublishers }
                             .thenReturn([
-                                OpenGroup.idFor(roomToken: "testRoom", server: "testServer"): Fail(error: NetworkError.unknown).eraseToAnyPublisher()
+                                OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"): Fail(error: NetworkError.unknown).eraseToAnyPublisher()
                             ])
                         
                         testPollInfo = OpenGroupAPI.RoomPollInfo.mockValue.with(
@@ -1785,7 +1809,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 waitForImageToComplete: true,
                                 using: dependencies
                             )
@@ -1819,7 +1843,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 pollInfo: testPollInfo,
                                 publicKey: TestConstants.publicKey,
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 waitForImageToComplete: true,
                                 using: dependencies
                             )
@@ -1840,6 +1864,14 @@ class OpenGroupManagerSpec: QuickSpec {
         
         // MARK: - an OpenGroupManager
         describe("an OpenGroupManager") {
+            beforeEach {
+                LibSession.loadState(
+                    userPublicKey: "05\(TestConstants.publicKey)",
+                    ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)),
+                    using: dependencies
+                )
+            }
+            
             // MARK: -- when handling messages
             context("when handling messages") {
                 beforeEach {
@@ -1872,7 +1904,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 )
                             ],
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -1894,7 +1926,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             db,
                             messages: [],
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -1935,7 +1967,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 )
                             ],
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -1969,7 +2001,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 )
                             ],
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -1984,7 +2016,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             db,
                             messages: [testMessage],
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -2015,7 +2047,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 testMessage,
                             ],
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -2055,7 +2087,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     )
                                 ],
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2085,7 +2117,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     )
                                 ],
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2132,7 +2164,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             db,
                             messages: [],
                             fromOutbox: false,
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -2166,7 +2198,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             db,
                             messages: [testDirectMessage],
                             fromOutbox: false,
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -2205,7 +2237,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             db,
                             messages: [testDirectMessage],
                             fromOutbox: false,
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     }
@@ -2228,7 +2260,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: false,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2270,7 +2302,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: false,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2285,7 +2317,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: false,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2310,7 +2342,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     testDirectMessage
                                 ],
                                 fromOutbox: false,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2334,7 +2366,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: true,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2355,7 +2387,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             try BlindedIdLookup(
                                 blindedId: "15\(TestConstants.publicKey)",
                                 sessionId: "TestSessionId",
-                                openGroupServer: "testserver",
+                                openGroupServer: "http://127.0.0.1",
                                 openGroupPublicKey: "05\(TestConstants.publicKey)"
                             ).insert(db)
                         }
@@ -2365,7 +2397,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: true,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2381,7 +2413,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: true,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2430,7 +2462,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: true,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2445,7 +2477,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                 db,
                                 messages: [testDirectMessage],
                                 fromOutbox: true,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2470,7 +2502,7 @@ class OpenGroupManagerSpec: QuickSpec {
                                     testDirectMessage
                                 ],
                                 fromOutbox: true,
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         }
@@ -2483,6 +2515,14 @@ class OpenGroupManagerSpec: QuickSpec {
         
         // MARK: - an OpenGroupManager
         describe("an OpenGroupManager") {
+            beforeEach {
+                LibSession.loadState(
+                    userPublicKey: "05\(TestConstants.publicKey)",
+                    ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)),
+                    using: dependencies
+                )
+            }
+            
             // MARK: -- when determining if a user is a moderator or an admin
             context("when determining if a user is a moderator or an admin") {
                 beforeEach {
@@ -2497,7 +2537,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "05\(TestConstants.publicKey)",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beFalse())
@@ -2509,7 +2549,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "05\(TestConstants.publicKey)",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beFalse())
@@ -2519,7 +2559,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 it("returns true if the key is in the moderator set") {
                     mockStorage.write { db in
                         try GroupMember(
-                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                             profileId: "05\(TestConstants.publicKey)",
                             role: .moderator,
                             isHidden: false
@@ -2530,7 +2570,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "05\(TestConstants.publicKey)",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beTrue())
@@ -2540,7 +2580,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 it("returns true if the key is in the admin set") {
                     mockStorage.write { db in
                         try GroupMember(
-                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                             profileId: "05\(TestConstants.publicKey)",
                             role: .admin,
                             isHidden: false
@@ -2551,7 +2591,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "05\(TestConstants.publicKey)",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beTrue())
@@ -2561,7 +2601,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 it("returns true if the moderator is hidden") {
                     mockStorage.write { db in
                         try GroupMember(
-                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                             profileId: "05\(TestConstants.publicKey)",
                             role: .moderator,
                             isHidden: true
@@ -2572,7 +2612,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "05\(TestConstants.publicKey)",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beTrue())
@@ -2582,7 +2622,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 it("returns true if the admin is hidden") {
                     mockStorage.write { db in
                         try GroupMember(
-                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                            groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                             profileId: "05\(TestConstants.publicKey)",
                             role: .admin,
                             isHidden: true
@@ -2593,7 +2633,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "05\(TestConstants.publicKey)",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beTrue())
@@ -2605,7 +2645,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         OpenGroupManager.isUserModeratorOrAdmin(
                             "InvalidValue",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             using: dependencies
                         )
                     ).to(beFalse())
@@ -2626,7 +2666,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "05\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beFalse())
@@ -2638,7 +2678,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             let otherKey: String = TestConstants.publicKey.replacingOccurrences(of: "7", with: "6")
                             
                             try GroupMember(
-                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 profileId: "00\(otherKey)",
                                 role: .moderator,
                                 isHidden: false
@@ -2652,7 +2692,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "05\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beTrue())
@@ -2671,7 +2711,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             )
                         mockStorage.write { db in
                             try GroupMember(
-                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 profileId: "15\(otherKey)",
                                 role: .moderator,
                                 isHidden: false
@@ -2682,7 +2722,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "05\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beTrue())
@@ -2702,7 +2742,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "00\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beFalse())
@@ -2721,7 +2761,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "00\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beFalse())
@@ -2733,7 +2773,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         mockGeneralCache.when { $0.encodedPublicKey }.thenReturn("05\(otherKey)")
                         mockStorage.write { db in
                             try GroupMember(
-                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 profileId: "05\(otherKey)",
                                 role: .moderator,
                                 isHidden: false
@@ -2749,7 +2789,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "00\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beTrue())
@@ -2768,7 +2808,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             )
                         mockStorage.write { db in
                             try GroupMember(
-                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 profileId: "15\(otherKey)",
                                 role: .moderator,
                                 isHidden: false
@@ -2784,7 +2824,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "00\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beTrue())
@@ -2804,7 +2844,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "15\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beFalse())
@@ -2820,7 +2860,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "15\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beFalse())
@@ -2842,7 +2882,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "15\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beFalse())
@@ -2862,7 +2902,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             )
                         mockStorage.write { db in
                             try GroupMember(
-                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 profileId: "05\(otherKey)",
                                 role: .moderator,
                                 isHidden: false
@@ -2878,7 +2918,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "15\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beTrue())
@@ -2898,7 +2938,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             let otherKey: String = TestConstants.publicKey.replacingOccurrences(of: "7", with: "6")
                             
                             try GroupMember(
-                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"),
+                                groupId: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"),
                                 profileId: "00\(otherKey)",
                                 role: .moderator,
                                 isHidden: false
@@ -2914,7 +2954,7 @@ class OpenGroupManagerSpec: QuickSpec {
                             OpenGroupManager.isUserModeratorOrAdmin(
                                 "15\(TestConstants.publicKey)",
                                 for: "testRoom",
-                                on: "testServer",
+                                on: "http://127.0.0.1",
                                 using: dependencies
                             )
                         ).to(beTrue())
@@ -3183,14 +3223,14 @@ class OpenGroupManagerSpec: QuickSpec {
                     .eraseToAnyPublisher()
                     mockOGMCache
                         .when { $0.groupImagePublishers }
-                        .thenReturn([OpenGroup.idFor(roomToken: "testRoom", server: "testServer"): publisher])
+                        .thenReturn([OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"): publisher])
                     
                     var result: Data?
                     OpenGroupManager
                         .roomImage(
                             fileId: "1",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             existingData: nil,
                             using: dependencies
                         )
@@ -3206,7 +3246,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         .roomImage(
                             fileId: "1",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             existingData: nil,
                             using: dependencies
                         )
@@ -3216,7 +3256,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         mockStorage.read { db -> Data? in
                             try OpenGroup
                                 .select(.imageData)
-                                .filter(id: OpenGroup.idFor(roomToken: "testRoom", server: "testServer"))
+                                .filter(id: OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"))
                                 .asRequest(of: Data.self)
                                 .fetchOne(db)
                         }
@@ -3229,7 +3269,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         .roomImage(
                             fileId: "1",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             existingData: nil,
                             using: dependencies
                         )
@@ -3250,7 +3290,7 @@ class OpenGroupManagerSpec: QuickSpec {
                         .roomImage(
                             fileId: "1",
                             for: "testRoom",
-                            on: "testServer",
+                            on: "http://127.0.0.1",
                             existingData: nil,
                             using: dependencies
                         )
@@ -3258,7 +3298,7 @@ class OpenGroupManagerSpec: QuickSpec {
                     
                     expect(mockOGMCache)
                         .to(call(matchingParameters: true) {
-                            $0.groupImagePublishers = [OpenGroup.idFor(roomToken: "testRoom", server: "testServer"): publisher]
+                            $0.groupImagePublishers = [OpenGroup.idFor(roomToken: "testRoom", server: "http://127.0.0.1"): publisher]
                         })
                 }
                 

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -169,7 +169,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                                         id: sender,
                                         variant: .contact,
                                         values: .existingOrDefault,
-                                        calledFromConfig: false,
+                                        calledFromConfig: nil,
                                         using: dependencies
                                     )
 

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -164,13 +164,14 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                                         using: dependencies
                                     )
                                 {
-                                    let thread: SessionThread = try SessionThread
-                                        .fetchOrCreate(
-                                            db,
-                                            id: sender,
-                                            variant: .contact,
-                                            shouldBeVisible: nil
-                                        )
+                                    let thread: SessionThread = try SessionThread.upsert(
+                                        db,
+                                        id: sender,
+                                        variant: .contact,
+                                        values: .existingOrDefault,
+                                        calledFromConfig: false,
+                                        using: dependencies
+                                    )
 
                                     // Notify the user if the call message wasn't already read
                                     if !interaction.wasRead {

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -199,7 +199,8 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                                     db,
                                     threadId: threadId,
                                     threadVariant: threadVariant,
-                                    message: messageInfo.message
+                                    message: messageInfo.message,
+                                    using: dependencies
                                 )
                                 
                                 return self?.handleSuccessForIncomingCall(db, for: callMessage)
@@ -210,7 +211,8 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                             db,
                             threadId: threadId,
                             threadVariant: threadVariant,
-                            message: messageInfo.message
+                            message: messageInfo.message,
+                            using: dependencies
                         )
                         
                     case .standard(let threadId, let threadVariant, let proto, let messageInfo):

--- a/SessionShareExtension/ThreadPickerVC.swift
+++ b/SessionShareExtension/ThreadPickerVC.swift
@@ -274,7 +274,8 @@ final class ThreadPickerVC: UIViewController, UITableViewDataSource, UITableView
                                 .updateAllAndConfig(
                                     db,
                                     SessionThread.Columns.shouldBeVisible.set(to: true),
-                                    SessionThread.Columns.pinnedPriority.set(to: LibSession.visiblePriority)
+                                    SessionThread.Columns.pinnedPriority.set(to: LibSession.visiblePriority),
+                                    using: dependencies
                                 )
                         }
                         

--- a/SessionUtilitiesKit/LibSession/LibSessionError.swift
+++ b/SessionUtilitiesKit/LibSession/LibSessionError.swift
@@ -13,6 +13,7 @@ public enum LibSessionError: Error, CustomStringConvertible {
     case processingLoopLimitReached
     case invalidCConversion
     case unableToGeneratePushData
+    case invalidConfigAccess
     
     case libSessionError(String)
     case unknown
@@ -70,6 +71,7 @@ public enum LibSessionError: Error, CustomStringConvertible {
             case .processingLoopLimitReached: return "Processing loop limit reached (LibSessionError.processingLoopLimitReached)."
             case .invalidCConversion: return "Invalid conversation to C type (LibSessionError.invalidCConversion)."
             case .unableToGeneratePushData: return "Unable to generate push data (LibSessionError.unableToGeneratePushData)."
+            case .invalidConfigAccess: return "Invalid config access (LibSessionError.invalidConfigAccess)."
             
             case .libSessionError(let error): return "\(error)\(error.hasSuffix(".") ? "" : ".")"
             case .unknown: return "An unknown error occurred (LibSessionError.unknown)."


### PR DESCRIPTION
- Added a few functions to retrieve conversation settings from libSession
- Updated the Note to Self swipe action to be "Hide" (hides the conversation but does not delete the messages)
- Updated the one-to-one deletion behaviour (now syncs both hiding the conversation and deleting it's messages)
- Updated the logic to retrieve the relevant disappearing messages setting from `libSession` when creating a thread if it doesn't exist (allows us to delete threads without worrying about losing settings)
• Updated a bunch of dependency management & injection code so the unit tests would pass
- Updated the `SessionCallManager` to be an updated singleton type (cleaned up more in Groups Rebuild)
- Updated the `PushRegistrationManager` to be an updated singleton type (cleaned up more in Groups Rebuild)
- Injected dependencies correctly in a bunch of places