### PR TITLE
Add accessibility id for broken media

### DIFF
--- a/Session/Conversations/Message Cells/Content Views/MediaView.swift
+++ b/Session/Conversations/Message Cells/Content Views/MediaView.swift
@@ -372,6 +372,8 @@ public class MediaView: UIView {
                     return
                 }
                 icon = asset
+                self.isAccessibilityElement = true
+                self.accessibilityIdentifier = "Media retry"
                 
             case .invalid:
                 guard let asset = UIImage(named: "media_invalid") else {
@@ -379,6 +381,8 @@ public class MediaView: UIView {
                     return
                 }
                 icon = asset
+                self.isAccessibilityElement = true
+                self.accessibilityIdentifier = "Media invalid"
                 
             case .missing: return
         }


### PR DESCRIPTION
- Add accessibility id(`Media retry`) for media message that needs to retry
- Add accessibility id(`Media invalid`) for media message that is failed or invalid