### PR TITLE
DBR - 5 - Config message handling

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -836,7 +836,6 @@
 		FD8A5B342DC1A732004C689B /* _008_ResetUserConfigLastHashes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */; };
 		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8A5B322DC191B4004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */; };
-		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8ECF7B29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */; };
 		FD8ECF7D2934293A00C0D1BB /* _013_SessionUtilChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */; };
 		FD8ECF7F2934298100C0D1BB /* ConfigDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */; };
@@ -2069,7 +2068,6 @@
 		FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _008_ResetUserConfigLastHashes.swift; sourceTree = "<group>"; };
 		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _025_DropLegacyClosedGroupKeyPairTable.swift; sourceTree = "<group>"; };
-		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibSession+SessionMessagingKit.swift"; sourceTree = "<group>"; };
 		FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _013_SessionUtilChanges.swift; sourceTree = "<group>"; };
 		FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigDump.swift; sourceTree = "<group>"; };

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -836,6 +836,7 @@
 		FD8A5B342DC1A732004C689B /* _008_ResetUserConfigLastHashes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */; };
 		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8A5B322DC191B4004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */; };
+		FD8A5B302DC18D61004C689B /* GeneralCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */; };
 		FD8ECF7B29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */; };
 		FD8ECF7D2934293A00C0D1BB /* _013_SessionUtilChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */; };
 		FD8ECF7F2934298100C0D1BB /* ConfigDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */; };
