### PR TITLE
DBR - 1 - Cached seckey, cleaned up crypto usage

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -813,6 +813,7 @@
 		FD8A5B1E2DBF4BBC004C689B /* ScreenLock+Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B1D2DBF4BB8004C689B /* ScreenLock+Errors.swift */; };
 		FD8A5B322DC191B4004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */; };
 		FD8A5B342DC1A732004C689B /* _008_ResetUserConfigLastHashes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */; };
+		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8ECF7B29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */; };
 		FD8ECF7D2934293A00C0D1BB /* _013_SessionUtilChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */; };
 		FD8ECF7F2934298100C0D1BB /* ConfigDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */; };
@@ -2005,6 +2006,7 @@
 		FD8A5B1D2DBF4BB8004C689B /* ScreenLock+Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenLock+Errors.swift"; sourceTree = "<group>"; };
 		FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _025_DropLegacyClosedGroupKeyPairTable.swift; sourceTree = "<group>"; };
 		FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _008_ResetUserConfigLastHashes.swift; sourceTree = "<group>"; };
+		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibSession+SessionMessagingKit.swift"; sourceTree = "<group>"; };
 		FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _013_SessionUtilChanges.swift; sourceTree = "<group>"; };
 		FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigDump.swift; sourceTree = "<group>"; };
@@ -4252,6 +4254,7 @@
 			children = (
 				FD0B77B129B82B7A009169BA /* ArrayUtilitiesSpec.swift */,
 				FD23CE252A676B5B0000B97C /* DependenciesSpec.swift */,
+				FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */,
 				FD83B9BA27CF20AF005E1583 /* SessionIdSpec.swift */,
 			);
 			path = General;
@@ -6600,6 +6603,7 @@
 				FD9DD2732A72516D00ECB68E /* TestExtensions.swift in Sources */,
 				FD3FAB6E2AF1B28C00DC5421 /* MockFileManager.swift in Sources */,
 				FD83B9BB27CF20AF005E1583 /* SessionIdSpec.swift in Sources */,
+				FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */,
 				FDC290A927D9B46D005DAE71 /* NimbleExtensions.swift in Sources */,
 				FD0150402CA2433D005B08A1 /* BencodeDecoderSpec.swift in Sources */,
 				FD0150412CA2433D005B08A1 /* BencodeEncoderSpec.swift in Sources */,

--- a/Session/Home/HomeVC.swift
+++ b/Session/Home/HomeVC.swift
@@ -354,7 +354,7 @@ public final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableVi
         
         // Start polling if needed (i.e. if the user just created or restored their Session ID)
         if
