### PR TITLE
Fixed the SwiftUI accessibility extension

### DIFF
--- a/SessionUIKit/Components/SwiftUI/SessionTextField.swift
+++ b/SessionUIKit/Components/SwiftUI/SessionTextField.swift
@@ -135,8 +135,7 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
                             .multilineTextAlignment(.center)
                             .accessibility(
                                 Accessibility(
-                                    identifier: "Error message",
-                                    label: error
+                                    identifier: "Error message"
                                 )
                             )
                     }

--- a/SessionUIKit/Utilities/SwiftUI+Utilities.swift
+++ b/SessionUIKit/Utilities/SwiftUI+Utilities.swift
@@ -177,14 +177,20 @@ extension View {
         }
     }
     
+    @ViewBuilder
     public func accessibility(_ accessibility: Accessibility) -> some View {
         if #available(iOSApplicationExtension 14.0, *) {
-            guard let identifier = accessibility.identifier else {
-                return self
+            switch (accessibility.identifier, accessibility.label) {
+                case (.none, _): self
+                case (.some(let identifier), .none):
+                    accessibilityIdentifier(identifier)
+                    
+                case (.some(let identifier), .some(let label)):
+                    accessibilityIdentifier(identifier).accessibilityLabel(label)
             }
-            return accessibilityIdentifier(identifier).accessibilityLabel(accessibility.label ?? "")
-        } else {
-            return self
+        }
+        else {
+            self
         }
     }
     


### PR DESCRIPTION
Fixed an issue where the accessibility extension could set the accessibility label to an empty string if it's not explicitly set