### PR TITLE
DBR - 4 - Saving and reading messages from disk

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -851,6 +851,11 @@
 		FDB11A502DCC6ADE00BEF49F /* PriorityVisibilityInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A4F2DCC6ADD00BEF49F /* PriorityVisibilityInfo.swift */; };
 		FDB11A522DCC6B0000BEF49F /* OpenGroupUrlInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A512DCC6AFF00BEF49F /* OpenGroupUrlInfo.swift */; };
 		FDB11A542DCD7A7F00BEF49F /* Task+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A532DCD7A7B00BEF49F /* Task+Utilities.swift */; };
+		FDB11A562DD17C3300BEF49F /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A552DD17C3000BEF49F /* MockLogger.swift */; };
+		FDB11A572DD17D0600BEF49F /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A552DD17C3000BEF49F /* MockLogger.swift */; };
+		FDB11A582DD17D0600BEF49F /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A552DD17C3000BEF49F /* MockLogger.swift */; };
+		FDB11A592DD17D0600BEF49F /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A552DD17C3000BEF49F /* MockLogger.swift */; };
+		FDB11A5B2DD1901000BEF49F /* CurrentValueAsyncStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A5A2DD1900B00BEF49F /* CurrentValueAsyncStream.swift */; };
 		FDB348632BE3774000B716C2 /* BezierPathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB348622BE3774000B716C2 /* BezierPathView.swift */; };
 		FDB3486E2BE8457F00B716C2 /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3486D2BE8457F00B716C2 /* BackgroundTaskManager.swift */; };
 		FDB3487E2BE856C800B716C2 /* UIBezierPath+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3487D2BE856C800B716C2 /* UIBezierPath+Utilities.swift */; };
@@ -2050,6 +2055,8 @@
 		FDB11A4F2DCC6ADD00BEF49F /* PriorityVisibilityInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityVisibilityInfo.swift; sourceTree = "<group>"; };
 		FDB11A512DCC6AFF00BEF49F /* OpenGroupUrlInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGroupUrlInfo.swift; sourceTree = "<group>"; };
 		FDB11A532DCD7A7B00BEF49F /* Task+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Utilities.swift"; sourceTree = "<group>"; };
+		FDB11A552DD17C3000BEF49F /* MockLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogger.swift; sourceTree = "<group>"; };
+		FDB11A5A2DD1900B00BEF49F /* CurrentValueAsyncStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueAsyncStream.swift; sourceTree = "<group>"; };
 		FDB348622BE3774000B716C2 /* BezierPathView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierPathView.swift; sourceTree = "<group>"; };
 		FDB3486C2BE8448500B716C2 /* SessionUtilitiesKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionUtilitiesKit.h; sourceTree = "<group>"; };
 		FDB3486D2BE8457F00B716C2 /* BackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManager.swift; sourceTree = "<group>"; };
@@ -3943,6 +3950,7 @@
 				FDE755042C9BB4ED002A2623 /* Bencode.swift */,
 				FDE755032C9BB4ED002A2623 /* BencodeDecoder.swift */,
 				FD2272D32C34ECE1004D8A6C /* BencodeEncoder.swift */,
+				FDB11A5A2DD1900B00BEF49F /* CurrentValueAsyncStream.swift */,
 				FD3FAB682AF1ADCA00DC5421 /* FileManager.swift */,
 				FD6A38F02C2A66B100762359 /* KeychainStorage.swift */,
 				FD8FD7632C37C24A001E38C7 /* EquatableIgnoring.swift */,
@@ -4300,6 +4308,7 @@
 				FD83B9D127D59495005E1583 /* MockUserDefaults.swift */,
 				FD49E2452B05C1D500FFBBB5 /* MockKeychain.swift */,
 				FD0150372CA24328005B08A1 /* MockJobRunner.swift */,
+				FDB11A552DD17C3000BEF49F /* MockLogger.swift */,
 				FD83B9BD27CF2243005E1583 /* TestConstants.swift */,
 				FD6531892AA025C500DFEEAA /* TestDependencies.swift */,
 				FD9DD2702A72516D00ECB68E /* TestExtensions.swift */,
@@ -6075,6 +6084,7 @@
 				FDC438CD27BC641200C60D73 /* Set+Utilities.swift in Sources */,
 				B8856DE6256F15F2001CE70E /* String+SSK.swift in Sources */,
 				FDE754E02C9BAF8A002A2623 /* Hex.swift in Sources */,
+				FDB11A5B2DD1901000BEF49F /* CurrentValueAsyncStream.swift in Sources */,
 				FDE754CC2C9BAF37002A2623 /* MediaUtils.swift in Sources */,
 				FDE754DE2C9BAF8A002A2623 /* Crypto+SessionUtilitiesKit.swift in Sources */,
 				FDF2220F281B55E6000A4995 /* QueryInterfaceRequest+Utilities.swift in Sources */,
@@ -6634,6 +6644,7 @@
 				FD65318A2AA025C500DFEEAA /* TestDependencies.swift in Sources */,
 				FD2AAAED28ED3E1000A49611 /* MockGeneralCache.swift in Sources */,
 				FD481A992CB4CAAA00ECC4CF /* MockLibSessionCache.swift in Sources */,
+				FDB11A572DD17D0600BEF49F /* MockLogger.swift in Sources */,
 				FD49E2462B05C1D500FFBBB5 /* MockKeychain.swift in Sources */,
 				FD01502C2CA23DB7005B08A1 /* GRDBExtensions.swift in Sources */,
 			);
@@ -6652,6 +6663,7 @@
 				FD9DD2732A72516D00ECB68E /* TestExtensions.swift in Sources */,
 				FD3FAB6E2AF1B28C00DC5421 /* MockFileManager.swift in Sources */,
 				FD83B9BB27CF20AF005E1583 /* SessionIdSpec.swift in Sources */,
+				FDB11A592DD17D0600BEF49F /* MockLogger.swift in Sources */,
 				FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */,
 				FDC290A927D9B46D005DAE71 /* NimbleExtensions.swift in Sources */,
 				FD0150402CA2433D005B08A1 /* BencodeDecoderSpec.swift in Sources */,
@@ -6686,6 +6698,7 @@
 				FD0150382CA24328005B08A1 /* MockJobRunner.swift in Sources */,
 				FD481A952CAE0AE000ECC4CF /* MockAppContext.swift in Sources */,
 				FD3765DF2AD8F03100DC1489 /* MockSnodeAPICache.swift in Sources */,
+				FDB11A582DD17D0600BEF49F /* MockLogger.swift in Sources */,
 				FDB5DB112A981FA6002C8721 /* TestExtensions.swift in Sources */,
 				FDB5DB092A981F8D002C8721 /* MockCrypto.swift in Sources */,
 				FDAA167B2AC28E2F00DDBF77 /* SnodeRequestSpec.swift in Sources */,
@@ -6727,6 +6740,7 @@
 				FD336F6F2CAA37CB00C0B51B /* MockCommunityPoller.swift in Sources */,
 				FDC2909827D7129B005DAE71 /* PersonalizationSpec.swift in Sources */,
 				FD481A962CAE0AE000ECC4CF /* MockAppContext.swift in Sources */,
+				FDB11A562DD17C3300BEF49F /* MockLogger.swift in Sources */,
 				FD0150452CA243BB005B08A1 /* LibSessionUtilSpec.swift in Sources */,
 				FD981BCD2DC81ABF00564172 /* MockExtensionHelper.swift in Sources */,
 				FD336F602CAA28CF00C0B51B /* CommonSMKMockExtensions.swift in Sources */,

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -850,6 +850,7 @@
 		FDB11A4C2DCC527D00BEF49F /* NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A4B2DCC527900BEF49F /* NotificationContent.swift */; };
 		FDB11A502DCC6ADE00BEF49F /* PriorityVisibilityInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A4F2DCC6ADD00BEF49F /* PriorityVisibilityInfo.swift */; };
 		FDB11A522DCC6B0000BEF49F /* OpenGroupUrlInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A512DCC6AFF00BEF49F /* OpenGroupUrlInfo.swift */; };
+		FDB11A542DCD7A7F00BEF49F /* Task+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB11A532DCD7A7B00BEF49F /* Task+Utilities.swift */; };
 		FDB348632BE3774000B716C2 /* BezierPathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB348622BE3774000B716C2 /* BezierPathView.swift */; };
 		FDB3486E2BE8457F00B716C2 /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3486D2BE8457F00B716C2 /* BackgroundTaskManager.swift */; };
 		FDB3487E2BE856C800B716C2 /* UIBezierPath+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3487D2BE856C800B716C2 /* UIBezierPath+Utilities.swift */; };
@@ -2048,6 +2049,7 @@
 		FDB11A4B2DCC527900BEF49F /* NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContent.swift; sourceTree = "<group>"; };
 		FDB11A4F2DCC6ADD00BEF49F /* PriorityVisibilityInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityVisibilityInfo.swift; sourceTree = "<group>"; };
 		FDB11A512DCC6AFF00BEF49F /* OpenGroupUrlInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGroupUrlInfo.swift; sourceTree = "<group>"; };
+		FDB11A532DCD7A7B00BEF49F /* Task+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Utilities.swift"; sourceTree = "<group>"; };
 		FDB348622BE3774000B716C2 /* BezierPathView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierPathView.swift; sourceTree = "<group>"; };
 		FDB3486C2BE8448500B716C2 /* SessionUtilitiesKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionUtilitiesKit.h; sourceTree = "<group>"; };
 		FDB3486D2BE8457F00B716C2 /* BackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManager.swift; sourceTree = "<group>"; };
@@ -3742,6 +3744,7 @@
 				FD09797127FAA2F500936362 /* Optional+Utilities.swift */,
 				FDE519F62AB7CDC700450C53 /* Result+Utilities.swift */,
 				FD00CDCA2D5317A3006B96D3 /* Scheduler+Utilities.swift */,
+				FDB11A532DCD7A7B00BEF49F /* Task+Utilities.swift */,
 				FDC0F0032BFECE12002CBFB9 /* TimeUnit.swift */,
 				FDE755132C9BC169002A2623 /* UIAlertAction+Utilities.swift */,
 				FDE755152C9BC169002A2623 /* UIApplicationState+Utilities.swift */,
@@ -6058,6 +6061,7 @@
 				FD17D7C727F5207C00122BE0 /* DatabaseMigrator+Utilities.swift in Sources */,
 				FD848B9328420164000E298B /* UnicodeScalar+Utilities.swift in Sources */,
 				FDE754CE2C9BAF37002A2623 /* ImageFormat.swift in Sources */,
+				FDB11A542DCD7A7F00BEF49F /* Task+Utilities.swift in Sources */,
 				FDE7551A2C9BC169002A2623 /* UIApplicationState+Utilities.swift in Sources */,
 				94C58AC92D2E037200609195 /* Permissions.swift in Sources */,
 				FD09796B27F6C67500936362 /* Failable.swift in Sources */,

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -814,7 +814,6 @@
 		FD8A5B342DC1A732004C689B /* _008_ResetUserConfigLastHashes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */; };
 		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8A5B322DC191B4004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */; };
-		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8ECF7B29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */; };
 		FD8ECF7D2934293A00C0D1BB /* _013_SessionUtilChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */; };
 		FD8ECF7F2934298100C0D1BB /* ConfigDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */; };
@@ -2019,7 +2018,6 @@
 		FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _008_ResetUserConfigLastHashes.swift; sourceTree = "<group>"; };
 		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _025_DropLegacyClosedGroupKeyPairTable.swift; sourceTree = "<group>"; };
-		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibSession+SessionMessagingKit.swift"; sourceTree = "<group>"; };
 		FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _013_SessionUtilChanges.swift; sourceTree = "<group>"; };
 		FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigDump.swift; sourceTree = "<group>"; };

--- a/Session/Notifications/NotificationPresenter.swift
+++ b/Session/Notifications/NotificationPresenter.swift
@@ -152,64 +152,6 @@ public class NotificationPresenter: NSObject, UNUserNotificationCenterDelegate, 
             shouldPlaySound: notificationShouldPlaySound(applicationState: content.applicationState)
         )
         