@@ -2068,6 +2069,7 @@
 		FD8A5B332DC1A726004C689B /* _008_ResetUserConfigLastHashes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _008_ResetUserConfigLastHashes.swift; sourceTree = "<group>"; };
 		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8A5B312DC191AB004C689B /* _025_DropLegacyClosedGroupKeyPairTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _025_DropLegacyClosedGroupKeyPairTable.swift; sourceTree = "<group>"; };
+		FD8A5B2F2DC18D5E004C689B /* GeneralCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCacheSpec.swift; sourceTree = "<group>"; };
 		FD8ECF7A29340FFD00C0D1BB /* LibSession+SessionMessagingKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibSession+SessionMessagingKit.swift"; sourceTree = "<group>"; };
 		FD8ECF7C2934293A00C0D1BB /* _013_SessionUtilChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _013_SessionUtilChanges.swift; sourceTree = "<group>"; };
 		FD8ECF7E2934298100C0D1BB /* ConfigDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigDump.swift; sourceTree = "<group>"; };

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -709,7 +709,7 @@ public class ConversationViewModel: OWSAudioPlayerDelegate, NavigatableStateHold
         // Generate the optimistic data
         let optimisticMessageId: UUID = UUID()
         let threadData: SessionThreadViewModel = self.internalThreadData
-        let currentUserProfile: Profile = Profile.fetchOrCreateCurrentUser(using: dependencies)
+        let currentUserProfile: Profile = dependencies.mutate(cache: .libSession) { $0.profile }
         let interaction: Interaction = Interaction(
             threadId: threadData.threadId,
             threadVariant: threadData.threadVariant,

--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -55,7 +55,7 @@ public class HomeViewModel: NavigatableStateHolder {
             showViewedSeedBanner: (initialState?.showViewedSeedBanner ?? true),
             hasHiddenMessageRequests: (initialState?.hasHiddenMessageRequests ?? false),
             unreadMessageRequestThreadCount: 0,
-            userProfile: (initialState?.userProfile ?? Profile.fetchOrCreateCurrentUser(using: dependencies))
+            userProfile: (initialState?.userProfile ?? dependencies.mutate(cache: .libSession) { $0.profile })
         )
         self.pagedDataObserver = nil
         

--- a/Session/Media Viewing & Editing/MessageInfoScreen.swift
+++ b/Session/Media Viewing & Editing/MessageInfoScreen.swift
@@ -612,7 +612,10 @@ struct MessageInfoView_Previews: PreviewProvider {
             expiresInSeconds: nil,
             state: .failed,
             isSenderModeratorOrAdmin: false,
-            currentUserProfile: Profile.fetchOrCreateCurrentUser(using: dependencies),
+            currentUserProfile: Profile(
+                id: "0588672ccb97f40bb57238989226cf429b575ba355443f47bc76c5ab144a96c65b",
+                name: "TestUser"
+            ),
             quote: nil,
             quoteAttachment: nil,
             linkPreview: nil,

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -245,7 +245,7 @@ extension Onboarding {
                     cache.loadDefaultStateFor(
                         variant: .userProfile,
                         sessionId: userSessionId,
-                        userEd25519KeyPair: identity.ed25519KeyPair,
+                        userEd25519SecretKey: identity.ed25519KeyPair.secretKey,
                         groupEd25519SecretKey: nil
                     )
                     try cache.unsafeDirectMergeConfigMessage(

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -82,6 +82,7 @@ extension Onboarding {
         
         public var displayName: String
         public var _displayNamePublisher: AnyPublisher<String?, Error>?
+        private var hasInitialDisplayName: Bool
         private var userProfileConfigMessage: ProcessedMessage?
         private var disposables: Set<AnyCancellable> = Set()
         
@@ -102,35 +103,46 @@ extension Onboarding {
             self.dependencies = dependencies
             self.initialFlow = flow
             
-            /// Determine the current state based on what's in the database
-            typealias StoredData = (
-                state: State,
-                displayName: String,
-                ed25519KeyPair: KeyPair,
-                x25519KeyPair: KeyPair
-            )
-            let storedData: StoredData = dependencies[singleton: .storage].read { db -> StoredData in
-                // If we have no ed25519KeyPair then the user doesn't have an account
+            /// Try to load the users `ed25519KeyPair` from the database
+            let ed25519KeyPair: KeyPair = dependencies[singleton: .storage]
+                .read { db -> KeyPair? in Identity.fetchUserEd25519KeyPair(db) }
+                .defaulting(to: .empty)
+            
+            /// Retrieve the users `displayName` from `libSession` (the source of truth)
+            let displayName: String = dependencies.mutate(cache: .libSession) { $0.profile }.name
+            let hasInitialDisplayName: Bool = dependencies.mutate(cache: .libSession) {
+                $0.displayName?.nullIfEmpty != nil
+            }
+            
+            self.ed25519KeyPair = ed25519KeyPair
+            self.displayName = displayName
+            self.hasInitialDisplayName = hasInitialDisplayName
+            self.x25519KeyPair = {
                 guard
-                    let x25519KeyPair: KeyPair = Identity.fetchUserKeyPair(db),
-                    let ed25519KeyPair: KeyPair = Identity.fetchUserEd25519KeyPair(db)
-                else { return (.noUser, "", KeyPair.empty, KeyPair.empty) }
+                    ed25519KeyPair != .empty,
+                    let x25519PublicKey: [UInt8] = dependencies[singleton: .crypto].generate(
+                        .x25519(ed25519Pubkey: ed25519KeyPair.publicKey)
+                    ),
+                    let x25519SecretKey: [UInt8] = dependencies[singleton: .crypto].generate(
+                        .x25519(ed25519Seckey: ed25519KeyPair.secretKey)
+                    )
+                else { return .empty }
                 
-                // If we have no display name then collect one (this can happen if the
-                // app crashed during onboarding which would leave the user in an invalid
-                // state with no display name)
-                let displayName: String = Profile.fetchOrCreateCurrentUser(db, using: dependencies).name
-                guard !displayName.isEmpty else { return (.missingName, "anonymous".localized(), x25519KeyPair, ed25519KeyPair) }
+                return KeyPair(publicKey: x25519PublicKey, secretKey: x25519SecretKey)
+            }()
+            self.userSessionId = (x25519KeyPair != .empty ?
+                SessionId(.standard, publicKey: x25519KeyPair.publicKey) :
+                .invalid
+            )
+            self.state = {
+                guard ed25519KeyPair != .empty else { return .noUser }
+                guard hasInitialDisplayName else { return .missingName }
                 
-                // Otherwise we have enough for a full user and can start the app
-                return (.completed, displayName, x25519KeyPair, ed25519KeyPair)
-            }.defaulting(to: (.noUser, "", KeyPair.empty, KeyPair.empty))
-
-            /// Store the initial `displayName` value in case we need it
-            self.displayName = storedData.displayName
+                return .completed
+            }()
             
             /// Update the cached values depending on the `initialState`
-            switch storedData.state {
+            switch state {
                 case .noUser, .noUserFailedIdentity:
                     /// Remove the `LibSession.Cache` just in case (to ensure no previous state remains)
                     dependencies.remove(cache: .libSession)
@@ -147,8 +159,8 @@ extension Onboarding {
                         /// recover somehow
                         self.state = .noUserFailedIdentity
                         self.seed = Data()
-                        self.ed25519KeyPair = KeyPair(publicKey: [], secretKey: [])
-                        self.x25519KeyPair = KeyPair(publicKey: [], secretKey: [])
+                        self.ed25519KeyPair = .empty
+                        self.x25519KeyPair = .empty
                         self.userSessionId = .invalid
                         self.useAPNS = false
                         return
@@ -157,17 +169,10 @@ extension Onboarding {
                     /// The identity data was successfully generated so store it for the onboarding process
                     self.state = .noUser
                     self.seed = finalSeedData
-                    self.ed25519KeyPair = identity.ed25519KeyPair
-                    self.x25519KeyPair = identity.x25519KeyPair
-                    self.userSessionId = SessionId(.standard, publicKey: x25519KeyPair.publicKey)
                     self.useAPNS = false
                     
                 case .missingName, .completed:
-                    self.state = storedData.state
                     self.seed = Data()
-                    self.ed25519KeyPair = storedData.ed25519KeyPair
-                    self.x25519KeyPair = storedData.x25519KeyPair
-                    self.userSessionId = dependencies[cache: .general].sessionId
                     self.useAPNS = dependencies[defaults: .standard, key: .isUsingFullAPNs]
                     
                     /// If we are already in a completed state then updated the completion subject accordingly
@@ -193,6 +198,7 @@ extension Onboarding {
             self.userSessionId = SessionId(.standard, publicKey: x25519KeyPair.publicKey)
             self.useAPNS = dependencies[defaults: .standard, key: .isUsingFullAPNs]
             self.displayName = displayName
+            self.hasInitialDisplayName = !displayName.isEmpty
             self._displayNamePublisher = nil
         }
         
@@ -230,7 +236,7 @@ extension Onboarding {
                 using: dependencies
             )
             
-            typealias PollResult = (configMessage: ProcessedMessage, displayName: String)
+            typealias PollResult = (configMessage: ProcessedMessage, displayName: String?)
             let publisher: AnyPublisher<String?, Error> = poller
                 .poll(forceSynchronousProcessing: true)
                 .tryMap { [userSessionId, dependencies] messages, _, _, _ -> PollResult? in
@@ -260,7 +266,7 @@ extension Onboarding {
                         ]
                     )
                     
-                    return (targetMessage, cache.userProfileDisplayName)
+                    return (targetMessage, cache.displayName)
                 }
                 .handleEvents(
                     receiveOutput: { [weak self] result in
@@ -269,8 +275,8 @@ extension Onboarding {
                         /// Only store the `displayName` returned from the swarm if the user hasn't provided one in the display
                         /// name step (otherwise the user could enter a display name and have it immediately overwritten due to the
                         /// config request running slow)
-                        if self?.displayName.isEmpty == true {
-                            self?.displayName = result.displayName
+                        if self?.hasInitialDisplayName != true, let displayName = result.displayName {
+                            self?.displayName = displayName
                         }
                         
                         self?.userProfileConfigMessage = result.configMessage
@@ -366,6 +372,8 @@ extension Onboarding {
                                         .messages
                                 )
                             }
+                            
+                            try? $0.updateProfile(displayName: displayName)
                         }
                         
                         /// Clear the `lastNameUpdate` timestamp and forcibly set the `displayName` provided during the onboarding

--- a/Session/Settings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettingsViewModel.swift
@@ -1082,7 +1082,8 @@ class DeveloperSettingsViewModel: SessionTableViewModel, NavigatableStateHolder,
         Onboarding.Cache(
             ed25519KeyPair: identityData.ed25519KeyPair,
             x25519KeyPair: identityData.x25519KeyPair,
-            displayName: Profile.fetchOrCreateCurrentUser(using: dependencies)
+            displayName: dependencies
+                .mutate(cache: .libSession) { $0.profile }
                 .name
                 .nullIfEmpty
                 .defaulting(to: "Anonymous"),

--- a/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
+++ b/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
@@ -53,6 +53,8 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
             groupEd25519SecretKey: nil,
             cachedData: nil
         )
+        cache.setConfig(for: .userProfile, sessionId: userSessionId, to: userProfileConfig)
+        
         let userProfile: Row? = try? Row.fetchOne(
             db,
             sql: """
@@ -62,13 +64,10 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
             """,
             arguments: [userSessionId.hexString]
         )
-        try LibSession.update(
-            profileInfo: LibSession.ProfileInfo(
-                name: (userProfile?["name"] ?? ""),
-                profilePictureUrl: userProfile?["profilePictureUrl"],
-                profileEncryptionKey: userProfile?["profileEncryptionKey"]
-            ),
-            in: userProfileConfig
+        try cache.updateProfile(
+            displayName: (userProfile?["name"] ?? ""),
+            profilePictureUrl: userProfile?["profilePictureUrl"],
+            profileEncryptionKey: userProfile?["profileEncryptionKey"]
         )
         
         try LibSession.updateNoteToSelf(
@@ -106,6 +105,8 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
             groupEd25519SecretKey: nil,
             cachedData: nil
         )
+        cache.setConfig(for: .contacts, sessionId: userSessionId, to: contactsConfig)
+        
         let validContactIds: [String] = allThreads
             .values
             .filter { thread in
@@ -199,6 +200,8 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
             groupEd25519SecretKey: nil,
             cachedData: nil
         )
+        cache.setConfig(for: .convoInfoVolatile, sessionId: userSessionId, to: convoInfoVolatileConfig)
+        
         let volatileThreadInfo: [Row] = try Row.fetchAll(db, sql: """
             SELECT
                 thread.id,
@@ -287,6 +290,8 @@ enum _014_GenerateInitialUserConfigDumps: Migration {
             groupEd25519SecretKey: nil,
             cachedData: nil
         )
+        cache.setConfig(for: .userGroups, sessionId: userSessionId, to: userGroupsConfig)
+        
         let legacyGroupInfo: [Row] = try Row.fetchAll(db, sql: """
             SELECT
                 closedGroup.threadId,

--- a/SessionMessagingKit/Database/Migrations/_015_BlockCommunityMessageRequests.swift
+++ b/SessionMessagingKit/Database/Migrations/_015_BlockCommunityMessageRequests.swift
@@ -42,15 +42,6 @@ enum _015_BlockCommunityMessageRequests: Migration {
                 """,
                 arguments: [userSessionId.hexString]
             )
-            let userProfileConfig: LibSession.Config = try cache.loadState(
-                for: .userProfile,
-                sessionId: userSessionId,
-                userEd25519SecretKey: Array(userEd25519SecretKey),
-                groupEd25519SecretKey: nil,
-                cachedData: configDump
-            )
-            
-            let rawBlindedMessageRequestValue: Int32 = try LibSession.rawBlindedMessageRequestValue(in: userProfileConfig)
             
             // Use the value in the config if we happen to have one, otherwise use the default
             try db.execute(sql: """
@@ -58,9 +49,9 @@ enum _015_BlockCommunityMessageRequests: Migration {
                 WHERE key = 'checkForCommunityMessageRequests'
             """)
             
-            var targetValue: Bool = (rawBlindedMessageRequestValue < 0 ?
+            var targetValue: Bool = (!cache.has(.checkForCommunityMessageRequests) ?
                 true :
-                (rawBlindedMessageRequestValue > 0)
+                cache.get(.checkForCommunityMessageRequests)
             )
             let boolAsData: Data = withUnsafeBytes(of: &targetValue) { Data($0) }
             try db.execute(

--- a/SessionMessagingKit/Database/Models/Profile.swift
+++ b/SessionMessagingKit/Database/Models/Profile.swift
@@ -289,18 +289,6 @@ public extension Profile {
     ///
     /// **Note:** This method intentionally does **not** save the newly created Profile,
     /// it will need to be explicitly saved after calling
-    static func fetchOrCreateCurrentUser(using dependencies: Dependencies) -> Profile {
-        let userSessionId: SessionId = dependencies[cache: .general].sessionId
-        
-        return dependencies[singleton: .storage]
-            .read { db in fetchOrCreateCurrentUser(db, using: dependencies) }
-            .defaulting(to: defaultFor(userSessionId.hexString))
-    }
-    
-    /// Fetches or creates a Profile for the current user
-    ///
-    /// **Note:** This method intentionally does **not** save the newly created Profile,
-    /// it will need to be explicitly saved after calling
     static func fetchOrCreateCurrentUser(_ db: Database, using dependencies: Dependencies) -> Profile {
         let userSessionId: SessionId = dependencies[cache: .general].sessionId
         

--- a/SessionMessagingKit/Jobs/GroupLeavingJob.swift
+++ b/SessionMessagingKit/Jobs/GroupLeavingJob.swift
@@ -57,12 +57,10 @@ public enum GroupLeavingJob: JobExecutor {
                     .defaulting(to: 0)
                 let finalBehaviour: GroupLeavingJob.Details.Behaviour = {
                     guard
-                        (
-                            dependencies.mutate(cache: .libSession) { cache in
-                                cache.wasKickedFromGroup(groupSessionId: SessionId(.group, hex: threadId)) ||
-                                cache.groupIsDestroyed(groupSessionId: SessionId(.group, hex: threadId))
-                            }
-                        )
+                        dependencies.mutate(cache: .libSession, { cache in
+                            cache.wasKickedFromGroup(groupSessionId: SessionId(.group, hex: threadId)) ||
+                            cache.groupIsDestroyed(groupSessionId: SessionId(.group, hex: threadId))
+                        })
                     else { return details.behaviour }
                     
                     return .delete

--- a/SessionMessagingKit/Jobs/UpdateProfilePictureJob.swift
+++ b/SessionMessagingKit/Jobs/UpdateProfilePictureJob.swift
@@ -51,7 +51,7 @@ public enum UpdateProfilePictureJob: JobExecutor {
         }
         
         // Note: The user defaults flag is updated in DisplayPictureManager
-        let profile: Profile = Profile.fetchOrCreateCurrentUser(using: dependencies)
+        let profile: Profile = dependencies.mutate(cache: .libSession) { $0.profile }
         let displayPictureUpdate: DisplayPictureManager.Update = profile.profilePictureFileName
             .map { dependencies[singleton: .displayPictureManager].loadDisplayPictureFromDisk(for: $0) }
             .map { .currentUserUploadImageData($0) }

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -489,10 +489,11 @@ internal extension LibSession {
         // Update the user profile first (if needed)
         if let updatedUserProfile: Profile = updatedProfiles.first(where: { $0.id == userSessionId.hexString }) {
             try dependencies.mutate(cache: .libSession) { cache in
-                try cache.performAndPushChange(db, for: .userProfile, sessionId: userSessionId) { config in
-                    try LibSession.update(
-                        profile: updatedUserProfile,
-                        in: config
+                try cache.performAndPushChange(db, for: .userProfile, sessionId: userSessionId) { _ in
+                    try cache.updateProfile(
+                        displayName: updatedUserProfile.name,
+                        profilePictureUrl: updatedUserProfile.profilePictureUrl,
+                        profileEncryptionKey: updatedUserProfile.profileEncryptionKey
                     )
                 }
             }

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+ConvoInfoVolatile.swift
@@ -471,6 +471,8 @@ public extension LibSession.Cache {
     }
 }
 
+// MARK: State Access
+
 public extension LibSessionCacheType {
     func timestampAlreadyRead(
         threadId: String,

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Shared.swift
@@ -805,9 +805,11 @@ public extension LibSession.Cache {
                 }
                 
             case .group:
-                guard case .userGroups(let conf) = config(for: .userGroups, sessionId: userSessionId) else {
-                    return nil
-                }
+                guard
+                    let groupSessionId: SessionId = try? SessionId(from: threadId),
+                    groupSessionId.prefix == .group,
+                    case .groupInfo(let conf) = config(for: .groupInfo, sessionId: groupSessionId)
+                else { return nil }
                 
                 let durationSeconds: Int32 = groups_info_get_expiry_timer(conf)
                 

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
@@ -68,7 +68,7 @@ internal extension LibSession {
         let groupSessionId: SessionId = SessionId(.group, publicKey: groupIdentityKeyPair.publicKey)
         let creationTimestamp: TimeInterval = TimeInterval(dependencies[cache: .snodeAPI].currentOffsetTimestampMs() / 1000)
         let userSessionId: SessionId = dependencies[cache: .general].sessionId
-        let currentUserProfile: Profile? = Profile.fetchOrCreateCurrentUser(db, using: dependencies)
+        let currentUserProfile: Profile = dependencies.mutate(cache: .libSession) { $0.profile }
         
         // Create the new config objects
         let groupState: [ConfigDump.Variant: Config] = try createGroupState(

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserGroups.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserGroups.swift
@@ -930,6 +930,20 @@ public extension LibSession.Cache {
         return (userGroup.have_auth_data || userGroup.have_secretkey)
     }
     
+    func secretKey(groupSessionId: SessionId) -> [UInt8]? {
+        var userGroup: ugroups_group_info = ugroups_group_info()
+        
+        /// If the group doesn't exist or a conversion fails then assume the user hasn't been kicked
+        guard
+            case .userGroups(let conf) = config(for: .userGroups, sessionId: userSessionId),
+            var cGroupId: [CChar] = groupSessionId.hexString.cString(using: .utf8),
+            user_groups_get_group(conf, &userGroup, &cGroupId),
+            userGroup.have_secretkey
+        else { return nil }
+        
+        return userGroup.get(\.secretkey, nullIfEmpty: true)
+    }
+    
     func wasKickedFromGroup(groupSessionId: SessionId) -> Bool {
         var userGroup: ugroups_group_info = ugroups_group_info()
         

--- a/SessionMessagingKit/Messages/Visible Messages/VisibleMessage+Profile.swift
+++ b/SessionMessagingKit/Messages/Visible Messages/VisibleMessage+Profile.swift
@@ -129,20 +129,6 @@ public extension VisibleMessage {
     }
 }
 
-// MARK: - Conversion
-
-extension VisibleMessage.VMProfile {
-    init(
-        profile: Profile,
-        blocksCommunityMessageRequests: Bool?
-    ) {
-        self.displayName = profile.name
-        self.profileKey = profile.profileEncryptionKey
-        self.profilePictureUrl = profile.profilePictureUrl
-        self.blocksCommunityMessageRequests = blocksCommunityMessageRequests
-    }
-}
-
 // MARK: - MessageWithProfile
 
 public protocol MessageWithProfile {

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+LibSession.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+LibSession.swift
@@ -7,15 +7,20 @@ import SessionSnodeKit
 import SessionUtilitiesKit
 
 extension MessageReceiver {
+    public typealias LibSessionMessageInfo = (
+        senderSessionId: SessionId,
+        domain: LibSession.Crypto.Domain,
+        plaintext: Data
+    )
+    
     /// Some messages are encrypted with `libSession` and don't use Protobuf, this function decrypts those messages and
     /// routes them accordingly
-    public static func handleLibSessionMessage(
-        _ db: Database,
+    public static func decryptLibSessionMessage(
         threadId: String,
         threadVariant: SessionThread.Variant,
         message: LibSessionMessage,
         using dependencies: Dependencies
-    ) throws {
+    ) throws -> [LibSessionMessageInfo] {
         guard
             let sender: String = message.sender,
             let senderSessionId: SessionId = try? SessionId(from: sender)
@@ -25,33 +30,49 @@ extension MessageReceiver {
             .kickedMessage
         ]
         
-        try supportedEncryptionDomains
-            .map { domain -> (domain: LibSession.Crypto.Domain, plaintext: Data) in
-                (
-                    domain,
-                    try dependencies[singleton: .crypto].tryGenerate(
-                        .plaintextWithMultiEncrypt(
-                            ciphertext: message.ciphertext,
-                            senderSessionId: senderSessionId,
-                            ed25519PrivateKey: dependencies[cache: .general].ed25519SecretKey,
-                            domain: domain
-                        )
+        return try supportedEncryptionDomains.map { domain -> LibSessionMessageInfo in
+            (
+                senderSessionId,
+                domain,
+                try dependencies[singleton: .crypto].tryGenerate(
+                    .plaintextWithMultiEncrypt(
+                        ciphertext: message.ciphertext,
+                        senderSessionId: senderSessionId,
+                        ed25519PrivateKey: dependencies[cache: .general].ed25519SecretKey,
+                        domain: domain
                     )
                 )
+            )
+        }
+    }
+    
+    public static func handleLibSessionMessage(
+        _ db: Database,
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        message: LibSessionMessage,
+        using dependencies: Dependencies
+    ) throws {
+        let result: [LibSessionMessageInfo] = try decryptLibSessionMessage(
+            threadId: threadId,
+            threadVariant: threadVariant,
+            message: message,
+            using: dependencies
+        )
+        
+        try result.forEach { senderSessionId, domain, plaintext in
+            switch domain {
+                case LibSession.Crypto.Domain.kickedMessage:
+                    try handleGroupDelete(
+                        db,
+                        groupSessionId: senderSessionId,
+                        plaintext: plaintext,
+                        using: dependencies
+                    )
+                    
+                default: Log.error(.messageReceiver, "Received libSession encrypted message with unsupported domain: \(domain)")
             }
-            .forEach { domain, plaintext in
-                switch domain {
-                    case LibSession.Crypto.Domain.kickedMessage:
-                        try handleGroupDelete(
-                            db,
-                            groupSessionId: senderSessionId,
-                            plaintext: plaintext,
-                            using: dependencies
-                        )
-                        
-                    default: Log.error(.messageReceiver, "Received libSession encrypted message with unsupported domain: \(domain)")
-                }
-            }
+        }
     }
 }
 

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -194,8 +194,8 @@ public enum MessageReceiver {
         
         // Don't process the envelope any further if the sender is blocked
         guard
-            !dependencies.mutate(cache: .libSession, { cache in
-                cache.isContactBlocked(contactId: sender)
+            dependencies.mutate(cache: .libSession, { cache in
+                !cache.isContactBlocked(contactId: sender)
             }) ||
             message.processWithBlockedSender
         else { throw MessageReceiverError.senderBlocked }

--- a/SessionMessagingKit/Sending & Receiving/Notifications/Models/NotificationMetadata.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/Models/NotificationMetadata.swift
@@ -47,9 +47,12 @@ extension PushNotificationAPI.NotificationMetadata {
     public init(from decoder: Decoder) throws {
         let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
         
-        let namespace: SnodeAPI.Namespace = SnodeAPI.Namespace(
-            rawValue: try container.decode(Int.self, forKey: .namespace)
-        ).defaulting(to: .unknown)
+        /// There was a bug at one point where the metadata would include a `null` value for the namespace because we were storing
+        /// messages in a namespace that the storage server didn't have an explicit `namespace_id` for, as a result we need to assume
+        /// that the `namespace` value may not be present in the payload
+        let namespace: SnodeAPI.Namespace = try container.decodeIfPresent(Int.self, forKey: .namespace)
+            .map { SnodeAPI.Namespace(rawValue: $0) }
+            .defaulting(to: .unknown)
         
         self = PushNotificationAPI.NotificationMetadata(
             accountId: try container.decode(String.self, forKey: .accountId),

--- a/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
@@ -119,15 +119,15 @@ public extension NotificationsManagerType {
         /// Ensure the sender isn't blocked (this should be checked when parsing the message but we should also check here in case
         /// that logic ever changes)
         guard
-            !dependencies.mutate(cache: .libSession, { cache in
-                cache.isContactBlocked(contactId: sender)
+            dependencies.mutate(cache: .libSession, { cache in
+                !cache.isContactBlocked(contactId: sender)
             })
         else { throw MessageReceiverError.senderBlocked }
         
         /// Ensure the message hasn't already been maked as read (don't want to show notification in that case)
         guard
-            !dependencies.mutate(cache: .libSession, { cache in
-                cache.timestampAlreadyRead(
+            dependencies.mutate(cache: .libSession, { cache in
+                !cache.timestampAlreadyRead(
                     threadId: threadId,
                     threadVariant: threadVariant,
                     timestampMs: (message.sentTimestampMs.map { Int64($0) } ?? 0),  /// Default to unread

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
@@ -161,7 +161,13 @@ public enum PushNotificationAPI {
                                         .configGroupMembers,
                                         .revokedRetrievableGroupMessages
                                     ]
-                                    default: return [.default, .configConvoInfoVolatile]
+                                    default: return [
+                                        .default,
+                                        .configUserProfile,
+                                        .configContacts,
+                                        .configConvoInfoVolatile,
+                                        .configUserGroups
+                                    ]
                                 }
                             }(),
                             /// Note: Unfortunately we always need the message content because without the content

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -169,7 +169,7 @@ public class ExtensionHelper: ExtensionHelperType {
     // MARK: - Deduping
     
     // stringlint:ignore_contents
-    private func threadDedupeRecordPath(_ threadId: String) -> String? {
+    private func dedupeRecordPath(_ threadId: String, _ uniqueIdentifier: String) -> String? {
         guard
             let conversationPath: String = conversationPath(threadId),
             let data: Data = "DedupeRecordSalt-\(uniqueIdentifier)".data(using: .utf8),
@@ -662,29 +662,6 @@ public extension ExtensionHelper {
         public let ed25519SecretKey: [UInt8]
         public let unreadCount: Int
     }
-    
-    // MARK: - Config Dumps
-    
-    private func hash(for sessionId: SessionId, variant: ConfigDump.Variant) -> [UInt8]? {
-        return "\(sessionId.hexString)-\(variant)".data(using: .utf8).map { dataToHash in
-            dependencies[singleton: .crypto].generate(
-                .hash(message: Array(dataToHash))
-            )
-        }
-    }
-    
-    public func lastUpdatedTimestamp(
-        for sessionId: SessionId,
-        variant: ConfigDump.Variant
-    ) -> TimeInterval {
-        guard let hash: [UInt8] = hash(for: sessionId, variant: variant) else { return 0 }
-        
-        return ((try? dependencies[singleton: .fileManager]
-            .attributesOfItem(atPath: "\(dumpFilePath(hash))")
-            .getting(.modificationDate) as? Date)?
-            .timeIntervalSince1970)
-            .defaulting(to: 0)
-    }
 }
 
 // MARK: - ExtensionHelperError
@@ -728,7 +705,6 @@ public protocol ExtensionHelperType {
     func dedupeRecordExists(threadId: String, uniqueIdentifier: String) -> Bool
     func createDedupeRecord(threadId: String, uniqueIdentifier: String) throws
     func removeDedupeRecord(threadId: String, uniqueIdentifier: String) throws
-    func deleteAllDedupeRecords()
     
     // MARK: - Config Dumps
     

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -169,7 +169,7 @@ public class ExtensionHelper: ExtensionHelperType {
     // MARK: - Deduping
     
     // stringlint:ignore_contents
-    private func dedupeRecordPath(_ threadId: String, _ uniqueIdentifier: String) -> String? {
+    private func threadDedupeRecordPath(_ threadId: String) -> String? {
         guard
             let conversationPath: String = conversationPath(threadId),
             let data: Data = "DedupeRecordSalt-\(uniqueIdentifier)".data(using: .utf8),
@@ -592,6 +592,29 @@ public extension ExtensionHelper {
         public let ed25519SecretKey: [UInt8]
         public let unreadCount: Int
     }
+    
+    // MARK: - Config Dumps
+    
+    private func hash(for sessionId: SessionId, variant: ConfigDump.Variant) -> [UInt8]? {
+        return "\(sessionId.hexString)-\(variant)".data(using: .utf8).map { dataToHash in
+            dependencies[singleton: .crypto].generate(
+                .hash(message: Array(dataToHash))
+            )
+        }
+    }
+    
+    public func lastUpdatedTimestamp(
+        for sessionId: SessionId,
+        variant: ConfigDump.Variant
+    ) -> TimeInterval {
+        guard let hash: [UInt8] = hash(for: sessionId, variant: variant) else { return 0 }
+        
+        return ((try? dependencies[singleton: .fileManager]
+            .attributesOfItem(atPath: "\(dumpFilePath(hash))")
+            .getting(.modificationDate) as? Date)?
+            .timeIntervalSince1970)
+            .defaulting(to: 0)
+    }
 }
 
 // MARK: - ExtensionHelperError
@@ -635,6 +658,7 @@ public protocol ExtensionHelperType {
     func dedupeRecordExists(threadId: String, uniqueIdentifier: String) -> Bool
     func createDedupeRecord(threadId: String, uniqueIdentifier: String) throws
     func removeDedupeRecord(threadId: String, uniqueIdentifier: String) throws
+    func deleteAllDedupeRecords()
     
     // MARK: - Config Dumps
     

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -490,8 +490,10 @@ public class ExtensionHelper: ExtensionHelperType {
             })
             .defaulting(to: [])
             .inserting(currentUserConversationHash, at: 0)
-        var successCount: Int = 0
-        var failureCount: Int = 0
+        var successConfigCount: Int = 0
+        var failureConfigCount: Int = 0
+        var successStandardCount: Int = 0
+        var failureStandardCount: Int = 0
         
         try await dependencies[singleton: .storage].writeAsync { [weak self, dependencies] db in
             guard let this = self else { return }
@@ -547,10 +549,10 @@ public class ExtensionHelper: ExtensionHelperType {
                             )
                     }
                     
-                    successCount += configMessageHashes.count
+                    successConfigCount += configMessageHashes.count
                 }
                 catch {
-                    failureCount += configMessageHashes.count
+                    failureConfigCount += configMessageHashes.count
                     Log.error(.cat, "Discarding some config message changes due to error: \(error)")
                 }
                 
@@ -611,10 +613,10 @@ public class ExtensionHelper: ExtensionHelperType {
                             sortedMessages: [(message.namespace, [message], nil)],
                             using: dependencies
                         )
-                        successCount += 1
+                        successStandardCount += 1
                     }
                     catch {
-                        failureCount += 1
+                        failureStandardCount += 1
                         Log.error(.cat, "Discarding standard message due to error: \(error)")
                     }
                 }
@@ -625,7 +627,7 @@ public class ExtensionHelper: ExtensionHelperType {
             }
         }
         
-        Log.info(.cat, "Finished: Successfully processed \(successCount) messages, \(failureCount) messages failed.")
+        Log.info(.cat, "Finished: Successfully processed \(successStandardCount)/\(successStandardCount + failureStandardCount) standard messages, \(successConfigCount)/\(failureConfigCount) config messages.")
         await messagesLoadedStream.send(true)
     }
     

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -676,8 +676,13 @@ class MessageReceiverGroupsSpec: QuickSpec {
                                         threadVariant: .group,
                                         identifier: "\(groupId.hexString)-1",
                                         category: .incomingMessage,
-                                        title: "notificationsIosGroup".localized(),
-                                        body: "messageNewYouveGot".localized(),
+                                        title: "notificationsIosGroup"
+                                            .put(key: "name", value: "0511...1111")
+                                            .put(key: "conversation_name", value: "TestGroupName")
+                                            .localized(),
+                                        body: "messageNewYouveGot"
+                                            .putNumber(1)
+                                            .localized(),
                                         sound: .defaultNotificationSound,
                                         applicationState: .active
                                     ),

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -3273,10 +3273,9 @@ class MessageReceiverGroupsSpec: QuickSpec {
                             )
                         }
                         
-                        var cGroupId: [CChar] = groupId.hexString.cString(using: .utf8)!
-                        var userGroup: ugroups_group_info = ugroups_group_info()
-                        expect(user_groups_get_group(userGroupsConfig.conf, &userGroup, &cGroupId)).to(beTrue())
-                        expect(ugroups_group_is_kicked(&userGroup)).to(beTrue())
+                        expect(mockLibSessionCache).to(call(.exactly(times: 1), matchingParameters: .all) {
+                            try $0.markAsKicked(groupSessionIds: [groupId.hexString])
+                        })
                     }
                 }
                 

--- a/SessionMessagingKitTests/_TestUtilities/CommonSMKMockExtensions.swift
+++ b/SessionMessagingKitTests/_TestUtilities/CommonSMKMockExtensions.swift
@@ -87,6 +87,10 @@ extension Interaction: Mocked {
     )
 }
 
+extension VisibleMessage: Mocked {
+    static var mock: VisibleMessage = VisibleMessage(text: "mock")
+}
+
 extension KeychainStorage.DataKey: Mocked {
     static var mock: KeychainStorage.DataKey = .dbCipherKeySpec
 }

--- a/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
@@ -61,6 +61,22 @@ class MockExtensionHelper: Mock<ExtensionHelperType>, ExtensionHelperType {
         mockNoReturn(args: [sessionId, variant])
     }
     
+    func loadUserConfigState(
+        into cache: LibSessionCacheType,
+        userSessionId: SessionId,
+        userEd25519SecretKey: [UInt8]
+    ) {
+        mockNoReturn(args: [cache, userSessionId, userEd25519SecretKey])
+    }
+    
+    func loadGroupConfigStateIfNeeded(
+        into cache: LibSessionCacheType,
+        swarmPublicKey: String,
+        userEd25519SecretKey: [UInt8]
+    ) throws {
+        mockNoReturn(args: [cache, swarmPublicKey, userEd25519SecretKey])
+    }
+    
     // MARK: - Messages
     
     func unreadMessageCount() -> Int? {

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -26,11 +26,14 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
         mockNoReturn(args: [variant, sessionId, userEd25519SecretKey, groupEd25519SecretKey])
     }
     
-    func loadAdminKey(
-        groupIdentitySeed: Data,
-        groupSessionId: SessionId
-    ) throws {
-        try mockThrowingNoReturn(args: [groupIdentitySeed, groupSessionId])
+    func loadState(
+        for variant: ConfigDump.Variant,
+        sessionId: SessionId,
+        userEd25519SecretKey: [UInt8],
+        groupEd25519SecretKey: [UInt8]?,
+        cachedData: Data?
+    ) throws -> LibSession.Config {
+        return try mockThrowing(args: [variant, sessionId, userEd25519SecretKey, groupEd25519SecretKey, cachedData])
     }
     
     func hasConfig(for variant: ConfigDump.Variant, sessionId: SessionId) -> Bool {
@@ -133,7 +136,22 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
     ) throws {
         try mockThrowingNoReturn(args: [swarmPublicKey, messages])
     }
+    
     // MARK: - State Access
+    
+    var displayName: String? { mock() }
+    
+    func has(_ key: Setting.BoolKey) -> Bool {
+        return mock(args: [key])
+    }
+    
+    func get(_ key: Setting.BoolKey) -> Bool {
+        return mock(args: [key])
+    }
+    
+    func updateProfile(displayName: String, profilePictureUrl: String?, profileEncryptionKey: Data?) throws {
+        try mockThrowingNoReturn(args: [displayName, profilePictureUrl, profileEncryptionKey])
+    }
     
     func canPerformChange(
         threadId: String,
@@ -206,20 +224,39 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
     }
     
     func profile(
-        threadId: String,
-        threadVariant: SessionThread.Variant,
         contactId: String,
+        threadId: String?,
+        threadVariant: SessionThread.Variant?,
         visibleMessage: VisibleMessage?
     ) -> Profile? {
-        return mock(args: [threadId, threadVariant, contactId, visibleMessage])
+        return mock(args: [contactId, threadId, threadVariant, visibleMessage])
     }
     
     func hasCredentials(groupSessionId: SessionId) -> Bool {
         return mock(args: [groupSessionId])
     }
     
+    func secretKey(groupSessionId: SessionId) -> [UInt8]? {
+        return mock(args: [groupSessionId])
+    }
+    
     func isAdmin(groupSessionId: SessionId) -> Bool {
         return mock(args: [groupSessionId])
+    }
+    
+    func loadAdminKey(
+        groupIdentitySeed: Data,
+        groupSessionId: SessionId
+    ) throws {
+        try mockThrowingNoReturn(args: [groupIdentitySeed, groupSessionId])
+    }
+    
+    func markAsInvited(groupSessionIds: [String]) throws {
+        try mockThrowingNoReturn(args: [groupSessionIds])
+    }
+    
+    func markAsKicked(groupSessionIds: [String]) throws {
+        try mockThrowingNoReturn(args: [groupSessionIds])
     }
     
     func wasKickedFromGroup(groupSessionId: SessionId) -> Bool {
@@ -261,6 +298,16 @@ extension Mock where T == LibSessionCacheType {
         self.when { $0.setConfig(for: .any, sessionId: .any, to: .any) }.thenReturn(())
         self.when { $0.removeConfigs(for: .any) }.thenReturn(())
         self.when { $0.hasConfig(for: .any, sessionId: .any) }.thenReturn(true)
+        self
+            .when {
+                $0.loadDefaultStateFor(
+                    variant: .any,
+                    sessionId: .any,
+                    userEd25519SecretKey: .any,
+                    groupEd25519SecretKey: .any
+                )
+            }
+            .thenReturn(())
         self
             .when { try $0.pendingChanges(swarmPublicKey: .any) }
             .thenReturn(LibSession.PendingChanges())
@@ -330,12 +377,18 @@ extension Mock where T == LibSessionCacheType {
             .when { $0.notificationSettings(threadId: .any, threadVariant: .any, openGroupUrlInfo: .any) }
             .thenReturn(.defaultFor(.contact))
         self.when { $0.isContactBlocked(contactId: .any) }.thenReturn(false)
+        self
+            .when { $0.profile(contactId: .any, threadId: .any, threadVariant: .any, visibleMessage: .any) }
+            .thenReturn(Profile(id: "TestProfileId", name: "TestProfileName"))
         self.when { $0.hasCredentials(groupSessionId: .any) }.thenReturn(true)
+        self.when { $0.secretKey(groupSessionId: .any) }.thenReturn(nil)
         self.when { $0.isAdmin(groupSessionId: .any) }.thenReturn(true)
         self.when { try $0.loadAdminKey(groupIdentitySeed: .any, groupSessionId: .any) }.thenReturn(())
+        self.when { try $0.markAsKicked(groupSessionIds: .any) }.thenReturn(())
+        self.when { try $0.markAsInvited(groupSessionIds: .any) }.thenReturn(())
+        self.when { $0.wasKickedFromGroup(groupSessionId: .any) }.thenReturn(false)
         self.when { $0.groupName(groupSessionId: .any) }.thenReturn("TestGroupName")
         self.when { $0.groupIsDestroyed(groupSessionId: .any) }.thenReturn(false)
-        self.when { $0.wasKickedFromGroup(groupSessionId: .any) }.thenReturn(false)
         self.when { $0.groupDeleteBefore(groupSessionId: .any) }.thenReturn(nil)
         self.when { $0.groupDeleteAttachmentsBefore(groupSessionId: .any) }.thenReturn(nil)
     }

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -20,10 +20,10 @@ class MockLibSessionCache: Mock<LibSessionCacheType>, LibSessionCacheType {
     func loadDefaultStateFor(
         variant: ConfigDump.Variant,
         sessionId: SessionId,
-        userEd25519KeyPair: KeyPair,
+        userEd25519SecretKey: [UInt8],
         groupEd25519SecretKey: [UInt8]?
     ) {
-        mockNoReturn(args: [variant, sessionId, userEd25519KeyPair, groupEd25519SecretKey])
+        mockNoReturn(args: [variant, sessionId, userEd25519SecretKey, groupEd25519SecretKey])
     }
     
     func loadAdminKey(

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -3,7 +3,6 @@
 import Foundation
 import AVFAudio
 import Combine
-import GRDB
 import CallKit
 import UserNotifications
 import BackgroundTasks
@@ -174,7 +173,22 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
             data: info.data,
             origin: .swarm(
                 publicKey: info.metadata.accountId,
-                namespace: info.metadata.namespace,
+                namespace: {
+                    switch (info.metadata.namespace, (try? SessionId(from: info.metadata.accountId))?.prefix) {
+                        /// There was a bug at one point where the metadata would include a `null` value for the namespace
+                        /// because the storage server didn't have an explicit `namespace_id` for the
+                        /// `revokedRetrievableGroupMessages` namespace
+                        ///
+                        /// This code tries to work around that issue
+                        ///
+                        /// **Note:** This issue was present in storage server version `2.10.0` but this work-around should
+                        /// be removed once the network has been fully updated with a fix
+                        case (.unknown, .group):
+                            return .revokedRetrievableGroupMessages
+                        
+                        default: return info.metadata.namespace
+                    }
+                }(),
                 serverHash: info.metadata.hash,
                 serverTimestampMs: info.metadata.createdTimestampMs,
                 serverExpirationTimestamp: (
@@ -261,23 +275,12 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                     )
                 ],
                 afterMerge: { sessionId, variant, config, timestampMs in
-                    guard cache.configNeedsDump(config) else {
-                        return dependencies[singleton: .extensionHelper].refreshDumpModifiedDate(
-                            sessionId: sessionId,
-                            variant: variant
-                        )
-                    }
-                    
-                    /// Update the replicated extension config dump (this way any subsequent push notifications will use the correct
-                    /// data - eg. group encryption keys)
-                    try dependencies[singleton: .extensionHelper].replicate(
-                        dump: cache.createDump(
-                            config: config,
-                            for: variant,
-                            sessionId: sessionId,
-                            timestampMs: timestampMs
-                        ),
-                        replaceExisting: true
+                    try updateConfigIfNeeded(
+                        cache: cache,
+                        config: config,
+                        variant: variant,
+                        sessionId: sessionId,
+                        timestampMs: timestampMs
                     )
                 }
             )
@@ -311,6 +314,33 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         completeSilenty(notification.info, .success(notification.info.metadata))
     }
     
+    private func updateConfigIfNeeded(
+        cache: LibSessionCacheType,
+        config: LibSession.Config?,
+        variant: ConfigDump.Variant,
+        sessionId: SessionId,
+        timestampMs: Int64
+    ) throws {
+        guard cache.configNeedsDump(config) else {
+            return dependencies[singleton: .extensionHelper].refreshDumpModifiedDate(
+                sessionId: sessionId,
+                variant: variant
+            )
+        }
+        
+        /// Update the replicated extension config dump (this way any subsequent push notifications will use the correct
+        /// data - eg. group encryption keys)
+        try dependencies[singleton: .extensionHelper].replicate(
+            dump: cache.createDump(
+                config: config,
+                for: variant,
+                sessionId: sessionId,
+                timestampMs: timestampMs
+            ),
+            replaceExisting: true
+        )
+    }
+    
     private func handleStandardMessage(
         _ notification: ProcessedNotification,
         threadId: String,
@@ -328,14 +358,18 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
             using: dependencies
         )
         
+        /// No need to check blinded ids as Communities currently don't support PNs
+        let userSessionId: SessionId = dependencies[cache: .general].sessionId
+        let currentUserSessionIds: Set<String> = [userSessionId.hexString]
+        
         /// Define the `displayNameRetriever` so it can be reused
         let displayNameRetriever: (String) -> String? = { [dependencies] sessionId in
             (dependencies
                 .mutate(cache: .libSession) { cache in
                     cache.profile(
+                        contactId: sessionId,
                         threadId: threadId,
                         threadVariant: threadVariant,
-                        contactId: sessionId,
                         visibleMessage: (messageInfo.message as? VisibleMessage)
                     )
                 }?
@@ -354,18 +388,187 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
             /// message so need database access in order to do anything (including removing existing notifications) so just ignore them
             case is ReadReceipt, is UnsendRequest: break
             
-            /// Control messages for `group` conversations
-            case is GroupUpdateInviteMessage, is GroupUpdateInfoChangeMessage,
-                is GroupUpdateMemberChangeMessage, is GroupUpdatePromoteMessage,
-                is GroupUpdateMemberLeftMessage, is GroupUpdateMemberLeftNotificationMessage,
-                is GroupUpdateInviteResponseMessage, is GroupUpdateDeleteMemberContentMessage:
-                // TODO: [Database Relocation] Handle group control messages in a separate PR
-                return handleNotificationViaDatabase(notification)
+            /// The invite control message for `group` conversations can result in a member who was kicked from a group
+            /// being re-added so we should handle that case (as it could result in the user starting to get valid notifications again)
+            ///
+            /// Otherwise just save the message to disk
+            case let inviteMessage as GroupUpdateInviteMessage:
+                try MessageReceiver.validateGroupInvite(message: inviteMessage, using: dependencies)
                 
-            /// Custom `group` conversation messages (eg. `kickedMessage`)
-            case is LibSessionMessage:
-                // TODO: [Database Relocation] Handle the LibSession message in a separate PR
-                return handleNotificationViaDatabase(notification)
+                /// Only update the state if the user had previously been kicked from the group
+                try dependencies.mutate(cache: .libSession) { cache in
+                    guard
+                        cache.wasKickedFromGroup(groupSessionId: inviteMessage.groupSessionId),
+                        let config: LibSession.Config = cache.config(for: .userGroups, sessionId: userSessionId)
+                    else { return }
+                    
+                    try cache.markAsInvited(groupSessionIds: [inviteMessage.groupSessionId.hexString])
+                    try LibSession.upsert(
+                        groups: [
+                            LibSession.GroupUpdateInfo(
+                                groupSessionId: inviteMessage.groupSessionId.hexString,
+                                authData: inviteMessage.memberAuthData
+                            )
+                        ],
+                        in: config,
+                        using: dependencies
+                    )
+                    
+                    try updateConfigIfNeeded(
+                        cache: cache,
+                        config: config,
+                        variant: .userGroups,
+                        sessionId: userSessionId,
+                        timestampMs: (
+                            inviteMessage.sentTimestampMs.map { Int64($0) } ??
+                            Int64(dependencies.dateNow.timeIntervalSince1970 * 1000)
+                        )
+                    )
+                }
+                
+                /// Save the message and complete silently
+                try saveMessage(
+                    notification,
+                    threadId: threadId,
+                    threadVariant: threadVariant,
+                    messageInfo: messageInfo,
+                    currentUserSessionIds: currentUserSessionIds
+                )
+                completeSilenty(notification.info, .success(notification.info.metadata))
+                return
+            
+            /// The promote control message for `group` conversations can result in a member who was kicked from a group
+            /// being re-added so we should handle that case (as it could result in the user starting to get valid notifications again)
+            ///
+            /// Otherwise just save the message to disk
+            case let promoteMessage as GroupUpdatePromoteMessage:
+                guard
+                    let sender: String = promoteMessage.sender,
+                    let sentTimestampMs: UInt64 = promoteMessage.sentTimestampMs,
+                    let groupIdentityKeyPair: KeyPair = dependencies[singleton: .crypto].generate(
+                        .ed25519KeyPair(seed: Array(promoteMessage.groupIdentitySeed))
+                    )
+                else { throw MessageReceiverError.invalidMessage }
+                
+                let groupSessionId: SessionId = SessionId(.group, publicKey: groupIdentityKeyPair.publicKey)
+                
+                try dependencies.mutate(cache: .libSession) { cache in
+                    guard let userGroupsConfig: LibSession.Config = cache.config(for: .userGroups, sessionId: userSessionId) else {
+                        return
+                    }
+                    
+                    /// Add the admin key to the `userGroups` config
+                    try LibSession.upsert(
+                        groups: [
+                            LibSession.GroupUpdateInfo(
+                                groupSessionId: groupSessionId.hexString,
+                                groupIdentityPrivateKey: Data(groupIdentityKeyPair.secretKey)
+                            )
+                        ],
+                        in: userGroupsConfig,
+                        using: dependencies
+                    )
+                    
+                    /// If we were previously marked as kicked from the group then we need to mark the user as invited again to
+                    /// clear the kicked state
+                    if cache.wasKickedFromGroup(groupSessionId: groupSessionId) {
+                        try cache.markAsInvited(groupSessionIds: [groupSessionId.hexString])
+                    }
+                    
+                    /// Save the updated `userGroups` config
+                    try updateConfigIfNeeded(
+                        cache: cache,
+                        config: userGroupsConfig,
+                        variant: .userGroups,
+                        sessionId: userSessionId,
+                        timestampMs: Int64(sentTimestampMs)
+                    )
+                    
+                    /// If we have a `groupKeys` config then we also need to update it with the admin key
+                    guard let groupKeysConfig: LibSession.Config = cache.config(for: .groupKeys, sessionId: groupSessionId) else {
+                        return
+                    }
+                    
+                    try cache.loadAdminKey(
+                        groupIdentitySeed: promoteMessage.groupIdentitySeed,
+                        groupSessionId: groupSessionId
+                    )
+                    try updateConfigIfNeeded(
+                        cache: cache,
+                        config: groupKeysConfig,
+                        variant: .groupKeys,
+                        sessionId: groupSessionId,
+                        timestampMs: Int64(sentTimestampMs)
+                    )
+                }
+                
+                /// Save the message to disk and complete silently
+                try saveMessage(
+                    notification,
+                    threadId: threadId,
+                    threadVariant: threadVariant,
+                    messageInfo: messageInfo,
+                    currentUserSessionIds: currentUserSessionIds
+                )
+                completeSilenty(notification.info, .success(notification.info.metadata))
+                return
+                
+            /// The `kickedMessage` for a `group` conversation will result in the credentials for the group being removed and
+            /// if the device receives subsequent notifications for the group which fail to decrypt (due to key rotation after being kicked)
+            /// then they will fail silently instead of using the fallback notification
+            case let libSessionMessage as LibSessionMessage:
+                let info: [MessageReceiver.LibSessionMessageInfo] = try MessageReceiver.decryptLibSessionMessage(
+                    threadId: threadId,
+                    threadVariant: threadVariant,
+                    message: libSessionMessage,
+                    using: dependencies
+                )
+                
+                try info.forEach { senderSessionId, domain, plaintext in
+                    switch domain {
+                        case LibSession.Crypto.Domain.kickedMessage:
+                            /// Ensure the `groupKicked` message was valid before continuing
+                            try LibSessionMessage.validateGroupKickedMessage(
+                                plaintext: plaintext,
+                                userSessionId: userSessionId,
+                                groupSessionId: senderSessionId,
+                                using: dependencies
+                            )
+                            
+                            /// Mark the group as kicked and save the updated config dump
+                            try dependencies.mutate(cache: .libSession) { cache in
+                                try cache.markAsKicked(groupSessionIds: [senderSessionId.hexString])
+                                
+                                guard let config: LibSession.Config = cache.config(for: .userGroups, sessionId: userSessionId) else {
+                                    return
+                                }
+                                
+                                try updateConfigIfNeeded(
+                                    cache: cache,
+                                    config: config,
+                                    variant: .userGroups,
+                                    sessionId: userSessionId,
+                                    timestampMs: (
+                                        libSessionMessage.sentTimestampMs.map { Int64($0) } ??
+                                        Int64(dependencies.dateNow.timeIntervalSince1970 * 1000)
+                                    )
+                                )
+                            }
+                            
+                        default: Log.error(.messageReceiver, "Received libSession encrypted message with unsupported domain: \(domain)")
+                    }
+                }
+                
+                /// Save the message and generate any deduplication files needed
+                try saveMessage(
+                    notification,
+                    threadId: threadId,
+                    threadVariant: threadVariant,
+                    messageInfo: messageInfo,
+                    currentUserSessionIds: currentUserSessionIds
+                )
+                completeSilenty(notification.info, .success(notification.info.metadata))
+                return
                 
             case let callMessage as CallMessage:
                 switch callMessage.kind {
@@ -436,12 +639,65 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                 }
                 
             case is VisibleMessage: break
-            default: throw MessageReceiverError.unknownMessage(proto)
+            
+            /// For any other message we don't have any custom handling (and don't want to show a notification) so just save these
+            /// messages to disk to be processed on next launch (letting the main app do any error handling) and just complete silently
+            default:
+                try saveMessage(
+                    notification,
+                    threadId: threadId,
+                    threadVariant: threadVariant,
+                    messageInfo: messageInfo,
+                    currentUserSessionIds: currentUserSessionIds
+                )
+                completeSilenty(notification.info, .success(notification.info.metadata))
+                return
         }
         
-        /// No need to check blinded ids as Communities currently don't support PNs
-        let currentUserSessionIds: Set<String> = [dependencies[cache: .general].sessionId.hexString]
+        /// Save the message and generate any deduplication files needed
+        try saveMessage(
+            notification,
+            threadId: threadId,
+            threadVariant: threadVariant,
+            messageInfo: messageInfo,
+            currentUserSessionIds: currentUserSessionIds
+        )
         
+        /// Try to show a notification for the message
+        try dependencies[singleton: .notificationsManager].notifyUser(
+            message: messageInfo.message,
+            threadId: threadId,
+            threadVariant: threadVariant,
+            interactionIdentifier: notification.info.metadata.hash,
+            interactionVariant: Interaction.Variant(
+                message: messageInfo.message,
+                currentUserSessionIds: currentUserSessionIds
+            ),
+            attachmentDescriptionInfo: proto.dataMessage?.attachments.map { attachment in
+                Attachment.DescriptionInfo(id: "", proto: attachment)
+            },
+            openGroupUrlInfo: nil,  /// Communities currently don't support PNs
+            applicationState: .background,
+            extensionBaseUnreadCount: notification.info.mainAppUnreadCount,
+            currentUserSessionIds: currentUserSessionIds,
+            displayNameRetriever: displayNameRetriever,
+            shouldShowForMessageRequest: {
+                !dependencies[singleton: .extensionHelper]
+                    .hasAtLeastOneDedupeRecord(threadId: threadId)
+            }
+        )
+        
+        /// Since we succeeded we can complete silently
+        completeSilenty(notification.info, .success(notification.info.metadata))
+    }
+    
+    private func saveMessage(
+        _ notification: ProcessedNotification,
+        threadId: String,
+        threadVariant: SessionThread.Variant,
+        messageInfo: MessageReceiveJob.Details.MessageInfo,
+        currentUserSessionIds: Set<String>
+    ) throws {
         /// Write the message to disk via the `extensionHelper` so the main app will have it immediately instead of having to wait
         /// for a poll to return
         do {
@@ -490,33 +746,6 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                 uniqueIdentifier: callMessage.uuid
             )
         }
-        
-        /// Try to show a notification for the message
-        try dependencies[singleton: .notificationsManager].notifyUser(
-            message: messageInfo.message,
-            threadId: threadId,
-            threadVariant: threadVariant,
-            interactionIdentifier: notification.info.metadata.hash,
-            interactionVariant: Interaction.Variant(
-                message: messageInfo.message,
-                currentUserSessionIds: currentUserSessionIds
-            ),
-            attachmentDescriptionInfo: proto.dataMessage?.attachments.map { attachment in
-                Attachment.DescriptionInfo(id: "", proto: attachment)
-            },
-            openGroupUrlInfo: nil,  /// Communities currently don't support PNs
-            applicationState: .background,
-            extensionBaseUnreadCount: notification.info.mainAppUnreadCount,
-            currentUserSessionIds: currentUserSessionIds,
-            displayNameRetriever: displayNameRetriever,
-            shouldShowForMessageRequest: {
-                !dependencies[singleton: .extensionHelper]
-                    .hasAtLeastOneDedupeRecord(threadId: threadId)
-            }
-        )
-        
-        /// Since we succeeded we can complete silently
-        completeSilenty(notification.info, .success(notification.info.metadata))
     }
     
     private func handleError(
@@ -525,7 +754,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         processedNotification: ProcessedNotification?,
         contentHandler: ((UNNotificationContent) -> Void)
     ) {
-        switch (error, processedNotification?.threadVariant, info.metadata.namespace.isConfigNamespace) {
+        switch (error, (try? SessionId(from: info.metadata.accountId))?.prefix, info.metadata.namespace.isConfigNamespace) {
             case (NotificationError.migration(let error), _, _):
                 self.completeSilenty(info, .errorDatabaseMigrations(error))
                 
@@ -617,158 +846,6 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         }
     }
     
-    @available(*, deprecated, message: "This function will be removed as part of the Database Relocation work, but is being build in parts so will remain for now")
-    private func handleNotificationViaDatabase(_ notification: ProcessedNotification) {
-        // HACK: It is important to use write synchronously here to avoid a race condition
-        // where the completeSilenty() is called before the local notification request
-        // is added to notification center
-        dependencies[singleton: .storage].write { [weak self, dependencies] db in
-            var processedThreadId: String?
-            var processedThreadVariant: SessionThread.Variant?
-            var threadDisplayName: String?
-            
-            do {
-                switch notification.processedMessage {
-                    case .config, .invalid: return
-                    case .standard(let threadId, let threadVariant, let proto, let messageInfo, _):
-                        /// Only allow the cases with don't have updated handling through
-                        switch messageInfo.message {
-                            case is GroupUpdateInviteMessage, is GroupUpdateInfoChangeMessage,
-                                is GroupUpdateMemberChangeMessage, is GroupUpdatePromoteMessage,
-                                is GroupUpdateMemberLeftMessage, is GroupUpdateMemberLeftNotificationMessage,
-                                is GroupUpdateInviteResponseMessage, is GroupUpdateDeleteMemberContentMessage:
-                                break
-                                
-                            case is LibSessionMessage: break
-                            default: throw MessageReceiverError.invalidMessage
-                        }
-                        
-                        processedThreadId = threadId
-                        processedThreadVariant = threadVariant
-                        threadDisplayName = SessionThread.displayName(
-                            threadId: threadId,
-                            variant: threadVariant,
-                            closedGroupName: (threadVariant != .group && threadVariant != .legacyGroup ? nil :
-                                try? ClosedGroup
-                                    .select(.name)
-                                    .filter(id: threadId)
-                                    .asRequest(of: String.self)
-                                    .fetchOne(db)
-                            ),
-                            openGroupName: (threadVariant != .community ? nil :
-                                try? OpenGroup
-                                    .select(.name)
-                                    .filter(id: threadId)
-                                    .asRequest(of: String.self)
-                                    .fetchOne(db)
-                            ),
-                            isNoteToSelf: (threadId == dependencies[cache: .general].sessionId.hexString),
-                            profile: (threadVariant != .contact ? nil :
-                                try? Profile
-                                    .filter(id: threadId)
-                                    .fetchOne(db)
-                            )
-                        )
-                        
-                        try MessageReceiver.handle(
-                            db,
-                            threadId: threadId,
-                            threadVariant: threadVariant,
-                            message: messageInfo.message,
-                            serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
-                            associatedWithProto: proto,
-                            suppressNotifications: false,
-                            using: dependencies
-                        )
-                }
-                
-                /// Since we successfully handled the message we should now create the dedupe file for the message so we don't
-                /// show duplicate PNs
-                try MessageDeduplication.createDedupeFile(notification.processedMessage, using: dependencies)
-                
-                db.afterNextTransaction(
-                    onCommit: { _ in self?.completeSilenty(notification.info, .success(notification.info.metadata)) },
-                    onRollback: { _ in self?.completeSilenty(notification.info, .errorTransactionFailure) }
-                )
-            }
-            catch {
-                // If an error occurred we want to rollback the transaction (by throwing) and then handle
-                // the error outside of the database
-                let handleError = {
-                    // Dispatch to the next run loop to ensure we are out of the database write thread before
-                    // handling the result (and suspending the database)
-                    DispatchQueue.main.async {
-                        switch (error, notification.threadVariant, notification.info.metadata.namespace.isConfigNamespace) {
-                            case (MessageReceiverError.noGroupKeyPair, _, _):
-                                self?.completeSilenty(notification.info, .errorLegacyPushNotification)
-
-                            case (MessageReceiverError.outdatedMessage, _, _):
-                                self?.completeSilenty(notification.info, .ignoreDueToOutdatedMessage)
-                                
-                            case (MessageReceiverError.ignorableMessage, _, _):
-                                self?.completeSilenty(notification.info, .ignoreDueToRequiresNoNotification)
-                                
-                            case (MessageReceiverError.ignorableMessageRequestMessage, _, _):
-                                self?.completeSilenty(notification.info, .ignoreDueToMessageRequest)
-                                
-                            case (MessageReceiverError.duplicateMessage, _, _):
-                                self?.completeSilenty(notification.info, .ignoreDueToDuplicateMessage)
-                                
-                            /// If it was a `decryptionFailed` error, but it was for a config namespace then just fail silently (don't
-                            /// want to show the fallback notification in this case)
-                            case (MessageReceiverError.decryptionFailed, _, true):
-                                self?.completeSilenty(notification.info, .errorMessageHandling(.decryptionFailed))
-                                
-                            /// If it was a `decryptionFailed` error for a group conversation and the group doesn't exist or
-                            /// doesn't have auth info (ie. group destroyed or member kicked), then just fail silently (don't want
-                            /// to show the fallback notification in these cases)
-                            case (MessageReceiverError.decryptionFailed, .group, _):
-                                guard
-                                    let group: ClosedGroup = try? ClosedGroup.fetchOne(db, id: notification.threadId), (
-                                        group.groupIdentityPrivateKey != nil ||
-                                        group.authData != nil
-                                    )
-                                else {
-                                    self?.completeSilenty(notification.info, .errorMessageHandling(.decryptionFailed))
-                                    return
-                                }
-                                
-                                /// The thread exists and we should have been able to decrypt so show the fallback message
-                                self?.handleFailure(
-                                    notification.info,
-                                    threadVariant: notification.threadVariant,
-                                    threadDisplayName: notification.threadDisplayName,
-                                    resolution: .errorMessageHandling(.decryptionFailed)
-                                )
-                                
-                            case (let msgError as MessageReceiverError, _, _):
-                                self?.handleFailure(
-                                    notification.info,
-                                    threadVariant: notification.threadVariant,
-                                    threadDisplayName: notification.threadDisplayName,
-                                    resolution: .errorMessageHandling(msgError)
-                                )
-                                
-                            default:
-                                self?.handleFailure(
-                                    notification.info,
-                                    threadVariant: notification.threadVariant,
-                                    threadDisplayName: notification.threadDisplayName,
-                                    resolution: .errorOther(error)
-                                )
-                        }
-                    }
-                }
-                
-                db.afterNextTransaction(
-                    onCommit: { _ in  handleError() },
-                    onRollback: { _ in handleError() }
-                )
-                throw error
-            }
-        }
-    }
-    
     // MARK: Handle completion
     
     override public func serviceExtensionTimeWillExpire() {
@@ -777,15 +854,6 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
     }
     
     private func completeSilenty(_ info: NotificationInfo, _ resolution: NotificationResolution) {
-        // This can be called from within database threads so to prevent blocking and weird
-        // behaviours make sure to send it to the main thread instead
-        // TODO: [Database Relocation] Should be able to remove this
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { [weak self] in
-                self?.completeSilenty(info, resolution)
-            }
-        }
-        
         // Ensure we only run this once
         guard _hasCompleted.performUpdateAndMap({ (true, $0) }) == false else { return }
         
@@ -902,20 +970,6 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         threadDisplayName: String?,
         resolution: NotificationResolution
     ) {
-        // This can be called from within database threads so to prevent blocking and weird
-        // behaviours make sure to send it to the main thread instead
-        // TODO: [Database Relocation] Should be able to remove this
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { [weak self] in
-                self?.handleFailure(
-                    info,
-                    threadVariant: threadVariant,
-                    threadDisplayName: threadDisplayName,
-                    resolution: resolution
-                )
-            }
-        }
-        
         let duration: CFTimeInterval = (CACurrentMediaTime() - startTime)
         let targetThreadVariant: SessionThread.Variant = (threadVariant ?? .contact) /// Fallback to `contact`
         let notificationSettings: Preferences.NotificationSettings = dependencies.mutate(cache: .libSession) { cache in

--- a/SessionSnodeKit/Types/BencodeResponse.swift
+++ b/SessionSnodeKit/Types/BencodeResponse.swift
@@ -31,7 +31,6 @@ extension BencodeResponse: Decodable {
             return try jsonDecoder.decode(T.self, from: infoData)
         }()
         
-        
         /// The second element (if present) will be the response data and should just
         guard container.count == 2 else {
             data = nil


### PR DESCRIPTION
- Added logic to handle config messages received via PNs
- Added code to handle invitations, promotions and kicked messages for groups
- Added code to fallback to writing a message to disk and showing no notification (means the main app gets content without notifications quicker)
- Added a work-around for an issue where PNs don't include the namespace value for messages sent to `revokedRetrievableGroupMessages`
- Updated the code to retrieve the current users profile from libSession instead of the database (in most places)
- Updated the code to subscribe for all user config message changes (to better handle updates via PNs)
- Removed duplicated code
- Removed remaining database logic from notification extension
- Fixed an issue with loading the disappearing messages config from a group

This is based on #450 