### PR TITLE
Further memory management fixes

### DIFF
--- a/SessionMessagingKit/Crypto/Crypto+LibSession.swift
+++ b/SessionMessagingKit/Crypto/Crypto+LibSession.swift
@@ -151,7 +151,7 @@ public extension Crypto.Generator {
                 guard didDecrypt else { throw MessageReceiverError.decryptionFailed }
                 
                 // We need to manually free 'maybePlaintext' upon a successful decryption
-                defer { maybePlaintext?.deallocate() }
+                defer { free(UnsafeMutableRawPointer(mutating: maybePlaintext)) }
                 
                 guard
                     plaintextLen > 0,

--- a/SessionMessagingKit/Crypto/Crypto+SessionMessagingKit.swift
+++ b/SessionMessagingKit/Crypto/Crypto+SessionMessagingKit.swift
@@ -59,7 +59,7 @@ public extension Crypto.Generator {
                 let ciphertext: Data = maybeCiphertext.map({ Data(bytes: $0, count: ciphertextLen) })
             else { throw MessageSenderError.encryptionFailed }
 
-            maybeCiphertext?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: maybeCiphertext))
 
             return ciphertext
         }
@@ -98,9 +98,7 @@ public extension Crypto.Generator {
                     )
 
                     let encryptedData: Data? = cEncryptedDataPtr.map { Data(bytes: $0, count: outLen) }
-                    cMessages.forEach { $0?.deallocate() }
-                    cRecipients.forEach { $0?.deallocate() }
-                    cEncryptedDataPtr?.deallocate()
+                    free(UnsafeMutableRawPointer(mutating: cEncryptedDataPtr))
 
                     return try encryptedData ?? { throw MessageSenderError.encryptionFailed }()
                 }
@@ -145,7 +143,7 @@ public extension Crypto.Generator {
                 let plaintext: Data = maybePlaintext.map({ Data(bytes: $0, count: plaintextLen) })
             else { throw MessageReceiverError.decryptionFailed }
 
-            maybePlaintext?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: maybePlaintext))
 
             return (plaintext, String(cString: cSenderSessionId))
         }
@@ -187,7 +185,7 @@ public extension Crypto.Generator {
                 let plaintext: Data = maybePlaintext.map({ Data(bytes: $0, count: plaintextLen) })
             else { throw MessageReceiverError.decryptionFailed }
 
-            maybePlaintext?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: maybePlaintext))
 
             return (plaintext, String(cString: cSenderSessionId))
         }
@@ -219,7 +217,7 @@ public extension Crypto.Generator {
                 let plaintext: Data = maybePlaintext.map({ Data(bytes: $0, count: plaintextLen) })
             else { throw MessageReceiverError.decryptionFailed }
 
-            maybePlaintext?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: maybePlaintext))
 
             return plaintext
         }
@@ -250,7 +248,7 @@ public extension Crypto.Generator {
             )
 
             let decryptedData: Data? = cDecryptedDataPtr.map { Data(bytes: $0, count: outLen) }
-            cDecryptedDataPtr?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: cDecryptedDataPtr))
 
             return try decryptedData ?? { throw MessageReceiverError.decryptionFailed }()
         }

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+GroupKeys.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+GroupKeys.swift
@@ -119,12 +119,12 @@ internal extension LibSession {
                     let cSupplementData: UnsafeMutablePointer<UInt8> = cSupplementData
                 else { throw LibSessionError.failedToKeySupplementGroup }
                 
-                // Must deallocate on success
+                // Must free on success
                 let supplementData: Data = Data(
                     bytes: cSupplementData,
                     count: cSupplementDataLen
                 )
-                cSupplementData.deallocate()
+                free(UnsafeMutableRawPointer(mutating: cSupplementData))
                 
                 return supplementData
             }

--- a/SessionMessagingKit/LibSession/Types/Config.swift
+++ b/SessionMessagingKit/LibSession/Types/Config.swift
@@ -145,7 +145,7 @@ public extension LibSession {
                         count: cPushData.pointee.config_len
                     )
                     let seqNo: Int64 = cPushData.pointee.seqno
