### PR TITLE
[WIP] Move the database from the AppGroup to main app Documents directory (OLD)

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -801,13 +801,13 @@
 		FD848B9628422A2A000E298B /* MessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD848B86283B844B000E298B /* MessageViewModel.swift */; };
 		FD848B9828422F1A000E298B /* Date+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD848B9728422F1A000E298B /* Date+Utilities.swift */; };
 		FD848B9A28442CE6000E298B /* StorageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD848B9928442CE6000E298B /* StorageError.swift */; };
-		FD860CBC2D6E7A9F00BBE29C /* _024_FixBustedInteractionVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CBB2D6E7A9400BBE29C /* _024_FixBustedInteractionVariant.swift */; };
-		FD860CBE2D6E7DAA00BBE29C /* DeveloperSettingsViewModel+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CBD2D6E7DA000BBE29C /* DeveloperSettingsViewModel+Testing.swift */; };
-		FD860CC92D6ED2ED00BBE29C /* DifferenceKit in Frameworks */ = {isa = PBXBuildFile; productRef = FD860CC82D6ED2ED00BBE29C /* DifferenceKit */; };
 		FD860CB42D668FD300BBE29C /* AppearanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CB32D668FD000BBE29C /* AppearanceViewModel.swift */; };
 		FD860CB62D66913F00BBE29C /* ThemePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CB52D66913B00BBE29C /* ThemePreviewView.swift */; };
 		FD860CB82D66BC9900BBE29C /* AppIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CB72D66BC9500BBE29C /* AppIconViewModel.swift */; };
 		FD860CBA2D66BF2A00BBE29C /* AppIconGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CB92D66BF2300BBE29C /* AppIconGridView.swift */; };
+		FD860CBC2D6E7A9F00BBE29C /* _024_FixBustedInteractionVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CBB2D6E7A9400BBE29C /* _024_FixBustedInteractionVariant.swift */; };
+		FD860CBE2D6E7DAA00BBE29C /* DeveloperSettingsViewModel+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD860CBD2D6E7DA000BBE29C /* DeveloperSettingsViewModel+Testing.swift */; };
+		FD860CC92D6ED2ED00BBE29C /* DifferenceKit in Frameworks */ = {isa = PBXBuildFile; productRef = FD860CC82D6ED2ED00BBE29C /* DifferenceKit */; };
 		FD86FDA32BC5020600EC251B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */; };
 		FD86FDA42BC51C5400EC251B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */; };
 		FD86FDA52BC51C5500EC251B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */; };
@@ -833,6 +833,7 @@
 		FD9DD2722A72516D00ECB68E /* TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9DD2702A72516D00ECB68E /* TestExtensions.swift */; };
 		FD9DD2732A72516D00ECB68E /* TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9DD2702A72516D00ECB68E /* TestExtensions.swift */; };
 		FDA335F52D91157A007E0EB6 /* AnimatedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA335F42D911576007E0EB6 /* AnimatedImageView.swift */; };
+		FDA3B2842D9DEA95007E0EB6 /* ExtensionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA3B2832D9DEA8F007E0EB6 /* ExtensionHelper.swift */; };
 		FDAA16762AC28A3B00DDBF77 /* UserDefaultsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA16752AC28A3B00DDBF77 /* UserDefaultsType.swift */; };
 		FDAA167B2AC28E2F00DDBF77 /* SnodeRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA167A2AC28E2F00DDBF77 /* SnodeRequestSpec.swift */; };
 		FDAA167D2AC528A200DDBF77 /* Preferences+Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA167C2AC528A200DDBF77 /* Preferences+Sound.swift */; };
@@ -1990,12 +1991,12 @@
 		FD859EEF27BF207700510D0C /* SessionProtos.proto */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.protobuf; path = SessionProtos.proto; sourceTree = "<group>"; };
 		FD859EF027BF207C00510D0C /* WebSocketResources.proto */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.protobuf; path = WebSocketResources.proto; sourceTree = "<group>"; };
 		FD859EF127BF6BA200510D0C /* Data+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Utilities.swift"; sourceTree = "<group>"; };
-		FD860CBB2D6E7A9400BBE29C /* _024_FixBustedInteractionVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _024_FixBustedInteractionVariant.swift; sourceTree = "<group>"; };
-		FD860CBD2D6E7DA000BBE29C /* DeveloperSettingsViewModel+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeveloperSettingsViewModel+Testing.swift"; sourceTree = "<group>"; };
 		FD860CB32D668FD000BBE29C /* AppearanceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceViewModel.swift; sourceTree = "<group>"; };
 		FD860CB52D66913B00BBE29C /* ThemePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePreviewView.swift; sourceTree = "<group>"; };
 		FD860CB72D66BC9500BBE29C /* AppIconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconViewModel.swift; sourceTree = "<group>"; };
 		FD860CB92D66BF2300BBE29C /* AppIconGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconGridView.swift; sourceTree = "<group>"; };
+		FD860CBB2D6E7A9400BBE29C /* _024_FixBustedInteractionVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _024_FixBustedInteractionVariant.swift; sourceTree = "<group>"; };
+		FD860CBD2D6E7DA000BBE29C /* DeveloperSettingsViewModel+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeveloperSettingsViewModel+Testing.swift"; sourceTree = "<group>"; };
 		FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		FD87DCF928B74DB300AF0F98 /* ConversationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSettingsViewModel.swift; sourceTree = "<group>"; };
 		FD87DCFD28B7582C00AF0F98 /* BlockedContactsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedContactsViewModel.swift; sourceTree = "<group>"; };
@@ -2014,6 +2015,7 @@
 		FD9AECA42AAA9609009B3406 /* NotificationResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationResolution.swift; sourceTree = "<group>"; };
 		FD9DD2702A72516D00ECB68E /* TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestExtensions.swift; sourceTree = "<group>"; };
 		FDA335F42D911576007E0EB6 /* AnimatedImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedImageView.swift; sourceTree = "<group>"; };
+		FDA3B2832D9DEA8F007E0EB6 /* ExtensionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionHelper.swift; sourceTree = "<group>"; };
 		FDAA16752AC28A3B00DDBF77 /* UserDefaultsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsType.swift; sourceTree = "<group>"; };
 		FDAA167A2AC28E2F00DDBF77 /* SnodeRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnodeRequestSpec.swift; sourceTree = "<group>"; };
 		FDAA167C2AC528A200DDBF77 /* Preferences+Sound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preferences+Sound.swift"; sourceTree = "<group>"; };
@@ -3389,6 +3391,7 @@
 				C38EF309255B6DBE007E1867 /* DeviceSleepManager.swift */,
 				FD4C4E9B2B02E2A300C72199 /* DisplayPictureError.swift */,
 				FD2273072C353109004D8A6C /* DisplayPictureManager.swift */,
