### PR TITLE
Fix a config push crash

### DIFF
--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -608,15 +608,8 @@ public extension LibSession {
                     // Only generate the push data if we need to do a push
                     guard config.needsPush else { return }
                     
-                    guard let data: PendingChanges.PushData = config.push(variant: info.variant) else {
-                        throw LibSessionError(
-                            config,
-                            fallbackError: .unableToGeneratePushData,
-                            logMessage: "Failed to generate push data for \(info.variant) config data, size: \(config.countDescription), error"
-                        )
-                    }
-                    
-                    result.append(data: data)
+                    // Try to generate the push data (will throw if there is an error)
+                    try result.append(data: config.push(variant: info.variant))
                 }
         }
         


### PR DESCRIPTION
Looks like the `config_push` function in `libSession` is throwing an exception and because the C API is annoying, it returns an implicitly unwrapped value - since we weren’t explicitly unwrapping this implicitly unwrapped value the app would crash when an error is thrown

The fix is to explicitly unwrap the result (and log if an error occurs so we can track down the underlying issue - not sure what the error `libSession` is throwing is, but potentially configs which are too large since we don't have the multi-config PR yet: https://github.com/session-foundation/libsession-util/pull/11)