### PR TITLE
Fix modal input clear button

### DIFF
--- a/Session/Shared/SessionTableViewController.swift
+++ b/Session/Shared/SessionTableViewController.swift
@@ -471,11 +471,15 @@ class SessionTableViewController<ViewModel>: BaseVC, UITableViewDataSource, UITa
                 cell.update(
                     with: info,
                     tableSize: tableView.bounds.size,
-                    onToggleExpansion: {
+                    onToggleExpansion: { [dependencies = viewModel.dependencies] in
+                        UIView.setAnimationsEnabled(false)
                         cell.setNeedsLayout()
                         cell.layoutIfNeeded()
                         tableView.beginUpdates()
                         tableView.endUpdates()
+                        if dependencies[feature: .animationsEnabled] {
+                            UIView.setAnimationsEnabled(true)
+                        }
                     },
                     using: viewModel.dependencies
                 )

--- a/SessionUIKit/Components/ConfirmationModal.swift
+++ b/SessionUIKit/Components/ConfirmationModal.swift
@@ -663,11 +663,13 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
     }
     
     @objc internal func textFieldClearButtonTapped() {
-        self.textField.text = ""
+        textField.text = ""
+        internalOnTextChanged?((textField.text ?? ""), textView.text)
     }
     
     @objc internal func textViewClearButtonTapped() {
-        self.textView.text = ""
+        textView.text = ""
+        internalOnTextChanged?((textField.text ?? ""), textView.text)
         textViewHeightConstraint?.constant = textViewMinHeight
         UIView.animate(withDuration: 0.2) {
             self.view.layoutIfNeeded()

--- a/SessionUIKit/Components/ConfirmationModal.swift
+++ b/SessionUIKit/Components/ConfirmationModal.swift
@@ -669,11 +669,7 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
     
     @objc internal func textViewClearButtonTapped() {
         textView.text = ""
-        internalOnTextChanged?((textField.text ?? ""), textView.text)
-        textViewHeightConstraint?.constant = textViewMinHeight
-        UIView.animate(withDuration: 0.2) {
-            self.view.layoutIfNeeded()
-        }
+        textViewDidChange(textView)
     }
     
     // MARK: - Keyboard Avoidance


### PR DESCRIPTION
- Fix an issue on confirmation modal that after clearing the Group Description via the “X” clear-icon, the Save button remains disabled. [SES-4066](https://optf.atlassian.net/browse/SES-4066)
- Disable animation on expanding group description for better UX