### PR TITLE
Memory management cleanup, tweak MRR logic, libSession 1.3.1

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -7810,7 +7810,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COMPILE_LIB_SESSION = "";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 567;
+				CURRENT_PROJECT_VERSION = 569;
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -7890,7 +7890,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				COMPILE_LIB_SESSION = "";
-				CURRENT_PROJECT_VERSION = 567;
+				CURRENT_PROJECT_VERSION = 569;
 				ENABLE_BITCODE = NO;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -8075,6 +8075,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.oxen.SessionSnodeKitTests;
 				PRODUCT_NAME = SessionSnodeKitTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -8085,6 +8086,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.oxen.SessionSnodeKitTests;
 				PRODUCT_NAME = SessionSnodeKitTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = App_Store_Release;
 		};
@@ -8279,14 +8281,20 @@
 		FD860CBF2D6E981900BBE29C /* Debug_Compile_LibSession */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.oxen.SessionSnodeKitTests;
 				PRODUCT_NAME = SessionSnodeKitTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug_Compile_LibSession;
 		};
 		FD860CC02D6E981900BBE29C /* App_Store_Release_Compile_LibSession */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = io.oxen.SessionSnodeKitTests;
 				PRODUCT_NAME = SessionSnodeKitTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = App_Store_Release_Compile_LibSession;
 		};
@@ -8413,7 +8421,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COMPILE_LIB_SESSION = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 567;
+				CURRENT_PROJECT_VERSION = 569;
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -9051,7 +9059,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				COMPILE_LIB_SESSION = YES;
-				CURRENT_PROJECT_VERSION = 567;
+				CURRENT_PROJECT_VERSION = 569;
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -10063,7 +10063,7 @@
 			repositoryURL = "https://github.com/session-foundation/libsession-util-spm";
 			requirement = {
 				kind = exactVersion;
-				version = 1.3.0;
+				version = 1.3.1;
 			};
 		};
 		FD6A38E72C2A630E00762359 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {

--- a/Session.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Session.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/session-foundation/libsession-util-spm",
       "state" : {
-        "revision" : "51580552aef35e52a3ae99ec72df2d70026ef415",
-        "version" : "1.3.0"
+        "revision" : "7c6665ffe8a458f57aa3cf9115873c7be9efe7cb",
+        "version" : "1.3.1"
       }
     },
     {

--- a/Session.xcodeproj/xcshareddata/xcschemes/Session.xcscheme
+++ b/Session.xcodeproj/xcshareddata/xcschemes/Session.xcscheme
@@ -20,34 +20,6 @@
                ReferencedContainer = "container:Session.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD71160828D00BAE00B47552"
-               BuildableName = "SessionTests.xctest"
-               BlueprintName = "SessionTests"
-               ReferencedContainer = "container:Session.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FDB5DAF92A981C42002C8721"
-               BuildableName = "SessionSnodeKitTests.xctest"
-               BlueprintName = "SessionSnodeKitTests"
-               ReferencedContainer = "container:Session.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -144,18 +116,6 @@
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD71160828D00BAE00B47552"
-               BuildableName = "SessionTests.xctest"
-               BlueprintName = "SessionTests"
-               ReferencedContainer = "container:Session.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "FDC4388D27B9FFC700C60D73"
                BuildableName = "SessionMessagingKitTests.xctest"
                BlueprintName = "SessionMessagingKitTests"
@@ -168,33 +128,9 @@
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FDB5DAF92A981C42002C8721"
-               BuildableName = "SessionSnodeKitTests.xctest"
-               BlueprintName = "SessionSnodeKitTests"
-               ReferencedContainer = "container:Session.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "FD83B9AE27CF200A005E1583"
                BuildableName = "SessionUtilitiesKitTests.xctest"
                BlueprintName = "SessionUtilitiesKitTests"
-               ReferencedContainer = "container:Session.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FDB5DAF92A981C42002C8721"
-               BuildableName = "SessionSnodeKitTests.xctest"
-               BlueprintName = "SessionSnodeKitTests"
                ReferencedContainer = "container:Session.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Session.xcodeproj/xcshareddata/xcschemes/Session_CompileLibSession.xcscheme
+++ b/Session.xcodeproj/xcshareddata/xcschemes/Session_CompileLibSession.xcscheme
@@ -6,24 +6,6 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "&#10;">
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
-      <PostActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "&#10;">
-            </ActionContent>
-         </ExecutionAction>
-      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -45,8 +27,13 @@
       buildConfiguration = "Debug_Compile_LibSession"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:SessionTests/Session.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug_Compile_LibSession"

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -561,14 +561,9 @@ extension ConversationVC:
             self?.scrollToBottom(isAnimated: false)
         }
 
-        // Note: 'shouldBeVisible' is set to true the first time a thread is saved so we can
-        // use it to determine if the user is creating a new thread and update the 'isApproved'
-        // flags appropriately
-        let oldThreadShouldBeVisible: Bool = (self.viewModel.threadData.threadShouldBeVisible == true)
-        let sentTimestampMs: Int64 = viewModel.dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
-
         // Optimistically insert the outgoing message (this will trigger a UI update)
         self.viewModel.sentMessageBeforeUpdate = true
