### PR TITLE
Dependency access crash fix

### DIFF
--- a/SessionUtilitiesKit/Dependency Injection/Dependencies.swift
+++ b/SessionUtilitiesKit/Dependency Injection/Dependencies.swift
@@ -386,14 +386,18 @@ private extension Dependencies {
     
     /// Convenience method to retrieve the existing dependency instance from memory in a thread-safe way
     private func getValue<T>(_ key: String, of variant: DependencyStorage.Key.Variant) -> T? {
-        guard let typedValue: DependencyStorage.Value = storage.instances[variant.key(key)] else { return nil }
-        guard let result: T = typedValue.value(as: T.self) else {
-            /// If there is a value stored for the key, but it's not the right type then something has gone wrong, and we should log
-            Log.critical("Failed to convert stored dependency '\(variant.key(key))' to expected type: \(T.self)")
-            return nil
+        return _storage.performMap { storage in
+            guard let typedValue: DependencyStorage.Value = storage.instances[variant.key(key)] else {
+                return nil
+            }
+            guard let result: T = typedValue.value(as: T.self) else {
+                /// If there is a value stored for the key, but it's not the right type then something has gone wrong, and we should log
+                Log.critical("Failed to convert stored dependency '\(variant.key(key))' to expected type: \(T.self)")
+                return nil
+            }
+            
+            return result
         }
-        
-        return result
     }
     
     /// Convenience method to store a dependency instance in memory in a thread-safe way


### PR DESCRIPTION
Looks like we have a new crash when accessing a dependency, it seems like the crash is most likely due to trying to retrieve a cached dependency (in a non-thread-safe way) while another thread is updating a dependency which results in a crash

This PR wraps the `getValue` logic in a `performMap` to ensure the dependency is retrieved in a thread-safe way (via our `@ThreadSafeObject` mechanism so we get the performance benefit of the `ReadWriteLock` rather than using the `threadSafeChange` mechanism which uses the exclusive `NSLock` that could have a worse impact on performance)