### PR TITLE
Fixed a crash which could occur when leaving the conversation screen

### DIFF
--- a/Session/Meta/MainAppContext.swift
+++ b/Session/Meta/MainAppContext.swift
@@ -154,6 +154,12 @@ final class MainAppContext: AppContext {
     
     // stringlint:ignore_contents
     func ensureSleepBlocking(_ shouldBeBlocking: Bool, blockingObjects: [Any]) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async { [weak self] in
+                self?.ensureSleepBlocking(shouldBeBlocking, blockingObjects: blockingObjects)
+            }
+        }
+        
         if UIApplication.shared.isIdleTimerDisabled != shouldBeBlocking {
             if shouldBeBlocking {
                 var logString: String = "Blocking sleep because of: \(String(describing: blockingObjects.first))"

--- a/Session/Meta/MainAppContext.swift
+++ b/Session/Meta/MainAppContext.swift
@@ -133,6 +133,12 @@ final class MainAppContext: AppContext {
     }
     
     func setStatusBarHidden(_ isHidden: Bool, animated isAnimated: Bool) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async { [weak self] in
+                self?.setStatusBarHidden(isHidden, animated: isAnimated)
+            }
+        }
+        
         UIApplication.shared.setStatusBarHidden(isHidden, with: (isAnimated ? .slide : .none))
     }
     
@@ -177,6 +183,12 @@ final class MainAppContext: AppContext {
     }
     
     func setNetworkActivityIndicatorVisible(_ value: Bool) {
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async { [weak self] in
+                self?.setNetworkActivityIndicatorVisible(value)
+            }
+        }
+        
         UIApplication.shared.isNetworkActivityIndicatorVisible = value
     }
     


### PR DESCRIPTION
Crash in question is: `FrontBoardServices: -[FBSMainRunLoopSerialQueue assertBarrierOnQueue] + 140` and it looks like the `ConversationViewModel` `deinit` function could result in `UIApplication.shared.isIdleTimerDisabled` being set on a background thread (is only allowed to be set on the main thread)

Also added a couple more thread checks just to be safe (though haven't seen crashes related to them)