-        /// Add the title if needed
-        switch notificationSettings.previewType {
-            case .noNameNoPreview: content = content.with(title: Constants.app_name)
-            case .nameNoPreview, .nameAndPreview:
-                content = content.with(
-                    title: dependencies.mutate(cache: .libSession) { cache in
-                        cache.conversationDisplayName(
-                            threadId: thread.id,
-                            threadVariant: thread.variant,
-                            contactProfile: (thread.variant != .contact ? nil :
-                                try? Profile.fetchOne(db, id: thread.id)
-                            ),
-                            visibleMessage: nil,    /// This notification is unrelated to the received message
-                            openGroupName: (thread.variant != .community ? nil :
-                                try? thread.openGroup
-                                    .select(.name)
-                                    .asRequest(of: String.self)
-                                    .fetchOne(db)
-                            ),
-                            openGroupUrlInfo: (thread.variant != .community ? nil :
-                                try? LibSession.OpenGroupUrlInfo.fetchOne(db, id: thread.id)
-                            )
-                        )
-                    }
-                )
-        }
-        
-        addNotificationRequest(
-            content: content,
-            notificationSettings: notificationSettings
-        )
-
-        Log.debug("presenting notification with identifier: \(content.identifier)")
-        
-        /// If we are replacing a notification then cancel the original one
-        if notifications[content.identifier] != nil {
-            cancelNotifications(identifiers: [content.identifier])
-        }
-        
-        notificationCenter.add(request)
-        _notifications.performUpdate { $0.setting(content.identifier, request) }
-    }
-    
-    public func addNotificationRequest(
-        content: NotificationContent,
-        notificationSettings: Preferences.NotificationSettings
-    ) {
-        var trigger: UNNotificationTrigger?
-        let shouldPresentNotification: Bool = shouldPresentNotification(
-            threadId: content.threadId,
-            category: content.category,
-            applicationState: content.applicationState,
-            using: dependencies
-        )
-        let mutableContent: UNMutableNotificationContent = content.toMutableContent(
-            shouldPlaySound: notificationShouldPlaySound(applicationState: content.applicationState)
-        )
-        
         switch shouldPresentNotification {
             case true:
                 let shouldGroupNotification: Bool = (

--- a/Session/Notifications/NotificationPresenter.swift
+++ b/Session/Notifications/NotificationPresenter.swift
@@ -101,6 +101,24 @@ public class NotificationPresenter: NSObject, UNUserNotificationCenterDelegate, 
             userInfo: notificationUserInfo(threadId: thread.id, threadVariant: thread.variant),
             applicationState: applicationState
         )
+    }
+    
+    public func addNotificationRequest(
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        identifier: String,
+        category: NotificationCategory,
+        content: UNMutableNotificationContent,
+        notificationSettings: Preferences.NotificationSettings,
+        applicationState: UIApplication.State
+    ) {
+        var trigger: UNNotificationTrigger?
+        let shouldPresentNotification: Bool = shouldPresentNotification(
+            threadId: threadId,
+            category: category,
+            applicationState: applicationState,
+            using: dependencies
+        )
         
         /// Add the title if needed
         switch notificationSettings.previewType {
@@ -133,6 +151,16 @@ public class NotificationPresenter: NSObject, UNUserNotificationCenterDelegate, 
             content: content,
             notificationSettings: notificationSettings
         )
+
+        Log.debug("presenting notification with identifier: \(identifier)")
+        
+        /// If we are replacing a notification then cancel the original one
+        if notifications[identifier] != nil {
+            cancelNotifications(identifiers: [identifier])
+        }
+        
+        notificationCenter.add(request)
+        _notifications.performUpdate { $0.setting(identifier, request) }
     }
     
     public func addNotificationRequest(

--- a/Session/Notifications/NotificationPresenter.swift
+++ b/Session/Notifications/NotificationPresenter.swift
@@ -131,13 +131,15 @@ public class NotificationPresenter: NSObject, UNUserNotificationCenterDelegate, 
         
         addNotificationRequest(
             content: content,
-            notificationSettings: notificationSettings
+            notificationSettings: notificationSettings,
+            extensionBaseUnreadCount: nil
         )
     }
     
     public func addNotificationRequest(
         content: NotificationContent,
-        notificationSettings: Preferences.NotificationSettings
+        notificationSettings: Preferences.NotificationSettings,
+        extensionBaseUnreadCount: Int?
     ) {
         var trigger: UNNotificationTrigger?
         let shouldPresentNotification: Bool = shouldPresentNotification(

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -408,6 +408,16 @@ extension Onboarding {
                     }
                 }
                 
+                /// Now that the onboarding process is completed we can store the `UserMetadata` for the Share and Notification
+                /// extensions (prior to this point the account is in an invalid state so they can't be used)
+                do {
+                    try dependencies[singleton: .extensionHelper].saveUserMetadata(
+                        sessionId: userSessionId,
+                        ed25519SecretKey: ed25519KeyPair.secretKey,
+                        unreadCount: 0
+                    )
+                } catch { Log.error(.onboarding, "Falied to save user metadata: \(error)") }
+                
                 /// Store whether the user wants to use APNS
                 dependencies[defaults: .standard, key: .isUsingFullAPNs] = useAPNS
                 

--- a/Session/Settings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettingsViewModel.swift
@@ -1002,8 +1002,8 @@ class DeveloperSettingsViewModel: SessionTableViewModel, NavigatableStateHolder,
             _ = try ConfigDump.deleteAll(db)
         }
         
-        /// Remove all dedupe record files
-        dependencies[singleton: .extensionHelper].deleteAllDedupeRecords()
+        /// Remove the `ExtensionHelper` cache
+        dependencies[singleton: .extensionHelper].deleteCache()
         
         Log.info("[DevSettings] Reloading state for \(String(describing: updatedNetwork))")
         

--- a/Session/Utilities/Permissions.swift
+++ b/Session/Utilities/Permissions.swift
@@ -187,12 +187,12 @@ extension Permissions {
             do {
                 if try await checkLocalNetworkPermissionWithBonjour() {
                     // Permission is granted, continue to next onboarding step
-                    dependencies[singleton: .storage].writeAsync { db in
+                    try await dependencies[singleton: .storage].writeAsync { db in
                         db[.lastSeenHasLocalNetworkPermission] = true
                     }
                 } else {
                     // Permission denied, explain why we need it and show button to open Settings
-                    dependencies[singleton: .storage].writeAsync { db in
+                    try await dependencies[singleton: .storage].writeAsync { db in
                         db[.lastSeenHasLocalNetworkPermission] = false
                     }
                 }

--- a/SessionMessagingKit/Database/Models/MessageDeduplication.swift
+++ b/SessionMessagingKit/Database/Models/MessageDeduplication.swift
@@ -195,7 +195,7 @@ public extension MessageDeduplication {
         }
     }
     
-    static func ensureCallMessageIsNotADuplicate (
+    static func ensureCallMessageIsNotADuplicate(
         threadId: String,
         callMessage: CallMessage?,
         using dependencies: Dependencies

--- a/SessionMessagingKit/Jobs/ConfigurationSyncJob.swift
+++ b/SessionMessagingKit/Jobs/ConfigurationSyncJob.swift
@@ -240,7 +240,10 @@ public enum ConfigurationSyncJob: JobExecutor {
                     // Lastly we need to save the updated dumps to the database
                     let updatedJob: Job? = dependencies[singleton: .storage].write { db in
                         // Save the updated dumps to the database
-                        try configDumps.forEach { try $0.upsert(db) }
+                        try configDumps.forEach { dump in
+                            try dump.upsert(db)
+                            Task { dependencies[singleton: .extensionHelper].replicate(dump: dump) }
+                        }
                         
                         // When we complete the 'ConfigurationSync' job we want to immediately schedule
                         // another one with a 'nextRunTimestamp' set to the 'maxRunFrequency' value to

--- a/SessionMessagingKit/Jobs/MessageReceiveJob.swift
+++ b/SessionMessagingKit/Jobs/MessageReceiveJob.swift
@@ -62,6 +62,7 @@ public enum MessageReceiveJob: JobExecutor {
                             message: messageInfo.message,
                             serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                             associatedWithProto: protoContent,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -678,31 +678,6 @@ public extension LibSession.Cache {
         
         return contact.blocked
     }
-    
-    func profile(contactId: String) -> Profile? {
-        guard
-            case .contacts(let conf) = self,
-            var cContactId: [CChar] = contactId.cString(using: .utf8)
-        else { return nil }
-        
-        var contact: contacts_contact = contacts_contact()
-        
-        guard contacts_get(conf, &contact, &cContactId) else {
-            LibSessionError.clear(conf)
-            return nil
-        }
-        
-        let profilePictureUrl: String? = contact.get(\.profile_pic.url, nullIfEmpty: true)
-        return Profile(
-            id: contactId,
-            name: contact.get(\.name),
-            lastNameUpdate: nil,
-            nickname: contact.get(\.nickname, nullIfEmpty: true),
-            profilePictureUrl: profilePictureUrl,
-            profileEncryptionKey: (profilePictureUrl == nil ? nil : contact.get(\.profile_pic.key)),
-            lastProfilePictureUpdate: nil
-        )
-    }
 }
 
 // MARK: - SyncedContactInfo

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -678,6 +678,31 @@ public extension LibSession.Cache {
         
         return contact.blocked
     }
+    
+    func profile(contactId: String) -> Profile? {
+        guard
+            case .contacts(let conf) = self,
+            var cContactId: [CChar] = contactId.cString(using: .utf8)
+        else { return nil }
+        
+        var contact: contacts_contact = contacts_contact()
+        
+        guard contacts_get(conf, &contact, &cContactId) else {
+            LibSessionError.clear(conf)
+            return nil
+        }
+        
+        let profilePictureUrl: String? = contact.get(\.profile_pic.url, nullIfEmpty: true)
+        return Profile(
+            id: contactId,
+            name: contact.get(\.name),
+            lastNameUpdate: nil,
+            nickname: contact.get(\.nickname, nullIfEmpty: true),
+            profilePictureUrl: profilePictureUrl,
+            profileEncryptionKey: (profilePictureUrl == nil ? nil : contact.get(\.profile_pic.key)),
+            lastProfilePictureUpdate: nil
+        )
+    }
 }
 
 // MARK: - SyncedContactInfo

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
@@ -86,7 +86,7 @@ internal extension LibSessionCacheType {
                     .filter(Interaction.Columns.timestampMs <= lastReadTimestampMs)
                     .filter(Interaction.Columns.wasRead == false)
                 let interactionInfoToMarkAsRead: [Interaction.ReadInfo] = try interactionQuery
-                    .select(.id, .variant, .timestampMs, .wasRead)
+                    .select(.id, .serverHash, .variant, .timestampMs, .wasRead)
                     .asRequest(of: Interaction.ReadInfo.self)
                     .fetchAll(db)
                 try interactionQuery

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
@@ -407,7 +407,7 @@ public extension LibSession {
 
 // MARK: State Access
 
-public extension LibSessionCacheType {
+public extension LibSession.Cache {
     func conversationLastRead(
         threadId: String,
         threadVariant: SessionThread.Variant,
@@ -469,7 +469,9 @@ public extension LibSessionCacheType {
                 return group.last_read
         }
     }
-    
+}
+
+public extension LibSessionCacheType {
     func timestampAlreadyRead(
         threadId: String,
         threadVariant: SessionThread.Variant,

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
@@ -469,11 +469,7 @@ public extension LibSessionCacheType {
                 return group.last_read
         }
     }
-}
-
-// MARK: State Access
-
-public extension LibSession.Config {
+    
     func timestampAlreadyRead(
         threadId: String,
         threadVariant: SessionThread.Variant,

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
@@ -469,7 +469,11 @@ public extension LibSessionCacheType {
                 return group.last_read
         }
     }
-    
+}
+
+// MARK: State Access
+
+public extension LibSession.Config {
     func timestampAlreadyRead(
         threadId: String,
         threadVariant: SessionThread.Variant,

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+GroupMembers.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+GroupMembers.swift
@@ -398,35 +398,6 @@ internal extension LibSession {
     }
 }
 
-// MARK: - State Access
-
-extension LibSession.Config {
-    public func memberProfile(memberId: String) -> Profile? {
-        guard
-            case .groupMembers(let conf) = self,
-            var cMemberId: [CChar] = memberId.cString(using: .utf8)
-        else { return nil }
-        
-        var member: config_group_member = config_group_member()
-        
-        guard groups_members_get(conf, &member, &cMemberId) else {
-            LibSessionError.clear(conf)
-            return nil
-        }
-        
-        let profilePictureUrl: String? = member.get(\.profile_pic.url, nullIfEmpty: true)
-        return Profile(
-            id: memberId,
-            name: member.get(\.name),
-            lastNameUpdate: nil,
-            nickname: nil,
-            profilePictureUrl: profilePictureUrl,
-            profileEncryptionKey: (profilePictureUrl == nil ? nil : member.get(\.profile_pic.key)),
-            lastProfilePictureUpdate: nil
-        )
-    }
-}
-
 // MARK: - MemberData
 
 private struct MemberData {

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+GroupMembers.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+GroupMembers.swift
@@ -398,6 +398,35 @@ internal extension LibSession {
     }
 }
 
+// MARK: - State Access
+
+extension LibSession.Config {
+    public func memberProfile(memberId: String) -> Profile? {
+        guard
+            case .groupMembers(let conf) = self,
+            var cMemberId: [CChar] = memberId.cString(using: .utf8)
+        else { return nil }
+        
+        var member: config_group_member = config_group_member()
+        
+        guard groups_members_get(conf, &member, &cMemberId) else {
+            LibSessionError.clear(conf)
+            return nil
+        }
+        
+        let profilePictureUrl: String? = member.get(\.profile_pic.url, nullIfEmpty: true)
+        return Profile(
+            id: memberId,
+            name: member.get(\.name),
+            lastNameUpdate: nil,
+            nickname: nil,
+            profilePictureUrl: profilePictureUrl,
+            profileEncryptionKey: (profilePictureUrl == nil ? nil : member.get(\.profile_pic.key)),
+            lastProfilePictureUpdate: nil
+        )
+    }
+}
+
 // MARK: - MemberData
 
 private struct MemberData {

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
@@ -694,7 +694,6 @@ public extension LibSession.Cache {
                     sound: sound,
                     mutedUntil: (contact.mute_until > 0 ? TimeInterval(contact.mute_until) : nil)
                 )
-                
             
             case .community:
                 guard
@@ -717,7 +716,7 @@ public extension LibSession.Cache {
                     sound: sound,
                     mutedUntil: (community.mute_until > 0 ? TimeInterval(community.mute_until) : nil)
                 )
-                
+            
             case .group:
                 guard case .userGroups(let conf) = config(for: .userGroups, sessionId: userSessionId) else {
                     return .defaultFor(threadVariant)

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
@@ -316,12 +316,15 @@ internal extension LibSession {
         // Create and save dumps for the configs
         try dependencies.mutate(cache: .libSession) { cache in
             try groupState.forEach { variant, config in
-                try cache.createDump(
+                let dump: ConfigDump? = try cache.createDump(
                     config: config,
                     for: variant,
                     sessionId: SessionId(.group, hex: group.id),
                     timestampMs: Int64(floor(group.formationTimestamp * 1000))
-                )?.upsert(db)
+                )
+                
+                try dump?.upsert(db)
+                Task { dependencies[singleton: .extensionHelper].replicate(dump: dump) }
             }
         }
         

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -934,6 +934,11 @@ public protocol LibSessionCacheType: LibSessionImmutableCacheType, MutableCacheT
         openGroupName: String?,
         openGroupUrlInfo: LibSession.OpenGroupUrlInfo?
     ) -> String
+    func conversationLastRead(
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        openGroupUrlInfo: LibSession.OpenGroupUrlInfo?
+    ) -> Int64?
     
     /// Returns whether the specified conversation is a message request
     ///
@@ -1087,6 +1092,11 @@ private final class NoopLibSessionCache: LibSessionCacheType {
         openGroupName: String?,
         openGroupUrlInfo: LibSession.OpenGroupUrlInfo?
     ) -> String { return "" }
+    func conversationLastRead(
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        openGroupUrlInfo: LibSession.OpenGroupUrlInfo?
+    ) -> Int64? { return nil }
     
     func isMessageRequest(
         threadId: String,

--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -373,7 +373,7 @@ public extension Message {
             case is VisibleMessage: return true
             case is ExpirationTimerUpdate: return true
             case is UnsendRequest: return true
-
+            
             case let callMessage as CallMessage:
                 switch callMessage.kind {
                     case .answer, .endCall: return true

--- a/SessionMessagingKit/Open Groups/OpenGroupManager.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupManager.swift
@@ -573,6 +573,7 @@ public final class OpenGroupManager {
                                 message: messageInfo.message,
                                 serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                                 associatedWithProto: try SNProtoContent.parseData(messageInfo.serializedProtoData),
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                             largestValidSeqNo = max(largestValidSeqNo, message.seqNo)
@@ -765,6 +766,7 @@ public final class OpenGroupManager {
                             message: messageInfo.message,
                             serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                             associatedWithProto: proto,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                 }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -241,6 +241,7 @@ public enum MessageReceiver {
         message: Message,
         serverExpirationTimestamp: TimeInterval?,
         associatedWithProto proto: SNProtoContent,
+        suppressNotifications: Bool,
         using dependencies: Dependencies
     ) throws {
         /// Throw if the message is outdated and shouldn't be processed (this is based on pretty flaky logic which checks if the config
@@ -293,6 +294,7 @@ public enum MessageReceiver {
                     threadVariant: threadVariant,
                     message: message,
                     serverExpirationTimestamp: serverExpirationTimestamp,
+                    suppressNotifications: suppressNotifications,
                     using: dependencies
                 )
                 
@@ -332,6 +334,7 @@ public enum MessageReceiver {
                     threadId: threadId,
                     threadVariant: threadVariant,
                     message: message,
+                    suppressNotifications: suppressNotifications,
                     using: dependencies
                 )
                 
@@ -350,6 +353,7 @@ public enum MessageReceiver {
                     message: message,
                     serverExpirationTimestamp: serverExpirationTimestamp,
                     associatedWithProto: proto,
+                    suppressNotifications: suppressNotifications,
                     using: dependencies
                 )
             

--- a/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
@@ -31,7 +31,8 @@ public protocol NotificationsManagerType {
     func notifyForFailedSend(_ db: Database, in thread: SessionThread, applicationState: UIApplication.State)
     func addNotificationRequest(
         content: NotificationContent,
-        notificationSettings: Preferences.NotificationSettings
+        notificationSettings: Preferences.NotificationSettings,
+        extensionBaseUnreadCount: Int?
     )
     
     func cancelNotifications(identifiers: [String])
@@ -265,16 +266,16 @@ public extension NotificationsManagerType {
         message: Message,
         threadId: String,
         threadVariant: SessionThread.Variant,
-        interactionId: Int64,
+        interactionIdentifier: String,
         interactionVariant: Interaction.Variant?,
         attachmentDescriptionInfo: [Attachment.DescriptionInfo]?,
         openGroupUrlInfo: LibSession.OpenGroupUrlInfo?,
         applicationState: UIApplication.State,
+        extensionBaseUnreadCount: Int?,
         currentUserSessionIds: Set<String>,
         displayNameRetriever: (String) -> String?,
         shouldShowForMessageRequest: () -> Bool
     ) throws {
-        let targetConfig: ConfigDump.Variant = (threadVariant == .contact ? .contacts : .userGroups)
         let isMessageRequest: Bool = dependencies.mutate(cache: .libSession) { cache in
             cache.isMessageRequest(
                 threadId: threadId,
@@ -316,7 +317,7 @@ public extension NotificationsManagerType {
                         case .some: return UUID().uuidString
                         default:
                             return Interaction.notificationIdentifier(
-                                for: interactionId,
+                                for: interactionIdentifier,
                                 threadId: threadId,
                                 shouldGroupMessagesForThread: (threadVariant == .community)
                             )
@@ -343,17 +344,12 @@ public extension NotificationsManagerType {
                     displayNameRetriever: displayNameRetriever,
                     using: dependencies
                 ),
-                // TODO: [Database Relocation] Need to figure out how to manage the unread count...
-                /// Update the app badge in case the unread count changed
-        //        if let unreadCount: Int = try? Interaction.fetchAppBadgeUnreadCount(db, using: dependencies) {
-        //            notificationContent.badge = NSNumber(value: unreadCount)
-        //        }
-    //            badge: ,
                 sound: notificationSettings.sound,
                 userInfo: notificationUserInfo(threadId: threadId, threadVariant: threadVariant),
                 applicationState: applicationState
             ),
-            notificationSettings: notificationSettings
+            notificationSettings: notificationSettings,
+            extensionBaseUnreadCount: extensionBaseUnreadCount
         )
     }
 }
@@ -385,7 +381,8 @@ public struct NoopNotificationsManager: NotificationsManagerType {
     
     public func addNotificationRequest(
         content: NotificationContent,
-        notificationSettings: Preferences.NotificationSettings
+        notificationSettings: Preferences.NotificationSettings,
+        extensionBaseUnreadCount: Int?
     ) {}
     public func cancelNotifications(identifiers: [String]) {}
     public func clearAllNotifications() {}

--- a/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
@@ -244,7 +244,7 @@ public extension NotificationsManagerType {
                 return "callsYouMissedCallPermissions"
                     .put(key: "name", value: senderName)
                     .localizedDeformatted()
-                
+            
             case is CallMessage:
                 let senderName: String = displayNameRetriever(sender)
                     .defaulting(to: Profile.truncated(id: sender, threadVariant: threadVariant))

--- a/SessionMessagingKit/Sending & Receiving/Notifications/Types/NotificationContent.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/Types/NotificationContent.swift
@@ -10,7 +10,6 @@ public struct NotificationContent {
     public let category: NotificationCategory
     public let title: String?
     public let body: String?
-    public let badge: Int?
     public let sound: Preferences.Sound
     public let userInfo: [AnyHashable: Any]
     public let applicationState: UIApplication.State
@@ -24,7 +23,6 @@ public struct NotificationContent {
         category: NotificationCategory,
         title: String? = nil,
         body: String? = nil,
-        badge: Int? = nil,
         sound: Preferences.Sound = .none,
         userInfo: [AnyHashable: Any] = [:],
         applicationState: UIApplication.State
@@ -35,7 +33,6 @@ public struct NotificationContent {
         self.category = category
         self.title = title
         self.body = body
-        self.badge = badge
         self.sound = sound
         self.userInfo = userInfo
         self.applicationState = applicationState
@@ -46,7 +43,6 @@ public struct NotificationContent {
     public func with(
         title: String? = nil,
         body: String? = nil,
-        badge: Int? = nil,
         sound: Preferences.Sound? = nil
     ) -> NotificationContent {
         return NotificationContent(
@@ -56,7 +52,6 @@ public struct NotificationContent {
             category: category,
             title: (title ?? self.title),
             body: (body ?? self.body),
-            badge: (badge ?? self.badge),
             sound: (sound ?? self.sound),
             userInfo: userInfo,
             applicationState: applicationState
@@ -71,7 +66,6 @@ public struct NotificationContent {
         
         if let title: String = title { content.title = title }
         if let body: String = body { content.body = body }
-        if let badge: Int = badge { content.badge = NSNumber(integerLiteral: badge) }
         
         if shouldPlaySound {
             content.sound = sound.notificationSound(isQuiet: (applicationState == .active))

--- a/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
@@ -20,6 +20,11 @@ public protocol SwarmPollerType {
 // MARK: - SwarmPoller
 
 public class SwarmPoller: SwarmPollerType & PollerType {
+    public enum PollSource: Equatable {
+        case snode(LibSession.Snode)
+        case pushNotification
+    }
+    
     public let dependencies: Dependencies
     public let pollerQueue: DispatchQueue
     public let pollerName: String
@@ -128,13 +133,35 @@ public class SwarmPoller: SwarmPollerType & PollerType {
                 request.send(using: dependencies)
                     .map { _, response in (snode, response) }
             }
-            .flatMapOptional { [weak self] (snode: LibSession.Snode, namespacedResults: SnodeAPI.PollResponse) -> AnyPublisher<(configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult), Error>? in
-                self?.processPollResponse(
+            .flatMapStorageWritePublisher(using: dependencies, updates: { [pollerDestination, shouldStoreMessages, forceSynchronousProcessing, dependencies] db, info -> (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) in
+                let (snode, namespacedResults): (LibSession.Snode, SnodeAPI.PollResponse) = info
+                
+                /// Get all of the messages and sort them by their required `processingOrder`
+                typealias MessageData = (namespace: SnodeAPI.Namespace, messages: [SnodeReceivedMessage], lastHash: String?)
+                let sortedMessages: [MessageData] = namespacedResults
+                    .compactMap { namespace, result -> MessageData? in
+                        (result.data?.messages).map { (namespace, $0, result.data?.lastHash) }
+                    }
+                    .sorted { lhs, rhs in lhs.namespace.processingOrder < rhs.namespace.processingOrder }
+                let rawMessageCount: Int = sortedMessages.map { $0.messages.count }.reduce(0, +)
+                
+                /// No need to do anything if there are no messages
+                guard rawMessageCount > 0 else {
+                    return ([], [], ([], 0, 0, false))
+                }
+                
+                return SwarmPoller.processPollResponse(
+                    db,
+                    cat: .poller,
+                    source: .snode(snode),
+                    swarmPublicKey: pollerDestination.target,
+                    shouldStoreMessages: shouldStoreMessages,
+                    ignoreDedupeRecords: false,
                     forceSynchronousProcessing: forceSynchronousProcessing,
-                    snode: snode,
-                    namespacedResults: namespacedResults
+                    sortedMessages: sortedMessages,
+                    using: dependencies
                 )
-            }
+            })
             .flatMap { [dependencies] (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) -> AnyPublisher<PollResult, Error> in
                 // If we don't want to forcible process the response synchronously then just finish immediately
                 guard forceSynchronousProcessing else {
@@ -198,279 +225,282 @@ public class SwarmPoller: SwarmPollerType & PollerType {
             .eraseToAnyPublisher()
     }
     
-    private func processPollResponse(
+    @discardableResult public static func processPollResponse(
+        _ db: Database,
+        cat: Log.Category,
+        source: PollSource,
+        swarmPublicKey: String,
+        shouldStoreMessages: Bool,
+        ignoreDedupeRecords: Bool,
         forceSynchronousProcessing: Bool,
-        snode: LibSession.Snode,
-        namespacedResults: SnodeAPI.PollResponse
-    ) -> AnyPublisher<(configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult), Error> {
-        // Get all of the messages and sort them by their required 'processingOrder'
-        let sortedMessages: [(namespace: SnodeAPI.Namespace, messages: [SnodeReceivedMessage])] = namespacedResults
-            .compactMap { namespace, result in (result.data?.messages).map { (namespace, $0) } }
-            .sorted { lhs, rhs in lhs.namespace.processingOrder < rhs.namespace.processingOrder }
+        sortedMessages: [(namespace: SnodeAPI.Namespace, messages: [SnodeReceivedMessage], lastHash: String?)],
+        using dependencies: Dependencies
+    ) -> (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) {
+        /// No need to do anything if there are no messages
         let rawMessageCount: Int = sortedMessages.map { $0.messages.count }.reduce(0, +)
         
-        // No need to do anything if there are no messages
         guard rawMessageCount > 0 else {
-            return Just(([], [], ([], 0, 0, false)))
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
+            return ([], [], ([], 0, 0, false))
         }
         
-        // Otherwise process the messages and add them to the queue for handling
-        let lastHashes: [String] = namespacedResults
-            .compactMap { $0.value.data?.lastHash }
-        let otherKnownHashes: [String] = namespacedResults
-            .filter { $0.key.shouldFetchSinceLastHash }
-            .compactMap { $0.value.data?.messages.map { $0.info.hash } }
+        /// Otherwise process the messages and add them to the queue for handling
+        let lastHashes: [String] = sortedMessages.compactMap { $0.lastHash }
+        let otherKnownHashes: [String] = sortedMessages
+            .filter { $0.namespace.shouldFetchSinceLastHash }
+            .compactMap { $0.messages.map { $0.hash } }
             .reduce([], +)
         var messageCount: Int = 0
         var finalProcessedMessages: [ProcessedMessage] = []
         var hadValidHashUpdate: Bool = false
         
-        return dependencies[singleton: .storage].writePublisher { [pollerDestination, shouldStoreMessages, dependencies] db -> (configMessageJobs: [Job], standardMessageJobs: [Job], pollResult: PollResult) in
-            // If the poll was successful we need to retrieve the `lastHash` values
-            // direct from the database again to ensure they still line up (if they
-            // have been reset in the database then we want to ignore the poll as it
-            // would invalidate whatever change modified the `lastHash` values potentially
-            // resulting in us not polling again from scratch even if we want to)
-            let lastHashesAfterFetch: Set<String> = try Set(namespacedResults
-                .compactMap { namespace, _ in
-                    try SnodeReceivedMessageInfo
-                        .fetchLastNotExpired(
-                            db,
-                            for: snode,
-                            namespace: namespace,
-                            swarmPublicKey: pollerDestination.target,
-                            using: dependencies
-                        )?
-                        .hash
-                })
-            
-            guard lastHashes.isEmpty || Set(lastHashes) == lastHashesAfterFetch else {
-                return ([], [], ([], 0, 0, false))
+        /// If the poll was successful we need to retrieve the `lastHash` values direct from the database again to ensure they
+        /// still line up (if they have been reset in the database then we want to ignore the poll as it would invalidate whatever
+        /// change modified the `lastHash` values potentially resulting in us not polling again from scratch even if we want to)
+        let lastHashesAfterFetch: Set<String> = {
+            switch source {
+                case .pushNotification: return []
+                case .snode(let snode):
+                    return Set(sortedMessages.compactMap { namespace, _, _ in
+                        try? SnodeReceivedMessageInfo
+                            .fetchLastNotExpired(
+                                db,
+                                for: snode,
+                                namespace: namespace,
+                                swarmPublicKey: swarmPublicKey,
+                                using: dependencies
+                            )?
+                            .hash
+                    })
             }
-            
-            // Since the hashes are still accurate we can now process the messages
-            let allProcessedMessages: [ProcessedMessage] = sortedMessages
-                .compactMap { namespace, messages -> [ProcessedMessage]? in
-                    let processedMessages: [ProcessedMessage] = messages
-                        .compactMap { message -> ProcessedMessage? in
-                            do {
-                                let processedMessage: ProcessedMessage = try MessageReceiver.parse(
-                                    data: message.data,
-                                    origin: .swarm(
-                                        publicKey: pollerDestination.target,
-                                        namespace: message.namespace,
-                                        serverHash: message.info.hash,
-                                        serverTimestampMs: message.timestampMs,
-                                        serverExpirationTimestamp: TimeInterval(Double(message.info.expirationDateMs) / 1000)
-                                    ),
-                                    using: dependencies
-                                )
-                                try MessageDeduplication.insert(
-                                    db,
-                                    processedMessage: processedMessage,
-                                    using: dependencies
-                                )
-                                hadValidHashUpdate = message.info.storeUpdatedLastHash(db)
-                                
-                                /// We need additional dedupe logic if the message is a `CallMessage` as multiple messages can
-                                /// related to the same call
-                                switch processedMessage {
-                                    case .standard(let threadId, _, _, let messageInfo, _):
-                                        guard let callMessage: CallMessage = messageInfo.message as? CallMessage else {
-                                            break
-                                        }
-                                        
-                                        try MessageDeduplication.ensureCallMessageIsNotADuplicate(
-                                            threadId: threadId,
-                                            callMessage: callMessage,
-                                            using: dependencies
-                                        )
-                                        try dependencies[singleton: .extensionHelper].createDedupeRecord(
-                                            threadId: threadId,
-                                            uniqueIdentifier: callMessage.uuid
-                                        )
-                                        
-                                    default: break
-                                }
-                                
-                                return processedMessage
-                            }
-                            catch {
-                                // For some error cases we want to update the last hash so do so
-                                if (error as? MessageReceiverError)?.shouldUpdateLastHash == true {
-                                    hadValidHashUpdate = message.info.storeUpdatedLastHash(db)
-                                }
-                                
-                                switch error {
-                                    /// Ignore duplicate & selfSend message errors (and don't bother logging them as there
-                                    /// will be a lot since we each service node duplicates messages)
-                                    case DatabaseError.SQLITE_CONSTRAINT_UNIQUE,
-                                        DatabaseError.SQLITE_CONSTRAINT,    /// Sometimes thrown for UNIQUE
-                                        MessageReceiverError.duplicateMessage,
-                                        MessageReceiverError.selfSend:
-                                        break
-                                    
-                                    case DatabaseError.SQLITE_ABORT:
-                                        Log.warn(.poller, "Failed to the database being suspended (running in background with no background task).")
-                                        
-                                    default: Log.error(.poller, "Failed to deserialize envelope due to error: \(error).")
-                                }
-                                
-                                return nil
-                            }
-                        }
-                    
-                    /// If this message should be handled by this poller and should be handled  synchronously then do so here before
-                    /// processing the next namespace
-                    guard shouldStoreMessages && namespace.shouldHandleSynchronously else {
-                        return processedMessages
-                    }
-                    
-                    if namespace.isConfigNamespace {
-                        do {
-                            /// Process config messages all at once in case they are multi-part messages
-                            try dependencies.mutate(cache: .libSession) {
-                                try $0.handleConfigMessages(
-                                    db,
-                                    swarmPublicKey: pollerDestination.target,
-                                    messages: ConfigMessageReceiveJob
-                                        .Details(messages: processedMessages)
-                                        .messages
-                                )
-                            }
-                        }
-                        catch { Log.error(.poller, "Failed to handle processed config message due to error: \(error).") }
-                    }
-                    else {
-                        /// Individually process non-config messages
-                        processedMessages.forEach { processedMessage in
-                            guard case .standard(let threadId, let threadVariant, let proto, let messageInfo, _) = processedMessage else {
-                                return
-                            }
-                            
-                            do {
-                                try MessageReceiver.handle(
-                                    db,
-                                    threadId: threadId,
-                                    threadVariant: threadVariant,
-                                    message: messageInfo.message,
-                                    serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
-                                    associatedWithProto: proto,
-                                    using: dependencies
-                                )
-                            }
-                            catch { Log.error(.poller, "Failed to handle processed message due to error: \(error).") }
-                        }
-                    }
-                    
-                    /// Make sure to add any synchronously processed messages to the `finalProcessedMessages`
-                    /// as otherwise they wouldn't be emitted by the `receivedPollResponseSubject`
-                    finalProcessedMessages += processedMessages
-                    return nil
-                }
-                .flatMap { $0 }
-            
-            // If we don't want to store the messages then no need to continue (don't want
-            // to create message receive jobs or mess with cached hashes)
-            guard shouldStoreMessages else {
-                messageCount += allProcessedMessages.count
-                finalProcessedMessages += allProcessedMessages
-                return ([], [], (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
-            }
-            
-            // Add a job to process the config messages first
-            let configMessageJobs: [Job] = allProcessedMessages
-                .filter { $0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
-                .grouped { $0.threadId }
-                .compactMap { threadId, threadMessages in
-                    messageCount += threadMessages.count
-                    finalProcessedMessages += threadMessages
-                    
-                    let job: Job? = Job(
-                        variant: .configMessageReceive,
-                        behaviour: .runOnce,
-                        threadId: threadId,
-                        details: ConfigMessageReceiveJob.Details(messages: threadMessages)
-                    )
-                    
-                    // If we are force-polling then add to the JobRunner so they are
-                    // persistent and will retry on the next app run if they fail but
-                    // don't let them auto-start
-                    return dependencies[singleton: .jobRunner].add(
-                        db,
-                        job: job,
-                        canStartJob: (
-                            !forceSynchronousProcessing &&
-                            !dependencies[singleton: .appContext].isInBackground
-                        )
-                    )
-                }
-            let configJobIds: [Int64] = configMessageJobs.compactMap { $0.id }
-            
-            // Add jobs for processing non-config messages which are dependant on the config message
-            // processing jobs
-            let standardMessageJobs: [Job] = allProcessedMessages
-                .filter { !$0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
-                .grouped { $0.threadId }
-                .compactMap { threadId, threadMessages in
-                    messageCount += threadMessages.count
-                    finalProcessedMessages += threadMessages
-                    
-                    let job: Job? = Job(
-                        variant: .messageReceive,
-                        behaviour: .runOnce,
-                        threadId: threadId,
-                        details: MessageReceiveJob.Details(messages: threadMessages)
-                    )
-                    
-                    // If we are force-polling then add to the JobRunner so they are
-                    // persistent and will retry on the next app run if they fail but
-                    // don't let them auto-start
-                    let updatedJob: Job? = dependencies[singleton: .jobRunner].add(
-                        db,
-                        job: job,
-                        canStartJob: (
-                            !forceSynchronousProcessing && (
-                                !dependencies[singleton: .appContext].isInBackground ||
-                                // FIXME: Better seperate the call messages handling, since we need to handle them all the time
-                                dependencies[singleton: .callManager].currentCall != nil
-                            )
-                        )
-                    )
-                    
-                    // Create the dependency between the jobs (config processing should happen before
-                    // standard message processing)
-                    if let updatedJobId: Int64 = updatedJob?.id {
-                        do {
-                            try configJobIds.forEach { configJobId in
-                                try JobDependencies(
-                                    jobId: updatedJobId,
-                                    dependantId: configJobId
-                                )
-                                .insert(db)
-                            }
-                        }
-                        catch {
-                            Log.warn(.poller, "Failed to add dependency between config processing and non-config processing messageReceive jobs.")
-                        }
-                    }
-                    
-                    return updatedJob
-                }
-            
-            // Update the cached validity of the messages
-            try SnodeReceivedMessageInfo.handlePotentialDeletedOrInvalidHash(
-                db,
-                potentiallyInvalidHashes: (sortedMessages.isEmpty && !hadValidHashUpdate ?
-                    lastHashes :
-                    []
-                ),
-                otherKnownValidHashes: otherKnownHashes
-            )
-            
-            return (configMessageJobs, standardMessageJobs, (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
+        }()
+        
+        guard lastHashes.isEmpty || Set(lastHashes) == lastHashesAfterFetch else {
+            return ([], [], ([], 0, 0, false))
         }
+        
+        /// Since the hashes are still accurate we can now process the messages
+        let allProcessedMessages: [ProcessedMessage] = sortedMessages
+            .compactMap { namespace, messages, _ -> [ProcessedMessage]? in
+                let processedMessages: [ProcessedMessage] = messages.compactMap { message -> ProcessedMessage? in
+                    do {
+                        let processedMessage: ProcessedMessage = try MessageReceiver.parse(
+                            data: message.data,
+                            origin: .swarm(
+                                publicKey: swarmPublicKey,
+                                namespace: message.namespace,
+                                serverHash: message.hash,
+                                serverTimestampMs: message.timestampMs,
+                                serverExpirationTimestamp: TimeInterval(Double(message.expirationTimestampMs) / 1000)
+                            ),
+                            using: dependencies
+                        )
+                        hadValidHashUpdate = (message.info?.storeUpdatedLastHash(db) == true)
+                        
+                        /// Only continue if we want to check/insert dedupe records
+                        guard !ignoreDedupeRecords else { return processedMessage }
+                        
+                        /// Insert the standard dedupe record
+                        try MessageDeduplication.insert(
+                            db,
+                            processedMessage: processedMessage,
+                            using: dependencies
+                        )
+                        
+                        /// We need additional dedupe logic if the message is a `CallMessage` as multiple messages can
+                        /// related to the same call
+                        switch processedMessage {
+                            case .standard(let threadId, _, _, let messageInfo, _):
+                                guard let callMessage: CallMessage = messageInfo.message as? CallMessage else {
+                                    break
+                                }
+                                
+                                try MessageDeduplication.ensureCallMessageIsNotADuplicate(
+                                    threadId: threadId,
+                                    callMessage: callMessage,
+                                    using: dependencies
+                                )
+                                try dependencies[singleton: .extensionHelper].createDedupeRecord(
+                                    threadId: threadId,
+                                    uniqueIdentifier: callMessage.uuid
+                                )
+                                
+                            default: break
+                        }
+                        
+                        return processedMessage
+                    }
+                    catch {
+                        /// For some error cases we want to update the last hash so do so
+                        if (error as? MessageReceiverError)?.shouldUpdateLastHash == true {
+                            hadValidHashUpdate = (message.info?.storeUpdatedLastHash(db) == true)
+                        }
+                        
+                        switch error {
+                            /// Ignore duplicate & selfSend message errors (and don't bother logging them as there
+                            /// will be a lot since we each service node duplicates messages)
+                            case DatabaseError.SQLITE_CONSTRAINT_UNIQUE,
+                                DatabaseError.SQLITE_CONSTRAINT,    /// Sometimes thrown for UNIQUE
+                                MessageReceiverError.duplicateMessage,
+                                MessageReceiverError.selfSend:
+                                break
+                            
+                            case DatabaseError.SQLITE_ABORT:
+                                Log.warn(cat, "Failed to the database being suspended (running in background with no background task).")
+                                
+                            default: Log.error(cat, "Failed to deserialize envelope due to error: \(error).")
+                        }
+                        
+                        return nil
+                    }
+                }
+                
+                /// If this message should be stored and should be handled synchronously then do so here before processing the next namespace
+                guard shouldStoreMessages && (namespace.shouldHandleSynchronously || forceSynchronousProcessing) else {
+                    return processedMessages
+                }
+                
+                if namespace.isConfigNamespace {
+                    do {
+                        /// Process config messages all at once in case they are multi-part messages
+                        try dependencies.mutate(cache: .libSession) {
+                            try $0.handleConfigMessages(
+                                db,
+                                swarmPublicKey: swarmPublicKey,
+                                messages: ConfigMessageReceiveJob
+                                    .Details(messages: processedMessages)
+                                    .messages
+                            )
+                        }
+                    }
+                    catch { Log.error(cat, "Failed to handle processed config message in \(swarmPublicKey) due to error: \(error).") }
+                }
+                else {
+                    /// Individually process non-config messages
+                    processedMessages.forEach { processedMessage in
+                        guard case .standard(let threadId, let threadVariant, let proto, let messageInfo, _) = processedMessage else {
+                            return
+                        }
+                        
+                        do {
+                            try MessageReceiver.handle(
+                                db,
+                                threadId: threadId,
+                                threadVariant: threadVariant,
+                                message: messageInfo.message,
+                                serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
+                                associatedWithProto: proto,
+                                suppressNotifications: (source == .pushNotification),   /// Have already shown
+                                using: dependencies
+                            )
+                        }
+                        catch { Log.error(cat, "Failed to handle processed message in \(threadId) due to error: \(error).") }
+                    }
+                }
+                
+                /// Make sure to add any synchronously processed messages to the `finalProcessedMessages`
+                /// as otherwise they wouldn't be emitted by the `receivedPollResponseSubject`
+                finalProcessedMessages += processedMessages
+                return nil
+            }
+            .flatMap { $0 }
+        
+        /// If we don't want to store the messages then no need to continue (don't want to create message receive jobs or mess with cached hashes)
+        guard shouldStoreMessages && !forceSynchronousProcessing else {
+            messageCount += allProcessedMessages.count
+            finalProcessedMessages += allProcessedMessages
+            return ([], [], (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
+        }
+        
+        /// Add a job to process the config messages first
+        let configMessageJobs: [Job] = allProcessedMessages
+            .filter { $0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
+            .grouped { $0.threadId }
+            .compactMap { threadId, threadMessages in
+                messageCount += threadMessages.count
+                finalProcessedMessages += threadMessages
+                
+                let job: Job? = Job(
+                    variant: .configMessageReceive,
+                    behaviour: .runOnce,
+                    threadId: threadId,
+                    details: ConfigMessageReceiveJob.Details(messages: threadMessages)
+                )
+                
+                /// If we are force-polling then add to the `JobRunner` so they are persistent and will retry on the next app
+                /// run if they fail but don't let them auto-start
+                return dependencies[singleton: .jobRunner].add(
+                    db,
+                    job: job,
+                    canStartJob: !dependencies[singleton: .appContext].isInBackground
+                )
+            }
+        let configJobIds: [Int64] = configMessageJobs.compactMap { $0.id }
+        
+        /// Add jobs for processing non-config messages which are dependant on the config message processing jobs
+        let standardMessageJobs: [Job] = allProcessedMessages
+            .filter { !$0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
+            .grouped { $0.threadId }
+            .compactMap { threadId, threadMessages in
+                messageCount += threadMessages.count
+                finalProcessedMessages += threadMessages
+                
+                let job: Job? = Job(
+                    variant: .messageReceive,
+                    behaviour: .runOnce,
+                    threadId: threadId,
+                    details: MessageReceiveJob.Details(messages: threadMessages)
+                )
+                
+                /// If we are force-polling then add to the `JobRunner` so they are persistent and will retry on the next app
+                /// run if they fail but don't let them auto-start
+                let updatedJob: Job? = dependencies[singleton: .jobRunner].add(
+                    db,
+                    job: job,
+                    canStartJob: (
+                        !dependencies[singleton: .appContext].isInBackground ||
+                        // FIXME: Better seperate the call messages handling, since we need to handle them all the time
+                        dependencies[singleton: .callManager].currentCall != nil
+                    )
+                )
+                
+                /// Create the dependency between the jobs (config processing should happen before standard message processing)
+                if let updatedJobId: Int64 = updatedJob?.id {
+                    do {
+                        try configJobIds.forEach { configJobId in
+                            try JobDependencies(
+                                jobId: updatedJobId,
+                                dependantId: configJobId
+                            )
+                            .insert(db)
+                        }
+                    }
+                    catch {
+                        Log.warn(cat, "Failed to add dependency between config processing and non-config processing messageReceive jobs.")
+                    }
+                }
+                
+                return updatedJob
+            }
+        
+        /// If the source was a snode then update the cached validity of the messages (for messages received via push notifications
+        /// we want to receive them in a subsequent poll to ensure we have the correct `lastHash` value as they can be received
+        /// out of order)
+        switch source {
+            case .pushNotification: break
+            case .snode:
+                do {
+                    try SnodeReceivedMessageInfo.handlePotentialDeletedOrInvalidHash(
+                        db,
+                        potentiallyInvalidHashes: (sortedMessages.isEmpty && !hadValidHashUpdate ?
+                            lastHashes :
+                            []
+                        ),
+                        otherKnownValidHashes: otherKnownHashes
+                    )
+                }
+                catch { Log.error(cat, "Failed to handle potential invalid/deleted hashes due to error: \(error).") }
+        }
+        
+        return (configMessageJobs, standardMessageJobs, (finalProcessedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
     }
 }

--- a/SessionMessagingKitTests/Database/Models/MessageDeduplicationSpec.swift
+++ b/SessionMessagingKitTests/Database/Models/MessageDeduplicationSpec.swift
@@ -25,6 +25,7 @@ class MessageDeduplicationSpec: QuickSpec {
         )
         @TestState(singleton: .extensionHelper, in: dependencies) var mockExtensionHelper: MockExtensionHelper! = MockExtensionHelper(
             initialSetup: { helper in
+                helper.when { $0.deleteCache() }.thenReturn(())
                 helper
                     .when { $0.dedupeRecordExists(threadId: .any, uniqueIdentifier: .any) }
                     .thenReturn(false)
@@ -34,7 +35,6 @@ class MessageDeduplicationSpec: QuickSpec {
                 helper
                     .when { try $0.removeDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
                     .thenReturn(())
-                helper.when { $0.deleteAllDedupeRecords() }.thenReturn(())
             }
         )
         @TestState var mockMessage: Message! = {

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -256,7 +256,8 @@ class MessageReceiverGroupsSpec: QuickSpec {
                     .when {
                         $0.addNotificationRequest(
                             content: .any,
-                            notificationSettings: .any
+                            notificationSettings: .any,
+                            extensionBaseUnreadCount: .any
                         )
                     }
                     .thenReturn(())
@@ -395,6 +396,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -416,6 +418,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -444,6 +447,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                     threadVariant: .group,
                                     message: inviteMessage,
                                     serverExpirationTimestamp: 1234567890,
+                                    suppressNotifications: false,
                                     using: dependencies
                                 )
                             }
@@ -486,6 +490,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                     threadVariant: .group,
                                     message: inviteMessage,
                                     serverExpirationTimestamp: 1234567890,
+                                    suppressNotifications: false,
                                     using: dependencies
                                 )
                             }
@@ -523,6 +528,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -541,6 +547,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -560,6 +567,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -588,6 +596,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -607,6 +616,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -627,6 +637,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -652,6 +663,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -674,7 +686,8 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                         previewType: .nameAndPreview,
                                         sound: .defaultNotificationSound,
                                         mutedUntil: nil
-                                    )
+                                    ),
+                                    extensionBaseUnreadCount: nil
                                 )
                             })
                     }
@@ -701,6 +714,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -723,6 +737,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -750,6 +765,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -770,6 +786,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -794,6 +811,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -802,7 +820,8 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             .toNot(call { notificationsManager in
                                 notificationsManager.addNotificationRequest(
                                     content: .any,
-                                    notificationSettings: .any
+                                    notificationSettings: .any,
+                                    extensionBaseUnreadCount: .any
                                 )
                             })
                     }
@@ -867,6 +886,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                     threadVariant: .group,
                                     message: inviteMessage,
                                     serverExpirationTimestamp: 1234567890,
+                                    suppressNotifications: false,
                                     using: dependencies
                                 )
                             }
@@ -936,6 +956,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                     threadVariant: .group,
                                     message: inviteMessage,
                                     serverExpirationTimestamp: 1234567890,
+                                    suppressNotifications: false,
                                     using: dependencies
                                 )
                             }
@@ -962,6 +983,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -994,6 +1016,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -1060,6 +1083,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: promoteMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         })
@@ -1081,6 +1105,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: promoteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -1114,6 +1139,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: promoteMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -1154,6 +1180,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: infoChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1172,6 +1199,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: infoChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1192,6 +1220,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: infoChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1209,6 +1238,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: infoChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1245,6 +1275,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: infoChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1281,6 +1312,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: infoChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1333,6 +1365,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1351,6 +1384,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1371,6 +1405,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1393,6 +1428,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: memberChangedMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -1428,6 +1464,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1466,6 +1503,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1505,6 +1543,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1545,6 +1584,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1579,6 +1619,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1614,6 +1655,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1650,6 +1692,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1684,6 +1727,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1719,6 +1763,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberChangedMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1760,6 +1805,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: memberLeftMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -1780,6 +1826,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberLeftMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1798,6 +1845,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberLeftMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -1844,6 +1892,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberLeftMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1863,6 +1912,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberLeftMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1881,6 +1931,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberLeftMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1910,6 +1961,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: memberLeftMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -1972,6 +2024,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: memberLeftNotificationMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -2001,6 +2054,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: memberLeftNotificationMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -2044,6 +2098,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteResponseMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -2062,6 +2117,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteResponseMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -2077,6 +2133,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             threadVariant: .group,
                             message: inviteResponseMessage,
                             serverExpirationTimestamp: 1234567890,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -2132,6 +2189,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteResponseMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2175,6 +2233,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteResponseMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2206,6 +2265,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteResponseMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2229,6 +2289,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: inviteResponseMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2375,6 +2436,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -2393,6 +2455,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -2413,6 +2476,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }.to(throwError(MessageReceiverError.invalidMessage))
@@ -2438,6 +2502,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2466,6 +2531,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2492,6 +2558,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2538,6 +2605,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2587,6 +2655,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2615,6 +2684,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2641,6 +2711,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2669,6 +2740,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2698,6 +2770,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2772,6 +2845,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -2807,6 +2881,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                 threadVariant: .group,
                                 message: deleteContentMessage,
                                 serverExpirationTimestamp: 1234567890,
+                                suppressNotifications: false,
                                 using: dependencies
                             )
                         }
@@ -3318,6 +3393,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             message: visibleMessage,
                             serverExpirationTimestamp: nil,
                             associatedWithProto: visibleMessageProto,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -3362,6 +3438,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             message: visibleMessage,
                             serverExpirationTimestamp: nil,
                             associatedWithProto: visibleMessageProto,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }
@@ -3394,6 +3471,7 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             message: visibleMessage,
                             serverExpirationTimestamp: nil,
                             associatedWithProto: visibleMessageProto,
+                            suppressNotifications: false,
                             using: dependencies
                         )
                     }

--- a/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
+++ b/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
@@ -59,6 +59,15 @@ class ExtesnionHelperSpec: QuickSpec {
         
         // MARK: - an ExtensionHelper - File Management
         describe("an ExtensionHelper") {
+            // MARK: -- can delete the entire cache
+            it("can delete the entire cache") {
+                extensionHelper.deleteCache()
+                
+                expect(mockFileManager).to(call(.exactly(times: 1), matchingParameters: .all) {
+                    try? $0.removeItem(atPath: "/test/extensionCache")
+                })
+            }
+            
             // MARK: -- when writing an encrypted file
             context("when writing an encrypted file") {
                 // MARK: ---- ensures the write directory exists
@@ -387,18 +396,6 @@ class ExtesnionHelperSpec: QuickSpec {
                             uniqueIdentifier: "uniqueId"
                         )
                     }.to(throwError(TestError.mock))
-                }
-            }
-            
-            // MARK: -- when removing all records
-            context("when removing all records") {
-                // MARK: ---- removes all dedupe records
-                it("removes all dedupe records") {
-                    extensionHelper.deleteAllDedupeRecords()
-                    
-                    expect(mockFileManager).to(call(.exactly(times: 1), matchingParameters: .all) {
-                        try? $0.removeItem(atPath: "/test/extensionCache/dedupe")
-                    })
                 }
             }
         }

--- a/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
@@ -6,6 +6,10 @@ import SessionUtilitiesKit
 @testable import SessionMessagingKit
 
 class MockExtensionHelper: Mock<ExtensionHelperType>, ExtensionHelperType {
+    func deleteCache() {
+        mockNoReturn()
+    }
+    
     // MARK: - Deduping
     
     func hasAtLeastOneDedupeRecord(threadId: String) -> Bool {
@@ -22,10 +26,6 @@ class MockExtensionHelper: Mock<ExtensionHelperType>, ExtensionHelperType {
     
     func removeDedupeRecord(threadId: String, uniqueIdentifier: String) throws {
         return try mockThrowing(args: [threadId, uniqueIdentifier])
-    }
-    
-    func deleteAllDedupeRecords() {
-        mockNoReturn()
     }
     
     // MARK: - Config Dumps

--- a/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
@@ -1,6 +1,7 @@
 // Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
 
 import Foundation
+import SessionSnodeKit
 import SessionUtilitiesKit
 
 @testable import SessionMessagingKit
@@ -8,6 +9,20 @@ import SessionUtilitiesKit
 class MockExtensionHelper: Mock<ExtensionHelperType>, ExtensionHelperType {
     func deleteCache() {
         mockNoReturn()
+    }
+    
+    // MARK: - User Metadata
+    
+    func saveUserMetadata(
+        sessionId: SessionId,
+        ed25519SecretKey: [UInt8],
+        unreadCount: Int?
+    ) throws {
+        try mockThrowingNoReturn(args: [sessionId, ed25519SecretKey, unreadCount])
+    }
+    
+    func loadUserMetadata() -> ExtensionHelper.UserMetadata? {
+        return mock()
     }
     
     // MARK: - Deduping
@@ -32,5 +47,39 @@ class MockExtensionHelper: Mock<ExtensionHelperType>, ExtensionHelperType {
     
     func lastUpdatedTimestamp(for sessionId: SessionId, variant: ConfigDump.Variant) -> TimeInterval {
         return mock(args: [sessionId, variant])
+    }
+    
+    func replicate(dump: ConfigDump?, replaceExisting: Bool) {
+        mockNoReturn(args: [dump, replaceExisting])
+    }
+    
+    func replicateAllConfigDumpsIfNeeded(userSessionId: SessionId) {
+        mockNoReturn(args: [userSessionId])
+    }
+    
+    func refreshDumpModifiedDate(sessionId: SessionId, variant: ConfigDump.Variant) {
+        mockNoReturn(args: [sessionId, variant])
+    }
+    
+    // MARK: - Messages
+    
+    func unreadMessageCount() -> Int? {
+        return mock()
+    }
+    
+    func saveMessage(_ message: SnodeReceivedMessage?, isUnread: Bool) throws {
+        try mockThrowingNoReturn(args: [message, isUnread])
+    }
+    
+    func willLoadMessages() {
+        mockNoReturn()
+    }
+    
+    func loadMessages() async throws {
+        try mockThrowingNoReturn()
+    }
+    
+    @discardableResult func waitUntilMessagesAreLoaded(timeout: DispatchTimeInterval) async -> Bool {
+        return mock(args: [timeout])
     }
 }

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -163,6 +163,14 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
         return mock(args: [threadId, threadVariant, contactProfile, visibleMessage, openGroupName, openGroupUrlInfo])
     }
     
+    func conversationLastRead(
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        openGroupUrlInfo: LibSession.OpenGroupUrlInfo?
+    ) -> Int64? {
+        return mock(args: [threadId, threadVariant, openGroupUrlInfo])
+    }
+    
     func isMessageRequest(
         threadId: String,
         threadVariant: SessionThread.Variant
@@ -297,6 +305,15 @@ extension Mock where T == LibSessionCacheType {
                 )
             }
             .thenReturn(true)
+        self
+            .when {
+                $0.conversationLastRead(
+                    threadId: .any,
+                    threadVariant: .any,
+                    openGroupUrlInfo: .any
+                )
+            }
+            .thenReturn(nil)
         self
             .when { $0.canPerformChange(threadId: .any, threadVariant: .any, changeTimestampMs: .any) }
             .thenReturn(true)

--- a/SessionMessagingKitTests/_TestUtilities/MockNotificationsManager.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockNotificationsManager.swift
@@ -42,9 +42,10 @@ public class MockNotificationsManager: Mock<NotificationsManagerType>, Notificat
     
     public func addNotificationRequest(
         content: NotificationContent,
-        notificationSettings: Preferences.NotificationSettings
+        notificationSettings: Preferences.NotificationSettings,
+        extensionBaseUnreadCount: Int?
     ) {
-        mockNoReturn(args: [content, notificationSettings])
+        mockNoReturn(args: [content, notificationSettings, extensionBaseUnreadCount])
     }
     
     public func cancelNotifications(identifiers: [String]) {

--- a/SessionNotificationServiceExtension/NSENotificationPresenter.swift
+++ b/SessionNotificationServiceExtension/NSENotificationPresenter.swift
@@ -49,13 +49,25 @@ public class NSENotificationPresenter: NotificationsManagerType {
     
     public func addNotificationRequest(
         content: NotificationContent,
-        notificationSettings: Preferences.NotificationSettings
+        notificationSettings: Preferences.NotificationSettings,
+        extensionBaseUnreadCount: Int?
     ) {
+        let notificationContent: UNMutableNotificationContent = content.toMutableContent(
+            shouldPlaySound: notificationShouldPlaySound(applicationState: content.applicationState)
+        )
+        
+        /// Since we will have already written the message to disk at this stage we can just add the number of unread message files
+        /// directly to the `originalUnreadCount` in order to get the updated unread count
+        if
+            let extensionBaseUnreadCount: Int = extensionBaseUnreadCount,
+            let unreadPendingMessageCount: Int = dependencies[singleton: .extensionHelper].unreadMessageCount()
+        {
+            notificationContent.badge = NSNumber(value: extensionBaseUnreadCount + unreadPendingMessageCount)
+        }
+        
         let request = UNNotificationRequest(
             identifier: content.identifier,
-            content: content.toMutableContent(
-                shouldPlaySound: notificationShouldPlaySound(applicationState: content.applicationState)
-            ),
+            content: notificationContent,
             trigger: nil
         )
         

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -475,6 +475,9 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                     .hasAtLeastOneDedupeRecord(threadId: threadId)
             }
         )
+        
+        /// Since we succeeded we can complete silently
+        completeSilenty(notification.info, .success(notification.info.metadata))
     }
     
     private func handleError(
@@ -940,11 +943,12 @@ private extension NotificationServiceExtension {
         
         func with(
             requestId: String? = nil,
+            content: UNMutableNotificationContent? = nil,
             contentHandler: ((UNNotificationContent) -> Void)? = nil,
             metadata: PushNotificationAPI.NotificationMetadata? = nil
         ) -> NotificationInfo {
             return NotificationInfo(
-                content: content,
+                content: (content ?? self.content),
                 requestId: (requestId ?? self.requestId),
                 contentHandler: (contentHandler ?? self.contentHandler),
                 metadata: (metadata ?? self.metadata),

--- a/SessionSnodeKit/LibSession/LibSession+Networking.swift
+++ b/SessionSnodeKit/LibSession/LibSession+Networking.swift
@@ -493,7 +493,7 @@ private extension NetworkStatus {
 // MARK: - Snode
 
 extension LibSession {
-    public struct Snode: Hashable, CustomStringConvertible {
+    public struct Snode: Codable, Hashable, CustomStringConvertible {
         public let ip: String
         public let quicPort: UInt16
         public let ed25519PubkeyHex: String

--- a/SessionSnodeKit/Models/GetMessagesResponse.swift
+++ b/SessionSnodeKit/Models/GetMessagesResponse.swift
@@ -11,15 +11,27 @@ public class GetMessagesResponse: SnodeResponse {
     public class RawMessage: Codable {
         private enum CodingKeys: String, CodingKey {
             case base64EncodedDataString = "data"
-            case expiration
+            case expirationMs = "expiration"
             case hash
             case timestampMs = "timestamp"
         }
         
         public let base64EncodedDataString: String
-        public let expiration: Int64?
+        public let expirationMs: Int64?
         public let hash: String
         public let timestampMs: Int64
+        
+        public init(
+            base64EncodedDataString: String,
+            expirationMs: Int64?,
+            hash: String,
+            timestampMs: Int64
+        ) {
+            self.base64EncodedDataString = base64EncodedDataString
+            self.expirationMs = expirationMs
+            self.hash = hash
+            self.timestampMs = timestampMs
+        }
     }
     
     public let messages: [RawMessage]

--- a/SessionSnodeKit/Models/SnodeReceivedMessage.swift
+++ b/SessionSnodeKit/Models/SnodeReceivedMessage.swift
@@ -5,7 +5,7 @@
 import Foundation
 import SessionUtilitiesKit
 
-public struct SnodeReceivedMessage: CustomDebugStringConvertible {
+public struct SnodeReceivedMessage: Codable, CustomDebugStringConvertible {
     /// Service nodes cache messages for 14 days so default the expiration for message hashes to '15' days
     /// so we don't end up indefinitely storing records which will never be used
     public static let defaultExpirationMs: Int64 = ((15 * 24 * 60 * 60) * 1000)
@@ -13,13 +13,28 @@ public struct SnodeReceivedMessage: CustomDebugStringConvertible {
     /// The storage server allows the timestamp within requests to be off by `60s` before erroring
     public static let serverClockToleranceMs: Int64 = ((1 * 60) * 1000)
     
-    public let info: SnodeReceivedMessageInfo
+    public let snode: LibSession.Snode?
+    public let swarmPublicKey: String
     public let namespace: SnodeAPI.Namespace
+    public let hash: String
     public let timestampMs: Int64
+    public let expirationTimestampMs: Int64
     public let data: Data
     
-    init?(
-        snode: LibSession.Snode,
+    public var info: SnodeReceivedMessageInfo? {
+        snode.map { snode in
+            SnodeReceivedMessageInfo(
+                snode: snode,
+                swarmPublicKey: swarmPublicKey,
+                namespace: namespace,
+                hash: hash,
+                expirationDateMs: expirationTimestampMs
+            )
+        }
+    }
+    
+    public init?(
+        snode: LibSession.Snode?,
         publicKey: String,
         namespace: SnodeAPI.Namespace,
         rawMessage: GetMessagesResponse.RawMessage
@@ -29,23 +44,22 @@ public struct SnodeReceivedMessage: CustomDebugStringConvertible {
             return nil
         }
         
-        self.info = SnodeReceivedMessageInfo(
-            snode: snode,
-            swarmPublicKey: publicKey,
-            namespace: namespace,
-            hash: rawMessage.hash,
-            expirationDateMs: (rawMessage.expiration ?? SnodeReceivedMessage.defaultExpirationMs)
-        )
+        self.snode = snode
+        self.swarmPublicKey = publicKey
         self.namespace = namespace
+        self.hash = rawMessage.hash
         self.timestampMs = rawMessage.timestampMs
+        self.expirationTimestampMs = (rawMessage.expirationMs ?? SnodeReceivedMessage.defaultExpirationMs)
         self.data = data
     }
     
     public var debugDescription: String {
         """
         SnodeReceivedMessage(
-            hash: \(info.hash),
-            expirationMs: \(info.expirationDateMs),
+            swarmPublicKey: \(swarmPublicKey),
+            namespace: \(namespace),
+            hash: \(hash),
+            expirationTimestampMs: \(expirationTimestampMs),
             timestampMs: \(timestampMs),
             data: \(data.base64EncodedString())
         )

--- a/SessionUtilitiesKit/Database/Storage.swift
+++ b/SessionUtilitiesKit/Database/Storage.swift
@@ -883,7 +883,7 @@ open class Storage {
     // MARK: - Functions
     
     @discardableResult public func write<T>(
-        fileName file: String = #file,
+        fileName file: String = #fileID,
         functionName funcN: String = #function,
         lineNumber line: Int = #line,
         updates: @escaping (Database) throws -> T?
@@ -895,7 +895,7 @@ open class Storage {
     }
     
     open func writeAsync<T>(
-        fileName file: String = #file,
+        fileName file: String = #fileID,
         functionName funcN: String = #function,
         lineNumber line: Int = #line,
         updates: @escaping (Database) throws -> T,
@@ -905,7 +905,7 @@ open class Storage {
     }
     
     @discardableResult public func writeAsync<T>(
-        fileName file: String = #file,
+        fileName file: String = #fileID,
         functionName funcN: String = #function,
         lineNumber line: Int = #line,
         updates: @escaping (Database) throws -> T
@@ -914,7 +914,7 @@ open class Storage {
     }
     
     open func writePublisher<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         updates: @escaping (Database) throws -> T
@@ -923,7 +923,7 @@ open class Storage {
     }
     
     @discardableResult public func read<T>(
-        fileName file: String = #file,
+        fileName file: String = #fileID,
         functionName funcN: String = #function,
         lineNumber line: Int = #line,
         _ value: @escaping (Database) throws -> T?
@@ -935,7 +935,7 @@ open class Storage {
     }
     
     @discardableResult public func readAsync<T>(
-        fileName file: String = #file,
+        fileName file: String = #fileID,
         functionName funcN: String = #function,
         lineNumber line: Int = #line,
         value: @escaping (Database) throws -> T
@@ -944,7 +944,7 @@ open class Storage {
     }
     
     open func readPublisher<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         value: @escaping (Database) throws -> T
@@ -963,7 +963,7 @@ open class Storage {
     /// - returns: a DatabaseCancellable
     public func start<Reducer: ValueReducer>(
         _ observation: ValueObservation<Reducer>,
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         scheduling scheduler: ValueObservationScheduler = .async(onQueue: .main),
@@ -998,7 +998,7 @@ open class Storage {
     ///
     /// **Note:** This function **MUST NOT** be called from the main thread
     public func addObserver(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         _ observer: IdentifiableTransactionObserver?
@@ -1020,7 +1020,7 @@ open class Storage {
     ///
     /// **Note:** This function **MUST NOT** be called from the main thread
     public func removeObserver(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         _ observer: IdentifiableTransactionObserver?

--- a/SessionUtilitiesKit/General/Logging.swift
+++ b/SessionUtilitiesKit/General/Logging.swift
@@ -207,126 +207,126 @@ public enum Log {
     // FIXME: Would be nice to properly require a category for all logs
     public static func verbose(
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.verbose, [], msg, file: file, function: function, line: line) }
     public static func verbose(
         _ cat: Category
         , _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.verbose, [cat], msg, file: file, function: function, line: line) }
     public static func verbose(
         _ cats: [Category],
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.verbose, cats, msg, file: file, function: function, line: line) }
     
     public static func debug(
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.debug, [], msg, file: file, function: function, line: line) }
     public static func debug(
         _ cat: Category,
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.debug, [cat], msg, file: file, function: function, line: line) }
     public static func debug(
         _ cats: [Category],
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.debug, cats, msg, file: file, function: function, line: line) }
     
     public static func info(
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.info, [], msg, file: file, function: function, line: line) }
     public static func info(
         _ cat: Category,
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.info, [cat], msg, file: file, function: function, line: line) }
     public static func info(
         _ cats: [Category],
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.info, cats, msg, file: file, function: function, line: line) }
     
     public static func warn(
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.warn, [], msg, file: file, function: function, line: line) }
     public static func warn(
         _ cat: Category,
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.warn, [cat], msg, file: file, function: function, line: line) }
     public static func warn(
         _ cats: [Category],
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.warn, cats, msg, file: file, function: function, line: line) }
     
     public static func error(
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.error, [], msg, file: file, function: function, line: line) }
     public static func error(
         _ cat: Category,
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.error, [cat], msg, file: file, function: function, line: line) }
     public static func error(
         _ cats: [Category],
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.error, cats, msg, file: file, function: function, line: line) }
     
     public static func critical(
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.critical, [], msg, file: file, function: function, line: line) }
     public static func critical(
         _ cat: Category,
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.critical, [cat], msg, file: file, function: function, line: line) }
     public static func critical(
         _ cats: [Category],
         _ msg: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) { custom(.critical, cats, msg, file: file, function: function, line: line) }
@@ -334,7 +334,7 @@ public enum Log {
     public static func assert(
         _ condition: Bool,
         _ message: @autoclosure () -> String = String(),
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) {
@@ -349,7 +349,7 @@ public enum Log {
     }
     
     public static func assertOnMainThread(
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) {
@@ -364,7 +364,7 @@ public enum Log {
     }
     
     public static func assertNotOnMainThread(
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) {
@@ -382,7 +382,7 @@ public enum Log {
         _ level: Level,
         _ categories: [Category],
         _ message: String,
-        file: StaticString = #file,
+        file: StaticString = #fileID,
         function: StaticString = #function,
         line: UInt = #line
     ) {
@@ -392,13 +392,13 @@ public enum Log {
             }
         }
         
-        logger.log(level, categories, message, file: file, function: function, line: line)
+        logger._internalLog(level, categories, message, file: file, function: function, line: line)
     }
 }
 
 // MARK: - Logger
 
-public class Logger {
+open class Logger {
     private let dependencies: Dependencies
     private let primaryPrefix: String
     @ThreadSafeObject private var systemLoggers: [String: SystemLoggerType] = [:]
@@ -462,7 +462,7 @@ public class Logger {
         // to a local directory (so they can be exported via XCode) - the below code reads any
         // logs from the shared directly and attempts to add them to the main app logs to make
         // debugging user issues in extensions easier
-        DispatchQueue.global(qos: .utility).async { [weak self, dependencies] in
+        DispatchQueue.global(qos: .utility).async(using: dependencies) { [weak self, dependencies] in
             guard let currentLogFileInfo: DDLogFileInfo = self?.fileLogger.currentLogFileInfo else {
                 self?.completeResumeLogging(error: "Unable to retrieve current log file.")
                 return
@@ -560,7 +560,7 @@ public class Logger {
         // If we had an error loading the extension logs then actually log it
         if let error: String = error {
             Log.empty()
-            log(.error, [], error, file: #file, function: #function, line: #line)
+            _internalLog(.error, [], error, file: #fileID, function: #function, line: #line)
         }
         
         // After creating a new logger we want to log two empty lines to make it easier to read
@@ -569,11 +569,11 @@ public class Logger {
         
         // Add any logs that were pending during the startup process
         pendingLogs.forEach { level, categories, message, file, function, line in
-            log(level, categories, message, file: file, function: function, line: line)
+            _internalLog(level, categories, message, file: file, function: function, line: line)
         }
     }
     
-    fileprivate func log(
+    internal func _internalLog(
         _ level: Log.Level,
         _ categories: [Log.Category],
         _ message: String,

--- a/SessionUtilitiesKit/General/SessionId.swift
+++ b/SessionUtilitiesKit/General/SessionId.swift
@@ -2,11 +2,11 @@
 
 import Foundation
 
-public struct SessionId: Equatable, Hashable, CustomStringConvertible {
+public struct SessionId: Codable, Equatable, Hashable, CustomStringConvertible {
     public static let byteCount: Int = 33
     public static let invalid: SessionId = SessionId(.standard, publicKey: [])
     
-    public enum Prefix: String, CaseIterable, Hashable {
+    public enum Prefix: String, Codable, CaseIterable, Hashable {
         case standard = "05"    // Used for identified users, open groups, etc.
         case blinded15 = "15"   // Used for authentication and participants in open groups with blinding enabled
         case blinded25 = "25"   // Used for authentication and participants in open groups with blinding enabled

--- a/SessionUtilitiesKit/General/String+Utilities.swift
+++ b/SessionUtilitiesKit/General/String+Utilities.swift
@@ -162,7 +162,19 @@ private extension CharacterSet {
     static let bidiPopDirectionalIsolate: String.UTF16View.Element = 0x2069
     
     static let bidiControlCharacterSet: CharacterSet = {
-        return CharacterSet(charactersIn: "\(bidiLeftToRightIsolate)\(bidiRightToLeftIsolate)\(bidiFirstStrongIsolate)\(bidiLeftToRightEmbedding)\(bidiRightToLeftEmbedding)\(bidiLeftToRightOverride)\(bidiRightToLeftOverride)\(bidiPopDirectionalFormatting)\(bidiPopDirectionalIsolate)")
+        let bidiCodeUnits: [String.UTF16View.Element] = [
+            bidiLeftToRightIsolate, bidiRightToLeftIsolate, bidiFirstStrongIsolate,
+            bidiLeftToRightEmbedding, bidiRightToLeftEmbedding,
+            bidiLeftToRightOverride, bidiRightToLeftOverride,
+            bidiPopDirectionalFormatting, bidiPopDirectionalIsolate
+        ]
+
+        return CharacterSet(
+            charactersIn: bidiCodeUnits
+                .compactMap { UnicodeScalar($0) }
+                .map { String($0) }
+                .joined()
+        )
     }()
     
     static let unsafeFilenameCharacterSet: CharacterSet = CharacterSet(charactersIn: "\u{202D}\u{202E}")
@@ -251,15 +263,19 @@ public extension String {
         
         var balancedString: String = ""
         
+        func charStr(_ utf16: String.UTF16View.Element) -> String {
+            return String(UnicodeScalar(utf16)!)
+        }
+        
         // If we have too many isolate pops, prepend FSI to balance
         while isolatePopCount > isolateStartsCount {
-            balancedString.append("\(CharacterSet.bidiFirstStrongIsolate)")
+            balancedString.append(charStr(CharacterSet.bidiFirstStrongIsolate))
             isolateStartsCount += 1
         }
         
         // If we have too many formatting pops, prepend LRE to balance
         while formattingPopCount > formattingStartsCount {
-            balancedString.append("\(CharacterSet.bidiLeftToRightEmbedding)")
+            balancedString.append(charStr(CharacterSet.bidiLeftToRightEmbedding))
             formattingStartsCount += 1
         }
         
@@ -267,13 +283,13 @@ public extension String {
         
         // If we have too many formatting starts, append PDF to balance
         while formattingStartsCount > formattingPopCount {
-            balancedString.append("\(CharacterSet.bidiPopDirectionalFormatting)")
+            balancedString.append(charStr(CharacterSet.bidiPopDirectionalFormatting))
             formattingPopCount += 1
         }
         
         // If we have too many isolate starts, append PDI to balance
         while isolateStartsCount > isolatePopCount {
-            balancedString.append("\(CharacterSet.bidiPopDirectionalIsolate)")
+            balancedString.append(charStr(CharacterSet.bidiPopDirectionalIsolate))
             isolatePopCount += 1
         }
         

--- a/SessionUtilitiesKit/Types/CurrentValueAsyncStream.swift
+++ b/SessionUtilitiesKit/Types/CurrentValueAsyncStream.swift
@@ -1,0 +1,35 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+
+public actor CurrentValueAsyncStream<Element: Sendable> {
+    private var _currentValue: Element
+    private let continuation: AsyncStream<Element>.Continuation
+    public let stream: AsyncStream<Element>
+
+    public var currentValue: Element { _currentValue }
+    
+    // MARK: - Initialization
+
+    public init(_ initialValue: Element) {
+        self._currentValue = initialValue
+
+        /// We use `.bufferingNewest(1)` to ensure that the stream always holds the most recent value. When a new iterator is
+        /// created for the stream, it will receive this buffered value first.
+        let (stream, continuation) = AsyncStream.makeStream(of: Element.self, bufferingPolicy: .bufferingNewest(1))
+        self.stream = stream
+        self.continuation = continuation
+        self.continuation.yield(initialValue)
+    }
+    
+    // MARK: - Functions
+
+    public func send(_ newValue: Element) {
+        _currentValue = newValue
+        continuation.yield(newValue)
+    }
+
+    public func finish() {
+        continuation.finish()
+    }
+}

--- a/SessionUtilitiesKit/Utilities/Task+Utilities.swift
+++ b/SessionUtilitiesKit/Utilities/Task+Utilities.swift
@@ -1,0 +1,12 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+
+public extension Task where Success == Never, Failure == Never {
+    /// Suspends the current task until the given deadline (compatibility version).
+    @available(iOS, introduced: 13.0, obsoleted: 16.0, message: "Use built-in Task.sleep(for:) accepting Swift.Duration on iOS 16+")
+    static func sleep(for interval: DispatchTimeInterval) async throws {
+        let nanosecondsToSleep: UInt64 = (UInt64(interval.milliseconds) * 1_000_000)
+        try await Task.sleep(nanoseconds: nanosecondsToSleep)
+    }
+}

--- a/_SharedTestUtilities/Mock.swift
+++ b/_SharedTestUtilities/Mock.swift
@@ -281,6 +281,11 @@ protocol MockFunctionHandler {
 internal struct CallDetails: Equatable, Hashable {
     let parameterSummary: String
     let allParameterSummaryCombinations: [ParameterCombination]
+    
+    internal init(parameterSummary: String, allParameterSummaryCombinations: [ParameterCombination]) {
+        self.parameterSummary = parameterSummary
+        self.allParameterSummaryCombinations = allParameterSummaryCombinations
+    }
 }
 
 // MARK: - ParameterCombination
@@ -568,9 +573,14 @@ protocol DependenciesSettable {
 // MARK: - FunctionConsumer
 
 internal class FunctionConsumer: MockFunctionHandler {
-    struct Key: Equatable, Hashable {
+    internal struct Key: Equatable, Hashable {
         let name: String
         let paramCount: Int
+        
+        internal init(name: String, paramCount: Int) {
+            self.name = name
+            self.paramCount = paramCount
+        }
     }
     
     var trackCalls: Bool = true

--- a/_SharedTestUtilities/MockFileManager.swift
+++ b/_SharedTestUtilities/MockFileManager.swift
@@ -54,8 +54,8 @@ class MockFileManager: Mock<FileManagerType>, FileManagerType {
     }
     
     func contents(atPath: String) -> Data? { return mock(args: [atPath]) }
-    func contentsOfDirectory(at url: URL) throws -> [URL] { return mock(args: [url]) }
-    func contentsOfDirectory(atPath path: String) throws -> [String] { return mock(args: [path]) }
+    func contentsOfDirectory(at url: URL) throws -> [URL] { return try mockThrowing(args: [url]) }
+    func contentsOfDirectory(atPath path: String) throws -> [String] { return try mockThrowing(args: [path]) }
     func isDirectoryEmpty(at url: URL) -> Bool { return mock(args: [url]) }
     func isDirectoryEmpty(atPath path: String) -> Bool { return mock(args: [path]) }
     

--- a/_SharedTestUtilities/MockLogger.swift
+++ b/_SharedTestUtilities/MockLogger.swift
@@ -1,0 +1,39 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+
+@testable import SessionUtilitiesKit
+
+public class MockLogger: Logger {
+    public struct LogOutput: Equatable {
+        let level: Log.Level
+        let categories: [Log.Category]
+        let message: String
+        let file: String
+        let function: String
+        
+        /// We don't include the `line` because it'd make test maintenance a pain
+        /// `let line: UInt`
+    }
+    
+    public var logs: [LogOutput] = []
+    
+    public override func _internalLog(
+        _ level: Log.Level,
+        _ categories: [Log.Category],
+        _ message: String,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    ) {
+        logs.append(
+            LogOutput(
+                level: level,
+                categories: categories,
+                message: message,
+                file: "\(file)",
+                function: "\(function)"
+            )
+        )
+    }
+}

--- a/_SharedTestUtilities/SynchronousStorage.swift
+++ b/_SharedTestUtilities/SynchronousStorage.swift
@@ -43,7 +43,7 @@ class SynchronousStorage: Storage {
     }
     
     @discardableResult override func write<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         updates: @escaping (Database) throws -> T?
@@ -94,7 +94,7 @@ class SynchronousStorage: Storage {
     }
     
     @discardableResult override func read<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         _ value: @escaping (Database) throws -> T?
@@ -147,7 +147,7 @@ class SynchronousStorage: Storage {
     // MARK: - Async Methods
     
     override func readPublisher<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         value: @escaping (Database) throws -> T
@@ -190,7 +190,7 @@ class SynchronousStorage: Storage {
     }
     
     override func writeAsync<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         updates: @escaping (Database) throws -> T,
@@ -206,7 +206,7 @@ class SynchronousStorage: Storage {
     }
     
     override func writePublisher<T>(
-        fileName: String = #file,
+        fileName: String = #fileID,
         functionName: String = #function,
         lineNumber: Int = #line,
         updates: @escaping (Database) throws -> T


### PR DESCRIPTION
- Added code to write user metadata to disk
- Added code to write config dumps to disk
- Added code to write push notification messages to disk
- Added code to read push notification messages from disk on launch
- Added code to calculate the unread count in the PN extension (based on the last known main app unread count)
- Added code to replicate config dumps to the AppGroup for extensions to load
- Added async/await read & write functions to `Storage`
- Added unit tests for new ExtensionHelper functions
- Tweaked the logic when the user taps on a notification to wait until after the PN extension message files have been loaded (with a 3s timeout)
- Tweaked the `#file` variables to use `#fileID` instead (relative to project dir)
- Updated AppDelegate so it doesn't run when running unit tests (could slow other stuff down or cause bugs)
- Removed the `startSignalStream` from the `performOperation` logic in `Storage` (updated it to behave more cleanly)
- Fixed an issue where notifications were being overwritten in all cases (now using the serverHash as the identifier when available)
- Fixed a bug where we could be incorrectly stripping numbers from messages

**Fixes likely impacting `dev`**
- Fixed an issue where the notification extension wasn't correctly reporting the successful handling of a push notification

This is based on #446 