### PR TITLE
Disabled screen lock when sharing within Session

### DIFF
--- a/SessionShareExtension/ShareNavController.swift
+++ b/SessionShareExtension/ShareNavController.swift
@@ -173,7 +173,7 @@ final class ShareNavController: UINavigationController, ShareViewDelegate {
     // MARK: - Updating
     
     private func showLockScreenOrMainContent() {
-        if dependencies[singleton: .storage, key: .isScreenLockEnabled] {
+        if dependencies[singleton: .storage, key: .isScreenLockEnabled] && !dependencies[defaults: .appGroup, key: .isMainAppActive] {
             showLockScreen()
         }
         else {


### PR DESCRIPTION
At the moment if you have Session open and try to share something from within Session via Session with "Lock App" enabled it'll get you to unlock twice before you can share - this is redundant (since you've already unlocked Session)

This PR changes the behaviour so if `isMainAppActive` is `true` then the share extension will already be unlocked