+				FDA3B2832D9DEA8F007E0EB6 /* ExtensionHelper.swift */,
 				C3BBE0C62554F1570050F1E3 /* FixedWidthInteger+BigEndian.swift */,
 				C3A71D0A2558989C0043A11F /* MessageWrapper.swift */,
 				C38EF2F5255B6DBC007E1867 /* OWSAudioPlayer.h */,
@@ -6269,6 +6272,7 @@
 				FDF8488029405994007DCAE5 /* HTTPQueryParam+OpenGroup.swift in Sources */,
 				FD09798527FD1A6500936362 /* ClosedGroupKeyPair.swift in Sources */,
 				FD245C632850664600B966DD /* Configuration.swift in Sources */,
+				FDA3B2842D9DEA95007E0EB6 /* ExtensionHelper.swift in Sources */,
 				FD2272FF2C352D8E004D8A6C /* LibSession+UserProfile.swift in Sources */,
 				FD5C7305284F0FF30029977D /* MessageReceiver+VisibleMessages.swift in Sources */,
 				FDB5DAE82A95D96C002C8721 /* MessageReceiver+Groups.swift in Sources */,

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -1850,7 +1850,8 @@ extension ConversationVC:
                                 successfullyAddedGroup: successfullyAddedGroup,
                                 roomToken: room,
                                 server: server,
-                                publicKey: publicKey
+                                publicKey: publicKey,
+                                joinedAt: TimeInterval(dependencies[cache: .snodeAPI].currentOffsetTimestampMs() / 1000)
                             )
                         }
                         .subscribe(on: DispatchQueue.global(qos: .userInitiated))

--- a/Session/Open Groups/JoinOpenGroupVC.swift
+++ b/Session/Open Groups/JoinOpenGroupVC.swift
@@ -221,7 +221,8 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
                         successfullyAddedGroup: successfullyAddedGroup,
                         roomToken: roomToken,
                         server: server,
-                        publicKey: publicKey
+                        publicKey: publicKey,
+                        joinedAt: TimeInterval(dependencies[cache: .snodeAPI].currentOffsetTimestampMs() / 1000)
                     )
                 }
                 .subscribe(on: DispatchQueue.global(qos: .userInitiated))