-                    cPushData.deallocate()
+                    free(UnsafeMutableRawPointer(mutating: cPushData))
                     
                     return PendingChanges.PushData(
                         data: pushData,
@@ -201,7 +201,7 @@ public extension LibSession {
             guard let dumpResult: UnsafeMutablePointer<UInt8> = dumpResult else { return nil }
             
             let dumpData: Data = Data(bytes: dumpResult, count: dumpResultLen)
-            dumpResult.deallocate()
+            free(UnsafeMutableRawPointer(mutating: dumpResult))
             
             return dumpData
         }
@@ -219,7 +219,7 @@ public extension LibSession {
                         cStringArray: hashList.pointee.value,
                         count: hashList.pointee.len
                     ).defaulting(to: [])
-                    hashList.deallocate()
+                    free(UnsafeMutableRawPointer(mutating: hashList))
                     
                     return result
                     
@@ -232,7 +232,7 @@ public extension LibSession {
                         cStringArray: hashList.pointee.value,
                         count: hashList.pointee.len
                     ).defaulting(to: [])
-                    hashList.deallocate()
+                    free(UnsafeMutableRawPointer(mutating: hashList))
                     
                     return result
             }
@@ -252,7 +252,7 @@ public extension LibSession {
                         cStringArray: hashList.pointee.value,
                         count: hashList.pointee.len
                     ).defaulting(to: [])
-                    hashList.deallocate()
+                    free(UnsafeMutableRawPointer(mutating: hashList))
                     
                     return result
             }
@@ -284,7 +284,7 @@ public extension LibSession {
                                         .defaulting(to: [])
                                 }
                                 .defaulting(to: [])
-                            mergedHashesPtr?.deallocate()
+                            free(UnsafeMutableRawPointer(mutating: mergedHashesPtr))
                             
                             if mergedHashes.count != messages.count {
                                 Log.warn(.libSession, "Unable to merge \(messages[0].namespace) messages (\(mergedHashes.count)/\(messages.count))")

--- a/SessionMessagingKit/Open Groups/Crypto/Crypto+OpenGroupAPI.swift
+++ b/SessionMessagingKit/Open Groups/Crypto/Crypto+OpenGroupAPI.swift
@@ -195,7 +195,7 @@ public extension Crypto.Generator {
                 let ciphertext: Data = maybeCiphertext.map({ Data(bytes: $0, count: ciphertextLen) })
             else { throw MessageSenderError.encryptionFailed }
 
-            maybeCiphertext?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: maybeCiphertext))
 
             return ciphertext
         }
@@ -244,7 +244,7 @@ public extension Crypto.Generator {
                 let plaintext: Data = maybePlaintext.map({ Data(bytes: $0, count: plaintextLen) })
             else { throw MessageReceiverError.decryptionFailed }
 
-            maybePlaintext?.deallocate()
+            free(UnsafeMutableRawPointer(mutating: maybePlaintext))
 
             return (plaintext, String(cString: cSenderSessionId))
         }

--- a/SessionUtilitiesKit/Crypto/Crypto+SessionUtilitiesKit.swift
+++ b/SessionUtilitiesKit/Crypto/Crypto+SessionUtilitiesKit.swift
@@ -14,13 +14,21 @@ public extension Crypto.Generator {
     
     static func randomBytes(_ count: Int) -> Crypto.Generator<Data> {
         return Crypto.Generator(id: "randomBytes_Data", args: [count]) { () -> Data in
-            Data(bytes: session_random(count), count: count)
+            let ptr: UnsafeMutablePointer<UInt8> = session_random(count)
+            let result: Data = Data(bytes: ptr, count: count)
+            free(ptr)
+            
+            return result
         }
     }
     
     static func randomBytes(_ count: Int) -> Crypto.Generator<[UInt8]> {
         return Crypto.Generator(id: "randomBytes_[UInt8]", args: [count]) { () -> [UInt8] in
-            Array(Data(bytes: session_random(count), count: count))
+            let ptr: UnsafeMutablePointer<UInt8> = session_random(count)
+            let result: Data = Data(bytes: ptr, count: count)
+            free(ptr)
+            
+            return Array(result)
         }
     }
 }


### PR DESCRIPTION
- Properly use `free` (instead of `dealloc`) for objects allocated via `malloc` (ie. anything from `libSession`)
- Updated the `LibSessionUtilSpec` to properly use the `withUnsafeCStrArray` and `withUnsafeUInt8CArray` functions
- Remove incorrect `dealloc` calls for pointers provided by `withUnsafeCStrArray` and `withUnsafeUInt8CArray`
- Reworked the `tryMapCallbackWrapper` function to (hopefully) prevent a memory release race condition
  - When calling `first()` on a stream it can rapidly clear out resources used, since we also had a `DispatchQueue.global(qos: .default).async` this could result in the `resultPublisher` being freed before it's downstream had completed, swapping this to use a `Future` instead will hopefully prevent this issue