### PR TITLE
Fixed an issue where groups with only some config dumps wouldn't load

### DIFF
--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -241,11 +241,11 @@ extension Onboarding {
                     /// In order to process the config message we need to create and load a `libSession` cache, but we don't want to load this into
                     /// memory at this stage in case the user cancels the onboarding process part way through
                     let cache: LibSession.Cache = LibSession.Cache(userSessionId: userSessionId, using: dependencies)
-                    cache.loadDefaultStatesFor(
-                        userConfigVariants: [.userProfile],
-                        groups: [],
-                        userSessionId: userSessionId,
-                        userEd25519KeyPair: identity.ed25519KeyPair
+                    cache.loadDefaultStateFor(
+                        variant: .userProfile,
+                        sessionId: userSessionId,
+                        userEd25519KeyPair: identity.ed25519KeyPair,
+                        groupEd25519SecretKey: nil
                     )
                     try cache.unsafeDirectMergeConfigMessage(
                         swarmPublicKey: userSessionId.hexString,

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -14,13 +14,13 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
     // MARK: - State Management
     
     func loadState(_ db: Database) { mockNoReturn(untrackedArgs: [db]) }
-    func loadDefaultStatesFor(
-        userConfigVariants: Set<ConfigDump.Variant>,
-        groups: [ClosedGroup],
-        userSessionId: SessionId,
-        userEd25519KeyPair: KeyPair
+    func loadDefaultStateFor(
+        variant: ConfigDump.Variant,
+        sessionId: SessionId,
+        userEd25519KeyPair: KeyPair,
+        groupEd25519SecretKey: [UInt8]?
     ) {
-        mockNoReturn(args: [userConfigVariants, groups, userSessionId, userEd25519KeyPair])
+        mockNoReturn(args: [variant, sessionId, userEd25519KeyPair, groupEd25519SecretKey])
     }
     
     func hasConfig(for variant: ConfigDump.Variant, sessionId: SessionId) -> Bool {


### PR DESCRIPTION
- Cleaned up the interface for loading the "default" state for configs (shouldn't really be used outside of onboarding to tweaked it's interface)
- Updated the logic so group configs would be initialised all at once per group (previously it would load them in variant load order, now it will be group -> variant load order)
- Fixed an issue where the default state for a group config wouldn't be loaded if there were some, but not all, dumps for the group configs
- Fixed an issue where groups in the invited state would incorrectly load their config states