--- a/Session/Settings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettingsViewModel.swift
@@ -1116,7 +1116,7 @@ class DeveloperSettingsViewModel: SessionTableViewModel, NavigatableStateHolder,
     }
     
     private func copyDatabasePath() {
-        UIPasteboard.general.string = Storage.sharedDatabaseDirectoryPath
+        UIPasteboard.general.string = Storage.databaseDirectoryPath
         
         showToast(
             text: "copied".localized(),

--- a/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
+++ b/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
@@ -386,13 +386,10 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
                 let threadId: String = info["threadId"]
                 let pinnedPriority: Int32? = allThreads[threadId]?["pinnedPriority"]
                 
-                return LibSession.CommunityInfo(
-                    urlInfo: LibSession.OpenGroupUrlInfo(
-                        threadId: threadId,
-                        server: info["server"],
-                        roomToken: info["roomToken"],
-                        publicKey: info["publicKey"]
-                    ),
+                return LibSession.CommunityUpdateInfo(
+                    server: info["server"],
+                    roomToken: info["roomToken"],
+                    publicKey: info["publicKey"],
                     priority: (pinnedPriority ?? 0)
                 )
             },

--- a/SessionMessagingKit/Jobs/ConfigurationSyncJob.swift
+++ b/SessionMessagingKit/Jobs/ConfigurationSyncJob.swift
@@ -239,7 +239,10 @@ public enum ConfigurationSyncJob: JobExecutor {
                     // Lastly we need to save the updated dumps to the database
                     let updatedJob: Job? = dependencies[singleton: .storage].write { db in
                         // Save the updated dumps to the database
-                        try configDumps.forEach { try $0.upsert(db) }
+                        try configDumps.forEach { dump in
+                            try dump.upsert(db)
+                            Task { dependencies[singleton: .extensionHelper].replicate(dump: dump) }
+                        }
                         
                         // When we complete the 'ConfigurationSync' job we want to immediately schedule
                         // another one with a 'nextRunTimestamp' set to the 'maxRunFrequency' value to

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -44,7 +44,7 @@ internal extension LibSessionCacheType {
         // The current users contact data is handled separately so exclude it if it's present (as that's
         // actually a bug)
         let userSessionId: SessionId = dependencies[cache: .general].sessionId
-        let targetContactData: [String: ContactData] = try LibSession.extractContacts(
+        let targetContactData: [String: LibSession.ContactData] = try LibSession.extractContacts(
             from: conf,
             serverTimestampMs: serverTimestampMs,
             using: dependencies
@@ -761,18 +761,20 @@ extension LibSession {
 
 // MARK: - ContactData
 
-private struct ContactData {
-    let contact: Contact
-    let profile: Profile
-    let config: DisappearingMessagesConfiguration
-    let priority: Int32
-    let created: TimeInterval
+extension LibSession {
+    internal struct ContactData {
+        let contact: Contact
+        let profile: Profile
+        let config: DisappearingMessagesConfiguration
+        let priority: Int32
+        let created: TimeInterval
+    }
 }
 
 // MARK: - Convenience
 
-private extension LibSession {
-    static func extractContacts(
+extension LibSession {
+    internal static func extractContacts(
         from conf: UnsafeMutablePointer<config_object>?,
         serverTimestampMs: Int64,
         using dependencies: Dependencies

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
@@ -140,10 +140,12 @@ internal extension LibSession {
                         try cache.performAndPushChange(db, for: .userGroups, sessionId: userSessionId) { config in
                             try LibSession.upsert(
                                 communities: threads
-                                    .compactMap { thread -> CommunityInfo? in
+                                    .compactMap { thread -> CommunityUpdateInfo? in
                                         urlInfo[thread.id].map { urlInfo in
-                                            CommunityInfo(
-                                                urlInfo: urlInfo,
+                                            CommunityUpdateInfo(
+                                                server: urlInfo.server,
+                                                roomToken: urlInfo.roomToken,
+                                                publicKey: urlInfo.publicKey,
                                                 priority: thread.pinnedPriority
                                                     .map { Int32($0 == 0 ? LibSession.visiblePriority : max($0, 1)) }
                                                     .defaulting(to: LibSession.visiblePriority)

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
@@ -314,12 +314,14 @@ internal extension LibSession {
         // Create and save dumps for the configs
         try dependencies.mutate(cache: .libSession) { cache in
             try groupState.forEach { variant, config in
-                try cache.createDump(
+                let dump: ConfigDump? = try cache.createDump(
                     config: config,
                     for: variant,
                     sessionId: SessionId(.group, hex: group.id),
                     timestampMs: Int64(floor(group.formationTimestamp * 1000))
-                )?.upsert(db)
+                )
+                try dump?.upsert(db)
+                Task { dependencies[singleton: .extensionHelper].replicate(dump: dump) }
             }
         }
         

--- a/SessionMessagingKit/LibSession/Database/QueryInterfaceRequest+Utilities.swift
+++ b/SessionMessagingKit/LibSession/Database/QueryInterfaceRequest+Utilities.swift
@@ -126,6 +126,9 @@ public extension QueryInterfaceRequest where RowDecoder: FetchableRecord & Table
                 try LibSession.updatingGroups(db, updatedData, using: dependencies)
                 return try LibSession.updatingGroupInfo(db, updatedData, using: dependencies)
                 
+            case is QueryInterfaceRequest<OpenGroup>:
+                return try LibSession.updatingCommunities(db, updatedData, using: dependencies)
+                
             case is QueryInterfaceRequest<GroupMember>:
                 return try LibSession.updatingGroupMembers(db, updatedData, using: dependencies)
                 

--- a/SessionMessagingKit/Open Groups/OpenGroupManager.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupManager.swift
@@ -214,7 +214,8 @@ public final class OpenGroupManager {
         successfullyAddedGroup: Bool,
         roomToken: String,
         server: String,
-        publicKey: String
+        publicKey: String,
+        joinedAt: TimeInterval
     ) -> AnyPublisher<Void, Error> {
         // Only bother performing the initial request if the network isn't suspended
         guard
@@ -253,6 +254,8 @@ public final class OpenGroupManager {
                     server: server,
                     rootToken: roomToken,
                     publicKey: publicKey,
+                    name: response.value.room.data.name,
+                    joinedAt: joinedAt,
                     using: dependencies
                 )
                 

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
@@ -10,7 +10,9 @@ import SessionUtilitiesKit
 
 // MARK: - KeychainStorage
 
-public extension KeychainStorage.DataKey { static let pushNotificationEncryptionKey: Self = "PNEncryptionKeyKey" }
+public extension KeychainStorage.DataKey {
+    static let pushNotificationEncryptionKey: Self = "PNEncryptionKeyKey"
+}
 
 // MARK: - Log.Category
 
@@ -216,9 +218,15 @@ public enum PushNotificationAPI {
             throw NetworkError.invalidPreparedRequest
         }
         
-        guard let notificationsEncryptionKey: Data = try? getOrGenerateEncryptionKey(using: dependencies) else {
+        guard let notificationsEncryptionKey: Data = try? dependencies[singleton: .keychain].getOrGenerateEncryptionKey(
+            forKey: .pushNotificationEncryptionKey,
+            length: encryptionKeyLength,
+            cat: .cat,
+            legacyKey: "PNEncryptionKeyKey",
+            legacyService: "PNKeyChainService"
+        ) else {
             Log.error(.cat, "Unable to retrieve PN encryption key.")
-            throw StorageError.invalidKeySpec
+            throw KeychainStorageError.keySpecInvalid
         }
         
         return try Network.PreparedRequest(
@@ -482,7 +490,13 @@ public enum PushNotificationAPI {
         // Decrypt and decode the payload
         guard
             let encryptedData: Data = Data(base64Encoded: base64EncodedEncString),
-            let notificationsEncryptionKey: Data = try? getOrGenerateEncryptionKey(using: dependencies),
+            let notificationsEncryptionKey: Data = try? dependencies[singleton: .keychain].getOrGenerateEncryptionKey(
+                forKey: .pushNotificationEncryptionKey,
+                length: encryptionKeyLength,
+                cat: .cat,
+                legacyKey: "PNEncryptionKeyKey",
+                legacyService: "PNKeyChainService"
+            ),
             let decryptedData: Data = dependencies[singleton: .crypto].generate(
                 .plaintextWithPushNotificationPayload(
                     payload: encryptedData,
@@ -512,55 +526,5 @@ public enum PushNotificationAPI {
         
         // Success, we have the notification content
         return (notificationData, notification.info, .success)
-    }
-                        
-    // MARK: - Security
-    
-    @discardableResult private static func getOrGenerateEncryptionKey(using dependencies: Dependencies) throws -> Data {
-        do {
-            try dependencies[singleton: .keychain].migrateLegacyKeyIfNeeded(
-                legacyKey: "PNEncryptionKeyKey",
-                legacyService: "PNKeyChainService",
-                toKey: .pushNotificationEncryptionKey
-            )
-            var encryptionKey: Data = try dependencies[singleton: .keychain].data(forKey: .pushNotificationEncryptionKey)
-            defer { encryptionKey.resetBytes(in: 0..<encryptionKey.count) }
-            
-            guard encryptionKey.count == encryptionKeyLength else { throw StorageError.invalidKeySpec }
-            
-            return encryptionKey
-        }
-        catch {
-            switch (error, (error as? KeychainStorageError)?.code) {
-                case (StorageError.invalidKeySpec, _), (_, errSecItemNotFound):
-                    // No keySpec was found so we need to generate a new one
-                    do {
-                        var keySpec: Data = try dependencies[singleton: .crypto]
-                            .tryGenerate(.randomBytes(encryptionKeyLength))
-                        defer { keySpec.resetBytes(in: 0..<keySpec.count) } // Reset content immediately after use
-                        
-                        try dependencies[singleton: .keychain].set(data: keySpec, forKey: .pushNotificationEncryptionKey)
-                        return keySpec
-                    }
-                    catch {
-                        Log.error(.cat, "Setting keychain value failed with error: \(error.localizedDescription)")
-                        throw StorageError.keySpecCreationFailed
-                    }
-                    
-                default:
-                    // Because we use kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, the keychain will be inaccessible
-                    // after device restart until device is unlocked for the first time. If the app receives a push
-                    // notification, we won't be able to access the keychain to process that notification, so we should
-                    // just terminate by throwing an uncaught exception
-                    if dependencies[singleton: .appContext].isMainApp || dependencies[singleton: .appContext].isInBackground {
-                        let appState: UIApplication.State = dependencies[singleton: .appContext].reportedApplicationState
-                        Log.error(.cat, "CipherKeySpec inaccessible. New install or no unlock since device restart?, ApplicationState: \(appState.name)")
-                        throw StorageError.keySpecInaccessible
-                    }
-                    
-                    Log.error(.cat, "CipherKeySpec inaccessible; not main app.")
-                    throw StorageError.keySpecInaccessible
-            }
-        }
     }
 }

--- a/SessionMessagingKit/Shared Models/SessionThreadViewModel.swift
+++ b/SessionMessagingKit/Shared Models/SessionThreadViewModel.swift
@@ -459,30 +459,39 @@ public extension SessionThreadViewModel {
     static let invalidId: String = "INVALID_THREAD_ID"
     static let messageRequestsSectionId: String = "MESSAGE_REQUESTS_SECTION_INVALID_THREAD_ID"
     
-    // Note: This init method is only used system-created cells or empty states
     init(
         threadId: String,
         threadVariant: SessionThread.Variant? = nil,
+        threadCreationDateTimestamp: TimeInterval = 0,
         threadIsNoteToSelf: Bool = false,
         threadIsMessageRequest: Bool? = nil,
+        threadPinnedPriority: Int32 = 0,
         threadIsBlocked: Bool? = nil,
+        displayPictureFilename: String? = nil,
         contactProfile: Profile? = nil,
+        closedGroupProfileFront: Profile? = nil,
+        closedGroupProfileBack: Profile? = nil,
+        closedGroupProfileBackFallback: Profile? = nil,
         closedGroupAdminProfile: Profile? = nil,
+        closedGroupName: String? = nil,
         closedGroupExpired: Bool? = nil,
         currentUserIsClosedGroupMember: Bool? = nil,
         currentUserIsClosedGroupAdmin: Bool? = nil,
+        openGroupName: String? = nil,
         openGroupPermissions: OpenGroup.Permissions? = nil,
         threadWasMarkedUnread: Bool? = nil,
         unreadCount: UInt = 0,
         hasUnreadMessagesOfAnyKind: Bool = false,
         threadCanWrite: Bool = true,
         disappearingMessagesConfiguration: DisappearingMessagesConfiguration? = nil,
+        wasKickedFromGroup: Bool = false,
+        groupIsDestroyed: Bool = false,
         using dependencies: Dependencies
     ) {
         self.rowId = -1
         self.threadId = threadId
         self.threadVariant = (threadVariant ?? .contact)
-        self.threadCreationDateTimestamp = 0
+        self.threadCreationDateTimestamp = threadCreationDateTimestamp
         self.threadMemberNames = nil
         
         self.threadIsNoteToSelf = threadIsNoteToSelf
@@ -490,7 +499,7 @@ public extension SessionThreadViewModel {
         self.threadIsMessageRequest = threadIsMessageRequest
         self.threadRequiresApproval = false
         self.threadShouldBeVisible = false
-        self.threadPinnedPriority = 0
+        self.threadPinnedPriority = threadPinnedPriority
         self.threadIsBlocked = threadIsBlocked
         self.threadMutedUntilTimestamp = nil
         self.threadOnlyNotifyForMentions = nil
@@ -509,19 +518,19 @@ public extension SessionThreadViewModel {
         self.disappearingMessagesConfiguration = disappearingMessagesConfiguration
         
         self.contactLastKnownClientVersion = nil
-        self.displayPictureFilename = nil
+        self.displayPictureFilename = displayPictureFilename
         self.contactProfile = contactProfile
-        self.closedGroupProfileFront = nil
-        self.closedGroupProfileBack = nil
-        self.closedGroupProfileBackFallback = nil
+        self.closedGroupProfileFront = closedGroupProfileFront
+        self.closedGroupProfileBack = closedGroupProfileBack
+        self.closedGroupProfileBackFallback = closedGroupProfileBackFallback
         self.closedGroupAdminProfile = closedGroupAdminProfile
-        self.closedGroupName = nil
+        self.closedGroupName = closedGroupName
         self.closedGroupDescription = nil
         self.closedGroupUserCount = nil
         self.closedGroupExpired = closedGroupExpired
         self.currentUserIsClosedGroupMember = currentUserIsClosedGroupMember
         self.currentUserIsClosedGroupAdmin = currentUserIsClosedGroupAdmin
-        self.openGroupName = nil
+        self.openGroupName = openGroupName
         self.openGroupDescription = nil
         self.openGroupServer = nil
         self.openGroupRoomToken = nil
@@ -548,8 +557,8 @@ public extension SessionThreadViewModel {
         self.currentUserBlinded15SessionId = nil
         self.currentUserBlinded25SessionId = nil
         self.recentReactionEmoji = nil
-        self.wasKickedFromGroup = false
-        self.groupIsDestroyed = false
+        self.wasKickedFromGroup = wasKickedFromGroup
+        self.groupIsDestroyed = groupIsDestroyed
     }
 }
 

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -1,0 +1,340 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import GRDB
+import SessionUtilitiesKit
+
+// MARK: - Singleton
+
+public extension Singleton {
+    static let extensionHelper: SingletonConfig<ExtensionHelper> = Dependencies.create(
+        identifier: "extensionHelper",
+        createInstance: { dependencies in ExtensionHelper(using: dependencies) }
+    )
+}
+
+// MARK: - KeychainStorage
+
+// stringlint:ignore_contents
+public extension KeychainStorage.DataKey {
+    static let extensionEncryptionKey: Self = "ExtensionEncryptionKeyKey"
+}
+
+// MARK: - Log.Category
+
+private extension Log.Category {
+    static let cat: Log.Category = .create("ExtensionHelper", defaultLevel: .info)
+}
+
+// MARK: - ExtensionHelper
+
+public class ExtensionHelper {
+    public static var sharedExtensionCacheDirectoryPath: String { "\(SessionFileManager.nonInjectedAppSharedDataDirectoryPath)/extensionCache" }
+    private static var metadataPath: String { "\(ExtensionHelper.sharedExtensionCacheDirectoryPath)/metadata" }
+    private static func dumpFilePath(_ hash: [UInt8]) -> String {
+        return "\(ExtensionHelper.sharedExtensionCacheDirectoryPath)/\(hash.toHexString())"
+    }
+    private let encryptionKeyLength: Int = 32
+    
+    private let dependencies: Dependencies
+    
+    // MARK: - Initialization
+    
+    init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+    }
+    
+    // MARK: - User Metadata
+    
+    public func saveUserMetadataIfNeeded(sessionId: SessionId, ed25519SecretKey: [UInt8]) {
+        /// Create the `UserMetadata` if needed
+        guard !dependencies[singleton: .fileManager].fileExists(atPath: ExtensionHelper.metadataPath) else {
+            return
+        }
+        
+        saveUserMetadata(
+            sessionId: sessionId,
+            ed25519SecretKey: ed25519SecretKey
+        )
+    }
+    
+    public func saveUserMetadata(sessionId: SessionId, ed25519SecretKey: [UInt8]) {
+        let metadata: UserMetadata = UserMetadata(
+            sessionId: sessionId,
+            ed25519SecretKey: ed25519SecretKey
+        )
+        
+        /// Load in the data and `encKey` and reset the `encKey` as soon as the function ends
+        guard
+            let metadataAsData: Data = try? JSONEncoder(using: dependencies).encode(metadata),
+            var encKey: [UInt8] = (try? dependencies[singleton: .keychain]
+                .getOrGenerateEncryptionKey(
+                    forKey: .extensionEncryptionKey,
+                    length: encryptionKeyLength,
+                    cat: .cat
+                )).map({ Array($0) })
+        else { return }
+        defer { encKey.resetBytes(in: 0..<encKey.count) }
+        
+        guard
+            let ciphertext: Data = dependencies[singleton: .crypto].generate(
+                .ciphertextWithXChaCha20(
+                    plaintext: metadataAsData,
+                    encKey: encKey
+                )
+            )
+        else { return }
+        
+        let plain: Data? = dependencies[singleton: .crypto].generate(
+            .plaintextWithXChaCha20(
+                ciphertext: ciphertext,
+                encKey: encKey
+            )
+        )
+        
+        /// Ensure the directory exists
+        try? dependencies[singleton: .fileManager]
+            .ensureDirectoryExists(at: ExtensionHelper.sharedExtensionCacheDirectoryPath)
+        try? dependencies[singleton: .fileManager]
+            .protectFileOrFolder(at: ExtensionHelper.sharedExtensionCacheDirectoryPath)
+        
+        /// Write the encrypted data to a temporary file, remove the old one and move it from the temp file to the final location
+        try? dependencies[singleton: .fileManager].removeItem(atPath: "\(ExtensionHelper.metadataPath)-new")
+        try? ciphertext.write(to: URL(fileURLWithPath: "\(ExtensionHelper.metadataPath)-new"))
+        try? dependencies[singleton: .fileManager].removeItem(atPath: ExtensionHelper.metadataPath)
+        try? dependencies[singleton: .fileManager].moveItem(
+            atPath: "\(ExtensionHelper.metadataPath)-new",
+            toPath: ExtensionHelper.metadataPath
+        )
+    }
+    
+    public func loadUserMetadata() -> UserMetadata? {
+        /// Load in the data and `encKey` and reset the `encKey` as soon as the function ends
+        guard
+            let ciphertext: Data = dependencies[singleton: .fileManager]
+                .contents(atPath: ExtensionHelper.metadataPath),
+            var encKey: [UInt8] = (try? dependencies[singleton: .keychain]
+                .getOrGenerateEncryptionKey(
+                    forKey: .extensionEncryptionKey,
+                    length: encryptionKeyLength,
+                    cat: .cat
+                )).map({ Array($0) })
+        else { return nil }
+        defer { encKey.resetBytes(in: 0..<encKey.count) }
+
+        guard
+            let plaintext: Data = dependencies[singleton: .crypto].generate(
+                .plaintextWithXChaCha20(
+                    ciphertext: ciphertext,
+                    encKey: encKey
+                )
+            )
+        else { return nil }
+        
+        return try? JSONDecoder(using: dependencies)
+            .decode(UserMetadata.self, from: plaintext)
+    }
+    
+    
+    // TODO: [DATABASE REFACTOR] Encrypt/Decrypt functions for files
+    
+    // TODO: [DATABASE REFACTOR] Write metadata to file in AppGroup
+    // TODO: [DATABASE REFACTOR] Load in metadata from file in AppGroup
+    // TODO: [DATABASE REFACTOR] Update config dumps in PN Extension (in case app doesn't get opened for a while)
+    // TODO: [DATABASE REFACTOR] Write message data to files in AppGroup
+    // TODO: [DATABASE REFACTOR] Read message data from files in AppGroup
+    // TODO: [DATABASE REFACTOR] Update share extension to send messages but not save to the database
+    // TODO: [DATABASE REFACTOR] Process message solely for notification purposes
+    
+    
+    // TODO: [DATABASE REFACTOR] LibSession Changes
+        // TODO: Add local_path to "profile_pic" and store locally in userProfile, contacts, userGroups, groupInfo, groupMembers.member config dumps
+        // TODO: Add community.name in local userGroup config dump
+        // TODO: Add community.permissions in local userGroup config dump
+        // TODO: Need to make sure we are syncing the 'joinedAt' for communities
+        // TODO: Need to start syncing the notification settings
+        // TODO: Need to add a new synced 'active_at' timestamp to the ConvoInfoVolatile config
+            // TODO: Update on:
+                // TODO: Create (or join) a conversation
+                // TODO: Receive a message (regardless of reading/deleting/disappearing)
+                // TODO: Sending a message or control message (but not a reaction)
+                // TODO: Unblock a contact
+                // TODO: Accepting a message request
+                // TODO: When unblinding a conversation (max value)
+    
+    // TODO: [DATABASE REFACTOR] Add support for blinded outgoing conversations? (in userGroups? contacts?)
+    
+    // MARK: - Config Dumps
+    
+    private func hash(for sessionId: SessionId, variant: ConfigDump.Variant) -> [UInt8]? {
+        return "\(sessionId.hexString)-\(variant)".data(using: .utf8).map { dataToHash in
+            dependencies[singleton: .crypto].generate(
+                .hash(message: Array(dataToHash))
+            )
+        }
+    }
+    
+    public func loadConfigState(
+        into cache: LibSession.Cache,
+        for sessionId: SessionId,
+        userSessionId: SessionId,
+        userEd25519SecretKey: [UInt8]
+    ) {
+        /// Load in the data and `encKey` and reset the `encKey` as soon as the function ends
+        guard
+            var encKey: [UInt8] = (try? dependencies[singleton: .keychain]
+                .getOrGenerateEncryptionKey(
+                    forKey: .extensionEncryptionKey,
+                    length: encryptionKeyLength,
+                    cat: .cat
+                )).map({ Array($0) })
+        else { return }
+        defer { encKey.resetBytes(in: 0..<encKey.count) }
+        
+        /// We always need to load the User Config states even if we want to load the config for a group (because they store the group
+        /// secret key if the user is an admin)
+        ConfigDump.Variant.userVariants
+            .sorted { $0.loadOrder < $1.loadOrder }
+            .forEach { variant in
+                guard
+                    let hash: [UInt8] = hash(for: userSessionId, variant: variant),
+                    let ciphertext: Data = dependencies[singleton: .fileManager].contents(
+                        atPath: "\(ExtensionHelper.dumpFilePath(hash))"
+                    ),
+                    let plaintext: Data = dependencies[singleton: .crypto].generate(
+                        .plaintextWithXChaCha20(
+                            ciphertext: ciphertext,
+                            encKey: encKey
+                        )
+                    ),
+                    let config: LibSession.Config = try? cache.loadState(
+                        for: variant,
+                        sessionId: userSessionId,
+                        userEd25519SecretKey: userEd25519SecretKey,
+                        groupEd25519SecretKey: nil,
+                        cachedData: plaintext
+                    )
+                else {
+                    /// If a file doesn't exist at the path then assume we don't have a config dump and just load in a default one
+                    return cache.loadDefaultStateFor(
+                        variant: variant,
+                        sessionId: userSessionId,
+                        userEd25519SecretKey: userEd25519SecretKey,
+                        groupEd25519SecretKey: nil
+                    )
+                }
+                
+                cache.setConfig(for: variant, sessionId: userSessionId, to: config)
+            }
+        
+        /// If we only care about the user configs then we can stop here
+        guard sessionId != userSessionId else { return }
+        
+        // TODO: [DATABASE REFACTOR] Load the config state for the desired group
+    }
+    
+    public func replicate(dump: ConfigDump?, replaceExisting: Bool = true) {
+        /// Load in the data and `encKey` and reset the `encKey` as soon as the function ends
+        guard
+            let dump: ConfigDump = dump,
+            let hash: [UInt8] = hash(for: dump.sessionId, variant: dump.variant),
+            var encKey: [UInt8] = (try? dependencies[singleton: .keychain]
+                .getOrGenerateEncryptionKey(
+                    forKey: .extensionEncryptionKey,
+                    length: encryptionKeyLength,
+                    cat: .cat
+                )).map({ Array($0) })
+        else { return }
+        defer { encKey.resetBytes(in: 0..<encKey.count) }
+        
+        /// Only continue if we want to replace an existing dump, or one doesn't exist
+        guard
+            replaceExisting ||
+            !dependencies[singleton: .fileManager].fileExists(
+                atPath: "\(ExtensionHelper.dumpFilePath(hash))"
+            )
+        else { return }
+        
+        /// Ensure the directory exists
+        try? dependencies[singleton: .fileManager]
+            .ensureDirectoryExists(at: ExtensionHelper.sharedExtensionCacheDirectoryPath)
+        try? dependencies[singleton: .fileManager]
+            .protectFileOrFolder(at: ExtensionHelper.sharedExtensionCacheDirectoryPath)
+        
+        /// Generate the `ciphertext` and save it to the `AppGroup`
+        do {
+            let ciphertext: Data = try dependencies[singleton: .crypto].tryGenerate(
+                .ciphertextWithXChaCha20(
+                    plaintext: dump.data,
+                    encKey: encKey
+                )
+            )
+            
+            try? dependencies[singleton: .fileManager].removeItem(
+                atPath: "\(ExtensionHelper.dumpFilePath(hash))-new"
+            )
+            try ciphertext.write(to: URL(fileURLWithPath: "\(ExtensionHelper.dumpFilePath(hash))-new"))
+            try? dependencies[singleton: .fileManager].removeItem(
+                atPath: "\(ExtensionHelper.dumpFilePath(hash))"
+            )
+            try dependencies[singleton: .fileManager].moveItem(
+                atPath: "\(ExtensionHelper.dumpFilePath(hash))-new",
+                toPath: "\(ExtensionHelper.dumpFilePath(hash))"
+            )
+        }
+        catch { Log.error(.cat, "Failed to replicate \(dump.variant) dump for \(dump.sessionId.hexString).") }
+    }
+    
+    // MARK: - Initial Database Location Migration
+
+    public func migrateDatabaseToMainAppIfNeeded() throws {
+        let sharedDatabaseDirectoryPath: String = "\(SessionFileManager.nonInjectedAppSharedDataDirectoryPath)/database"
+        
+        /// No need to move the database if it's already been moved
+        guard dependencies[singleton: .fileManager].fileExists(atPath: sharedDatabaseDirectoryPath) else {
+            return
+        }
+        
+        /// Move the database directory from the `AppGroup` to the local documents directory
+        do {
+            try dependencies[singleton: .fileManager]
+                .moveItem(atPath: sharedDatabaseDirectoryPath, toPath: Storage.databaseDirectoryPath)
+        }
+        catch {
+            Log.critical("Failed to migrate database file: \(error)")
+            throw error
+        }
+    }
+    
+    public func replicateAllConfigDumpsIfNeeded(userSessionId: SessionId) {
+        /// We can be reasonably sure that if the `userProfile` config dump is missing then we probably haven't replicated any
+        /// config dumps yet and should do so
+        guard
+            let hash: [UInt8] = hash(for: userSessionId, variant: .userProfile),
+            !dependencies[singleton: .fileManager].fileExists(
+                atPath: "\(ExtensionHelper.dumpFilePath(hash))"
+            )
+        else { return }
+        
+        /// Load the config dumps from the database
+        let dumps: [ConfigDump] = dependencies[singleton: .storage]
+            .read { db in try ConfigDump.fetchAll(db) }
+            .defaulting(to: [])
+        
+        /// Persist each dump to disk (if there isn't already one there)
+        ///
+        /// **Note:** Because it's likely that this function runs in the background it's possible that another thread could trigger
+        /// a config update which would result in the dump getting replicated - if that occurs then we don't want to override what
+        /// is likely a newer dump
+        dumps.forEach { dump in replicate(dump: dump, replaceExisting: false) }
+    }
+}
+
+// MARK: - ExtensionHelper.UserMetadata
+
+public extension ExtensionHelper {
+    struct UserMetadata: Codable {
+        public let sessionId: SessionId
+        public let ed25519SecretKey: [UInt8]
+    }
+}

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -20,10 +20,10 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
     func loadDefaultStateFor(
         variant: ConfigDump.Variant,
         sessionId: SessionId,
-        userEd25519KeyPair: KeyPair,
+        userEd25519SecretKey: [UInt8],
         groupEd25519SecretKey: [UInt8]?
     ) {
-        mockNoReturn(args: [variant, sessionId, userEd25519KeyPair, groupEd25519SecretKey])
+        mockNoReturn(args: [variant, sessionId, userEd25519SecretKey, groupEd25519SecretKey])
     }
     
     func hasConfig(for variant: ConfigDump.Variant, sessionId: SessionId) -> Bool {

--- a/SessionShareExtension/SAEScreenLockViewController.swift
+++ b/SessionShareExtension/SAEScreenLockViewController.swift
@@ -9,11 +9,14 @@ final class SAEScreenLockViewController: ScreenLockViewController {
     private var hasShownAuthUIOnce: Bool = false
     private var isShowingAuthUI: Bool = false
     
+    private let hasUserMetadata: Bool
     private weak var shareViewDelegate: ShareViewDelegate?
     
     // MARK: - Initialization
     
-    init(shareViewDelegate: ShareViewDelegate) {
+    init(hasUserMetadata: Bool, shareViewDelegate: ShareViewDelegate) {
+        self.hasUserMetadata = hasUserMetadata
+        
         super.init()
         
         self.onUnlockPressed = { [weak self] in self?.unlockButtonWasTapped() }
@@ -108,12 +111,12 @@ final class SAEScreenLockViewController: ScreenLockViewController {
         isShowingAuthUI = true
         
         ScreenLock.tryToUnlockScreenLock(
-            success: { [weak self] in
+            success: { [weak self, hasUserMetadata] in
                 Log.assertOnMainThread()
                 Log.info("unlock screen lock succeeded.")
                 
                 self?.isShowingAuthUI = false
-                self?.shareViewDelegate?.shareViewWasUnlocked()
+                self?.shareViewDelegate?.shareViewWasUnlocked(hasUserMetadata: hasUserMetadata)
             },
             failure: { [weak self] error in
                 Log.assertOnMainThread()

--- a/SessionShareExtension/ThreadPickerViewModel.swift
+++ b/SessionShareExtension/ThreadPickerViewModel.swift
@@ -1,6 +1,7 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
 
 import Foundation
+import Combine
 import GRDB
 import DifferenceKit
 import SignalUtilitiesKit
@@ -21,55 +22,20 @@ public class ThreadPickerViewModel {
     /// This value is the current state of the view
     public private(set) var viewData: [SessionThreadViewModel] = []
     
-    /// This is all the data the screen needs to populate itself, please see the following link for tips to help optimise
-    /// performance https://github.com/groue/GRDB.swift#valueobservation-performance
-    ///
-    /// **Note:** The 'trackingConstantRegion' is optimised in such a way that the request needs to be static
-    /// otherwise there may be situations where it doesn't get updates, this means we can't have conditional queries
-    ///
-    /// **Note:** This observation will be triggered twice immediately (and be de-duped by the `removeDuplicates`)
-    /// this is due to the behaviour of `ValueConcurrentObserver.asyncStartObservation` which triggers it's own
-    /// fetch (after the ones in `ValueConcurrentObserver.asyncStart`/`ValueConcurrentObserver.syncStart`)
-    /// just in case the database has changed between the two reads - unfortunately it doesn't look like there is a way to prevent this
-    public lazy var observableViewData = ValueObservation
-        .trackingConstantRegion { [dependencies] db -> [SessionThreadViewModel] in
-            let userSessionId: SessionId = dependencies[cache: .general].sessionId
-            
-            return try SessionThreadViewModel
-                .shareQuery(userSessionId: userSessionId)
-                .fetchAll(db)
-                .map { threadViewModel in
-                    let wasKickedFromGroup: Bool = (
-                        threadViewModel.threadVariant == .group &&
-                        LibSession.wasKickedFromGroup(
-                            groupSessionId: SessionId(.group, hex: threadViewModel.threadId),
-                            using: dependencies
-                        )
-                    )
-                    let groupIsDestroyed: Bool = (
-                        threadViewModel.threadVariant == .group &&
-                        LibSession.groupIsDestroyed(
-                            groupSessionId: SessionId(.group, hex: threadViewModel.threadId),
-                            using: dependencies
-                        )
-                    )
-                    
-                    return threadViewModel.populatingPostQueryData(
-                        db,
-                        currentUserBlinded15SessionIdForThisThread: nil,
-                        currentUserBlinded25SessionIdForThisThread: nil,
-                        wasKickedFromGroup: wasKickedFromGroup,
-                        groupIsDestroyed: groupIsDestroyed,
-                        threadCanWrite: threadViewModel.determineInitialCanWriteFlag(using: dependencies),
-                        using: dependencies
-                    )
+    public lazy var observableViewData: AnyPublisher<([SessionThreadViewModel], StagedChangeset<[SessionThreadViewModel]>), Never> = dependencies[cache: .libSession].conversations
+        .map { conversations -> [SessionThreadViewModel] in
+            conversations
+                .filter {
+                    $0.threadIsBlocked == false &&  // Exclude blocked threads
+                    $0.threadCanWrite == true       // Exclude unwritable threads
                 }
         }
-        .map { [dependencies] threads -> [SessionThreadViewModel] in
-            threads.filter { $0.threadCanWrite == true }   // Exclude unwritable threads
-        }
         .removeDuplicates()
-        .handleEvents(didFail: { Log.error("Observation failed with error: \($0)") })
+        .withPrevious([])
+        .map { (previous: [SessionThreadViewModel], current: [SessionThreadViewModel]) in
+            (current, StagedChangeset(source: current, target: previous))
+        }
+        .eraseToAnyPublisher()
     
     // MARK: - Functions
     

--- a/SessionUtilitiesKit/Database/StorageError.swift
+++ b/SessionUtilitiesKit/Database/StorageError.swift
@@ -9,11 +9,9 @@ public enum StorageError: Error {
     case startupFailed
     case migrationFailed
     case migrationNoLongerSupported
-    case invalidKeySpec
-    case keySpecCreationFailed
-    case keySpecInaccessible
     case decodingFailed
     case invalidQueryResult
+    case fileMigrationFailed
     
     /// This error is thrown when a synchronous operation takes longer than `Storage.transactionDeadlockTimeoutSeconds`,
     /// the assumption being that if we know an operation is going to take a long time then we should probably be handling it asynchronously

--- a/SessionUtilitiesKit/General/SessionId.swift
+++ b/SessionUtilitiesKit/General/SessionId.swift
@@ -2,11 +2,11 @@
 
 import Foundation
 
-public struct SessionId: Equatable, Hashable, CustomStringConvertible {
+public struct SessionId: Codable, Equatable, Hashable, CustomStringConvertible {
     public static let byteCount: Int = 33
     public static let invalid: SessionId = SessionId(.standard, publicKey: [])
     
-    public enum Prefix: String, CaseIterable, Hashable {
+    public enum Prefix: String, Codable, CaseIterable, Hashable {
         case standard = "05"    // Used for identified users, open groups, etc.
         case blinded15 = "15"   // Used for authentication and participants in open groups with blinding enabled
         case blinded25 = "25"   // Used for authentication and participants in open groups with blinding enabled

--- a/SessionUtilitiesKit/LibSession/LibSessionError.swift
+++ b/SessionUtilitiesKit/LibSession/LibSessionError.swift
@@ -20,6 +20,7 @@ public enum LibSessionError: Error, CustomStringConvertible {
     case invalidCConversion
     case unableToGeneratePushData
     case attemptedToModifyGroupWithoutAdminKey
+    case missingUserConfig
     
     case libSessionError(String)
     
@@ -132,6 +133,7 @@ public enum LibSessionError: Error, CustomStringConvertible {
             case .unableToGeneratePushData: return "Unable to generate push data (LibSessionError.unableToGeneratePushData)."
             case .attemptedToModifyGroupWithoutAdminKey:
                 return "Attempted to modify group without admin key (LibSessionError.attemptedToModifyGroupWithoutAdminKey)."
+            case .missingUserConfig: return "Missing user config (LibSessionError.missingUserConfig)."
             
             case .libSessionError(let error): return "\(error)"
         }

--- a/SessionUtilitiesKit/Types/FileManager.swift
+++ b/SessionUtilitiesKit/Types/FileManager.swift
@@ -53,6 +53,8 @@ public protocol FileManagerType {
     func createDirectory(atPath: String, withIntermediateDirectories: Bool, attributes: [FileAttributeKey: Any]?) throws
     func copyItem(atPath: String, toPath: String) throws
     func copyItem(at fromUrl: URL, to toUrl: URL) throws
+    func moveItem(atPath: String, toPath: String) throws
+    func moveItem(at fromUrl: URL, to toUrl: URL) throws
     func removeItem(atPath: String) throws
     
     func attributesOfItem(atPath path: String) throws -> [FileAttributeKey: Any]
@@ -106,6 +108,10 @@ public extension FileManagerType {
 public extension SessionFileManager {
     static var cachesDirectoryPath: String {
         return NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)[0]
+    }
+    
+    static var documentDirectoryPath: String {
+        return NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
     }
     
     static var nonInjectedAppSharedDataDirectoryPath: String {
@@ -310,15 +316,23 @@ public class SessionFileManager: FileManagerType {
     }
     
     public func copyItem(atPath: String, toPath: String) throws {
-        return try fileManager.copyItem(atPath: atPath, toPath: toPath)
+        try fileManager.copyItem(atPath: atPath, toPath: toPath)
     }
     
     public func copyItem(at fromUrl: URL, to toUrl: URL) throws {
-        return try fileManager.copyItem(at: fromUrl, to: toUrl)
+        try fileManager.copyItem(at: fromUrl, to: toUrl)
+    }
+    
+    public func moveItem(atPath: String, toPath: String) throws {
+        try fileManager.moveItem(atPath: atPath, toPath: toPath)
+    }
+    
+    public func moveItem(at fromUrl: URL, to toUrl: URL) throws {
+        try fileManager.moveItem(at: fromUrl, to: toUrl)
     }
     
     public func removeItem(atPath: String) throws {
-        return try fileManager.removeItem(atPath: atPath)
+        try fileManager.removeItem(atPath: atPath)
     }
     
     public func attributesOfItem(atPath path: String) throws -> [FileAttributeKey: Any] {

--- a/SignalUtilitiesKit/Utilities/AppSetup.swift
+++ b/SignalUtilitiesKit/Utilities/AppSetup.swift
@@ -64,6 +64,16 @@ public enum AppSetup {
     ) {
         var backgroundTask: SessionBackgroundTask? = (backgroundTask ?? SessionBackgroundTask(label: #function, using: dependencies))
         
+        /// Migrate the database file from the `AppGroup` to the documents directory if we haven't already done so
+        do { try dependencies[singleton: .extensionHelper].migrateDatabaseToMainAppIfNeeded() }
+        catch {
+            dependencies.set(
+                singleton: .storage,
+                to: Storage.createInvalid(with: error, using: dependencies)
+            )
+        }
+        
+        /// Perform any database migrations
         dependencies[singleton: .storage].perform(
             migrationTargets: additionalMigrationTargets
                 .appending(contentsOf: [
@@ -75,11 +85,13 @@ public enum AppSetup {
             onComplete: { result in
                 // Now that the migrations are complete there are a few more states which need
                 // to be setup
-                dependencies[singleton: .storage].read { db in
+                typealias UserInfo = (sessionId: SessionId, ed25519SecretKey: [UInt8])
+                let maybeUserInfo: UserInfo? = dependencies[singleton: .storage].read { db -> UserInfo? in
                     guard
                         Identity.userExists(db, using: dependencies),
-                        let userKeyPair: KeyPair = Identity.fetchUserKeyPair(db)
-                    else { return }
+                        let userKeyPair: KeyPair = Identity.fetchUserKeyPair(db),
+                        let userEdKeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db)
+                    else { return nil }
                     
                     let userSessionId: SessionId = SessionId(.standard, publicKey: userKeyPair.publicKey)
                     
@@ -95,6 +107,22 @@ public enum AppSetup {
                     )
                     cache.loadState(db, requestId: requestId)
                     dependencies.set(cache: .libSession, to: cache)
+                    
+                    return (userSessionId, userEdKeyPair.secretKey)
+                }
+                
+                /// Save the `UserMetadata` and replicate `ConfigDump` data if needed
+                if let userInfo: UserInfo = maybeUserInfo {
+                    dependencies[singleton: .extensionHelper].saveUserMetadataIfNeeded(
+                        sessionId: userInfo.sessionId,
+                        ed25519SecretKey: userInfo.ed25519SecretKey
+                    )
+                    
+                    Task {
+                        dependencies[singleton: .extensionHelper].replicateAllConfigDumpsIfNeeded(
+                            userSessionId: userInfo.sessionId
+                        )
+                    }
                 }
                 
                 /// Ensure any recurring jobs are properly scheduled

--- a/SignalUtilitiesKit/Utilities/ShareViewDelegate.swift
+++ b/SignalUtilitiesKit/Utilities/ShareViewDelegate.swift
@@ -6,7 +6,7 @@ import Foundation
 // All Observer methods will be invoked from the main thread.
 @objc
 public protocol ShareViewDelegate: AnyObject {
-    func shareViewWasUnlocked()
+    func shareViewWasUnlocked(hasUserMetadata: Bool)
     func shareViewWasCompleted()
     func shareViewWasCancelled()
     func shareViewFailed(error: Error)


### PR DESCRIPTION
The iOS app has had a long standing crash related to the database, the app crashes with the error code `0xdead10cc` (or “Deadlock”) and it happens when the app goes into a “suspended” state whilst it still maintains a lock on the database. We've tried a number of times to resolve this issue without a large structural change but, while we seem to have reduced the frequency, we've been unable to entirely resolve it.

While the above describes the situation where this crash occurs there is one other important piece of information - this crash can only occur if the database is stored within the “AppGroup” directory (this is a shared directory that the main app, notification extension and share extension all have access to). When there is a database file in this location the OS will put a lock on the file to ensure two processes can’t access it at the same time and, when one process goes into the “suspended” state, the OS will throw a `0xdead10cc` error when the process hasn’t properly shut down the database access.

Annoyingly this crash doesn’t occur at all on the simulator and may not occur on debug builds, we also have no good way to intentionally replicate the crash because the OS decides when the app goes into a “suspended” state (we can try to force it by going into the background while there is an open database transaction by just making the transaction thread “sleep” for more than ~30s but it doesn’t work all the time, and isn't exactly the same crash 😞)
- **Note:** The approach above to cause the crash will only occur if a write has already occurred within the transaction, otherwise it’s able to just discard the transaction without issue

The purpose of this PR is to move the database file from the “AppGroup” into the main app directory where the OS will no longer need to put a lock on the file, and as a result the `0xdead10cc` should no longer be possible.