+        let sentTimestampMs: Int64 = viewModel.dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
         let optimisticData: ConversationViewModel.OptimisticMessageData = self.viewModel.optimisticallyAppendOutgoingMessage(
             text: processedText,
             sentTimestampMs: sentTimestampMs,
@@ -581,7 +576,8 @@ extension ConversationVC:
         approveMessageRequestIfNeeded(
             for: self.viewModel.threadData.threadId,
             threadVariant: self.viewModel.threadData.threadVariant,
-            isNewThread: !oldThreadShouldBeVisible,
+            displayName: self.viewModel.threadData.displayName,
+            isDraft: (self.viewModel.threadData.threadIsDraft == true),
             timestampMs: (sentTimestampMs - 1)  // Set 1ms earlier as this is used for sorting
         ).sinkUntilComplete(
             receiveCompletion: { [weak self] _ in
@@ -2576,7 +2572,8 @@ extension ConversationVC {
     fileprivate func approveMessageRequestIfNeeded(
         for threadId: String,
         threadVariant: SessionThread.Variant,
-        isNewThread: Bool,
+        displayName: String,
+        isDraft: Bool,
         timestampMs: Int64
     ) -> AnyPublisher<Void, Never> {
         let updateNavigationBackStack: () -> Void = {
@@ -2610,11 +2607,11 @@ extension ConversationVC {
                 else { return Just(()).eraseToAnyPublisher() }
                 
                 return viewModel.dependencies[singleton: .storage]
-                    .writePublisher { [displayName = self.viewModel.threadData.displayName, dependencies = viewModel.dependencies] db in
-                        // If we aren't creating a new thread (ie. sending a message request) then send a
-                        // messageRequestResponse back to the sender (this allows the sender to know that
-                        // they have been approved and can now use this contact in closed groups)
-                        if !isNewThread {
+                    .writePublisher { [dependencies = viewModel.dependencies] db in
+                        /// If this isn't a draft thread (ie. sending a message request) then send a `messageRequestResponse`
+                        /// back to the sender (this allows the sender to know that they have been approved and can now use this
+                        /// contact in closed groups)
+                        if !isDraft {
                             _ = try? Interaction(
                                 threadId: threadId,
                                 threadVariant: threadVariant,
@@ -2648,7 +2645,7 @@ extension ConversationVC {
                                 db,
                                 Contact.Columns.isApproved.set(to: true),
                                 Contact.Columns.didApproveMe
-                                    .set(to: contact.didApproveMe || !isNewThread),
+                                    .set(to: contact.didApproveMe || !isDraft),
                                 using: dependencies
                             )
                     }
@@ -2673,8 +2670,8 @@ extension ConversationVC {
                 
                 return viewModel.dependencies[singleton: .storage]
                     .writePublisher { [dependencies = viewModel.dependencies] db in
-                        /// Remove any existing `infoGroupInfoInvited` interactions from the group (don't want to have a duplicate one from
-                        /// inside the group history)
+                        /// Remove any existing `infoGroupInfoInvited` interactions from the group (don't want to have a
+                        /// duplicate one from inside the group history)
                         _ = try Interaction
                             .filter(Interaction.Columns.threadId == group.id)
                             .filter(Interaction.Columns.variant == Interaction.Variant.infoGroupInfoInvited)
@@ -2691,10 +2688,10 @@ extension ConversationVC {
                             isHidden: false
                         ).upsert(db)
                         
-                        /// If we aren't creating a new thread (ie. sending a message request) and the user is not an admin
-                        /// then schedule sending a `GroupUpdateInviteResponseMessage` to the group (this allows
-                        /// other members to know that the user has joined the group)
-                        if !isNewThread && group.groupIdentityPrivateKey == nil {
+                        /// If this isn't a draft thread (ie. sending a message request) and the user is not an admin then schedule
+                        /// sending a `GroupUpdateInviteResponseMessage` to the group (this allows other members to
+                        /// know that the user has joined the group)
+                        if !isDraft && group.groupIdentityPrivateKey == nil {
                             try MessageSender.send(
                                 db,
                                 message: GroupUpdateInviteResponseMessage(
@@ -2733,7 +2730,8 @@ extension ConversationVC {
         approveMessageRequestIfNeeded(
             for: self.viewModel.threadData.threadId,
             threadVariant: self.viewModel.threadData.threadVariant,
-            isNewThread: false,
+            displayName: self.viewModel.threadData.displayName,
+            isDraft: (self.viewModel.threadData.threadIsDraft == true),
             timestampMs: viewModel.dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
         ).sinkUntilComplete()
     }

--- a/SessionMessagingKitTests/LibSession/LibSessionUtilSpec.swift
+++ b/SessionMessagingKitTests/LibSession/LibSessionUtilSpec.swift
@@ -402,7 +402,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData4.pointee.config)]
                 var mergeSize: [Int] = [pushData4.pointee.config_len]
                 let mergedHashes: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes, &mergeData, &mergeSize, 1)
-                expect([String](pointer: mergedHashes?.pointee.value, count: mergedHashes?.pointee.len))
+                expect([String](cStringArray: mergedHashes?.pointee.value, count: mergedHashes?.pointee.len))
                     .to(equal(["fakehash2"]))
                 config_confirm_pushed(conf2, pushData4.pointee.seqno, &cFakeHash2)
                 mergeHashes.forEach { $0?.deallocate() }
@@ -465,9 +465,9 @@ fileprivate extension LibSessionUtilSpec {
                 let pushData6Data: Data = Data(bytes: pushData6.pointee.config, count: pushData6.pointee.config_len)
                 let pushData7Data: Data = Data(bytes: pushData7.pointee.config, count: pushData7.pointee.config_len)
                 expect(pushData6Data).toNot(equal(pushData7Data))
-                expect([String](pointer: pushData6.pointee.obsolete, count: pushData6.pointee.obsolete_len))
+                expect([String](cStringArray: pushData6.pointee.obsolete, count: pushData6.pointee.obsolete_len))
                     .to(equal([fakeHash2]))
-                expect([String](pointer: pushData7.pointee.obsolete, count: pushData7.pointee.obsolete_len))
+                expect([String](cStringArray: pushData7.pointee.obsolete, count: pushData7.pointee.obsolete_len))
                     .to(equal([fakeHash2]))
                 
                 let fakeHash3a: String = "fakehash3a"
@@ -481,7 +481,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData2: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData7.pointee.config)]
                 var mergeSize2: [Int] = [pushData7.pointee.config_len]
                 let mergedHashes2: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes2, &mergeData2, &mergeSize2, 1)
-                expect([String](pointer: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
+                expect([String](cStringArray: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
                     .to(equal(["fakehash3b"]))
                 expect(config_needs_push(conf)).to(beTrue())
                 mergeHashes2.forEach { $0?.deallocate() }
@@ -492,7 +492,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData3: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData6.pointee.config)]
                 var mergeSize3: [Int] = [pushData6.pointee.config_len]
                 let mergedHashes3: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes3, &mergeData3, &mergeSize3, 1)
-                expect([String](pointer: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
+                expect([String](cStringArray: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
                     .to(equal(["fakehash3a"]))
                 expect(config_needs_push(conf2)).to(beTrue())
                 mergeHashes3.forEach { $0?.deallocate() }
@@ -508,9 +508,9 @@ fileprivate extension LibSessionUtilSpec {
                 let pushData8Data: Data = Data(bytes: pushData8.pointee.config, count: pushData8.pointee.config_len)
                 let pushData9Data: Data = Data(bytes: pushData9.pointee.config, count: pushData9.pointee.config_len)
                 expect(pushData8Data).to(equal(pushData9Data))
-                expect([String](pointer: pushData8.pointee.obsolete, count: pushData8.pointee.obsolete_len))
+                expect([String](cStringArray: pushData8.pointee.obsolete, count: pushData8.pointee.obsolete_len))
                     .to(equal([fakeHash3b, fakeHash3a]))
-                expect([String](pointer: pushData9.pointee.obsolete, count: pushData9.pointee.obsolete_len))
+                expect([String](cStringArray: pushData9.pointee.obsolete, count: pushData9.pointee.obsolete_len))
                     .to(equal([fakeHash3a, fakeHash3b]))
                 
                 let fakeHash4: String = "fakeHash4"
@@ -712,7 +712,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData: [UnsafePointer<UInt8>?] = ((try? [expPush1Encrypted].unsafeCopyUInt8Array()) ?? [])
                 var mergeSize: [Int] = [expPush1Encrypted.count]
                 let mergedHashes: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes, &mergeData, &mergeSize, 1)
-                expect([String](pointer: mergedHashes?.pointee.value, count: mergedHashes?.pointee.len))
+                expect([String](cStringArray: mergedHashes?.pointee.value, count: mergedHashes?.pointee.len))
                     .to(equal(["fakehash1"]))
                 mergeHashes.forEach { $0?.deallocate() }
                 mergeData.forEach { $0?.deallocate() }
@@ -795,7 +795,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData2: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData3.pointee.config)]
                 var mergeSize2: [Int] = [pushData3.pointee.config_len]
                 let mergedHashes2: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes2, &mergeData2, &mergeSize2, 1)
-                expect([String](pointer: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
+                expect([String](cStringArray: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
                     .to(equal(["fakehash2"]))
                 mergeHashes2.forEach { $0?.deallocate() }
                 mergedHashes2?.deallocate()
@@ -805,7 +805,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData3: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData4.pointee.config)]
                 var mergeSize3: [Int] = [pushData4.pointee.config_len]
                 let mergedHashes3: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes3, &mergeData3, &mergeSize3, 1)
-                expect([String](pointer: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
+                expect([String](cStringArray: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
                     .to(equal(["fakehash3"]))
                 mergeHashes3.forEach { $0?.deallocate() }
                 mergedHashes3?.deallocate()
@@ -1021,7 +1021,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData2.pointee.config)]
                 var mergeSize: [Int] = [pushData2.pointee.config_len]
                 let mergedHashes: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes, &mergeData, &mergeSize, 1)
-                expect([String](pointer: mergedHashes?.pointee.value, count: mergedHashes?.pointee.len))
+                expect([String](cStringArray: mergedHashes?.pointee.value, count: mergedHashes?.pointee.len))
                     .to(equal(["fakehash2"]))
                 config_confirm_pushed(conf, pushData2.pointee.seqno, &cFakeHash2)
                 mergeHashes.forEach { $0?.deallocate() }
@@ -1188,7 +1188,7 @@ fileprivate extension LibSessionUtilSpec {
                 // testing:
                 let pushData1: UnsafeMutablePointer<config_push_data> = config_push(conf)
                 expect(pushData1.pointee.seqno).to(equal(0))
-                expect([String](pointer: pushData1.pointee.obsolete, count: pushData1.pointee.obsolete_len))
+                expect([String](cStringArray: pushData1.pointee.obsolete, count: pushData1.pointee.obsolete_len))
                     .to(beEmpty())
                 expect(pushData1.pointee.config_len).to(equal(432))
                 pushData1.deallocate()
@@ -1286,7 +1286,7 @@ fileprivate extension LibSessionUtilSpec {
                 // dumps; even though we changed two fields here).
                 let pushData2: UnsafeMutablePointer<config_push_data> = config_push(conf)
                 expect(pushData2.pointee.seqno).to(equal(1))
-                expect([String](pointer: pushData2.pointee.obsolete, count: pushData2.pointee.obsolete_len))
+                expect([String](cStringArray: pushData2.pointee.obsolete, count: pushData2.pointee.obsolete_len))
                     .to(beEmpty())
                 
                 // Pretend we uploaded it
@@ -1310,12 +1310,12 @@ fileprivate extension LibSessionUtilSpec {
                 
                 let pushData3: UnsafeMutablePointer<config_push_data> = config_push(conf)
                 expect(pushData3.pointee.seqno).to(equal(1))
-                expect([String](pointer: pushData3.pointee.obsolete, count: pushData3.pointee.obsolete_len))
+                expect([String](cStringArray: pushData3.pointee.obsolete, count: pushData3.pointee.obsolete_len))
                     .to(beEmpty())
                 pushData3.deallocate()
                 
                 let currentHashes1: UnsafeMutablePointer<config_string_list>? = config_current_hashes(conf)
-                expect([String](pointer: currentHashes1?.pointee.value, count: currentHashes1?.pointee.len))
+                expect([String](cStringArray: currentHashes1?.pointee.value, count: currentHashes1?.pointee.len))
                     .to(equal(["fakehash1"]))
                 currentHashes1?.deallocate()
                 
@@ -1325,12 +1325,12 @@ fileprivate extension LibSessionUtilSpec {
                 let pushData4: UnsafeMutablePointer<config_push_data> = config_push(conf2)
                 expect(pushData4.pointee.seqno).to(equal(1))
                 expect(config_needs_dump(conf2)).to(beFalse())
-                expect([String](pointer: pushData4.pointee.obsolete, count: pushData4.pointee.obsolete_len))
+                expect([String](cStringArray: pushData4.pointee.obsolete, count: pushData4.pointee.obsolete_len))
                     .to(beEmpty())
                 pushData4.deallocate()
                 
                 let currentHashes2: UnsafeMutablePointer<config_string_list>? = config_current_hashes(conf2)
-                expect([String](pointer: currentHashes2?.pointee.value, count: currentHashes2?.pointee.len))
+                expect([String](cStringArray: currentHashes2?.pointee.value, count: currentHashes2?.pointee.len))
                     .to(equal(["fakehash1"]))
                 currentHashes2?.deallocate()
                 
@@ -1440,11 +1440,11 @@ fileprivate extension LibSessionUtilSpec {
                 let pushData7: UnsafeMutablePointer<config_push_data> = config_push(conf2)
                 expect(pushData7.pointee.seqno).to(equal(2))
                 config_confirm_pushed(conf2, pushData7.pointee.seqno, &cFakeHash2)
-                expect([String](pointer: pushData7.pointee.obsolete, count: pushData7.pointee.obsolete_len))
+                expect([String](cStringArray: pushData7.pointee.obsolete, count: pushData7.pointee.obsolete_len))
                     .to(equal([fakeHash1]))
                 
                 let currentHashes3: UnsafeMutablePointer<config_string_list>? = config_current_hashes(conf2)
-                expect([String](pointer: currentHashes3?.pointee.value, count: currentHashes3?.pointee.len))
+                expect([String](cStringArray: currentHashes3?.pointee.value, count: currentHashes3?.pointee.len))
                     .to(equal([fakeHash2]))
                 currentHashes3?.deallocate()
                 
@@ -1464,7 +1464,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData1: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData8.pointee.config)]
                 var mergeSize1: [Int] = [pushData8.pointee.config_len]
                 let mergedHashes1: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes1, &mergeData1, &mergeSize1, 1)
-                expect([String](pointer: mergedHashes1?.pointee.value, count: mergedHashes1?.pointee.len))
+                expect([String](cStringArray: mergedHashes1?.pointee.value, count: mergedHashes1?.pointee.len))
                     .to(equal(["fakehash2"]))
                 mergeHashes1.forEach { $0?.deallocate() }
                 mergedHashes1?.deallocate()
@@ -1509,11 +1509,11 @@ fileprivate extension LibSessionUtilSpec {
                 config_confirm_pushed(conf2, pushData10.pointee.seqno, &cFakeHash3)
                 
                 expect(pushData10.pointee.seqno).to(equal(3))
-                expect([String](pointer: pushData10.pointee.obsolete, count: pushData10.pointee.obsolete_len))
+                expect([String](cStringArray: pushData10.pointee.obsolete, count: pushData10.pointee.obsolete_len))
                     .to(equal([fakeHash2]))
                 
                 let currentHashes4: UnsafeMutablePointer<config_string_list>? = config_current_hashes(conf2)
-                expect([String](pointer: currentHashes4?.pointee.value, count: currentHashes4?.pointee.len))
+                expect([String](cStringArray: currentHashes4?.pointee.value, count: currentHashes4?.pointee.len))
                     .to(equal([fakeHash3]))
                 currentHashes4?.deallocate()
                 
@@ -1521,7 +1521,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData2: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData10.pointee.config)]
                 var mergeSize2: [Int] = [pushData10.pointee.config_len]
                 let mergedHashes2: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes2, &mergeData2, &mergeSize2, 1)
-                expect([String](pointer: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
+                expect([String](cStringArray: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
                     .to(equal(["fakehash3"]))
                 mergeHashes2.forEach { $0?.deallocate() }
                 mergedHashes2?.deallocate()
@@ -1556,7 +1556,7 @@ fileprivate extension LibSessionUtilSpec {
                 let pushData11: UnsafeMutablePointer<config_push_data> = config_push(conf)
                 config_confirm_pushed(conf, pushData11.pointee.seqno, &cFakeHash4)
                 expect(pushData11.pointee.seqno).to(equal(4))
-                expect([String](pointer: pushData11.pointee.obsolete, count: pushData11.pointee.obsolete_len))
+                expect([String](cStringArray: pushData11.pointee.obsolete, count: pushData11.pointee.obsolete_len))
                     .to(equal([fakeHash3, fakeHash2, fakeHash1]))
                 
                 // Load some obsolete ones in just to check that they get immediately obsoleted
@@ -1580,7 +1580,7 @@ fileprivate extension LibSessionUtilSpec {
                     pushData11.pointee.config_len
                 ]
                 let mergedHashes3: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes3, &mergeData3, &mergeSize3, 4)
-                expect([String](pointer: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
+                expect([String](cStringArray: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
                     .to(equal(["fakehash10", "fakehash11", "fakehash12", "fakehash4"]))
                 expect(config_needs_dump(conf2)).to(beTrue())
                 expect(config_needs_push(conf2)).to(beFalse())
@@ -1592,13 +1592,13 @@ fileprivate extension LibSessionUtilSpec {
                 pushData11.deallocate()
                 
                 let currentHashes5: UnsafeMutablePointer<config_string_list>? = config_current_hashes(conf2)
-                expect([String](pointer: currentHashes5?.pointee.value, count: currentHashes5?.pointee.len))
+                expect([String](cStringArray: currentHashes5?.pointee.value, count: currentHashes5?.pointee.len))
                     .to(equal([fakeHash4]))
                 currentHashes5?.deallocate()
                 
                 let pushData12: UnsafeMutablePointer<config_push_data> = config_push(conf2)
                 expect(pushData12.pointee.seqno).to(equal(4))
-                expect([String](pointer: pushData12.pointee.obsolete, count: pushData12.pointee.obsolete_len))
+                expect([String](cStringArray: pushData12.pointee.obsolete, count: pushData12.pointee.obsolete_len))
                     .to(equal([fakeHash11, fakeHash12, fakeHash10, fakeHash3]))
                 pushData12.deallocate()
                 
@@ -1716,7 +1716,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData1: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData1.pointee.config)]
                 var mergeSize1: [Int] = [pushData1.pointee.config_len]
                 let mergedHashes1: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes1, &mergeData1, &mergeSize1, 1)
-                expect([String](pointer: mergedHashes1?.pointee.value, count: mergedHashes1?.pointee.len))
+                expect([String](cStringArray: mergedHashes1?.pointee.value, count: mergedHashes1?.pointee.len))
                     .to(equal(["fakehash1"]))
                 expect(config_needs_push(conf2)).to(beFalse())
                 mergeHashes1.forEach { $0?.deallocate() }
@@ -1745,10 +1745,9 @@ fileprivate extension LibSessionUtilSpec {
                 groups_info_destroy_group(conf2)
                 
                 let pushData2: UnsafeMutablePointer<config_push_data> = config_push(conf2)
-                let obsoleteHashes: [String] = [String](
-                    pointer: pushData2.pointee.obsolete,
-                    count: pushData2.pointee.obsolete_len,
-                    defaultValue: []
+                let obsoleteHashes: [String]? = [String](
+                    cStringArray: pushData2.pointee.obsolete,
+                    count: pushData2.pointee.obsolete_len
                 )
                 expect(pushData2.pointee.seqno).to(equal(2))
                 expect(pushData2.pointee.config_len).to(equal(512))
@@ -1762,7 +1761,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData2: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData2.pointee.config)]
                 var mergeSize2: [Int] = [pushData2.pointee.config_len]
                 let mergedHashes2: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes2, &mergeData2, &mergeSize2, 1)
-                expect([String](pointer: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
+                expect([String](cStringArray: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
                     .to(equal(["fakehash2"]))
                 mergeHashes2.forEach { $0?.deallocate() }
                 mergedHashes2?.deallocate()
@@ -1800,7 +1799,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData3: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData3.pointee.config)]
                 var mergeSize3: [Int] = [pushData3.pointee.config_len]
                 let mergedHashes3: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes3, &mergeData3, &mergeSize3, 1)
-                expect([String](pointer: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
+                expect([String](cStringArray: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
                     .to(equal(["fakehash3"]))
                 mergeHashes3.forEach { $0?.deallocate() }
                 mergedHashes3?.deallocate()
@@ -2069,7 +2068,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData1: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData1.pointee.config)]
                 var mergeSize1: [Int] = [pushData1.pointee.config_len]
                 let mergedHashes1: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes1, &mergeData1, &mergeSize1, 1)
-                expect([String](pointer: mergedHashes1?.pointee.value, count: mergedHashes1?.pointee.len))
+                expect([String](cStringArray: mergedHashes1?.pointee.value, count: mergedHashes1?.pointee.len))
                     .to(equal(["fakehash1"]))
                 expect(config_needs_push(conf2)).to(beFalse())
                 mergeHashes1.forEach { $0?.deallocate() }
@@ -2160,10 +2159,9 @@ fileprivate extension LibSessionUtilSpec {
                 groups_members_set(conf2, &member1)
                 
                 let pushData2: UnsafeMutablePointer<config_push_data> = config_push(conf2)
-                let obsoleteHashes: [String] = [String](
-                    pointer: pushData2.pointee.obsolete,
-                    count: pushData2.pointee.obsolete_len,
-                    defaultValue: []
+                let obsoleteHashes: [String]? = [String](
+                    cStringArray: pushData2.pointee.obsolete,
+                    count: pushData2.pointee.obsolete_len
                 )
                 expect(pushData2.pointee.seqno).to(equal(2))
                 expect(pushData2.pointee.config_len).to(equal(1024))
@@ -2177,7 +2175,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData2: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData2.pointee.config)]
                 var mergeSize2: [Int] = [pushData2.pointee.config_len]
                 let mergedHashes2: UnsafeMutablePointer<config_string_list>? = config_merge(conf, &mergeHashes2, &mergeData2, &mergeSize2, 1)
-                expect([String](pointer: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
+                expect([String](cStringArray: mergedHashes2?.pointee.value, count: mergedHashes2?.pointee.len))
                     .to(equal(["fakehash2"]))
                 mergeHashes2.forEach { $0?.deallocate() }
                 mergedHashes2?.deallocate()
@@ -2334,10 +2332,9 @@ fileprivate extension LibSessionUtilSpec {
                 }
                 
                 let pushData3: UnsafeMutablePointer<config_push_data> = config_push(conf)
-                let obsoleteHashes3: [String] = [String](
-                    pointer: pushData3.pointee.obsolete,
-                    count: pushData3.pointee.obsolete_len,
-                    defaultValue: []
+                let obsoleteHashes3: [String]? = [String](
+                    cStringArray: pushData3.pointee.obsolete,
+                    count: pushData3.pointee.obsolete_len
                 )
                 expect(pushData3.pointee.seqno).to(equal(3))
                 expect(pushData3.pointee.config_len).to(equal(1024))
@@ -2351,7 +2348,7 @@ fileprivate extension LibSessionUtilSpec {
                 var mergeData3: [UnsafePointer<UInt8>?] = [UnsafePointer(pushData3.pointee.config)]
                 var mergeSize3: [Int] = [pushData3.pointee.config_len]
                 let mergedHashes3: UnsafeMutablePointer<config_string_list>? = config_merge(conf2, &mergeHashes3, &mergeData3, &mergeSize3, 1)
-                expect([String](pointer: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
+                expect([String](cStringArray: mergedHashes3?.pointee.value, count: mergedHashes3?.pointee.len))
                     .to(equal(["fakehash3"]))
                 mergeHashes3.forEach { $0?.deallocate() }
                 mergedHashes3?.deallocate()
@@ -2701,5 +2698,52 @@ private extension LibSessionUtilSpec {
         // Increment the number of records
         numRecords += 1
         return false
+    }
+}
+
+private extension Collection where Element == [CChar]? {
+    /// This creates an array of UnsafePointer types to access data of the C strings in memory. This array provides no automated
+    /// memory management of it's children so after use you are responsible for handling the life cycle of the child elements and
+    /// need to call `deallocate()` on each child.
+    func unsafeCopyCStringArray() throws -> [UnsafePointer<CChar>?] {
+        return try self.map { value in
+            guard let value: [CChar] = value else { return nil }
+            
+            let copy = UnsafeMutableBufferPointer<CChar>.allocate(capacity: value.underestimatedCount)
+            var remaining: (unwritten: Array<CChar>.Iterator, index: Int) = copy.initialize(from: value)
+            guard remaining.unwritten.next() == nil else { throw LibSessionError.invalidCConversion }
+            
+            return UnsafePointer(copy.baseAddress)
+        }
+    }
+}
+
+private extension Collection where Element == [CChar] {
+    /// This creates an array of UnsafePointer types to access data of the C strings in memory. This array provides no automated
+    /// memory management of it's children so after use you are responsible for handling the life cycle of the child elements and
+    /// need to call `deallocate()` on each child.
+    func unsafeCopyCStringArray() throws -> [UnsafePointer<CChar>?] {
+        return try self.map { value in
+            let copy = UnsafeMutableBufferPointer<CChar>.allocate(capacity: value.underestimatedCount)
+            var remaining: (unwritten: Array<CChar>.Iterator, index: Int) = copy.initialize(from: value)
+            guard remaining.unwritten.next() == nil else { throw LibSessionError.invalidCConversion }
+            
+            return UnsafePointer(copy.baseAddress)
+        }
+    }
+}
+
+private extension Collection where Element == [UInt8] {
+    /// This creates an array of UnsafePointer types to access data of the C strings in memory. This array provides no automated
+    /// memory management of it's children so after use you are responsible for handling the life cycle of the child elements and
+    /// need to call `deallocate()` on each child.
+    func unsafeCopyUInt8Array() throws -> [UnsafePointer<UInt8>?] {
+        return try self.map { value in
+            let copy = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: value.underestimatedCount)
+            var remaining: (unwritten: Array<UInt8>.Iterator, index: Int) = copy.initialize(from: value)
+            guard remaining.unwritten.next() == nil else { throw LibSessionError.invalidCConversion }
+            
+            return UnsafePointer(copy.baseAddress)
+        }
     }
 }

--- a/SessionSnodeKitTests/Types/BatchRequestSpec.swift
+++ b/SessionSnodeKitTests/Types/BatchRequestSpec.swift
@@ -116,7 +116,7 @@ class BatchRequestSpec: QuickSpec {
                     
                     let requestData: Data? = try? JSONEncoder().encode(request)
                     let requestJson: [[String: Any]]? = requestData
-                        .map { try? JSONSerialization.jsonObject(with: $0) as? [[String: Any]] }
+                        .map { (try? JSONSerialization.jsonObject(with: $0)) as? [[String: Any]] }
                     expect(requestJson?.first?["path"] as? String).to(equal("/endpoint1"))
                     expect(requestJson?.first?["method"] as? String).to(equal("GET"))
                     expect(requestJson?.first?["b64"] as? String).to(equal("testBody"))

--- a/SessionUtilitiesKit/LibSession/Utilities/TypeConversion+Utilities.swift
+++ b/SessionUtilitiesKit/LibSession/Utilities/TypeConversion+Utilities.swift
@@ -21,68 +21,37 @@ public extension String {
 // MARK: - Array
 
 public extension Array where Element == String {
-    init?(pointer: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?, count: Int?) {
+    init?(cStringArray: UnsafePointer<UnsafePointer<CChar>?>?, count: Int?) {
         /// If `count` was provided but is `0` then accessing the pointer could crash (as it could be bad memory) so just return an empty array
-        guard let count: Int = count else { return nil }
-        guard count > 0 else {
-            self = []
-            return
-        }
-        
-        self.init(pointee: pointer.map { $0.pointee.map { UnsafePointer($0) } }, count: count)
-    }
-    
-    init?(pointer: UnsafeMutablePointer<UnsafePointer<CChar>?>?, count: Int?) {
-        /// If `count` was provided but is `0` then accessing the pointer could crash (as it could be bad memory) so just return an empty array
-        guard let count: Int = count else { return nil }
-        guard count > 0 else {
-            self = []
-            return
-        }
-        
-        self.init(pointee: pointer.map { $0.pointee }, count: count)
-    }
-    
-    init(
-        pointer: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
-        count: Int?,
-        defaultValue: [String]
-    ) {
-        self = ([String](pointer: pointer, count: count) ?? defaultValue)
-    }
-    
-    init(
-        pointer: UnsafeMutablePointer<UnsafePointer<CChar>?>?,
-        count: Int?,
-        defaultValue: [String]
-    ) {
-        self = ([String](pointer: pointer, count: count) ?? defaultValue)
-    }
-    
-    init?(
-        pointee: UnsafePointer<CChar>?,
-        count: Int?
-    ) {
         guard
-            let count: Int = count,
-            let pointee: UnsafePointer<CChar> = pointee
+            let cStringArray: UnsafePointer<UnsafePointer<CChar>?> = cStringArray,
+            let count: Int = count
         else { return nil }
         
-        /// If `count` was provided but is `0` then accessing the pointer could crash (as it could be bad memory) so just return an empty array
-        guard count > 0 else {
-            self = []
-            return
-        }
+        self.init()
+        self.reserveCapacity(count)
         
-        self = (0..<count).reduce(into: []) { result, index in
-            /// We need to calculate the start position of each of the hashes in memory which will
-            /// be at the end of the previous hash plus one (due to the null termination character
-            /// which isn't included in Swift strings so isn't included in `count`)
-            let prevLength: Int = (result.isEmpty ? 0 :
-                result.map { ($0.count + 1) }.reduce(0, +)
-            )
-            
-            result.append(String(cString: pointee.advanced(by: prevLength)))
+        for i in 0..<count {
+            if let cStringPtr: UnsafePointer<CChar> = cStringArray[i] {
+                self.append(String(cString: cStringPtr))
+            }
+        }
+    }
+    
+    init?(cStringArray: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?, count: Int?) {
+        /// If `count` was provided but is `0` then accessing the pointer could crash (as it could be bad memory) so just return an empty array
+        guard
+            let cStringArray: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> = cStringArray,
+            let count: Int = count
+        else { return nil }
+        
+        self.init()
+        self.reserveCapacity(count)
+        
+        for i in 0..<count {
+            if let cStringPtr: UnsafeMutablePointer<CChar> = cStringArray[i] {
+                self.append(String(cString: cStringPtr))
+            }
         }
     }
 }

--- a/SessionUtilitiesKitTests/LibSession/Utilities/TypeConversionUtilitiesSpec.swift
+++ b/SessionUtilitiesKitTests/LibSession/Utilities/TypeConversionUtilitiesSpec.swift
@@ -304,70 +304,50 @@ class TypeConversionUtilitiesSpec: QuickSpec {
             context("when initialised with a 2D C array") {
                 // MARK: ---- returns the correct array
                 it("returns the correct array") {
-                    var test: [CChar] = (
-                        "Test1".cString(using: .utf8)! +
-                        "Test2".cString(using: .utf8)! +
-                        "Test3AndExtra".cString(using: .utf8)!
-                    )
-                    let result = test.withUnsafeMutableBufferPointer { ptr in
-                        var mutablePtr = UnsafePointer(ptr.baseAddress)
-                        
-                        return [String](pointer: &mutablePtr, count: 3)
-                    }
+                    var test: [String] = ["Test1", "Test2", "Test3AndExtra"]
                     
+                    let result = try! test.withUnsafeCStrArray { ptr in
+                        return [String](cStringArray: ptr.baseAddress, count: 3)
+                    }
                     expect(result).to(equal(["Test1", "Test2", "Test3AndExtra"]))
                 }
                 
                 // MARK: ---- returns an empty array if given one
                 it("returns an empty array if given one") {
-                    var test = [CChar]()
-                    let result = test.withUnsafeMutableBufferPointer { ptr in
-                        var mutablePtr = UnsafePointer(ptr.baseAddress)
-                        
-                        return [String](pointer: &mutablePtr, count: 0)
+                    var test: [String] = []
+                    
+                    let result = try! test.withUnsafeCStrArray { ptr in
+                        return [String](cStringArray: ptr.baseAddress, count: 0)
                     }
-
                     expect(result).to(equal([]))
                 }
 
                 // MARK: ---- handles empty strings without issues
                 it("handles empty strings without issues") {
-                    var test: [CChar] = (
-                        "Test1".cString(using: .utf8)! +
-                        "".cString(using: .utf8)! +
-                        "Test2".cString(using: .utf8)!
-                    )
-                    let result = test.withUnsafeMutableBufferPointer { ptr in
-                        var mutablePtr = UnsafePointer(ptr.baseAddress)
-                        
-                        return [String](pointer: &mutablePtr, count: 3)
+                    var test: [String] = ["Test1", "", "Test2"]
+                    
+                    let result = try! test.withUnsafeCStrArray { ptr in
+                        return [String](cStringArray: ptr.baseAddress, count: 3)
                     }
-
                     expect(result).to(equal(["Test1", "", "Test2"]))
                 }
                 
                 // MARK: ---- returns null when given a null pointer
                 it("returns null when given a null pointer") {
-                    expect([String](pointee: nil, count: 5)).to(beNil())
+                    expect([String](
+                        cStringArray: Optional<UnsafePointer<UnsafePointer<CChar>?>>.none,
+                        count: 5)
+                    ).to(beNil())
                 }
                 
                 // MARK: ---- returns null when given a null count
                 it("returns null when given a null count") {
-                    var test: [CChar] = "Test1".cString(using: .utf8)!
-                    let result = test.withUnsafeMutableBufferPointer { ptr in
-                        var mutablePtr = UnsafeMutablePointer(ptr.baseAddress)
-                        
-                        return [String](pointer: &mutablePtr, count: nil)
+                    var test: [String] = ["Test1"]
+                    
+                    let result = try! test.withUnsafeCStrArray { ptr in
+                        return [String](cStringArray: ptr.baseAddress, count: nil)
                     }
-
                     expect(result).to(beNil())
-                }
-                
-                // MARK: ---- returns the default value if given null values
-                it("returns the default value if given null values") {
-                    let ptr: UnsafeMutablePointer<UnsafePointer<CChar>?>? = nil
-                    expect([String](pointer: ptr, count: 5, defaultValue: ["Test"]))
-                        .to(equal(["Test"]))
                 }
             }
         }


### PR DESCRIPTION
- Updated to libSession 1.3.1
- Reworked how we were passing some variables to libSession to more safely manage scope
- Updated the message request logic to be based on the `isDraft` flag on a conversation (rather than `shouldBeVisible)