-            Identity.userExists(using: viewModel.dependencies),
+            viewModel.dependencies[cache: .general].userExists,
             let appDelegate: AppDelegate = UIApplication.shared.delegate as? AppDelegate,
             viewModel.dependencies[singleton: .appContext].isMainAppAndActive
         {

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -224,7 +224,8 @@ extension Onboarding {
                 logStartAndStopCalls: false,
                 customAuthMethod: Authentication.standard(
                     sessionId: userSessionId,
-                    ed25519KeyPair: identity.ed25519KeyPair
+                    ed25519PublicKey: identity.ed25519KeyPair.publicKey,
+                    ed25519SecretKey: identity.ed25519KeyPair.secretKey
                 ),
                 using: dependencies
             )
@@ -305,7 +306,7 @@ extension Onboarding {
             DispatchQueue.global(qos: .userInitiated).async(using: dependencies) { [weak self, initialFlow, userSessionId, ed25519KeyPair, x25519KeyPair, useAPNS, displayName, userProfileConfigMessage, dependencies] in
                 /// Cache the users session id (so we don't need to fetch it from the database every time)
                 dependencies.mutate(cache: .general) {
-                    $0.setCachedSessionId(sessionId: userSessionId)
+                    $0.setSecretKey(ed25519SecretKey: ed25519KeyPair.secretKey)
                 }
                 
                 /// If we had a proper `initialFlow` then create a new `libSession` cache for the user

--- a/SessionMessagingKit/Crypto/Crypto+Attachments.swift
+++ b/SessionMessagingKit/Crypto/Crypto+Attachments.swift
@@ -15,13 +15,12 @@ public extension Crypto.Generator {
     private static var aesKeySize: Int { 32 }
     
     static func encryptAttachment(
-        plaintext: Data,
-        using dependencies: Dependencies
+        plaintext: Data
     ) -> Crypto.Generator<(ciphertext: Data, encryptionKey: Data, digest: Data)> {
         return Crypto.Generator(
             id: "encryptAttachment",
             args: [plaintext]
-        ) {
+        ) { dependencies in
             // Due to paddedSize, we need to divide by two.
             guard plaintext.count < (UInt.max / 2) else {
                 Log.error("[Crypto] Attachment data too long to encrypt.")

--- a/SessionMessagingKit/Crypto/Crypto+LibSession.swift
+++ b/SessionMessagingKit/Crypto/Crypto+LibSession.swift
@@ -175,7 +175,10 @@ public extension Crypto.Verification {
             id: "memberAuthData",
             args: [groupSessionId, ed25519SecretKey, memberAuthData]
         ) {
-            guard var cGroupId: [CChar] = groupSessionId.hexString.cString(using: .utf8) else { return false }
+            guard
+                var cGroupId: [CChar] = groupSessionId.hexString.cString(using: .utf8),
+                ed25519SecretKey.count == 64
+            else { return false }
             
             var cEd25519SecretKey: [UInt8] = ed25519SecretKey
             var cAuthData: [UInt8] = Array(memberAuthData)

--- a/SessionMessagingKit/Database/Models/Attachment.swift
+++ b/SessionMessagingKit/Database/Models/Attachment.swift
@@ -1214,7 +1214,7 @@ extension Attachment {
             if destination.shouldEncrypt {
                 guard
                     let result: EncryptionData = dependencies[singleton: .crypto].generate(
-                        .encryptAttachment(plaintext: rawData, using: dependencies)
+                        .encryptAttachment(plaintext: rawData)
                     )
                 else {
                     Log.error([cat].compactMap { $0 }, "Couldn't encrypt attachment.")

--- a/SessionMessagingKit/Database/Models/ClosedGroup.swift
+++ b/SessionMessagingKit/Database/Models/ClosedGroup.swift
@@ -174,10 +174,6 @@ public extension ClosedGroup {
         group: ClosedGroup,
         using dependencies: Dependencies
     ) throws {
-        guard let userED25519KeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db) else {
-            throw MessageReceiverError.noUserED25519KeyPair
-        }
-        
         /// Update the `USER_GROUPS` config
         try? LibSession.update(
             db,
@@ -226,7 +222,7 @@ public extension ClosedGroup {
             
             _ = try? cache.createAndLoadGroupState(
                 groupSessionId: groupSessionId,
-                userED25519KeyPair: userED25519KeyPair,
+                userED25519SecretKey: dependencies[cache: .general].ed25519SecretKey,
                 groupIdentityPrivateKey: group.groupIdentityPrivateKey
             )
         }

--- a/SessionMessagingKit/Database/Models/Contact.swift
+++ b/SessionMessagingKit/Database/Models/Contact.swift
@@ -53,7 +53,6 @@ public struct Contact: Codable, Identifiable, Equatable, FetchableRecord, Persis
     // MARK: - Initialization
     
     public init(
-        _ db: Database? = nil,
         id: String,
         isTrusted: Bool = false,
         isApproved: Bool = false,
@@ -84,7 +83,7 @@ public extension Contact {
     /// **Note:** This method intentionally does **not** save the newly created Contact,
     /// it will need to be explicitly saved after calling
     static func fetchOrCreate(_ db: Database, id: ID, using dependencies: Dependencies) -> Contact {
-        return ((try? fetchOne(db, id: id)) ?? Contact(db, id: id, using: dependencies))
+        return ((try? fetchOne(db, id: id)) ?? Contact(id: id, using: dependencies))
     }
 }
 

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -921,12 +921,17 @@ public extension Interaction {
         // If the thread is an open group then add the blinded id as a key to check
         if let openGroup: OpenGroup = try? OpenGroup.fetchOne(db, id: threadId) {
             if
-                let userEd25519KeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db),
                 let blinded15KeyPair: KeyPair = dependencies[singleton: .crypto].generate(
-                    .blinded15KeyPair(serverPublicKey: openGroup.publicKey, ed25519SecretKey: userEd25519KeyPair.secretKey)
+                    .blinded15KeyPair(
+                        serverPublicKey: openGroup.publicKey,
+                        ed25519SecretKey: dependencies[cache: .general].ed25519SecretKey
+                    )
                 ),
                 let blinded25KeyPair: KeyPair = dependencies[singleton: .crypto].generate(
-                    .blinded25KeyPair(serverPublicKey: openGroup.publicKey, ed25519SecretKey: userEd25519KeyPair.secretKey)
+                    .blinded25KeyPair(
+                        serverPublicKey: openGroup.publicKey,
+                        ed25519SecretKey: dependencies[cache: .general].ed25519SecretKey
+                    )
                 )
             {
                 publicKeysToCheck.append(SessionId(.blinded15, publicKey: blinded15KeyPair.publicKey).hexString)

--- a/SessionMessagingKit/Database/Models/SessionThread.swift
+++ b/SessionMessagingKit/Database/Models/SessionThread.swift
@@ -761,7 +761,6 @@ public extension SessionThread {
         }
         
         guard
-            let userEdKeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db),
             let openGroupInfo: OpenGroupInfo = try? OpenGroup
                 .filter(id: threadId)
                 .select(.publicKey, .server)
@@ -785,7 +784,7 @@ public extension SessionThread {
                     .generate(
                         .blinded15KeyPair(
                             serverPublicKey: openGroupInfo.publicKey,
-                            ed25519SecretKey: userEdKeyPair.secretKey
+                            ed25519SecretKey: dependencies[cache: .general].ed25519SecretKey
                         )
                     )
                     .map { SessionId(.blinded15, publicKey: $0.publicKey) }
@@ -795,7 +794,7 @@ public extension SessionThread {
                     .generate(
                         .blinded25KeyPair(
                             serverPublicKey: openGroupInfo.publicKey,
-                            ed25519SecretKey: userEdKeyPair.secretKey
+                            ed25519SecretKey: dependencies[cache: .general].ed25519SecretKey
                         )
                     )
                     .map { SessionId(.blinded25, publicKey: $0.publicKey) }

--- a/SessionMessagingKit/Jobs/ConfigurationSyncJob.swift
+++ b/SessionMessagingKit/Jobs/ConfigurationSyncJob.swift
@@ -67,10 +67,8 @@ public enum ConfigurationSyncJob: JobExecutor {
         // fresh install due to the migrations getting run)
         guard
             let swarmPublicKey: String = job.threadId,
-            let pendingChanges: LibSession.PendingChanges = dependencies[singleton: .storage].read({ db in
-                try dependencies.mutate(cache: .libSession) {
-                    try $0.pendingChanges(db, swarmPublicKey: swarmPublicKey)
-                }
+            let pendingChanges: LibSession.PendingChanges = try? dependencies.mutate(cache: .libSession, {
+                try $0.pendingChanges(swarmPublicKey: swarmPublicKey)
             })
         else {
             Log.info(.cat, "For \(job.threadId ?? "UnknownId") failed due to invalid data")

--- a/SessionMessagingKit/Jobs/DisappearingMessagesJob.swift
+++ b/SessionMessagingKit/Jobs/DisappearingMessagesJob.swift
@@ -27,7 +27,7 @@ public enum DisappearingMessagesJob: JobExecutor {
         deferred: @escaping (Job) -> Void,
         using dependencies: Dependencies
     ) {
-        guard Identity.userExists(using: dependencies) else { return success(job, false) }
+        guard dependencies[cache: .general].userExists else { return success(job, false) }
         
         // The 'backgroundTask' gets captured and cleared within the 'completion' block
         let timestampNowMs: Double = dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
@@ -60,7 +60,7 @@ public enum DisappearingMessagesJob: JobExecutor {
 
 public extension DisappearingMessagesJob {
     static func cleanExpiredMessagesOnLaunch(using dependencies: Dependencies) {
-        guard Identity.userExists(using: dependencies) else { return }
+        guard dependencies[cache: .general].userExists else { return }
         
         let timestampNowMs: Double = dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
         var numDeleted: Int = -1

--- a/SessionMessagingKit/Jobs/DisplayPictureDownloadJob.swift
+++ b/SessionMessagingKit/Jobs/DisplayPictureDownloadJob.swift
@@ -93,7 +93,7 @@ public enum DisplayPictureDownloadJob: JobExecutor {
                                 case .community: return data    // Community data is unencrypted
                                 case .profile(_, _, let encryptionKey), .group(_, _, let encryptionKey):
                                     return dependencies[singleton: .crypto].generate(
-                                        .decryptedDataDisplayPicture(data: data, key: encryptionKey, using: dependencies)
+                                        .decryptedDataDisplayPicture(data: data, key: encryptionKey)
                                     )
                             }
                         }()

--- a/SessionMessagingKit/Jobs/FailedAttachmentDownloadsJob.swift
+++ b/SessionMessagingKit/Jobs/FailedAttachmentDownloadsJob.swift
@@ -26,7 +26,7 @@ public enum FailedAttachmentDownloadsJob: JobExecutor {
         deferred: @escaping (Job) -> Void,
         using dependencies: Dependencies
     ) {
-        guard Identity.userExists(using: dependencies) else { return success(job, false) }
+        guard dependencies[cache: .general].userExists else { return success(job, false) }
         
         var changeCount: Int = -1
         

--- a/SessionMessagingKit/Jobs/FailedGroupInvitesAndPromotionsJob.swift
+++ b/SessionMessagingKit/Jobs/FailedGroupInvitesAndPromotionsJob.swift
@@ -26,7 +26,7 @@ public enum FailedGroupInvitesAndPromotionsJob: JobExecutor {
         deferred: @escaping (Job) -> Void,
         using dependencies: Dependencies
     ) {
-        guard Identity.userExists(using: dependencies) else { return success(job, false) }
+        guard dependencies[cache: .general].userExists else { return success(job, false) }
         guard !dependencies[cache: .libSession].isEmpty else {
             return failure(job, JobRunnerError.missingRequiredDetails, false)
         }

--- a/SessionMessagingKit/Jobs/FailedMessageSendsJob.swift
+++ b/SessionMessagingKit/Jobs/FailedMessageSendsJob.swift
@@ -26,7 +26,7 @@ public enum FailedMessageSendsJob: JobExecutor {
         deferred: @escaping (Job) -> Void,
         using dependencies: Dependencies
     ) {
-        guard Identity.userExists(using: dependencies) else { return success(job, false) }
+        guard dependencies[cache: .general].userExists else { return success(job, false) }
         
         var changeCount: Int = -1
         var attachmentChangeCount: Int = -1

--- a/SessionMessagingKit/Open Groups/Crypto/Crypto+OpenGroupAPI.swift
+++ b/SessionMessagingKit/Open Groups/Crypto/Crypto+OpenGroupAPI.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import CryptoKit
-import GRDB
 import SessionUtil
 import SessionUtilitiesKit
 
@@ -158,27 +157,22 @@ public extension Crypto.Verification {
 
 public extension Crypto.Generator {
     static func ciphertextWithSessionBlindingProtocol(
-        _ db: Database,
         plaintext: Data,
         recipientBlindedId: String,
-        serverPublicKey: String,
-        using dependencies: Dependencies
+        serverPublicKey: String
     ) -> Crypto.Generator<Data> {
         return Crypto.Generator(
             id: "ciphertextWithSessionBlindingProtocol",
             args: [plaintext, serverPublicKey]
-        ) {
-            let ed25519KeyPair: KeyPair = try Identity.fetchUserEd25519KeyPair(db) ?? {
-                throw MessageSenderError.noUserED25519KeyPair
-            }()
-
+        ) { dependencies in
             var cPlaintext: [UInt8] = Array(plaintext)
-            var cEd25519SecretKey: [UInt8] = ed25519KeyPair.secretKey
+            var cEd25519SecretKey: [UInt8] = dependencies[cache: .general].ed25519SecretKey
             var cRecipientBlindedId: [UInt8] = Array(Data(hex: recipientBlindedId))
             var cServerPublicKey: [UInt8] = Array(Data(hex: serverPublicKey))
             var maybeCiphertext: UnsafeMutablePointer<UInt8>? = nil
             var ciphertextLen: Int = 0
 
+            guard !cEd25519SecretKey.isEmpty else { throw MessageSenderError.noUserED25519KeyPair }
             guard
                 cEd25519SecretKey.count == 64,
                 cServerPublicKey.count == 32,
@@ -202,23 +196,17 @@ public extension Crypto.Generator {
     }
 
     static func plaintextWithSessionBlindingProtocol(
-        _ db: Database,
         ciphertext: Data,
         senderId: String,
         recipientId: String,
-        serverPublicKey: String,
-        using dependencies: Dependencies
+        serverPublicKey: String
     ) -> Crypto.Generator<(plaintext: Data, senderSessionIdHex: String)> {
         return Crypto.Generator(
             id: "plaintextWithSessionBlindingProtocol",
             args: [ciphertext, senderId, recipientId]
-        ) {
-            let ed25519KeyPair: KeyPair = try Identity.fetchUserEd25519KeyPair(db) ?? {
-                throw MessageSenderError.noUserED25519KeyPair
-            }()
-            
+        ) { dependencies in
             var cCiphertext: [UInt8] = Array(ciphertext)
-            var cEd25519SecretKey: [UInt8] = ed25519KeyPair.secretKey
+            var cEd25519SecretKey: [UInt8] = dependencies[cache: .general].ed25519SecretKey
             var cSenderId: [UInt8] = Array(Data(hex: senderId))
             var cRecipientId: [UInt8] = Array(Data(hex: recipientId))
             var cServerPublicKey: [UInt8] = Array(Data(hex: serverPublicKey))
@@ -226,6 +214,7 @@ public extension Crypto.Generator {
             var maybePlaintext: UnsafeMutablePointer<UInt8>? = nil
             var plaintextLen: Int = 0
 
+            guard !cEd25519SecretKey.isEmpty else { throw MessageSenderError.noUserED25519KeyPair }
             guard
                 cEd25519SecretKey.count == 64,
                 cServerPublicKey.count == 32,

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Groups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Groups.swift
@@ -108,11 +108,10 @@ extension MessageReceiver {
             ),
             // Somewhat redundant because we know the sender was a group admin but this confirms the
             // authData is valid so protects against invalid invite spam from a group admin
-            let userEd25519KeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db),
             dependencies[singleton: .crypto].verify(
                 .memberAuthData(
                     groupSessionId: message.groupSessionId,
-                    ed25519SecretKey: userEd25519KeyPair.secretKey,
+                    ed25519SecretKey: dependencies[cache: .general].ed25519SecretKey,
                     memberAuthData: message.memberAuthData
                 )
             )

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+LibSession.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+LibSession.swift
@@ -18,8 +18,7 @@ extension MessageReceiver {
     ) throws {
         guard
             let sender: String = message.sender,
-            let senderSessionId: SessionId = try? SessionId(from: sender),
-            let userEd25519KeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db)
+            let senderSessionId: SessionId = try? SessionId(from: sender)
         else { throw MessageReceiverError.decryptionFailed }
         
         let supportedEncryptionDomains: [LibSession.Crypto.Domain] = [
@@ -34,7 +33,7 @@ extension MessageReceiver {
                         .plaintextWithMultiEncrypt(
                             ciphertext: message.ciphertext,
                             senderSessionId: senderSessionId,
-                            ed25519PrivateKey: userEd25519KeyPair.secretKey,
+                            ed25519PrivateKey: dependencies[cache: .general].ed25519SecretKey,
                             domain: domain
                         )
                     )

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -68,12 +68,10 @@ public enum MessageReceiver {
             case (_, .openGroupInbox(let timestamp, let messageServerId, let serverPublicKey, let senderId, let recipientId)):
                 (plaintext, sender) = try dependencies[singleton: .crypto].tryGenerate(
                     .plaintextWithSessionBlindingProtocol(
-                        db,
                         ciphertext: data,
                         senderId: senderId,
                         recipientId: recipientId,
-                        serverPublicKey: serverPublicKey,
-                        using: dependencies
+                        serverPublicKey: serverPublicKey
                     )
                 )
                 
@@ -99,11 +97,7 @@ public enum MessageReceiver {
                         }
                         
                         (plaintext, sender) = try dependencies[singleton: .crypto].tryGenerate(
-                            .plaintextWithSessionProtocol(
-                                db,
-                                ciphertext: ciphertext,
-                                using: dependencies
-                            )
+                            .plaintextWithSessionProtocol(ciphertext: ciphertext)
                         )
                         plaintext = plaintext.removePadding()   // Remove the padding
                         sentTimestampMs = envelope.timestamp

--- a/SessionMessagingKit/Sending & Receiving/Notifications/Models/AuthenticatedRequest.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/Models/AuthenticatedRequest.swift
@@ -45,9 +45,9 @@ extension PushNotificationAPI {
             try container.encode(timestamp, forKey: .timestamp)
             
             switch authMethod.info {
-                case .standard(let sessionId, let ed25519KeyPair):
+                case .standard(let sessionId, let ed25519PublicKey):
                     try container.encode(sessionId.hexString, forKey: .pubkey)
-                    try container.encode(ed25519KeyPair.publicKey.toHexString(), forKey: .ed25519PublicKey)
+                    try container.encode(ed25519PublicKey.toHexString(), forKey: .ed25519PublicKey)
                     
                 case .groupAdmin(let sessionId, _):
                     try container.encode(sessionId.hexString, forKey: .pubkey)

--- a/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
@@ -128,243 +128,12 @@ public class SwarmPoller: SwarmPollerType & PollerType {
                 request.send(using: dependencies)
                     .map { _, response in (snode, response) }
             }
-            .flatMap { [pollerDestination, shouldStoreMessages, dependencies] (snode: LibSession.Snode, namespacedResults: SnodeAPI.PollResponse) -> AnyPublisher<(configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult), Error> in
-                // Get all of the messages and sort them by their required 'processingOrder'
-                let sortedMessages: [(namespace: SnodeAPI.Namespace, messages: [SnodeReceivedMessage])] = namespacedResults
-                    .compactMap { namespace, result in (result.data?.messages).map { (namespace, $0) } }
-                    .sorted { lhs, rhs in lhs.namespace.processingOrder < rhs.namespace.processingOrder }
-                let rawMessageCount: Int = sortedMessages.map { $0.messages.count }.reduce(0, +)
-                
-                // No need to do anything if there are no messages
-                guard rawMessageCount > 0 else {
-                    return Just(([], [], ([], 0, 0, false)))
-                        .setFailureType(to: Error.self)
-                        .eraseToAnyPublisher()
-                }
-                
-                // Otherwise process the messages and add them to the queue for handling
-                let lastHashes: [String] = namespacedResults
-                    .compactMap { $0.value.data?.lastHash }
-                let otherKnownHashes: [String] = namespacedResults
-                    .filter { $0.key.shouldFetchSinceLastHash }
-                    .compactMap { $0.value.data?.messages.map { $0.info.hash } }
-                    .reduce([], +)
-                var messageCount: Int = 0
-                var finalProcessedMessages: [ProcessedMessage] = []
-                var hadValidHashUpdate: Bool = false
-                
-                return dependencies[singleton: .storage].writePublisher { db -> (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) in
-                    // If the poll was successful we need to retrieve the `lastHash` values
-                    // direct from the database again to ensure they still line up (if they
-                    // have been reset in the database then we want to ignore the poll as it
-                    // would invalidate whatever change modified the `lastHash` values potentially
-                    // resulting in us not polling again from scratch even if we want to)
-                    let lastHashesAfterFetch: Set<String> = try Set(namespacedResults
-                        .compactMap { namespace, _ in
-                            try SnodeReceivedMessageInfo
-                                .fetchLastNotExpired(
-                                    db,
-                                    for: snode,
-                                    namespace: namespace,
-                                    swarmPublicKey: pollerDestination.target,
-                                    using: dependencies
-                                )?
-                                .hash
-                        })
-                    
-                    guard lastHashes.isEmpty || Set(lastHashes) == lastHashesAfterFetch else {
-                        return ([], [], ([], 0, 0, false))
-                    }
-                    
-                    // Since the hashes are still accurate we can now process the messages
-                    let allProcessedMessages: [ProcessedMessage] = sortedMessages
-                        .compactMap { namespace, messages -> [ProcessedMessage]? in
-                            let processedMessages: [ProcessedMessage] = messages
-                                .compactMap { message -> ProcessedMessage? in
-                                    do {
-                                        return try Message.processRawReceivedMessage(
-                                            db,
-                                            rawMessage: message,
-                                            swarmPublicKey: pollerDestination.target,
-                                            shouldStoreMessages: shouldStoreMessages,
-                                            using: dependencies
-                                        )
-                                    }
-                                    catch {
-                                        switch error {
-                                            /// Ignore duplicate & selfSend message errors (and don't bother logging them as there
-                                            /// will be a lot since we each service node duplicates messages)
-                                            case DatabaseError.SQLITE_CONSTRAINT_UNIQUE,
-                                                DatabaseError.SQLITE_CONSTRAINT,    /// Sometimes thrown for UNIQUE
-                                                MessageReceiverError.duplicateMessage,
-                                                MessageReceiverError.duplicateControlMessage,
-                                                MessageReceiverError.selfSend:
-                                                break
-                                                
-                                            case MessageReceiverError.duplicateMessageNewSnode:
-                                                hadValidHashUpdate = true
-                                                break
-                                                
-                                            case DatabaseError.SQLITE_ABORT:
-                                                Log.warn(.poller, "Failed to the database being suspended (running in background with no background task).")
-                                                
-                                            default: Log.error(.poller, "Failed to deserialize envelope due to error: \(error).")
-                                        }
-                                        
-                                        return nil
-                                    }
-                                }
-                            
-                            /// If this message should be handled by this poller and should be handled  synchronously then do so here before
-                            /// processing the next namespace
-                            guard shouldStoreMessages && namespace.shouldHandleSynchronously else {
-                                return processedMessages
-                            }
-                            
-                            if namespace.isConfigNamespace {
-                                do {
-                                    /// Process config messages all at once in case they are multi-part messages
-                                    try dependencies.mutate(cache: .libSession) {
-                                        try $0.handleConfigMessages(
-                                            db,
-                                            swarmPublicKey: pollerDestination.target,
-                                            messages: ConfigMessageReceiveJob
-                                                .Details(messages: processedMessages)
-                                                .messages
-                                        )
-                                    }
-                                }
-                                catch { Log.error(.poller, "Failed to handle processed config message due to error: \(error).") }
-                            }
-                            else {
-                                /// Individually process non-config messages
-                                processedMessages.forEach { processedMessage in
-                                    guard case .standard(let threadId, let threadVariant, let proto, let messageInfo) = processedMessage else {
-                                        return
-                                    }
-                                    
-                                    do {
-                                        try MessageReceiver.handle(
-                                            db,
-                                            threadId: threadId,
-                                            threadVariant: threadVariant,
-                                            message: messageInfo.message,
-                                            serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
-                                            associatedWithProto: proto,
-                                            using: dependencies
-                                        )
-                                    }
-                                    catch { Log.error(.poller, "Failed to handle processed message due to error: \(error).") }
-                                }
-                            }
-                            
-                            /// Make sure to add any synchronously processed messages to the `finalProcessedMessages`
-                            /// as otherwise they wouldn't be emitted by the `receivedPollResponseSubject`
-                            finalProcessedMessages += processedMessages
-                            return nil
-                        }
-                        .flatMap { $0 }
-                    
-                    // If we don't want to store the messages then no need to continue (don't want
-                    // to create message receive jobs or mess with cached hashes)
-                    guard shouldStoreMessages else {
-                        messageCount += allProcessedMessages.count
-                        finalProcessedMessages += allProcessedMessages
-                        return ([], [], (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
-                    }
-                    
-                    // Add a job to process the config messages first
-                    let configMessageJobs: [Job] = allProcessedMessages
-                        .filter { $0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
-                        .grouped { $0.threadId }
-                        .compactMap { threadId, threadMessages in
-                            messageCount += threadMessages.count
-                            finalProcessedMessages += threadMessages
-                            
-                            let job: Job? = Job(
-                                variant: .configMessageReceive,
-                                behaviour: .runOnce,
-                                threadId: threadId,
-                                details: ConfigMessageReceiveJob.Details(messages: threadMessages)
-                            )
-                            
-                            // If we are force-polling then add to the JobRunner so they are
-                            // persistent and will retry on the next app run if they fail but
-                            // don't let them auto-start
-                            return dependencies[singleton: .jobRunner].add(
-                                db,
-                                job: job,
-                                canStartJob: (
-                                    !forceSynchronousProcessing &&
-                                    !dependencies[singleton: .appContext].isInBackground
-                                )
-                            )
-                        }
-                    let configJobIds: [Int64] = configMessageJobs.compactMap { $0.id }
-                    
-                    // Add jobs for processing non-config messages which are dependant on the config message
-                    // processing jobs
-                    let standardMessageJobs: [Job] = allProcessedMessages
-                        .filter { !$0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
-                        .grouped { $0.threadId }
-                        .compactMap { threadId, threadMessages in
-                            messageCount += threadMessages.count
-                            finalProcessedMessages += threadMessages
-                            
-                            let job: Job? = Job(
-                                variant: .messageReceive,
-                                behaviour: .runOnce,
-                                threadId: threadId,
-                                details: MessageReceiveJob.Details(messages: threadMessages)
-                            )
-                            
-                            // If we are force-polling then add to the JobRunner so they are
-                            // persistent and will retry on the next app run if they fail but
-                            // don't let them auto-start
-                            let updatedJob: Job? = dependencies[singleton: .jobRunner].add(
-                                db,
-                                job: job,
-                                canStartJob: (
-                                    !forceSynchronousProcessing && (
-                                        !dependencies[singleton: .appContext].isInBackground ||
-                                        // FIXME: Better seperate the call messages handling, since we need to handle them all the time
-                                        dependencies[singleton: .callManager].currentCall != nil
-                                    )
-                                )
-                            )
-                            
-                            // Create the dependency between the jobs (config processing should happen before
-                            // standard message processing)
-                            if let updatedJobId: Int64 = updatedJob?.id {
-                                do {
-                                    try configJobIds.forEach { configJobId in
-                                        try JobDependencies(
-                                            jobId: updatedJobId,
-                                            dependantId: configJobId
-                                        )
-                                        .insert(db)
-                                    }
-                                }
-                                catch {
-                                    Log.warn(.poller, "Failed to add dependency between config processing and non-config processing messageReceive jobs.")
-                                }
-                            }
-                            
-                            return updatedJob
-                        }
-                    
-                    // Update the cached validity of the messages
-                    try SnodeReceivedMessageInfo.handlePotentialDeletedOrInvalidHash(
-                        db,
-                        potentiallyInvalidHashes: (sortedMessages.isEmpty && !hadValidHashUpdate ?
-                            lastHashes :
-                            []
-                        ),
-                        otherKnownValidHashes: otherKnownHashes
-                    )
-                    
-                    return (configMessageJobs, standardMessageJobs, (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
-                }
+            .flatMapOptional { [weak self] (snode: LibSession.Snode, namespacedResults: SnodeAPI.PollResponse) -> AnyPublisher<(configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult), Error>? in
+                self?.processPollResponse(
+                    forceSynchronousProcessing: forceSynchronousProcessing,
+                    snode: snode,
+                    namespacedResults: namespacedResults
+                )
             }
             .flatMap { [dependencies] (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) -> AnyPublisher<PollResult, Error> in
                 // If we don't want to forcible process the response synchronously then just finish immediately
@@ -427,5 +196,248 @@ public class SwarmPoller: SwarmPollerType & PollerType {
                 }
             )
             .eraseToAnyPublisher()
+    }
+    
+    private func processPollResponse(
+        forceSynchronousProcessing: Bool,
+        snode: LibSession.Snode,
+        namespacedResults: SnodeAPI.PollResponse
+    ) -> AnyPublisher<(configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult), Error> {
+        // Get all of the messages and sort them by their required 'processingOrder'
+        let sortedMessages: [(namespace: SnodeAPI.Namespace, messages: [SnodeReceivedMessage])] = namespacedResults
+            .compactMap { namespace, result in (result.data?.messages).map { (namespace, $0) } }
+            .sorted { lhs, rhs in lhs.namespace.processingOrder < rhs.namespace.processingOrder }
+        let rawMessageCount: Int = sortedMessages.map { $0.messages.count }.reduce(0, +)
+        
+        // No need to do anything if there are no messages
+        guard rawMessageCount > 0 else {
+            return Just(([], [], ([], 0, 0, false)))
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        
+        // Otherwise process the messages and add them to the queue for handling
+        let lastHashes: [String] = namespacedResults
+            .compactMap { $0.value.data?.lastHash }
+        let otherKnownHashes: [String] = namespacedResults
+            .filter { $0.key.shouldFetchSinceLastHash }
+            .compactMap { $0.value.data?.messages.map { $0.info.hash } }
+            .reduce([], +)
+        var messageCount: Int = 0
+        var finalProcessedMessages: [ProcessedMessage] = []
+        var hadValidHashUpdate: Bool = false
+        
+        return dependencies[singleton: .storage].writePublisher { [pollerDestination, shouldStoreMessages, dependencies] db -> (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) in
+            // If the poll was successful we need to retrieve the `lastHash` values
+            // direct from the database again to ensure they still line up (if they
+            // have been reset in the database then we want to ignore the poll as it
+            // would invalidate whatever change modified the `lastHash` values potentially
+            // resulting in us not polling again from scratch even if we want to)
+            let lastHashesAfterFetch: Set<String> = try Set(namespacedResults
+                .compactMap { namespace, _ in
+                    try SnodeReceivedMessageInfo
+                        .fetchLastNotExpired(
+                            db,
+                            for: snode,
+                            namespace: namespace,
+                            swarmPublicKey: pollerDestination.target,
+                            using: dependencies
+                        )?
+                        .hash
+                })
+            
+            guard lastHashes.isEmpty || Set(lastHashes) == lastHashesAfterFetch else {
+                return ([], [], ([], 0, 0, false))
+            }
+            
+            // Since the hashes are still accurate we can now process the messages
+            let allProcessedMessages: [ProcessedMessage] = sortedMessages
+                .compactMap { namespace, messages -> [ProcessedMessage]? in
+                    let processedMessages: [ProcessedMessage] = messages
+                        .compactMap { message -> ProcessedMessage? in
+                            do {
+                                return try Message.processRawReceivedMessage(
+                                    db,
+                                    rawMessage: message,
+                                    swarmPublicKey: pollerDestination.target,
+                                    shouldStoreMessages: shouldStoreMessages,
+                                    using: dependencies
+                                )
+                            }
+                            catch {
+                                switch error {
+                                    /// Ignore duplicate & selfSend message errors (and don't bother logging them as there
+                                    /// will be a lot since we each service node duplicates messages)
+                                    case DatabaseError.SQLITE_CONSTRAINT_UNIQUE,
+                                        DatabaseError.SQLITE_CONSTRAINT,    /// Sometimes thrown for UNIQUE
+                                        MessageReceiverError.duplicateMessage,
+                                        MessageReceiverError.duplicateControlMessage,
+                                        MessageReceiverError.selfSend:
+                                        break
+                                        
+                                    case MessageReceiverError.duplicateMessageNewSnode:
+                                        hadValidHashUpdate = true
+                                        break
+                                        
+                                    case DatabaseError.SQLITE_ABORT:
+                                        Log.warn(.poller, "Failed to the database being suspended (running in background with no background task).")
+                                        
+                                    default: Log.error(.poller, "Failed to deserialize envelope due to error: \(error).")
+                                }
+                                
+                                return nil
+                            }
+                        }
+                    
+                    /// If this message should be handled by this poller and should be handled  synchronously then do so here before
+                    /// processing the next namespace
+                    guard shouldStoreMessages && namespace.shouldHandleSynchronously else {
+                        return processedMessages
+                    }
+                    
+                    if namespace.isConfigNamespace {
+                        do {
+                            /// Process config messages all at once in case they are multi-part messages
+                            try dependencies.mutate(cache: .libSession) {
+                                try $0.handleConfigMessages(
+                                    db,
+                                    swarmPublicKey: pollerDestination.target,
+                                    messages: ConfigMessageReceiveJob
+                                        .Details(messages: processedMessages)
+                                        .messages
+                                )
+                            }
+                        }
+                        catch { Log.error(.poller, "Failed to handle processed config message due to error: \(error).") }
+                    }
+                    else {
+                        /// Individually process non-config messages
+                        processedMessages.forEach { processedMessage in
+                            guard case .standard(let threadId, let threadVariant, let proto, let messageInfo) = processedMessage else {
+                                return
+                            }
+                            
+                            do {
+                                try MessageReceiver.handle(
+                                    db,
+                                    threadId: threadId,
+                                    threadVariant: threadVariant,
+                                    message: messageInfo.message,
+                                    serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
+                                    associatedWithProto: proto,
+                                    using: dependencies
+                                )
+                            }
+                            catch { Log.error(.poller, "Failed to handle processed message due to error: \(error).") }
+                        }
+                    }
+                    
+                    /// Make sure to add any synchronously processed messages to the `finalProcessedMessages`
+                    /// as otherwise they wouldn't be emitted by the `receivedPollResponseSubject`
+                    finalProcessedMessages += processedMessages
+                    return nil
+                }
+                .flatMap { $0 }
+            
+            // If we don't want to store the messages then no need to continue (don't want
+            // to create message receive jobs or mess with cached hashes)
+            guard shouldStoreMessages else {
+                messageCount += allProcessedMessages.count
+                finalProcessedMessages += allProcessedMessages
+                return ([], [], (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
+            }
+            
+            // Add a job to process the config messages first
+            let configMessageJobs: [Job] = allProcessedMessages
+                .filter { $0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
+                .grouped { $0.threadId }
+                .compactMap { threadId, threadMessages in
+                    messageCount += threadMessages.count
+                    finalProcessedMessages += threadMessages
+                    
+                    let job: Job? = Job(
+                        variant: .configMessageReceive,
+                        behaviour: .runOnce,
+                        threadId: threadId,
+                        details: ConfigMessageReceiveJob.Details(messages: threadMessages)
+                    )
+                    
+                    // If we are force-polling then add to the JobRunner so they are
+                    // persistent and will retry on the next app run if they fail but
+                    // don't let them auto-start
+                    return dependencies[singleton: .jobRunner].add(
+                        db,
+                        job: job,
+                        canStartJob: (
+                            !forceSynchronousProcessing &&
+                            !dependencies[singleton: .appContext].isInBackground
+                        )
+                    )
+                }
+            let configJobIds: [Int64] = configMessageJobs.compactMap { $0.id }
+            
+            // Add jobs for processing non-config messages which are dependant on the config message
+            // processing jobs
+            let standardMessageJobs: [Job] = allProcessedMessages
+                .filter { !$0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
+                .grouped { $0.threadId }
+                .compactMap { threadId, threadMessages in
+                    messageCount += threadMessages.count
+                    finalProcessedMessages += threadMessages
+                    
+                    let job: Job? = Job(
+                        variant: .messageReceive,
+                        behaviour: .runOnce,
+                        threadId: threadId,
+                        details: MessageReceiveJob.Details(messages: threadMessages)
+                    )
+                    
+                    // If we are force-polling then add to the JobRunner so they are
+                    // persistent and will retry on the next app run if they fail but
+                    // don't let them auto-start
+                    let updatedJob: Job? = dependencies[singleton: .jobRunner].add(
+                        db,
+                        job: job,
+                        canStartJob: (
+                            !forceSynchronousProcessing && (
+                                !dependencies[singleton: .appContext].isInBackground ||
+                                // FIXME: Better seperate the call messages handling, since we need to handle them all the time
+                                dependencies[singleton: .callManager].currentCall != nil
+                            )
+                        )
+                    )
+                    
+                    // Create the dependency between the jobs (config processing should happen before
+                    // standard message processing)
+                    if let updatedJobId: Int64 = updatedJob?.id {
+                        do {
+                            try configJobIds.forEach { configJobId in
+                                try JobDependencies(
+                                    jobId: updatedJobId,
+                                    dependantId: configJobId
+                                )
+                                .insert(db)
+                            }
+                        }
+                        catch {
+                            Log.warn(.poller, "Failed to add dependency between config processing and non-config processing messageReceive jobs.")
+                        }
+                    }
+                    
+                    return updatedJob
+                }
+            
+            // Update the cached validity of the messages
+            try SnodeReceivedMessageInfo.handlePotentialDeletedOrInvalidHash(
+                db,
+                potentiallyInvalidHashes: (sortedMessages.isEmpty && !hadValidHashUpdate ?
+                    lastHashes :
+                    []
+                ),
+                otherKnownValidHashes: otherKnownHashes
+            )
+            
+            return (configMessageJobs, standardMessageJobs, (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
+        }
     }
 }

--- a/SessionMessagingKit/Utilities/DisplayPictureManager.swift
+++ b/SessionMessagingKit/Utilities/DisplayPictureManager.swift
@@ -326,7 +326,7 @@ public class DisplayPictureManager {
                 // Encrypt the avatar for upload
                 guard
                     let encryptedData: Data = dependencies[singleton: .crypto].generate(
-                        .encryptedDataDisplayPicture(data: finalImageData, key: newEncryptionKey, using: dependencies)
+                        .encryptedDataDisplayPicture(data: finalImageData, key: newEncryptionKey)
                     )
                 else {
                     Log.error(.displayPictureManager, "Updating service with profile failed.")

--- a/SessionMessagingKitTests/Crypto/CryptoSMKSpec.swift
+++ b/SessionMessagingKitTests/Crypto/CryptoSMKSpec.swift
@@ -1,7 +1,6 @@
 // Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
 
 import Foundation
-import GRDB
 import SessionUtilitiesKit
 
 import Quick
@@ -14,20 +13,13 @@ class CryptoSMKSpec: QuickSpec {
         // MARK: Configuration
 
         @TestState var dependencies: TestDependencies! = TestDependencies()
-        @TestState(singleton: .storage, in: dependencies) var mockStorage: Storage! = SynchronousStorage(
-            customWriter: try! DatabaseQueue(),
-            migrationTargets: [
-                SNUtilitiesKit.self,
-                SNMessagingKit.self
-            ],
-            using: dependencies,
-            initialData: { db in
-                try Identity(variant: .ed25519PublicKey, data: Data(hex: TestConstants.edPublicKey)).insert(db)
-                try Identity(variant: .ed25519SecretKey, data: Data(hex: TestConstants.edSecretKey)).insert(db)
+        @TestState(singleton: .crypto, in: dependencies) var crypto: Crypto! = Crypto(using: dependencies)
+        @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
+            initialSetup: { cache in
+                cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
-        @TestState(singleton: .crypto, in: dependencies) var crypto: Crypto! = Crypto(using: .any)
-        @TestState var mockCrypto: MockCrypto! = MockCrypto()
 
         // MARK: - Crypto for SessionMessagingKit
         describe("Crypto for SessionMessagingKit") {
@@ -78,16 +70,12 @@ class CryptoSMKSpec: QuickSpec {
             context("when encrypting with the session protocol") {
                 // MARK: ---- can encrypt correctly
                 it("can encrypt correctly") {
-                    let result: Data? = mockStorage.read { db in
-                        try crypto.tryGenerate(
-                            .ciphertextWithSessionProtocol(
-                                db,
-                                plaintext: "TestMessage".data(using: .utf8)!,
-                                destination: .contact(publicKey: "05\(TestConstants.publicKey)"),
-                                using: dependencies
-                            )
+                    let result: Data? = try? crypto.tryGenerate(
+                        .ciphertextWithSessionProtocol(
+                            plaintext: "TestMessage".data(using: .utf8)!,
+                            destination: .contact(publicKey: "05\(TestConstants.publicKey)")
                         )
-                    }
+                    )
 
                     // Note: A Nonce is used for this so we can't compare the exact value when not mocked
                     expect(result).toNot(beNil())
@@ -96,24 +84,17 @@ class CryptoSMKSpec: QuickSpec {
 
                 // MARK: ---- throws an error if there is no ed25519 keyPair
                 it("throws an error if there is no ed25519 keyPair") {
-                    mockStorage.write { db in
-                        _ = try Identity.filter(id: .ed25519PublicKey).deleteAll(db)
-                        _ = try Identity.filter(id: .ed25519SecretKey).deleteAll(db)
-                    }
+                    mockGeneralCache.when { $0.ed25519SecretKey }.thenReturn([])
 
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .ciphertextWithSessionProtocol(
-                                    db,
-                                    plaintext: "TestMessage".data(using: .utf8)!,
-                                    destination: .contact(publicKey: "05\(TestConstants.publicKey)"),
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .ciphertextWithSessionProtocol(
+                                plaintext: "TestMessage".data(using: .utf8)!,
+                                destination: .contact(publicKey: "05\(TestConstants.publicKey)")
                             )
-                        }
-                        .to(throwError(MessageSenderError.noUserED25519KeyPair))
+                        )
                     }
+                    .to(throwError(MessageSenderError.noUserED25519KeyPair))
                 }
             }
 
@@ -121,19 +102,15 @@ class CryptoSMKSpec: QuickSpec {
             context("when decrypting with the session protocol") {
                 // MARK: ---- successfully decrypts a message
                 it("successfully decrypts a message") {
-                    let result = mockStorage.read { db in
-                        crypto.generate(
-                            .plaintextWithSessionProtocol(
-                                db,
-                                ciphertext: Data(
-                                    base64Encoded: "SRP0eBUWh4ez6ppWjUs5/Wph5fhnPRgB5zsWWnTz+FBAw/YI3oS2pDpIfyetMTbU" +
-                                    "sFMhE5G4PbRtQFey1hsxLl221Qivc3ayaX2Mm/X89Dl8e45BC+Lb/KU9EdesxIK4pVgYXs9XrMtX3v8" +
-                                    "dt0eBaXneOBfr7qB8pHwwMZjtkOu1ED07T9nszgbWabBphUfWXe2U9K3PTRisSCI="
-                                )!,
-                                using: dependencies
-                            )
+                    let result = crypto.generate(
+                        .plaintextWithSessionProtocol(
+                            ciphertext: Data(
+                                base64Encoded: "SRP0eBUWh4ez6ppWjUs5/Wph5fhnPRgB5zsWWnTz+FBAw/YI3oS2pDpIfyetMTbU" +
+                                "sFMhE5G4PbRtQFey1hsxLl221Qivc3ayaX2Mm/X89Dl8e45BC+Lb/KU9EdesxIK4pVgYXs9XrMtX3v8" +
+                                "dt0eBaXneOBfr7qB8pHwwMZjtkOu1ED07T9nszgbWabBphUfWXe2U9K3PTRisSCI="
+                            )!
                         )
-                    }
+                    )
 
                     expect(String(data: (result?.plaintext ?? Data()), encoding: .utf8)).to(equal("TestMessage"))
                     expect(result?.senderSessionIdHex)
@@ -142,43 +119,32 @@ class CryptoSMKSpec: QuickSpec {
 
                 // MARK: ---- throws an error if there is no ed25519 keyPair
                 it("throws an error if there is no ed25519 keyPair") {
-                    mockStorage.write { db in
-                        _ = try Identity.filter(id: .ed25519PublicKey).deleteAll(db)
-                        _ = try Identity.filter(id: .ed25519SecretKey).deleteAll(db)
-                    }
+                    mockGeneralCache.when { $0.ed25519SecretKey }.thenReturn([])
 
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionProtocol(
-                                    db,
-                                    ciphertext: Data(
-                                        base64Encoded: "SRP0eBUWh4ez6ppWjUs5/Wph5fhnPRgB5zsWWnTz+FBAw/YI3oS2pDpIfyetMTbU" +
-                                        "sFMhE5G4PbRtQFey1hsxLl221Qivc3ayaX2Mm/X89Dl8e45BC+Lb/KU9EdesxIK4pVgYXs9XrMtX3v8" +
-                                        "dt0eBaXneOBfr7qB8pHwwMZjtkOu1ED07T9nszgbWabBphUfWXe2U9K3PTRisSCI="
-                                    )!,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionProtocol(
+                                ciphertext: Data(
+                                    base64Encoded: "SRP0eBUWh4ez6ppWjUs5/Wph5fhnPRgB5zsWWnTz+FBAw/YI3oS2pDpIfyetMTbU" +
+                                    "sFMhE5G4PbRtQFey1hsxLl221Qivc3ayaX2Mm/X89Dl8e45BC+Lb/KU9EdesxIK4pVgYXs9XrMtX3v8" +
+                                    "dt0eBaXneOBfr7qB8pHwwMZjtkOu1ED07T9nszgbWabBphUfWXe2U9K3PTRisSCI="
+                                )!
                             )
-                        }
-                        .to(throwError(MessageSenderError.noUserED25519KeyPair))
+                        )
                     }
+                    .to(throwError(MessageSenderError.noUserED25519KeyPair))
                 }
 
                 // MARK: ---- throws an error if the ciphertext is too short
                 it("throws an error if the ciphertext is too short") {
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionProtocol(
-                                    db,
-                                    ciphertext: Data([1, 2, 3]),
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionProtocol(
+                                ciphertext: Data([1, 2, 3])
                             )
-                        }
-                        .to(throwError(MessageReceiverError.decryptionFailed))
+                        )
                     }
+                    .to(throwError(MessageReceiverError.decryptionFailed))
                 }
             }
         }

--- a/SessionMessagingKitTests/Jobs/DisplayPictureDownloadJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/DisplayPictureDownloadJobSpec.swift
@@ -93,7 +93,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
             initialSetup: { crypto in
                 crypto.when { $0.generate(.uuid()) }.thenReturn(UUID(uuidString: "00000000-0000-0000-0000-000000001234"))
                 crypto
-                    .when { $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any)) }
+                    .when { $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any)) }
                     .thenReturn(imageData)
                 crypto.when { $0.generate(.hash(message: .any, length: .any)) }.thenReturn("TestHash".bytes)
                 crypto
@@ -116,6 +116,15 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
             initialSetup: { displayPictureCache in
                 displayPictureCache.when { $0.imageData }.thenReturn([:])
                 displayPictureCache.when { $0.imageData = .any }.thenReturn(())
+            }
+        )
+        @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
+            initialSetup: { cache in
+                cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
+                cache
+                    .when { $0.ed25519Seed }
+                    .thenReturn(Array(Array(Data(hex: TestConstants.edSecretKey)).prefix(upTo: 32)))
             }
         )
         
@@ -633,7 +642,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                 context("when it fails to decrypt the data") {
                     beforeEach {
                         mockCrypto
-                            .when { $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any)) }
+                            .when { $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any)) }
                             .thenReturn(nil)
                     }
                     
@@ -650,7 +659,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                 context("when it decrypts invalid image data") {
                     beforeEach {
                         mockCrypto
-                            .when { $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any)) }
+                            .when { $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any)) }
                             .thenReturn(Data([1, 2, 3]))
                     }
                     
@@ -742,7 +751,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("does not save the picture") {
                             expect(mockCrypto)
                                 .toNot(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager)
                                 .toNot(call { $0.createFile(atPath: .any, contents: .any, attributes: .any) })
@@ -768,7 +777,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("does not save the picture") {
                             expect(mockCrypto)
                                 .toNot(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager)
                                 .toNot(call { $0.createFile(atPath: .any, contents: .any, attributes: .any) })
@@ -804,7 +813,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("does not save the picture") {
                             expect(mockCrypto)
                                 .toNot(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager)
                                 .toNot(call { $0.createFile(atPath: .any, contents: .any, attributes: .any) })
@@ -839,7 +848,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("saves the picture") {
                             expect(mockCrypto)
                                 .to(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager).to(call(.exactly(times: 1), matchingParameters: .all) {
                                 $0.createFile(
@@ -936,7 +945,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("does not save the picture") {
                             expect(mockCrypto)
                                 .toNot(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager)
                                 .toNot(call { $0.createFile(atPath: .any, contents: .any, attributes: .any) })
@@ -962,7 +971,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("does not save the picture") {
                             expect(mockCrypto)
                                 .toNot(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager)
                                 .toNot(call { $0.createFile(atPath: .any, contents: .any, attributes: .any) })
@@ -1004,7 +1013,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("does not save the picture") {
                             expect(mockCrypto)
                                 .toNot(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager)
                                 .toNot(call { $0.createFile(atPath: .any, contents: .any, attributes: .any) })
@@ -1045,7 +1054,7 @@ class DisplayPictureDownloadJobSpec: QuickSpec {
                         it("saves the picture") {
                             expect(mockCrypto)
                                 .to(call {
-                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any, using: .any))
+                                    $0.generate(.decryptedDataDisplayPicture(data: .any, key: .any))
                                 })
                             expect(mockFileManager).to(call(.exactly(times: 1), matchingParameters: .all) {
                                 $0.createFile(

--- a/SessionMessagingKitTests/Jobs/RetrieveDefaultOpenGroupRoomsJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/RetrieveDefaultOpenGroupRoomsJobSpec.swift
@@ -86,6 +86,15 @@ class RetrieveDefaultOpenGroupRoomsJobSpec: QuickSpec {
                 cache.when { $0.setDefaultRoomInfo(.any) }.thenReturn(())
             }
         )
+        @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
+            initialSetup: { cache in
+                cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
+                cache
+                    .when { $0.ed25519Seed }
+                    .thenReturn(Array(Array(Data(hex: TestConstants.edSecretKey)).prefix(upTo: 32)))
+            }
+        )
         @TestState var job: Job! = Job(variant: .retrieveDefaultOpenGroupRooms)
         @TestState var error: Error? = nil
         @TestState var permanentFailure: Bool! = false

--- a/SessionMessagingKitTests/LibSession/LibSessionGroupInfoSpec.swift
+++ b/SessionMessagingKitTests/LibSession/LibSessionGroupInfoSpec.swift
@@ -23,6 +23,7 @@ class LibSessionGroupInfoSpec: QuickSpec {
         @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
             initialSetup: { cache in
                 cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
         @TestState(singleton: .storage, in: dependencies) var mockStorage: Storage! = SynchronousStorage(

--- a/SessionMessagingKitTests/LibSession/LibSessionGroupMembersSpec.swift
+++ b/SessionMessagingKitTests/LibSession/LibSessionGroupMembersSpec.swift
@@ -22,6 +22,7 @@ class LibSessionGroupMembersSpec: QuickSpec {
         @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
             initialSetup: { cache in
                 cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
         @TestState(singleton: .storage, in: dependencies) var mockStorage: Storage! = SynchronousStorage(

--- a/SessionMessagingKitTests/LibSession/LibSessionSpec.swift
+++ b/SessionMessagingKitTests/LibSession/LibSessionSpec.swift
@@ -22,6 +22,7 @@ class LibSessionSpec: QuickSpec {
         @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
             initialSetup: { cache in
                 cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
         @TestState(singleton: .storage, in: dependencies) var mockStorage: Storage! = SynchronousStorage(
@@ -345,11 +346,8 @@ class LibSessionSpec: QuickSpec {
                 // MARK: ---- throws when there is no user ed25519 keyPair
                 it("throws when there is no user ed25519 keyPair") {
                     var resultError: Error? = nil
-                    
+                    mockGeneralCache.when { $0.ed25519SecretKey }.thenReturn([])
                     mockStorage.write { db in
-                        try Identity.filter(id: .ed25519PublicKey).deleteAll(db)
-                        try Identity.filter(id: .ed25519SecretKey).deleteAll(db)
-                        
                         do {
                             _ = try LibSession.createGroup(
                                 db,

--- a/SessionMessagingKitTests/Open Groups/Crypto/CryptoOpenGroupAPISpec.swift
+++ b/SessionMessagingKitTests/Open Groups/Crypto/CryptoOpenGroupAPISpec.swift
@@ -1,7 +1,6 @@
 // Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
 
 import Foundation
-import GRDB
 import SessionUtilitiesKit
 
 import Quick
@@ -14,19 +13,13 @@ class CryptoOpenGroupAPISpec: QuickSpec {
         // MARK: Configuration
         
         @TestState var dependencies: TestDependencies! = TestDependencies()
-        @TestState(singleton: .storage, in: dependencies) var mockStorage: Storage! = SynchronousStorage(
-            customWriter: try! DatabaseQueue(),
-            migrationTargets: [
-                SNUtilitiesKit.self,
-                SNMessagingKit.self
-            ],
-            using: dependencies,
-            initialData: { db in
-                try Identity(variant: .ed25519PublicKey, data: Data(hex: TestConstants.edPublicKey)).insert(db)
-                try Identity(variant: .ed25519SecretKey, data: Data(hex: TestConstants.edSecretKey)).insert(db)
+        @TestState(singleton: .crypto, in: dependencies) var crypto: Crypto! = Crypto(using: dependencies)
+        @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
+            initialSetup: { cache in
+                cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
-        @TestState(singleton: .crypto, in: dependencies) var crypto: Crypto! = Crypto(using: .any)
         
         // MARK: - Crypto for OpenGroupAPI
         describe("Crypto for OpenGroupAPI") {
@@ -187,17 +180,13 @@ class CryptoOpenGroupAPISpec: QuickSpec {
             context("when encrypting with the session blinding protocol") {
                 // MARK: ---- can encrypt for a blind15 recipient correctly
                 it("can encrypt for a blind15 recipient correctly") {
-                    let result: Data? = mockStorage.read { db in
-                        try crypto.tryGenerate(
-                            .ciphertextWithSessionBlindingProtocol(
-                                db,
-                                plaintext: "TestMessage".data(using: .utf8)!,
-                                recipientBlindedId: "15\(TestConstants.blind15PublicKey)",
-                                serverPublicKey: TestConstants.serverPublicKey,
-                                using: dependencies
-                            )
+                    let result: Data? = try? crypto.tryGenerate(
+                        .ciphertextWithSessionBlindingProtocol(
+                            plaintext: "TestMessage".data(using: .utf8)!,
+                            recipientBlindedId: "15\(TestConstants.blind15PublicKey)",
+                            serverPublicKey: TestConstants.serverPublicKey
                         )
-                    }
+                    )
                     
                     // Note: A Nonce is used for this so we can't compare the exact value when not mocked
                     expect(result).toNot(beNil())
@@ -206,17 +195,13 @@ class CryptoOpenGroupAPISpec: QuickSpec {
                 
                 // MARK: ---- can encrypt for a blind25 recipient correctly
                 it("can encrypt for a blind25 recipient correctly") {
-                    let result: Data? = mockStorage.read { db in
-                        try crypto.tryGenerate(
-                            .ciphertextWithSessionBlindingProtocol(
-                                db,
-                                plaintext: "TestMessage".data(using: .utf8)!,
-                                recipientBlindedId: "25\(TestConstants.blind25PublicKey)",
-                                serverPublicKey: TestConstants.serverPublicKey,
-                                using: dependencies
-                            )
+                    let result: Data? = try? crypto.tryGenerate(
+                        .ciphertextWithSessionBlindingProtocol(
+                            plaintext: "TestMessage".data(using: .utf8)!,
+                            recipientBlindedId: "25\(TestConstants.blind25PublicKey)",
+                            serverPublicKey: TestConstants.serverPublicKey
                         )
-                    }
+                    )
                     
                     // Note: A Nonce is used for this so we can't compare the exact value when not mocked
                     expect(result).toNot(beNil())
@@ -225,60 +210,45 @@ class CryptoOpenGroupAPISpec: QuickSpec {
                 
                 // MARK: ---- includes a version at the start of the encrypted value
                 it("includes a version at the start of the encrypted value") {
-                    let result: Data? = mockStorage.read { db in
-                        try crypto.tryGenerate(
-                            .ciphertextWithSessionBlindingProtocol(
-                                db,
-                                plaintext: "TestMessage".data(using: .utf8)!,
-                                recipientBlindedId: "15\(TestConstants.blind15PublicKey)",
-                                serverPublicKey: TestConstants.serverPublicKey,
-                                using: dependencies
-                            )
+                    let result: Data? = try? crypto.tryGenerate(
+                        .ciphertextWithSessionBlindingProtocol(
+                            plaintext: "TestMessage".data(using: .utf8)!,
+                            recipientBlindedId: "15\(TestConstants.blind15PublicKey)",
+                            serverPublicKey: TestConstants.serverPublicKey
                         )
-                    }
+                    )
                     
                     expect(result?.toHexString().prefix(2)).to(equal("00"))
                 }
                 
                 // MARK: ---- throws an error if the recipient isn't a blinded id
                 it("throws an error if the recipient isn't a blinded id") {
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .ciphertextWithSessionBlindingProtocol(
-                                    db,
-                                    plaintext: "TestMessage".data(using: .utf8)!,
-                                    recipientBlindedId: "05\(TestConstants.publicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .ciphertextWithSessionBlindingProtocol(
+                                plaintext: "TestMessage".data(using: .utf8)!,
+                                recipientBlindedId: "05\(TestConstants.publicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageSenderError.encryptionFailed))
+                        )
                     }
+                    .to(throwError(MessageSenderError.encryptionFailed))
                 }
                 
                 // MARK: ---- throws an error if there is no ed25519 keyPair
                 it("throws an error if there is no ed25519 keyPair") {
-                    mockStorage.write { db in
-                        _ = try Identity.filter(id: .ed25519PublicKey).deleteAll(db)
-                        _ = try Identity.filter(id: .ed25519SecretKey).deleteAll(db)
-                    }
+                    mockGeneralCache.when { $0.ed25519SecretKey }.thenReturn([])
                     
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .ciphertextWithSessionBlindingProtocol(
-                                    db,
-                                    plaintext: "TestMessage".data(using: .utf8)!,
-                                    recipientBlindedId: "15\(TestConstants.blind15PublicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .ciphertextWithSessionBlindingProtocol(
+                                plaintext: "TestMessage".data(using: .utf8)!,
+                                recipientBlindedId: "15\(TestConstants.blind15PublicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageSenderError.noUserED25519KeyPair))
+                        )
                     }
+                    .to(throwError(MessageSenderError.noUserED25519KeyPair))
                 }
             }
             
@@ -286,21 +256,17 @@ class CryptoOpenGroupAPISpec: QuickSpec {
             context("when decrypting with the session blinding protocol") {
                 // MARK: ---- can decrypt a blind15 message correctly
                 it("can decrypt a blind15 message correctly") {
-                    let result = mockStorage.read { db in
-                        try crypto.tryGenerate(
-                            .plaintextWithSessionBlindingProtocol(
-                                db,
-                                ciphertext: Data(
-                                    base64Encoded: "AMuM6E07xyYzN1/gP64v9TelMjkylHsFZznTzE7rDIykIHBHKbdkLnXo4Q1iVWdD" +
-                                    "ct9F9YqIsRsqmdLl1t6nfQtWoiUSkjBChvg3J61f7rpS3/A+"
-                                )!,
-                                senderId: "15\(TestConstants.blind15PublicKey)",
-                                recipientId: "15\(TestConstants.blind15PublicKey)",
-                                serverPublicKey: TestConstants.serverPublicKey,
-                                using: dependencies
-                            )
+                    let result = try? crypto.tryGenerate(
+                        .plaintextWithSessionBlindingProtocol(
+                            ciphertext: Data(
+                                base64Encoded: "AMuM6E07xyYzN1/gP64v9TelMjkylHsFZznTzE7rDIykIHBHKbdkLnXo4Q1iVWdD" +
+                                "ct9F9YqIsRsqmdLl1t6nfQtWoiUSkjBChvg3J61f7rpS3/A+"
+                            )!,
+                            senderId: "15\(TestConstants.blind15PublicKey)",
+                            recipientId: "15\(TestConstants.blind15PublicKey)",
+                            serverPublicKey: TestConstants.serverPublicKey
                         )
-                    }
+                    )
                     
                     expect(String(data: (result?.plaintext ?? Data()), encoding: .utf8)).to(equal("TestMessage"))
                     expect(result?.senderSessionIdHex).to(equal("05\(TestConstants.publicKey)"))
@@ -308,21 +274,17 @@ class CryptoOpenGroupAPISpec: QuickSpec {
                 
                 // MARK: ---- can decrypt a blind25 message correctly
                 it("can decrypt a blind25 message correctly") {
-                    let result = mockStorage.read { db in
-                        try crypto.tryGenerate(
-                            .plaintextWithSessionBlindingProtocol(
-                                db,
-                                ciphertext: Data(
-                                    base64Encoded: "ALLcu/jtQsel6HewKdRCsRYXrQl7r60Oz2SX/DKmjCRo4mO2yqMx2+oGwm39n6+p" +
-                                    "6dK1n+UWPnm4qGRiN6BvZ+xwNsBruPgyW1EV9i8AcEO0P/1X"
-                                )!,
-                                senderId: "25\(TestConstants.blind25PublicKey)",
-                                recipientId: "25\(TestConstants.blind25PublicKey)",
-                                serverPublicKey: TestConstants.serverPublicKey,
-                                using: dependencies
-                            )
+                    let result = try? crypto.tryGenerate(
+                        .plaintextWithSessionBlindingProtocol(
+                            ciphertext: Data(
+                                base64Encoded: "ALLcu/jtQsel6HewKdRCsRYXrQl7r60Oz2SX/DKmjCRo4mO2yqMx2+oGwm39n6+p" +
+                                "6dK1n+UWPnm4qGRiN6BvZ+xwNsBruPgyW1EV9i8AcEO0P/1X"
+                            )!,
+                            senderId: "25\(TestConstants.blind25PublicKey)",
+                            recipientId: "25\(TestConstants.blind25PublicKey)",
+                            serverPublicKey: TestConstants.serverPublicKey
                         )
-                    }
+                    )
                     
                     expect(String(data: (result?.plaintext ?? Data()), encoding: .utf8)).to(equal("TestMessage"))
                     expect(result?.senderSessionIdHex).to(equal("05\(TestConstants.publicKey)"))
@@ -330,114 +292,91 @@ class CryptoOpenGroupAPISpec: QuickSpec {
                 
                 // MARK: ---- throws an error if there is no ed25519 keyPair
                 it("throws an error if there is no ed25519 keyPair") {
-                    mockStorage.write { db in
-                        _ = try Identity.filter(id: .ed25519PublicKey).deleteAll(db)
-                        _ = try Identity.filter(id: .ed25519SecretKey).deleteAll(db)
-                    }
+                    mockGeneralCache.when { $0.ed25519SecretKey }.thenReturn([])
                     
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionBlindingProtocol(
-                                    db,
-                                    ciphertext: Data(
-                                        base64Encoded: "SRP0eBUWh4ez6ppWjUs5/Wph5fhnPRgB5zsWWnTz+FBAw/YI3oS2pDpIfyetMTbU" +
-                                        "sFMhE5G4PbRtQFey1hsxLl221Qivc3ayaX2Mm/X89Dl8e45BC+Lb/KU9EdesxIK4pVgYXs9XrMtX3v8" +
-                                        "dt0eBaXneOBfr7qB8pHwwMZjtkOu1ED07T9nszgbWabBphUfWXe2U9K3PTRisSCI="
-                                    )!,
-                                    senderId: "25\(TestConstants.blind25PublicKey)",
-                                    recipientId: "25\(TestConstants.blind25PublicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionBlindingProtocol(
+                                ciphertext: Data(
+                                    base64Encoded: "SRP0eBUWh4ez6ppWjUs5/Wph5fhnPRgB5zsWWnTz+FBAw/YI3oS2pDpIfyetMTbU" +
+                                    "sFMhE5G4PbRtQFey1hsxLl221Qivc3ayaX2Mm/X89Dl8e45BC+Lb/KU9EdesxIK4pVgYXs9XrMtX3v8" +
+                                    "dt0eBaXneOBfr7qB8pHwwMZjtkOu1ED07T9nszgbWabBphUfWXe2U9K3PTRisSCI="
+                                )!,
+                                senderId: "25\(TestConstants.blind25PublicKey)",
+                                recipientId: "25\(TestConstants.blind25PublicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageSenderError.noUserED25519KeyPair))
+                        )
                     }
+                    .to(throwError(MessageSenderError.noUserED25519KeyPair))
                 }
                 
                 // MARK: ---- throws an error if the data is too short
                 it("throws an error if the data is too short") {
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionBlindingProtocol(
-                                    db,
-                                    ciphertext: Data([1, 2, 3]),
-                                    senderId: "15\(TestConstants.blind15PublicKey)",
-                                    recipientId: "15\(TestConstants.blind15PublicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionBlindingProtocol(
+                                ciphertext: Data([1, 2, 3]),
+                                senderId: "15\(TestConstants.blind15PublicKey)",
+                                recipientId: "15\(TestConstants.blind15PublicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageReceiverError.decryptionFailed))
+                        )
                     }
+                    .to(throwError(MessageReceiverError.decryptionFailed))
                 }
                 
                 // MARK: ---- throws an error if the data version is not 0
                 it("throws an error if the data version is not 0") {
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionBlindingProtocol(
-                                    db,
-                                    ciphertext: (
-                                        Data([1]) +
-                                        "TestMessage".data(using: .utf8)! +
-                                        Data(base64Encoded: "pbTUizreT0sqJ2R2LloseQDyVL2RYztD")!
-                                    ),
-                                    senderId: "15\(TestConstants.blind15PublicKey)",
-                                    recipientId: "15\(TestConstants.blind15PublicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionBlindingProtocol(
+                                ciphertext: (
+                                    Data([1]) +
+                                    "TestMessage".data(using: .utf8)! +
+                                    Data(base64Encoded: "pbTUizreT0sqJ2R2LloseQDyVL2RYztD")!
+                                ),
+                                senderId: "15\(TestConstants.blind15PublicKey)",
+                                recipientId: "15\(TestConstants.blind15PublicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageReceiverError.decryptionFailed))
+                        )
                     }
+                    .to(throwError(MessageReceiverError.decryptionFailed))
                 }
                 
                 // MARK: ---- throws an error if it cannot decrypt the data
                 it("throws an error if it cannot decrypt the data") {
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionBlindingProtocol(
-                                    db,
-                                    ciphertext: "RandomData".data(using: .utf8)!,
-                                    senderId: "25\(TestConstants.blind25PublicKey)",
-                                    recipientId: "25\(TestConstants.blind25PublicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionBlindingProtocol(
+                                ciphertext: "RandomData".data(using: .utf8)!,
+                                senderId: "25\(TestConstants.blind25PublicKey)",
+                                recipientId: "25\(TestConstants.blind25PublicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageReceiverError.decryptionFailed))
+                        )
                     }
+                    .to(throwError(MessageReceiverError.decryptionFailed))
                 }
                 
                 // MARK: ---- throws an error if the inner bytes are too short
                 it("throws an error if the inner bytes are too short") {
-                    mockStorage.read { db in
-                        expect {
-                            try crypto.tryGenerate(
-                                .plaintextWithSessionBlindingProtocol(
-                                    db,
-                                    ciphertext: (
-                                        Data([0]) +
-                                        "TestMessage".data(using: .utf8)! +
-                                        Data(base64Encoded: "pbTUizreT0sqJ2R2LloseQDyVL2RYztD")!
-                                    ),
-                                    senderId: "15\(TestConstants.blind15PublicKey)",
-                                    recipientId: "15\(TestConstants.blind15PublicKey)",
-                                    serverPublicKey: TestConstants.serverPublicKey,
-                                    using: dependencies
-                                )
+                    expect {
+                        try crypto.tryGenerate(
+                            .plaintextWithSessionBlindingProtocol(
+                                ciphertext: (
+                                    Data([0]) +
+                                    "TestMessage".data(using: .utf8)! +
+                                    Data(base64Encoded: "pbTUizreT0sqJ2R2LloseQDyVL2RYztD")!
+                                ),
+                                senderId: "15\(TestConstants.blind15PublicKey)",
+                                recipientId: "15\(TestConstants.blind15PublicKey)",
+                                serverPublicKey: TestConstants.serverPublicKey
                             )
-                        }
-                        .to(throwError(MessageReceiverError.decryptionFailed))
+                        )
                     }
+                    .to(throwError(MessageReceiverError.decryptionFailed))
                 }
             }
         }

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -137,6 +137,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
         @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
             initialSetup: { cache in
                 cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
         @TestState var secretKey: [UInt8]! = Array(Data(hex: TestConstants.edSecretKey))
@@ -203,7 +204,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                     .when { $0.config(for: .groupKeys, sessionId: groupId) }
                     .thenReturn(groupKeysConfig)
                 cache
-                    .when { try $0.pendingChanges(.any, swarmPublicKey: .any) }
+                    .when { try $0.pendingChanges(swarmPublicKey: .any) }
                     .thenReturn(LibSession.PendingChanges())
                 cache.when { $0.configNeedsDump(.any) }.thenReturn(false)
                 cache

--- a/SessionMessagingKitTests/Sending & Receiving/MessageSenderGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageSenderGroupsSpec.swift
@@ -128,7 +128,7 @@ class MessageSenderGroupsSpec: QuickSpec {
                     .when { $0.generate(.uuid()) }
                     .thenReturn(UUID(uuidString: "00000000-0000-0000-0000-000000000000")!)
                 crypto
-                    .when { $0.generate(.encryptedDataDisplayPicture(data: .any, key: .any, using: .any)) }
+                    .when { $0.generate(.encryptedDataDisplayPicture(data: .any, key: .any)) }
                     .thenReturn(TestConstants.validImageData)
                 crypto
                     .when { $0.generate(.ciphertextForGroupMessage(groupSessionId: .any, message: .any)) }
@@ -154,6 +154,7 @@ class MessageSenderGroupsSpec: QuickSpec {
         @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
             initialSetup: { cache in
                 cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
             }
         )
         @TestState var secretKey: [UInt8]! = Array(Data(hex: TestConstants.edSecretKey))
@@ -208,7 +209,7 @@ class MessageSenderGroupsSpec: QuickSpec {
                     .when { $0.config(for: .groupKeys, sessionId: groupId) }
                     .thenReturn(groupKeysConfig)
                 cache
-                    .when { try $0.pendingChanges(.any, swarmPublicKey: .any) }
+                    .when { try $0.pendingChanges(swarmPublicKey: .any) }
                     .thenReturn(LibSession.PendingChanges(obsoleteHashes: ["testHash"]))
                 cache.when { $0.configNeedsDump(.any) }.thenReturn(false)
                 cache
@@ -285,7 +286,7 @@ class MessageSenderGroupsSpec: QuickSpec {
             context("when creating a group") {
                 beforeEach {
                     mockLibSessionCache
-                        .when { try $0.pendingChanges(.any, swarmPublicKey: .any) }
+                        .when { try $0.pendingChanges(swarmPublicKey: .any) }
                         .thenReturn(LibSession.PendingChanges())
                 }
                 
@@ -454,7 +455,7 @@ class MessageSenderGroupsSpec: QuickSpec {
                 // MARK: ---- syncs the group configuration messages
                 it("syncs the group configuration messages") {
                     mockLibSessionCache
-                        .when { try $0.pendingChanges(.any, swarmPublicKey: .any) }
+                        .when { try $0.pendingChanges(swarmPublicKey: .any) }
                         .thenReturn(
                             LibSession.PendingChanges(
                                 pushData: [

--- a/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
@@ -35,11 +35,23 @@ class MessageSenderSpec: QuickSpec {
                 crypto
                     .when { $0.generate(.randomBytes(24)) }
                     .thenReturn(Array(Data(base64Encoded: "pbTUizreT0sqJ2R2LloseQDyVL2RYztD")!))
+                crypto
+                    .when { $0.generate(.ed25519KeyPair(seed: .any)) }
+                    .thenReturn(
+                        KeyPair(
+                            publicKey: Array(Data(hex: TestConstants.edPublicKey)),
+                            secretKey: Array(Data(hex: TestConstants.edSecretKey))
+                        )
+                    )
             }
         )
         @TestState(cache: .general, in: dependencies) var mockGeneralCache: MockGeneralCache! = MockGeneralCache(
             initialSetup: { cache in
                 cache.when { $0.sessionId }.thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+                cache.when { $0.ed25519SecretKey }.thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
+                cache
+                    .when { $0.ed25519Seed }
+                    .thenReturn(Array(Array(Data(hex: TestConstants.edSecretKey)).prefix(upTo: 32)))
             }
         )
         
@@ -50,7 +62,7 @@ class MessageSenderSpec: QuickSpec {
                 beforeEach {
                     mockCrypto
                         .when {
-                            $0.generate(.ciphertextWithSessionProtocol(.any, plaintext: .any, destination: .any, using: .any))
+                            $0.generate(.ciphertextWithSessionProtocol(plaintext: .any, destination: .any))
                         }
                         .thenReturn(Data([1, 2, 3]))
                     mockCrypto

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -70,8 +70,8 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
         try mockThrowingNoReturn(args: [variant, sessionId], untrackedArgs: [db, change])
     }
     
-    func pendingChanges(_ db: Database, swarmPublicKey: String) throws -> LibSession.PendingChanges {
-        return mock(args: [swarmPublicKey], untrackedArgs: [db])
+    func pendingChanges(swarmPublicKey: String) throws -> LibSession.PendingChanges {
+        return mock(args: [swarmPublicKey])
     }
     
     func createDumpMarkingAsPushed(

--- a/SessionSnodeKit/Models/SnodeAuthenticatedRequestBody.swift
+++ b/SessionSnodeKit/Models/SnodeAuthenticatedRequestBody.swift
@@ -41,9 +41,9 @@ public class SnodeAuthenticatedRequestBody: Encodable {
         try container.encodeIfPresent(timestampMs, forKey: .timestampMs)
         
         switch authMethod.info {
-            case .standard(let sessionId, let ed25519KeyPair):
+            case .standard(let sessionId, let ed25519PublicKey):
                 try container.encode(sessionId.hexString, forKey: .pubkey)
-                try container.encode(ed25519KeyPair.publicKey.toHexString(), forKey: .ed25519PublicKey)
+                try container.encode(ed25519PublicKey.toHexString(), forKey: .ed25519PublicKey)
                 
             case .groupAdmin(let sessionId, _):
                 try container.encode(sessionId.hexString, forKey: .pubkey)

--- a/SessionTests/Conversations/Settings/ThreadSettingsViewModelSpec.swift
+++ b/SessionTests/Conversations/Settings/ThreadSettingsViewModelSpec.swift
@@ -85,7 +85,7 @@ class ThreadSettingsViewModelSpec: QuickSpec {
                     .thenReturn(())
                 cache.when { $0.isEmpty }.thenReturn(false)
                 cache
-                    .when { try $0.pendingChanges(.any, swarmPublicKey: .any) }
+                    .when { try $0.pendingChanges(swarmPublicKey: .any) }
                     .thenReturn(LibSession.PendingChanges())
             }
         )

--- a/SessionUtilitiesKit/Crypto/CryptoError.swift
+++ b/SessionUtilitiesKit/Crypto/CryptoError.swift
@@ -11,4 +11,5 @@ public enum CryptoError: Error {
     case encryptionFailed
     case decryptionFailed
     case failedToGenerateOutput
+    case missingUserSecretKey
 }

--- a/SessionUtilitiesKit/Database/Models/Identity.swift
+++ b/SessionUtilitiesKit/Database/Models/Identity.swift
@@ -77,17 +77,6 @@ public extension Identity {
         try Identity(variant: .x25519PublicKey, data: Data(x25519KeyPair.publicKey)).upsert(db)
     }
     
-    static func userExists(
-        _ db: Database? = nil,
-        using dependencies: Dependencies
-    ) -> Bool {
-        guard let db: Database = db else {
-            return (dependencies[singleton: .storage].read { db in Identity.userExists(db, using: dependencies) } ?? false)
-        }
-        
-        return (fetchUserEd25519KeyPair(db) != nil)
-    }
-    
     static func fetchUserKeyPair(_ db: Database) -> KeyPair? {
         guard
             let publicKey: Data = try? Identity.fetchOne(db, id: .x25519PublicKey)?.data,

--- a/SessionUtilitiesKit/General/Authentication.swift
+++ b/SessionUtilitiesKit/General/Authentication.swift
@@ -52,7 +52,7 @@ public extension Authentication {
 public extension Authentication {
     enum Info: Equatable {
         /// Used for when interacting as the current user
-        case standard(sessionId: SessionId, ed25519KeyPair: KeyPair)
+        case standard(sessionId: SessionId, ed25519PublicKey: [UInt8])
         
         /// Used for when interacting as a group admin
         case groupAdmin(groupSessionId: SessionId, ed25519SecretKey: [UInt8])

--- a/SessionUtilitiesKit/General/General.swift
+++ b/SessionUtilitiesKit/General/General.swift
@@ -8,7 +8,7 @@ import GRDB
 public extension Cache {
     static let general: CacheConfig<GeneralCacheType, ImmutableGeneralCacheType> = Dependencies.create(
         identifier: "general",
-        createInstance: { _ in General.Cache() },
+        createInstance: { dependencies in General.Cache(using: dependencies) },
         mutableInstance: { $0 },
         immutableInstance: { $0 }
     )
@@ -18,15 +18,41 @@ public extension Cache {
 
 public enum General {
     public class Cache: GeneralCacheType {
+        private let dependencies: Dependencies
         public var sessionId: SessionId = SessionId.invalid
+        public var ed25519SecretKey: [UInt8] = []
         public var recentReactionTimestamps: [Int64] = []
         public let placeholderCache: LRUCache<String, UIImage> = LRUCache(maxCacheSize: 50)
         public var contextualActionLookupMap: [Int: [String: [Int: Any]]] = [:]
         
+        public var userExists: Bool { !ed25519SecretKey.isEmpty }
+        public var ed25519Seed: [UInt8] {
+            guard ed25519SecretKey.count >= 32 else { return [] }
+            
+            return Array(ed25519SecretKey.prefix(upTo: 32))
+        }
+        
+        // MARK: - Initialization
+        
+        init(using dependencies: Dependencies) {
+            self.dependencies = dependencies
+        }
+        
         // MARK: - Functions
         
-        public func setCachedSessionId(sessionId: SessionId) {
-            self.sessionId = sessionId
+        public func setSecretKey(ed25519SecretKey: [UInt8]) {
+            guard
+                ed25519SecretKey.count >= 32,
+                let ed25519KeyPair: KeyPair = dependencies[singleton: .crypto].generate(
+                    .ed25519KeyPair(seed: Array(ed25519SecretKey.prefix(upTo: 32)))
+                ),
+                let x25519PublicKey: [UInt8] = dependencies[singleton: .crypto].generate(
+                    .x25519(ed25519Pubkey: ed25519KeyPair.publicKey)
+                )
+            else { return }
+            
+            self.sessionId = SessionId(.standard, publicKey: x25519PublicKey)
+            self.ed25519SecretKey = ed25519SecretKey
         }
     }
 }
@@ -35,17 +61,23 @@ public enum General {
 
 /// This is a read-only version of the Cache designed to avoid unintentionally mutating the instance in a non-thread-safe way
 public protocol ImmutableGeneralCacheType: ImmutableCacheType {
+    var userExists: Bool { get }
     var sessionId: SessionId { get }
+    var ed25519Seed: [UInt8] { get }
+    var ed25519SecretKey: [UInt8] { get }
     var recentReactionTimestamps: [Int64] { get }
     var placeholderCache: LRUCache<String, UIImage> { get }
     var contextualActionLookupMap: [Int: [String: [Int: Any]]] { get }
 }
 
 public protocol GeneralCacheType: ImmutableGeneralCacheType, MutableCacheType {
+    var userExists: Bool { get }
     var sessionId: SessionId { get }
+    var ed25519Seed: [UInt8] { get }
+    var ed25519SecretKey: [UInt8] { get }
     var recentReactionTimestamps: [Int64] { get set }
     var placeholderCache: LRUCache<String, UIImage> { get }
     var contextualActionLookupMap: [Int: [String: [Int: Any]]] { get set }
     
-    func setCachedSessionId(sessionId: SessionId)
+    func setSecretKey(ed25519SecretKey: [UInt8])
 }

--- a/SessionUtilitiesKitTests/Database/Models/IdentitySpec.swift
+++ b/SessionUtilitiesKitTests/Database/Models/IdentitySpec.swift
@@ -56,19 +56,6 @@ class IdentitySpec: QuickSpec {
                         .to(equal("Test6".data(using: .utf8)?.bytes))
                 }
             }
-            
-            // MARK: -- correctly determines if the user exists
-            it("correctly determines if the user exists") {
-                mockStorage.write { db in
-                    try Identity(variant: .ed25519PublicKey, data: "Test3".data(using: .utf8)!).insert(db)
-                    try Identity(variant: .ed25519SecretKey, data: "Test4".data(using: .utf8)!).insert(db)
-                }
-
-                mockStorage.read { db in
-                    expect(Identity.userExists(db, using: dependencies))
-                        .to(equal(true))
-                }
-            }
         }
     }
 }

--- a/SessionUtilitiesKitTests/General/GeneralCacheSpec.swift
+++ b/SessionUtilitiesKitTests/General/GeneralCacheSpec.swift
@@ -1,0 +1,92 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+
+import Quick
+import Nimble
+
+@testable import SessionUtilitiesKit
+
+class GeneralCacheSpec: QuickSpec {
+    override class func spec() {
+        // MARK: Configuration
+        
+        @TestState var dependencies: TestDependencies! = TestDependencies()
+        @TestState(singleton: .crypto, in: dependencies) var mockCrypto: MockCrypto! = MockCrypto(
+            initialSetup: { crypto in
+                crypto
+                    .when { $0.generate(.ed25519KeyPair(seed: .any)) }
+                    .thenReturn(
+                        KeyPair(
+                            publicKey: Array(Data(hex: TestConstants.edPublicKey)),
+                            secretKey: Array(Data(hex: TestConstants.edSecretKey))
+                        )
+                    )
+                crypto
+                    .when { $0.generate(.x25519(ed25519Pubkey: .any)) }
+                    .thenReturn(Array(Data(hex: TestConstants.publicKey)))
+            }
+        )
+        
+        // MARK: - a General Cache
+        describe("a General Cache") {
+            // MARK: -- starts with an invalid state
+            it("starts with an invalid state") {
+                let cache: General.Cache = General.Cache(using: dependencies)
+                
+                expect(cache.userExists).to(beFalse())
+                expect(cache.sessionId).to(equal(.invalid))
+                expect(cache.ed25519SecretKey).to(beEmpty())
+            }
+            
+            // MARK: -- correctly indicates whether the user exists
+            it("correctly indicates whether the user exists") {
+                let cache: General.Cache = General.Cache(using: dependencies)
+                cache.setSecretKey(ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)))
+
+                expect(cache.userExists).to(beTrue())
+            }
+            
+            // MARK: -- generates the correct sessionId
+            it("generates the correct sessionId") {
+                let cache: General.Cache = General.Cache(using: dependencies)
+                cache.setSecretKey(ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)))
+                
+                expect(cache.sessionId).to(equal(SessionId(.standard, hex: TestConstants.publicKey)))
+            }
+            
+            // MARK: -- remains invalid when given a seckey that is too short
+            it("remains invalid when given a seckey that is too short") {
+                mockCrypto.when { $0.generate(.ed25519KeyPair(seed: .any)) }.thenReturn(nil)
+                let cache: General.Cache = General.Cache(using: dependencies)
+                cache.setSecretKey(ed25519SecretKey: [1, 2, 3])
+                
+                expect(cache.userExists).to(beFalse())
+                expect(cache.sessionId).to(equal(.invalid))
+                expect(cache.ed25519SecretKey).to(beEmpty())
+            }
+            
+            // MARK: -- remains invalid when ed key pair generation fails
+            it("remains invalid when ed key pair generation fails") {
+                mockCrypto.when { $0.generate(.ed25519KeyPair(seed: .any)) }.thenReturn(nil)
+                let cache: General.Cache = General.Cache(using: dependencies)
+                cache.setSecretKey(ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)))
+                
+                expect(cache.userExists).to(beFalse())
+                expect(cache.sessionId).to(equal(.invalid))
+                expect(cache.ed25519SecretKey).to(beEmpty())
+            }
+            
+            // MARK: -- remains invalid when x25519 pubkey generation fails
+            it("remains invalid when x25519 pubkey generation fails") {
+                mockCrypto.when { $0.generate(.x25519(ed25519Pubkey: .any)) }.thenReturn(nil)
+                let cache: General.Cache = General.Cache(using: dependencies)
+                cache.setSecretKey(ed25519SecretKey: Array(Data(hex: TestConstants.edSecretKey)))
+                
+                expect(cache.userExists).to(beFalse())
+                expect(cache.sessionId).to(equal(.invalid))
+                expect(cache.ed25519SecretKey).to(beEmpty())
+            }
+        }
+    }
+}

--- a/_SharedTestUtilities/MockGeneralCache.swift
+++ b/_SharedTestUtilities/MockGeneralCache.swift
@@ -4,7 +4,22 @@ import UIKit
 import SessionUtilitiesKit
 
 class MockGeneralCache: Mock<GeneralCacheType>, GeneralCacheType {
+    var userExists: Bool {
+        get { return mock() }
+        set { mockNoReturn(args: [newValue]) }
+    }
+    
     var sessionId: SessionId {
+        get { return mock() }
+        set { mockNoReturn(args: [newValue]) }
+    }
+    
+    var ed25519Seed: [UInt8] {
+        get { return mock() }
+        set { mockNoReturn(args: [newValue]) }
+    }
+    
+    var ed25519SecretKey: [UInt8] {
         get { return mock() }
         set { mockNoReturn(args: [newValue]) }
     }
@@ -24,7 +39,7 @@ class MockGeneralCache: Mock<GeneralCacheType>, GeneralCacheType {
         set { mockNoReturn(args: [newValue]) }
     }
     
-    func setCachedSessionId(sessionId: SessionId) {
-        mockNoReturn(args: [sessionId])
+    func setSecretKey(ed25519SecretKey: [UInt8]) {
+        mockNoReturn(args: [ed25519SecretKey])
     }
 }


### PR DESCRIPTION
This PR is one of the changes needed for the "Database Relocation" work but the changes included are self-contained so it can be reviewed & merged independently from other `DBR` PRs

The changes include:
- Updated the General cache to include the users seckey (rather than fetching it from the DB every time causing unneeded load)
- Updated a bunch of Crypto usage to no longer need a `db` or `dependencies` instance passed to it
- Added unit tests for General.Cache
- Replaced `Identity.userExists` with `General.Cache.userExists` (no need for database access anymore)
- Moved the SwarmPoller message handling logic into it's own function to make debugging stack traces a little easier
- Cleaned up some hard-to-read logic

**Note:** This PR is based on the following two PRs:
- #426 
- #401 