### PR TITLE
Fix emoji reacts notification

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,7 @@ local clean_up_old_test_sims_on_commit_trigger = {
       {
         name: 'Build and Run Tests',
         commands: [
-          'echo "Explicitly running unit tests on `App_Store_Release` configuration to ensure optimisation behaviour is consistent"',
+          'echo "Explicitly running unit tests on \'App_Store_Release\' configuration to ensure optimisation behaviour is consistent"',
           'echo "If tests fail inconsistently from local builds this is likely the difference"',
           'echo ""',
           'NSUnbufferedIO=YES set -o pipefail && xcodebuild test -project Session.xcodeproj -scheme Session -derivedDataPath ./build/derivedData -resultBundlePath ./build/artifacts/testResults.xcresult -parallelizeTargets -configuration "App_Store_Release" -destination "platform=iOS Simulator,id=$(<./build/artifacts/sim_uuid)" -parallel-testing-enabled NO -test-timeouts-enabled YES -maximum-test-execution-time-allowance 10 -collect-test-diagnostics never ENABLE_TESTABILITY=YES 2>&1 | xcbeautify --is-ci',
@@ -89,9 +89,19 @@ local clean_up_old_test_sims_on_commit_trigger = {
         ],
       },
       {
+        name: 'Stop Simulator Keep-Alive',
+        commands: [
+          'echo "Signaling simulator keep-alive to stop and clean up..."',
+          sim_delete_cmd,
+        ],
+        depends_on: ['Build and Run Tests'],
+        when: {
+          status: ['success', 'failure'],
+        },
+      },
+      {
         name: 'Unit Test Summary',
         commands: [
-          sim_delete_cmd,
           'xcresultparser --output-format cli --failed-tests-only ./build/artifacts/testResults.xcresult'
         ],
         depends_on: ['Build and Run Tests']

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -516,7 +516,7 @@ extension MessageReceiver {
         using dependencies: Dependencies
     ) throws -> Int64? {
         guard
-            let reaction: VisibleMessage.VMReaction = message.reaction,
+            let vmReaction: VisibleMessage.VMReaction = message.reaction,
             proto.dataMessage?.reaction != nil
         else { return nil }
         
@@ -525,8 +525,8 @@ extension MessageReceiver {
         let maybeInteractionId: Int64? = try? Interaction
             .select(.id)
             .filter(Interaction.Columns.threadId == thread.id)
-            .filter(Interaction.Columns.timestampMs == reaction.timestamp)
-            .filter(Interaction.Columns.authorId == reaction.publicKey)
+            .filter(Interaction.Columns.timestampMs == vmReaction.timestamp)
+            .filter(Interaction.Columns.authorId == vmReaction.publicKey)
             .filter(Interaction.Columns.variant != Interaction.Variant.standardIncomingDeleted)
             .filter(Interaction.Columns.state != Interaction.State.deleted)
             .asRequest(of: Int64.self)
@@ -539,10 +539,10 @@ extension MessageReceiver {
         let sortId = Reaction.getSortId(
             db,
             interactionId: interactionId,
-            emoji: reaction.emoji
+            emoji: vmReaction.emoji
         )
         
-        switch reaction.kind {
+        switch vmReaction.kind {
             case .react:
                 // Determine whether the app is active based on the prefs rather than the UIApplication state to avoid
                 // requiring main-thread execution
@@ -554,7 +554,7 @@ extension MessageReceiver {
                     serverHash: message.serverHash,
                     timestampMs: timestampMs,
                     authorId: sender,
-                    emoji: reaction.emoji,
+                    emoji: vmReaction.emoji,
                     count: 1,
                     sortId: sortId
                 ).inserted(db)
@@ -568,11 +568,12 @@ extension MessageReceiver {
                 }
                 
                 // Don't notify if the reaction was added before the lastest read timestamp for
-                // the conversation
+                // the conversation or the reaction is for the sender's own message
                 if
                     !suppressNotifications &&
                     sender != userSessionId.hexString &&
-                    !timestampAlreadyRead
+                    !timestampAlreadyRead &&
+                    vmReaction.publicKey != sender
                 {
                     try? dependencies[singleton: .notificationsManager].notifyUser(
                         cat: .messageReceiver,
@@ -619,7 +620,7 @@ extension MessageReceiver {
                 try Reaction
                     .filter(Reaction.Columns.interactionId == interactionId)
                     .filter(Reaction.Columns.authorId == sender)
-                    .filter(Reaction.Columns.emoji == reaction.emoji)
+                    .filter(Reaction.Columns.emoji == vmReaction.emoji)
                     .deleteAll(db)
         }
         

--- a/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
@@ -95,10 +95,16 @@ public extension NotificationsManagerType {
                     )
                 else { throw MessageReceiverError.ignorableMessage }
                 
-                /// If the message is a reaction then we only want to show notifications for `contact` conversations
+                /// If the message is a reaction then we only want to show notifications for `contact` conversations, any only if the
+                /// reaction isn't added to a message sent by the reactor
                 if visibleMessage.reaction != nil {
                     switch threadVariant {
-                        case .contact: break
+                        case .contact:
+                            guard visibleMessage.reaction?.publicKey != sender else {
+                                throw MessageReceiverError.ignorableMessage
+                            }
+                            break
+                            
                         case .legacyGroup, .group, .community: throw MessageReceiverError.ignorableMessage
                     }
                 }


### PR DESCRIPTION
Fix [SES-4090](https://optf.atlassian.net/browse/SES-4090)

Currently, users get notified when a contact reacts to their own message with an emoji.
This shouldn’t happen, and only reactions, in a 1on1 chat, to the current user’s messages should generate a notification.