### PR TITLE
Added SessionAsyncImage and improvements to image handling

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -866,6 +866,9 @@
 		FDB3486E2BE8457F00B716C2 /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3486D2BE8457F00B716C2 /* BackgroundTaskManager.swift */; };
 		FDB3487E2BE856C800B716C2 /* UIBezierPath+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3487D2BE856C800B716C2 /* UIBezierPath+Utilities.swift */; };
 		FDB348892BE8705D00B716C2 /* SessionUtilitiesKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FDB3486C2BE8448500B716C2 /* SessionUtilitiesKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDB3DA882E24810C00148F8D /* SessionAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3DA872E24810900148F8D /* SessionAsyncImage.swift */; };
+		FDB3DA8B2E24834000148F8D /* AVURLAsset+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3DA892E2482A400148F8D /* AVURLAsset+Utilities.swift */; };
+		FDB3DA8D2E24881B00148F8D /* ImageLoading+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB3DA8C2E24881200148F8D /* ImageLoading+Convenience.swift */; };
 		FDB4BBC72838B91E00B7C95D /* LinkPreviewError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4BBC62838B91E00B7C95D /* LinkPreviewError.swift */; };
 		FDB5DAC12A9443A5002C8721 /* MessageSender+Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB5DAC02A9443A5002C8721 /* MessageSender+Groups.swift */; };
 		FDB5DAC72A9447E7002C8721 /* _022_GroupsRebuildChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB5DAC62A9447E7002C8721 /* _022_GroupsRebuildChanges.swift */; };
@@ -2079,6 +2082,9 @@
 		FDB3486C2BE8448500B716C2 /* SessionUtilitiesKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionUtilitiesKit.h; sourceTree = "<group>"; };
 		FDB3486D2BE8457F00B716C2 /* BackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManager.swift; sourceTree = "<group>"; };
 		FDB3487D2BE856C800B716C2 /* UIBezierPath+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBezierPath+Utilities.swift"; sourceTree = "<group>"; };
+		FDB3DA872E24810900148F8D /* SessionAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAsyncImage.swift; sourceTree = "<group>"; };
+		FDB3DA892E2482A400148F8D /* AVURLAsset+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVURLAsset+Utilities.swift"; sourceTree = "<group>"; };
+		FDB3DA8C2E24881200148F8D /* ImageLoading+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageLoading+Convenience.swift"; sourceTree = "<group>"; };
 		FDB4BBC62838B91E00B7C95D /* LinkPreviewError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewError.swift; sourceTree = "<group>"; };
 		FDB5DAC02A9443A5002C8721 /* MessageSender+Groups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageSender+Groups.swift"; sourceTree = "<group>"; };
 		FDB5DAC62A9447E7002C8721 /* _022_GroupsRebuildChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _022_GroupsRebuildChanges.swift; sourceTree = "<group>"; };
@@ -2580,6 +2586,7 @@
 				C35E8AAD2485E51D00ACB629 /* IP2Country.swift */,
 				B84664F4235022F30083A1CD /* MentionUtilities.swift */,
 				B886B4A82398BA1500211ABE /* QRCode.swift */,
+				FDB3DA8C2E24881200148F8D /* ImageLoading+Convenience.swift */,
 				B8783E9D23EB948D00404FB8 /* UILabel+Interaction.swift */,
 				B83F2B87240CB75A000A54AB /* UIImage+Scaling.swift */,
 				FD1C98E3282E3C5B00B76F9E /* UINavigationBar+Utilities.swift */,
@@ -2711,6 +2718,7 @@
 				9422568D2C23F8DD00C0FDBF /* ActivityView.swift */,
 				9422568E2C23F8DD00C0FDBF /* AttributedText.swift */,
 				9422568F2C23F8DD00C0FDBF /* CompatibleScrollingVStack.swift */,
+				FDB3DA872E24810900148F8D /* SessionAsyncImage.swift */,
 				942256902C23F8DD00C0FDBF /* SessionSearchBar.swift */,
 				942256912C23F8DD00C0FDBF /* SessionTextField.swift */,
 				942256922C23F8DD00C0FDBF /* Toast.swift */,
@@ -3786,6 +3794,7 @@
 		FD09796527F6B0A800936362 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				FDB3DA892E2482A400148F8D /* AVURLAsset+Utilities.swift */,
 				94C58AC82D2E036E00609195 /* Permissions.swift */,
 				FD97B23F2A3FEB050027DD57 /* ARC4RandomNumberGenerator.swift */,
 				FD7443452D07CA9F00862443 /* CGFloat+Utilities.swift */,
@@ -5873,6 +5882,7 @@
 				9422EE2B2B8C3A97004C740D /* String+Utilities.swift in Sources */,
 				FD37EA0128A60473003AE748 /* UIKit+Theme.swift in Sources */,
 				FD37E9CF28A1EB1B003AE748 /* Theme.swift in Sources */,
+				FDB3DA882E24810C00148F8D /* SessionAsyncImage.swift in Sources */,
 				9499E6032DDD9BF900091434 /* ExpandableLabel.swift in Sources */,
 				FDE754BA2C9B97B8002A2623 /* UIDevice+Utilities.swift in Sources */,
 				C331FFB92558FA8D00070591 /* UIView+Constraints.swift in Sources */,
@@ -6117,6 +6127,7 @@
 				FDC6D7602862B3F600B04575 /* Dependencies.swift in Sources */,
 				FD6673FF2D77F9C100041530 /* ScreenLock.swift in Sources */,
 				FD78E9F02DD6D61200D55B50 /* Data+Image.swift in Sources */,
+				FDB3DA8B2E24834000148F8D /* AVURLAsset+Utilities.swift in Sources */,
 				FD17D7C727F5207C00122BE0 /* DatabaseMigrator+Utilities.swift in Sources */,
 				FD848B9328420164000E298B /* UnicodeScalar+Utilities.swift in Sources */,
 				FDE754CE2C9BAF37002A2623 /* ImageFormat.swift in Sources */,
@@ -6506,6 +6517,7 @@
 				FDFDE128282D05530098B17F /* MediaPresentationContext.swift in Sources */,
 				FD37EA0328A9FDCC003AE748 /* HelpViewModel.swift in Sources */,
 				FDFDE124282D04F20098B17F /* MediaDismissAnimationController.swift in Sources */,
+				FDB3DA8D2E24881B00148F8D /* ImageLoading+Convenience.swift in Sources */,
 				7BA6890F27325CE300EFC32F /* SessionCallManager+CXProvider.swift in Sources */,
 				7B46AAAF28766DF4001AF2DC /* AllMediaViewController.swift in Sources */,
 				FD71162228D983ED00B47552 /* QRCodeScanningViewController.swift in Sources */,

--- a/Session/Calls/CallVC.swift
+++ b/Session/Calls/CallVC.swift
@@ -570,10 +570,10 @@ final class CallVC: UIViewController, VideoPreviewDelegate, AVRoutePickerViewDel
             try Profile.fetchOne(db, id: call.sessionId)
         }
         
-        switch profile?.profilePictureFileName {
-            case .some(let fileName): profilePictureView.loadImage(from: fileName)
+        switch profile?.profilePictureFileName.map({ try? dependencies[singleton: .displayPictureManager].filepath(for: $0) }) {
+            case .some(let filePath): profilePictureView.loadImage(from: filePath)
             case .none:
-                profilePictureView.image = PlaceholderIcon.generate(
+                profilePictureView.loadPlaceholder(
                     seed: call.sessionId,
                     text: call.contactName,
                     size: 300

--- a/Session/Conversations/Message Cells/Content Views/MediaView.swift
+++ b/Session/Conversations/Message Cells/Content Views/MediaView.swift
@@ -206,7 +206,7 @@ public class MediaView: UIView {
                     /// Otherwise we want to load a thumbnail instead of the original image
                     let thumbnailPath: String = attachment.thumbnailPath(for: Attachment.ThumbnailSize.medium.dimension)
                     
-                    imageView.loadImage(identifier: thumbnailPath) { [weak self] in
+                    imageView.loadImage(.closure(thumbnailPath, { [weak self] in
                         guard let self = self else { return nil }
                         
                         var data: Data?
@@ -230,7 +230,7 @@ public class MediaView: UIView {
                         }
                         
                         return data
-                    }
+                    }))
                 }
         }
         

--- a/Session/Conversations/Message Cells/Content Views/QuoteView.swift
+++ b/Session/Conversations/Message Cells/Content Views/QuoteView.swift
@@ -141,8 +141,7 @@ final class QuoteView: UIView {
                 let thumbnailPath: String = attachment.thumbnailPath(for: Attachment.ThumbnailSize.medium.dimension)
                 
                 imageView.loadImage(
-                    identifier: thumbnailPath,
-                    from: { [weak self] () -> Data? in
+                    .closure(thumbnailPath, { [weak self] () -> Data? in
                         guard let self = self else { return nil }
                         
                         var data: Data?
@@ -160,8 +159,12 @@ final class QuoteView: UIView {
                         semaphore.wait()
                         
                         return data
-                    },
-                    onComplete: { [weak imageView] in imageView?.contentMode = .scaleAspectFill }
+                    }),
+                    onComplete: { [weak imageView] success in
+                        guard success else { return }
+                        
+                        imageView?.contentMode = .scaleAspectFill
+                    }
                 )
             }
         }

--- a/Session/Conversations/Settings/ProfilePictureVC.swift
+++ b/Session/Conversations/Settings/ProfilePictureVC.swift
@@ -34,7 +34,7 @@ final class ProfilePictureVC: BaseVC {
         result.clipsToBounds = true
         result.contentMode = .scaleAspectFill
         result.layer.cornerRadius = (imageSize / 2)
-        result.loadImage(identifier: imageIdentifier, from: imageSource)
+        result.loadImage(imageSource)
         result.set(.width, to: imageSize)
         result.set(.height, to: imageSize)
         

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -1641,7 +1641,6 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigatableStateHolder, Ob
                 info: ConfirmationModal.Info(
                     title: "groupSetDisplayPicture".localized(),
                     body: .image(
-                        identifier: (currentFileName ?? iconName),
                         source: currentFileName
                             .map { try? dependencies[singleton: .displayPictureManager].filepath(for: $0) }
                             .map { ImageDataManager.DataSource.url(URL(fileURLWithPath: $0)) },
@@ -1663,7 +1662,7 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigatableStateHolder, Ob
                     confirmTitle: "save".localized(),
                     confirmEnabled: .afterChange { info in
                         switch info.body {
-                            case .image(_, let source, _, _, _, _, _, _): return (source?.imageData != nil)
+                            case .image(let source, _, _, _, _, _, _): return (source?.imageData != nil)
                             default: return false
                         }
                     },
@@ -1673,7 +1672,7 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigatableStateHolder, Ob
                     dismissOnConfirm: false,
                     onConfirm: { [weak self] modal in
                         switch modal.info.body {
-                            case .image(_, .some(let source), _, _, _, _, _, _):
+                            case .image(.some(let source), _, _, _, _, _, _):
                                 guard let imageData: Data = source.imageData else { return }
                                 
                                 self?.updateGroupDisplayPicture(

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -124,12 +124,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 /// Because the `SessionUIKit` target doesn't depend on the `SessionUtilitiesKit` dependency (it shouldn't
                 /// need to since it should just be UI) but since the theme settings are stored in the database we need to pass these through
                 /// to `SessionUIKit` and expose a mechanism to save updated settings - this is done here (once the migrations complete)
-                SNUIKit.configure(
-                    with: SessionSNUIKitConfig(using: dependencies),
-                    themeSettings: dependencies[singleton: .storage].read { db in
-                        (db[.theme], db[.themePrimaryColor], db[.themeMatchSystemDayNightCycle])
-                    }
-                )
+                Task { @MainActor in
+                    SNUIKit.configure(
+                        with: SessionSNUIKitConfig(using: dependencies),
+                        themeSettings: dependencies[singleton: .storage].read { db in
+                            (db[.theme], db[.themePrimaryColor], db[.themeMatchSystemDayNightCycle])
+                        }
+                    )
+                }
                 
                 /// Adding this to prevent new users being asked for local network permission in the wrong order in the permission chain.
                 /// We need to check the local nework permission status every time the app is activated to refresh the UI in Settings screen.

--- a/Session/Meta/MainAppContext.swift
+++ b/Session/Meta/MainAppContext.swift
@@ -130,7 +130,7 @@ final class MainAppContext: AppContext {
     
     // MARK: - AppContext Functions
     
-    func setMainWindow(_ mainWindow: UIWindow) {
+    @MainActor func setMainWindow(_ mainWindow: UIWindow) {
         self.mainWindow = mainWindow
         
         // Store in SessionUIKit to avoid needing the SessionUtilitiesKit dependency

--- a/Session/Meta/Session+SNUIKit.swift
+++ b/Session/Meta/Session+SNUIKit.swift
@@ -1,6 +1,7 @@
 // Copyright © 2024 Rangeproof Pty Ltd. All rights reserved.
 
 import UIKit
+import AVFoundation
 import SessionUIKit
 import SessionSnodeKit
 import SessionUtilitiesKit
@@ -76,36 +77,16 @@ internal struct SessionSNUIKitConfig: SNUIKit.ConfigType {
         }
     }
     
-    func placeholderIconCacher(cacheKey: String, generator: @escaping () -> UIImage) -> UIImage {
-        let semaphore: DispatchSemaphore = DispatchSemaphore(value: 0)
-        var cachedIcon: UIImage?
-        
-        Task {
-            switch await dependencies[singleton: .imageDataManager].cachedImage(identifier: cacheKey)?.type {
-                case .staticImage(let image): cachedIcon = image
-                case .animatedImage(let frames, _): cachedIcon = frames.first // Shouldn't be possible
-                case .none: break
-            }
-            
-            semaphore.signal()
-        }
-        semaphore.wait()
-        
-        switch cachedIcon {
-            case .some(let image): return image
-            case .none:
-                let generatedImage: UIImage = generator()
-                Task {
-                    await dependencies[singleton: .imageDataManager].cacheImage(
-                        generatedImage,
-                        for: cacheKey
-                    )
-                }
-                return generatedImage
-        }
-    }
-    
     func shouldShowStringKeys() -> Bool {
         return dependencies[feature: .showStringKeys]
+    }
+    
+    func asset(for path: String, mimeType: String, sourceFilename: String?) -> (asset: AVURLAsset, cleanup: () -> Void)? {
+        return AVURLAsset.asset(
+            for: path,
+            mimeType: mimeType,
+            sourceFilename: sourceFilename,
+            using: dependencies
+        )
     }
 }

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -551,7 +551,6 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
                 info: ConfirmationModal.Info(
                     title: "profileDisplayPictureSet".localized(),
                     body: .image(
-                        identifier: (currentFileName ?? iconName),
                         source: currentFileName
                             .map { try? dependencies[singleton: .displayPictureManager].filepath(for: $0) }
                             .map { ImageDataManager.DataSource.url(URL(fileURLWithPath: $0)) },
@@ -573,7 +572,7 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
                     confirmTitle: "save".localized(),
                     confirmEnabled: .afterChange { info in
                         switch info.body {
-                            case .image(_, let source, _, _, _, _, _, _): return (source?.imageData != nil)
+                            case .image(let source, _, _, _, _, _, _): return (source?.imageData != nil)
                             default: return false
                         }
                     },
@@ -583,7 +582,7 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
                     dismissOnConfirm: false,
                     onConfirm: { [weak self] modal in
                         switch modal.info.body {
-                            case .image(_, .some(let source), _, _, _, _, _, _):
+                            case .image(.some(let source), _, _, _, _, _, _):
                                 guard let imageData: Data = source.imageData else { return }
                                 
                                 self?.updateProfile(

--- a/Session/Settings/Views/PrimaryColorSelectionView.swift
+++ b/Session/Settings/Views/PrimaryColorSelectionView.swift
@@ -102,7 +102,7 @@ extension PrimaryColorSelectionView: SessionCell.Accessory.CustomView {
         typealias View = PrimaryColorSelectionView
         
         let primaryColor: Theme.PrimaryColor
-        let onChange: (Theme.PrimaryColor) -> ()
+        let onChange: @MainActor (Theme.PrimaryColor) -> ()
         
         static func == (lhs: Info, rhs: Info) -> Bool {
             return (lhs.primaryColor == rhs.primaryColor)

--- a/Session/Shared/BaseVC.swift
+++ b/Session/Shared/BaseVC.swift
@@ -37,7 +37,6 @@ public class BaseVC: UIViewController {
         
         navigationItem.backButtonTitle = ""
         view.themeBackgroundColor = .backgroundPrimary
-        ThemeManager.applyNavigationStylingIfNeeded(to: self)
         
         setNeedsStatusBarAppearanceUpdate()
     }
@@ -45,6 +44,9 @@ public class BaseVC: UIViewController {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        /// Apply the nav styling in `viewWillAppear` instead of `viewDidLoad` as it's possible the nav stack isn't fully setup
+        /// and could crash when trying to access it (whereas by the time `viewWillAppear` is called it should be setup)
+        ThemeManager.applyNavigationStylingIfNeeded(to: self)
         onViewWillAppear?(self)
     }
     

--- a/Session/Shared/Types/SessionCell+Info.swift
+++ b/Session/Shared/Types/SessionCell+Info.swift
@@ -18,8 +18,8 @@ extension SessionCell {
         let isEnabled: Bool
         let accessibility: Accessibility?
         let confirmationInfo: ConfirmationModal.Info?
-        let onTap: (() -> Void)?
-        let onTapView: ((UIView?) -> Void)?
+        let onTap: (@MainActor () -> Void)?
+        let onTapView: (@MainActor (UIView?) -> Void)?
         
         var currentBoolValue: Bool {
             return (
@@ -42,8 +42,8 @@ extension SessionCell {
             isEnabled: Bool = true,
             accessibility: Accessibility? = nil,
             confirmationInfo: ConfirmationModal.Info? = nil,
-            onTap: (() -> Void)? = nil,
-            onTapView: ((UIView?) -> Void)? = nil
+            onTap: (@MainActor () -> Void)? = nil,
+            onTapView: (@MainActor (UIView?) -> Void)? = nil
         ) {
             self.id = id
             self.position = position
@@ -126,7 +126,7 @@ public extension SessionCell.Info {
         isEnabled: Bool = true,
         accessibility: Accessibility? = nil,
         confirmationInfo: ConfirmationModal.Info? = nil,
-        onTap: (() -> Void)? = nil
+        onTap: (@MainActor () -> Void)? = nil
     ) {
         self.id = id
         self.position = position
@@ -182,7 +182,7 @@ public extension SessionCell.Info {
         isEnabled: Bool = true,
         accessibility: Accessibility? = nil,
         confirmationInfo: ConfirmationModal.Info? = nil,
-        onTap: (() -> Void)? = nil
+        onTap: (@MainActor () -> Void)? = nil
     ) {
         self.id = id
         self.position = position
@@ -211,7 +211,7 @@ public extension SessionCell.Info {
         isEnabled: Bool = true,
         accessibility: Accessibility? = nil,
         confirmationInfo: ConfirmationModal.Info? = nil,
-        onTap: (() -> Void)? = nil
+        onTap: (@MainActor () -> Void)? = nil
     ) {
         self.id = id
         self.position = position
@@ -241,8 +241,8 @@ public extension SessionCell.Info {
         isEnabled: Bool = true,
         accessibility: Accessibility? = nil,
         confirmationInfo: ConfirmationModal.Info? = nil,
-        onTap: (() -> Void)? = nil,
-        onTapView: ((UIView?) -> Void)? = nil
+        onTap: (@MainActor () -> Void)? = nil,
+        onTapView: (@MainActor (UIView?) -> Void)? = nil
     ) {
         self.id = id
         self.position = position

--- a/Session/Utilities/ImageLoading+Convenience.swift
+++ b/Session/Utilities/ImageLoading+Convenience.swift
@@ -1,0 +1,21 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import UIKit
+import SwiftUI
+import SessionUIKit
+import SessionMessagingKit
+import SessionUtilitiesKit
+
+// MARK: - SessionImageView Convenience
+
+public extension SessionImageView {
+    @MainActor
+    func loadImage(from path: String, onComplete: ((Bool) -> Void)? = nil) {
+        loadImage(.url(URL(fileURLWithPath: path)), onComplete: onComplete)
+    }
+    
+    @MainActor
+    func loadPlaceholder(seed: String, text: String, size: CGFloat, onComplete: ((Bool) -> Void)? = nil) {
+        loadImage(.placeholderIcon(seed: seed, text: text, size: size), onComplete: onComplete)
+    }
+}

--- a/SessionMessagingKit/Utilities/ProfilePictureView+Convenience.swift
+++ b/SessionMessagingKit/Utilities/ProfilePictureView+Convenience.swift
@@ -51,7 +51,6 @@ public extension ProfilePictureView {
                 .filepath(for: displayPictureFilename)
         {
             return (Info(
-                identifier: displayPictureFilename,
                 source: .url(URL(fileURLWithPath: path)),
                 icon: profileIcon
             ), nil)
@@ -62,7 +61,6 @@ public extension ProfilePictureView {
             case .community:
                 return (
                     Info(
-                        identifier: "\(publicKey)-placeholder",
                         source: {
                             switch size {
                                 case .navigation, .message: return .image("SessionWhite16", #imageLiteral(resourceName: "SessionWhite16"))
@@ -87,22 +85,17 @@ public extension ProfilePictureView {
                 
                 return (
                     Info(
-                        identifier: (profile?.profilePictureFileName)
-                            .defaulting(to: "\(profile?.id ?? publicKey)-placeholder"),
                         source: (
                             profile?.profilePictureFileName
                                 .map { try? dependencies[singleton: .displayPictureManager].filepath(for: $0) }
                                 .map { ImageDataManager.DataSource.url(URL(fileURLWithPath: $0)) } ??
-                            .image(
-                                "\(profile?.id ?? publicKey)-placeholder",
-                                PlaceholderIcon.generate(
-                                    seed: (profile?.id ?? publicKey),
-                                    text: (profile?.displayName(for: threadVariant))
-                                        .defaulting(to: publicKey),
-                                    size: (additionalProfile != nil ?
-                                           size.multiImageSize :
-                                            size.viewSize
-                                          )
+                            .placeholderIcon(
+                                seed: (profile?.id ?? publicKey),
+                                text: (profile?.displayName(for: threadVariant))
+                                    .defaulting(to: publicKey),
+                                size: (additionalProfile != nil ?
+                                    size.multiImageSize :
+                                    size.viewSize
                                 )
                             )
                         ),
@@ -111,8 +104,6 @@ public extension ProfilePictureView {
                     additionalProfile
                         .map { other in
                             Info(
-                                identifier: (other.profilePictureFileName)
-                                    .defaulting(to: "\(other.id)-placeholder"),
                                 source: (
                                     other.profilePictureFileName
                                         .map { fileName in
@@ -120,13 +111,10 @@ public extension ProfilePictureView {
                                                 .filepath(for: fileName)
                                         }
                                         .map { ImageDataManager.DataSource.url(URL(fileURLWithPath: $0)) } ??
-                                    .image(
-                                        "\(other.id)-placeholder",
-                                        PlaceholderIcon.generate(
-                                            seed: other.id,
-                                            text: other.displayName(for: threadVariant),
-                                            size: size.multiImageSize
-                                        )
+                                    .placeholderIcon(
+                                        seed: other.id,
+                                        text: other.displayName(for: threadVariant),
+                                        size: size.multiImageSize
                                     )
                                 ),
                                 icon: additionalProfileIcon
@@ -134,8 +122,7 @@ public extension ProfilePictureView {
                         }
                         .defaulting(
                             to: Info(
-                                identifier: "GroupFallbackIcon",    // stringlint:ignore
-                                source: .image("person.fill", UIImage(named: "ic_user_round_fill")),
+                                source: .image("ic_user_round_fill", UIImage(named: "ic_user_round_fill")),
                                 renderingMode: .alwaysTemplate,
                                 themeTintColor: .white,
                                 inset: UIEdgeInsets(
@@ -154,20 +141,15 @@ public extension ProfilePictureView {
                 
                 return (
                     Info(
-                        identifier: (profile?.profilePictureFileName)
-                            .defaulting(to: "\(publicKey)-placeholder"),
                         source: (
                             profile?.profilePictureFileName
                                 .map { try? dependencies[singleton: .displayPictureManager].filepath(for: $0) }
                                 .map { ImageDataManager.DataSource.url(URL(fileURLWithPath: $0)) } ??
-                            .image(
-                                "\(profile?.id ?? publicKey)-placeholder",
-                                PlaceholderIcon.generate(
-                                    seed: publicKey,
-                                    text: (profile?.displayName(for: threadVariant))
-                                        .defaulting(to: publicKey),
-                                    size: size.viewSize
-                                )
+                            .placeholderIcon(
+                                seed: publicKey,
+                                text: (profile?.displayName(for: threadVariant))
+                                    .defaulting(to: publicKey),
+                                size: size.viewSize
                             )
                         ),
                         icon: profileIcon

--- a/SessionShareExtension/ShareNavController.swift
+++ b/SessionShareExtension/ShareNavController.swift
@@ -1,6 +1,7 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
 
 import UIKit
+import AVFoundation
 import Combine
 import CoreServices
 import UniformTypeIdentifiers
@@ -727,13 +728,8 @@ private struct SAESNUIKitConfig: SNUIKit.ConfigType {
     
     // MARK: - Functions
     
-    func themeChanged(_ theme: Theme, _ primaryColor: Theme.PrimaryColor, _ matchSystemNightModeSetting: Bool) {
-        dependencies[singleton: .storage].write { db in
-            db[.theme] = theme
-            db[.themePrimaryColor] = primaryColor
-            db[.themeMatchSystemDayNightCycle] = matchSystemNightModeSetting
-        }
-    }
+    /// Unable to change the theme from the Share extension
+    func themeChanged(_ theme: Theme, _ primaryColor: Theme.PrimaryColor, _ matchSystemNightModeSetting: Bool) {}
     
     func navBarSessionIcon() -> NavBarSessionIcon {
         switch (dependencies[feature: .serviceNetwork], dependencies[feature: .forceOffline]) {
@@ -762,36 +758,16 @@ private struct SAESNUIKitConfig: SNUIKit.ConfigType {
     
     func removeCachedContextualActionInfo(tableViewHash: Int, keys: [String]) {}
     
-    func placeholderIconCacher(cacheKey: String, generator: @escaping () -> UIImage) -> UIImage {
-        let semaphore: DispatchSemaphore = DispatchSemaphore(value: 0)
-        var cachedIcon: UIImage?
-        
-        Task {
-            switch await dependencies[singleton: .imageDataManager].cachedImage(identifier: cacheKey)?.type {
-                case .staticImage(let image): cachedIcon = image
-                case .animatedImage(let frames, _): cachedIcon = frames.first // Shouldn't be possible
-                case .none: break
-            }
-            
-            semaphore.signal()
-        }
-        semaphore.wait()
-        
-        switch cachedIcon {
-            case .some(let image): return image
-            case .none:
-                let generatedImage: UIImage = generator()
-                Task {
-                    await dependencies[singleton: .imageDataManager].cacheImage(
-                        generatedImage,
-                        for: cacheKey
-                    )
-                }
-                return generatedImage
-        }
-    }
-    
     func shouldShowStringKeys() -> Bool {
         return dependencies[feature: .showStringKeys]
+    }
+    
+    func asset(for path: String, mimeType: String, sourceFilename: String?) -> (asset: AVURLAsset, cleanup: () -> Void)? {
+        return AVURLAsset.asset(
+            for: path,
+            mimeType: mimeType,
+            sourceFilename: sourceFilename,
+            using: dependencies
+        )
     }
 }

--- a/SessionShareExtension/ThreadPickerVC.swift
+++ b/SessionShareExtension/ThreadPickerVC.swift
@@ -90,7 +90,6 @@ final class ThreadPickerVC: UIViewController, UITableViewDataSource, UITableView
         super.viewDidLoad()
         
         navigationItem.titleView = titleLabel
-        ThemeManager.applyNavigationStylingIfNeeded(to: self)
         
         view.themeBackgroundColor = .backgroundPrimary
         view.addSubview(tableView)
@@ -103,6 +102,9 @@ final class ThreadPickerVC: UIViewController, UITableViewDataSource, UITableView
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        /// Apply the nav styling in `viewWillAppear` instead of `viewDidLoad` as it's possible the nav stack isn't fully setup
+        /// and could crash when trying to access it (whereas by the time `viewWillAppear` is called it should be setup)
+        ThemeManager.applyNavigationStylingIfNeeded(to: self)
         startObservingChanges()
     }
     

--- a/SessionUIKit/Components/ConfirmationModal.swift
+++ b/SessionUIKit/Components/ConfirmationModal.swift
@@ -501,7 +501,7 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
                     contentStackView.addArrangedSubview(radioButton)
                 }
                 
-            case .image(let identifier, let source, let placeholder, let icon, let style, let accessibility, let dataManager, let onClick):
+            case .image(let source, let placeholder, let icon, let style, let accessibility, let dataManager, let onClick):
                 imageViewContainer.isAccessibilityElement = (accessibility != nil)
                 imageViewContainer.accessibilityIdentifier = accessibility?.identifier
                 imageViewContainer.accessibilityLabel = accessibility?.label
@@ -511,7 +511,6 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
                 profileView.setDataManager(dataManager)
                 profileView.update(
                     ProfilePictureView.Info(
-                        identifier: identifier,
                         source: (source ?? placeholder),
                         icon: icon
                     )
@@ -633,12 +632,13 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
     @objc private func imageViewTapped() {
         internalOnBodyTap?({ [weak self, info = self.info] valueUpdate in
             switch (valueUpdate, info.body) {
-                case (.image(let updatedIdentifier, let updatedData), .image(_, _, let placeholder, let icon, let style, let accessibility, let dataManager, let onClick)):
+                case (.image(let updatedIdentifier, let updatedData), .image(_, let placeholder, let icon, let style, let accessibility, let dataManager, let onClick)):
                     self?.updateContent(
                         with: info.with(
                             body: .image(
-                                identifier: updatedIdentifier,
-                                source: updatedData.map { ImageDataManager.DataSource.data($0) },
+                                source: updatedData.map {
+                                    ImageDataManager.DataSource.data(updatedIdentifier, $0)
+                                },
                                 placeholder: placeholder,
                                 icon: icon,
                                 style: style,
@@ -755,8 +755,8 @@ public extension ConfirmationModal {
         let hasCloseButton: Bool
         let dismissOnConfirm: Bool
         let dismissType: Modal.DismissType
-        public let onConfirm: ((ConfirmationModal) -> ())?
-        let onCancel: ((ConfirmationModal) -> ())?
+        public let onConfirm: (@MainActor (ConfirmationModal) -> ())?
+        let onCancel: (@MainActor (ConfirmationModal) -> ())?
         let afterClosed: (() -> ())?
         
         // MARK: - Initialization
@@ -774,8 +774,8 @@ public extension ConfirmationModal {
             hasCloseButton: Bool = false,
             dismissOnConfirm: Bool = true,
             dismissType: Modal.DismissType = .recursive,
-            onConfirm: ((ConfirmationModal) -> ())? = nil,
-            onCancel: ((ConfirmationModal) -> ())? = nil,
+            onConfirm: (@MainActor (ConfirmationModal) -> ())? = nil,
+            onCancel: (@MainActor (ConfirmationModal) -> ())? = nil,
             afterClosed: (() -> ())? = nil
         ) {
             self.title = title
@@ -1007,7 +1007,6 @@ public extension ConfirmationModal.Info {
             options: [RadioOptionInfo]
         )
         case image(
-            identifier: String,
             source: ImageDataManager.DataSource?,
             placeholder: ImageDataManager.DataSource?,
             icon: ProfilePictureView.ProfileIcon = .none,
@@ -1048,9 +1047,8 @@ public extension ConfirmationModal.Info {
                         lhsOptions == rhsOptions
                     )
                     
-                case (.image(let lhsIdentifier, let lhsSource, let lhsPlaceholder, let lhsIcon, let lhsStyle, let lhsAccessibility, _, _), .image(let rhsIdentifier, let rhsSource, let rhsPlaceholder, let rhsIcon, let rhsStyle, let rhsAccessibility, _, _)):
+                case (.image(let lhsSource, let lhsPlaceholder, let lhsIcon, let lhsStyle, let lhsAccessibility, _, _), .image(let rhsSource, let rhsPlaceholder, let rhsIcon, let rhsStyle, let rhsAccessibility, _, _)):
                     return (
-                        lhsIdentifier == rhsIdentifier &&
                         lhsSource == rhsSource &&
                         lhsPlaceholder == rhsPlaceholder &&
                         lhsIcon == rhsIcon &&
@@ -1082,8 +1080,7 @@ public extension ConfirmationModal.Info {
                     warning.hash(into: &hasher)
                     options.hash(into: &hasher)
                 
-                case .image(let identifier, let source, let placeholder, let icon, let style, let accessibility, _, _):
-                    identifier.hash(into: &hasher)
+                case .image(let source, let placeholder, let icon, let style, let accessibility, _, _):
                     source.hash(into: &hasher)
                     placeholder.hash(into: &hasher)
                     icon.hash(into: &hasher)

--- a/SessionUIKit/Components/Modal.swift
+++ b/SessionUIKit/Components/Modal.swift
@@ -88,7 +88,6 @@ open class Modal: UIViewController, UIGestureRecognizerDelegate {
         
         navigationItem.backButtonTitle = ""
         view.themeBackgroundColor = .clear
-        ThemeManager.applyNavigationStylingIfNeeded(to: self)
 
         setNeedsStatusBarAppearanceUpdate()
         
@@ -128,6 +127,14 @@ open class Modal: UIViewController, UIGestureRecognizerDelegate {
         dimmingView.addGestureRecognizer(tapGestureRecognizer)
         
         populateContentView()
+    }
+    
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        /// Apply the nav styling in `viewWillAppear` instead of `viewDidLoad` as it's possible the nav stack isn't fully setup
+        /// and could crash when trying to access it (whereas by the time `viewWillAppear` is called it should be setup)
+        ThemeManager.applyNavigationStylingIfNeeded(to: self)
     }
     
     open override func viewDidDisappear(_ animated: Bool) {

--- a/SessionUIKit/Components/PlaceholderIcon.swift
+++ b/SessionUIKit/Components/PlaceholderIcon.swift
@@ -3,41 +3,39 @@
 import UIKit
 import CryptoKit
 
-public class PlaceholderIcon {
+public enum PlaceholderIcon {
     private static let colors: [UIColor] = Theme.PrimaryColor.allCases.map { $0.color }
-    
-    private let seed: Int
-    
-    // MARK: - Initialization
-    
-    init(seed: Int) {
-        self.seed = seed
-    }
-    
-    // stringlint:ignore_contents
-    convenience init(seed: String) {
-        // Ensure we have a correct hash
-        var hash = seed
-        
-        if (hash.matches("^[0-9A-Fa-f]+$") && hash.count >= 12) {
-            // This is the same as the `SessionUtilitiesKit` `toHexString` function
-            hash = Data(SHA512.hash(data: Data(Array(seed.utf8))).makeIterator())
-                .map { String(format: "%02x", $0) }.joined()
-        }
-        
-        guard let number = Int(String(hash.prefix(12)), radix: 16) else {
-            self.init(seed: 0)
-            return
-        }
-        
-        self.init(seed: number)
-    }
-    
-    // MARK: - Convenience
     
     // stringlint:ignore_contents
     public static func generate(seed: String, text: String, size: CGFloat) -> UIImage {
-        let icon = PlaceholderIcon(seed: seed)
+        let content: (intSeed: Int, initials: String) = content(seed: seed, text: text)
+        let layer = generateLayer(
+            with: size,
+            text: content.initials,
+            seed: content.intSeed
+        )
+        
+        let rect = CGRect(origin: CGPoint.zero, size: layer.frame.size)
+        let renderer = UIGraphicsImageRenderer(size: rect.size)
+        
+        return renderer.image { layer.render(in: $0.cgContext) }
+    }
+    
+    // MARK: - Internal
+    
+    internal static func content(seed: String, text: String) -> (intSeed: Int, initials: String) {
+        let intSeed: Int = {
+            var hash = seed
+            
+            if (hash.matches("^[0-9A-Fa-f]+$") && hash.count >= 12) {
+                // This is the same as the `SessionUtilitiesKit` `toHexString` function
+                hash = Data(SHA512.hash(data: Data(Array(seed.utf8))).makeIterator())
+                    .map { String(format: "%02x", $0) }.joined()
+            }
+            
+            
+            return (Int(String(hash.prefix(12)), radix: 16) ?? 0)
+        }()
         
         var content: String = {
             guard text.hasSuffix("\(String(seed.suffix(4))))") else {
@@ -60,33 +58,17 @@ public class PlaceholderIcon {
             .compactMap { word in word.first.map { String($0) } }
             .joined()
         
-        return SNUIKit.placeholderIconCacher(cacheKey: "\(seed)-\(initials)-\(Int(floor(size)))") {
-            let layer = icon.generateLayer(
-                with: size,
-                text: (initials.count >= 2 ?
-                    String(initials.prefix(2)).uppercased() :
-                    String(content.prefix(2)).uppercased()
-                )
+        return (
+            intSeed,
+            (initials.count >= 2 ?
+                String(initials.prefix(2)).uppercased() :
+                String(content.prefix(2)).uppercased()
             )
-            
-            let rect = CGRect(origin: CGPoint.zero, size: layer.frame.size)
-            let renderer = UIGraphicsImageRenderer(size: rect.size)
-            
-            return renderer.image { layer.render(in: $0.cgContext) }
-        }
+        )
     }
     
-    // MARK: - Internal
-    
-    private func generateLayer(with diameter: CGFloat, text: String) -> CALayer {
+    private static func generateLayer(with diameter: CGFloat, text: String, seed: Int) -> CALayer {
         let color: UIColor = PlaceholderIcon.colors[seed % PlaceholderIcon.colors.count]
-        let base: CALayer = getTextLayer(with: diameter, color: color, text: text)
-        base.masksToBounds = true
-        
-        return base
-    }
-    
-    private func getTextLayer(with diameter: CGFloat, color: UIColor, text: String) -> CALayer {
         let font = UIFont.boldSystemFont(ofSize: diameter / 2)
         let height = NSString(string: text).boundingRect(with: CGSize(width: diameter, height: CGFloat.greatestFiniteMagnitude),
             options: .usesLineFragmentOrigin, attributes: [ NSAttributedString.Key.font : font ], context: nil).height
@@ -106,6 +88,7 @@ public class PlaceholderIcon {
         
         let base = CALayer()
         base.frame = CGRect(x: 0, y: 0, width: diameter, height: diameter)
+        base.masksToBounds = true
         base.themeBackgroundColorForced = .color(color)
         base.addSublayer(layer)
         

--- a/SessionUIKit/Components/ProfilePictureView.swift
+++ b/SessionUIKit/Components/ProfilePictureView.swift
@@ -5,7 +5,6 @@ import Combine
 
 public final class ProfilePictureView: UIView {
     public struct Info {
-        let identifier: String
         let source: ImageDataManager.DataSource?
         let renderingMode: UIImage.RenderingMode?
         let themeTintColor: ThemeValue?
@@ -15,7 +14,6 @@ public final class ProfilePictureView: UIView {
         let forcedBackgroundColor: ForcedThemeValue?
         
         public init(
-            identifier: String,
             source: ImageDataManager.DataSource?,
             renderingMode: UIImage.RenderingMode? = nil,
             themeTintColor: ThemeValue? = nil,
@@ -24,7 +22,6 @@ public final class ProfilePictureView: UIView {
             backgroundColor: ThemeValue? = nil,
             forcedBackgroundColor: ForcedThemeValue? = nil
         ) {
-            self.identifier = identifier
             self.source = source
             self.renderingMode = renderingMode
             self.themeTintColor = themeTintColor
@@ -482,8 +479,7 @@ public final class ProfilePictureView: UIView {
             case (.some(let source), .some(let renderingMode)) where source.directImage != nil:
                 imageView.image = source.directImage?.withRenderingMode(renderingMode)
                 
-            case (.some(let source), _):
-                imageView.loadImage(identifier: info.identifier, from: source)
+            case (.some(let source), _): imageView.loadImage(source)
                 
             default: imageView.image = nil
         }
@@ -529,7 +525,7 @@ public final class ProfilePictureView: UIView {
                 additionalImageContainerView.isHidden = false
                 
             case (.some(let source), _):
-                additionalImageView.loadImage(identifier: additionalInfo.identifier, from: source)
+                additionalImageView.loadImage(source)
                 additionalImageContainerView.isHidden = false
                 
             default:

--- a/SessionUIKit/Components/SessionHostingViewController.swift
+++ b/SessionUIKit/Components/SessionHostingViewController.swift
@@ -58,12 +58,15 @@ open class SessionHostingViewController<Content>: UIHostingController<ModifiedCo
 
         navigationItem.backButtonTitle = ""
         view.themeBackgroundColor = .backgroundPrimary
-        ThemeManager.applyNavigationStylingIfNeeded(to: self)
 
         setNeedsStatusBarAppearanceUpdate()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
+        /// Apply the nav styling in `viewWillAppear` instead of `viewDidLoad` as it's possible the nav stack isn't fully setup
+        /// and could crash when trying to access it (whereas by the time `viewWillAppear` is called it should be setup)
+        ThemeManager.applyNavigationStylingIfNeeded(to: self)
+
         if shouldHideNavigationBar {
             self.navigationController?.setNavigationBarHidden(true, animated: animated)
         }

--- a/SessionUIKit/Components/SwiftUI/SessionAsyncImage.swift
+++ b/SessionUIKit/Components/SwiftUI/SessionAsyncImage.swift
@@ -1,0 +1,167 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import SwiftUI
+import Combine
+import NaturalLanguage
+
+public struct SessionAsyncImage<Content: View, Placeholder: View>: View {
+    @State private var loadedImage: UIImage? = nil
+    @State private var animationFrames: [UIImage]?
+    @State private var animationFrameDurations: [TimeInterval]?
+    @State private var isAnimating: Bool = false
+    
+    @State private var currentFrameIndex: Int = 0
+    @State private var accumulatedTime: TimeInterval = 0.0
+    @State private var lastFrameDate: Date? = nil
+    
+    private let source: ImageDataManager.DataSource
+    private let dataManager: ImageDataManagerType
+    
+    private let content: (Image) -> Content
+    private let placeholder: () -> Placeholder
+    
+    public init(
+        source: ImageDataManager.DataSource,
+        dataManager: ImageDataManagerType,
+        @ViewBuilder content: @escaping (Image) -> Content,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.source = source
+        self.dataManager = dataManager
+        self.content = content
+        self.placeholder = placeholder
+    }
+    
+    public var body: some View {
+        ZStack {
+            if let uiImage = loadedImage {
+                let imageView = content(Image(uiImage: uiImage))
+                
+                if isAnimating {
+                    TimelineView(.animation) { context in
+                        imageView
+                            .onChange(of: context.date) { newDate in
+                                updateAnimationFrame(at: newDate)
+                            }
+                    }
+                }
+                else {
+                    imageView
+                }
+            } else {
+                placeholder()
+            }
+        }
+        .task(id: source.identifier) {
+            await loadAndProcessData()
+        }
+    }
+    
+    // MARK: - Internal Functions
+    
+    private func loadAndProcessData() async {
+        let processedData = await dataManager.load(source)
+        
+        /// Reset the state before loading new data
+        await MainActor.run {
+            self.loadedImage = nil
+            self.animationFrames = nil
+            self.animationFrameDurations = nil
+            self.isAnimating = false
+            self.currentFrameIndex = 0
+            self.accumulatedTime = 0.0
+            self.lastFrameDate = .now
+        }
+        
+        switch processedData?.type {
+            case .staticImage(let image):
+                await MainActor.run {
+                    self.loadedImage = image
+                }
+            
+            case .animatedImage(let frames, let durations) where frames.count > 1:
+                await MainActor.run {
+                    self.animationFrames = frames
+                    self.animationFrameDurations = durations
+                    self.loadedImage = frames.first
+                    self.isAnimating = true /// Activate the `TimelineView`
+                }
+                
+            case .animatedImage(let frames, _):
+                await MainActor.run {
+                    self.loadedImage = frames.first
+                }
+
+            default:
+                await MainActor.run {
+                    self.loadedImage = nil
+                }
+        }
+    }
+    
+    private func updateAnimationFrame(at date: Date) {
+        guard
+            isAnimating,
+            let frames: [UIImage] = animationFrames,
+            let durations = animationFrameDurations,
+            !frames.isEmpty,
+            frames.count == durations.count,
+            currentFrameIndex < durations.count,
+            let lastDate = lastFrameDate
+        else { return }
+        
+        /// Calculate elapsed time since the last frame
+        let elapsed: TimeInterval = date.timeIntervalSince(lastDate)
+        self.lastFrameDate = date
+        accumulatedTime += elapsed
+        
+        let currentFrameDuration: TimeInterval = durations[currentFrameIndex]
+        
+        // Advance frames if the accumulated time exceeds the current frame's duration
+        while accumulatedTime >= currentFrameDuration {
+            accumulatedTime -= currentFrameDuration
+            currentFrameIndex = (currentFrameIndex + 1) % frames.count
+            
+            /// Check if we need to break after advancing to the next frame
+            if currentFrameIndex < durations.count, accumulatedTime < durations[currentFrameIndex] {
+                break
+            }
+            
+            /// Prevent an infinite loop for all zero durations
+            if
+                durations[currentFrameIndex] <= 0.001 &&
+                currentFrameIndex == (currentFrameIndex + 1) % frames.count
+            {
+                break
+            }
+        }
+        
+        /// Make sure we don't cause an index-out-of-bounds somehow
+        guard currentFrameIndex < frames.count else {
+            isAnimating = false
+            return
+        }
+        
+        /// Update the displayed image only if the frame has changed
+        if loadedImage !== frames[currentFrameIndex] {
+            loadedImage = frames[currentFrameIndex]
+        }
+    }
+}
+
+// MARK: - Convenience
+
+extension SessionAsyncImage where Content == Image, Placeholder == ProgressView<EmptyView, EmptyView> {
+    init(
+        identifier: String,
+        source: ImageDataManager.DataSource,
+        dataManager: ImageDataManagerType
+    ) {
+        self.init(
+            source: source,
+            dataManager: dataManager,
+            content: { $0.resizable() },
+            placeholder: { ProgressView() }
+        )
+    }
+}

--- a/SessionUIKit/Style Guide/ThemeManager.swift
+++ b/SessionUIKit/Style Guide/ThemeManager.swift
@@ -28,7 +28,7 @@ public enum ThemeManager {
     
     // MARK: - Styling
     
-    public static func updateThemeState(
+    @MainActor public static func updateThemeState(
         theme: Theme? = nil,
         primaryColor: Theme.PrimaryColor? = nil,
         matchSystemNightModeSetting: Bool? = nil
@@ -73,7 +73,7 @@ public enum ThemeManager {
         SNUIKit.themeSettingsChanged(targetTheme, targetPrimaryColor, targetMatchSystemNightModeSetting)
     }
     
-    public static func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    @MainActor public static func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         let currentUserInterfaceStyle: UIUserInterfaceStyle = UITraitCollection.current.userInterfaceStyle
         
         // Only trigger updates if the style changed and the device is set to match the system style
@@ -92,11 +92,7 @@ public enum ThemeManager {
         }
     }
     
-    public static func applyNavigationStyling() {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { applyNavigationStyling() }
-        }
-        
+    @MainActor public static func applyNavigationStyling() {
         let textPrimary: UIColor = (color(for: .textPrimary, in: currentTheme) ?? .white)
         let backgroundColor: UIColor? = color(for: .backgroundPrimary, in: currentTheme)
         
@@ -180,7 +176,7 @@ public enum ThemeManager {
         updateIfNeeded(viewController: SNUIKit.mainWindow?.rootViewController)
     }
     
-    public static func applyNavigationStylingIfNeeded(to viewController: UIViewController) {
+    @MainActor public static func applyNavigationStylingIfNeeded(to viewController: UIViewController) {
         // Will use the 'primary' style for all other cases
         guard
             let navController: UINavigationController = ((viewController as? UINavigationController) ?? viewController.navigationController),
@@ -207,11 +203,7 @@ public enum ThemeManager {
         navController.navigationBar.scrollEdgeAppearance = appearance
     }
     
-    public static func applyWindowStyling() {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { applyWindowStyling() }
-        }
-        
+    @MainActor public static func applyWindowStyling() {
         SNUIKit.mainWindow?.overrideUserInterfaceStyle = {
             guard !ThemeManager.matchSystemNightModeSetting else { return .unspecified }
             
@@ -266,11 +258,7 @@ public enum ThemeManager {
     
     // MARK: -  Internal Functions
     
-    private static func updateAllUI() {
-        guard Thread.isMainThread else {
-            return DispatchQueue.main.async { updateAllUI() }
-        }
-        
+    @MainActor private static func updateAllUI() {
         ThemeManager.uiRegistry.objectEnumerator()?.forEach { applier in
             (applier as? ThemeApplier)?.apply(theme: currentTheme)
         }

--- a/SessionUIKit/Types/ImageDataManager.swift
+++ b/SessionUIKit/Types/ImageDataManager.swift
@@ -27,7 +27,9 @@ public actor ImageDataManager: ImageDataManagerType {
     
     // MARK: - Functions
     
-    @discardableResult public func loadImageData(identifier: String, source: DataSource) async -> ProcessedImageData? {
+    @discardableResult public func load(_ source: DataSource) async -> ProcessedImageData? {
+        let identifier: String = source.identifier
+        
         if let cachedData: ProcessedImageData = cache.object(forKey: identifier as NSString) {
             return cachedData
         }
@@ -35,25 +37,35 @@ public actor ImageDataManager: ImageDataManagerType {
         if let existingTask: Task<ProcessedImageData?, Never> = activeLoadTasks[identifier] {
             return await existingTask.value
         }
-
-        let newTask: Task<ProcessedImageData?, Never> = Task {
-            let processedData: ProcessedImageData? = await self.processSourceOnQueue(source)
-
-            if let data: ProcessedImageData = processedData {
-                self.cache.setObject(data, forKey: identifier as NSString, cost: data.estimatedCost)
-            }
-            
-            self.activeLoadTasks[identifier] = nil
-            return processedData
+        
+        /// Kick off a new processing task in the background
+        let newTask: Task<ProcessedImageData?, Never> = Task.detached(priority: .userInitiated) {
+            await ImageDataManager.processSource(source)
+        }
+        activeLoadTasks[identifier] = newTask
+        
+        /// Wait for the result then cache and return it
+        let processedData: ProcessedImageData? = await newTask.value
+        
+        if let data: ProcessedImageData = processedData {
+            self.cache.setObject(data, forKey: identifier as NSString, cost: data.estimatedCost)
         }
         
-        activeLoadTasks[identifier] = newTask
-        return await newTask.value
+        self.activeLoadTasks[identifier] = nil
+        return processedData
     }
     
-    public func cacheImage(_ image: UIImage, for identifier: String) async {
-        let data: ProcessedImageData = ProcessedImageData(type: .staticImage(image))
-        cache.setObject(data, forKey: identifier as NSString, cost: data.estimatedCost)
+    nonisolated public func load(
+        _ source: ImageDataManager.DataSource,
+        onComplete: @escaping (ImageDataManager.ProcessedImageData?) -> Void
+    ) {
+        Task { [weak self] in
+            let result: ImageDataManager.ProcessedImageData? = await self?.load(source)
+            
+            await MainActor.run {
+                onComplete(result)
+            }
+        }
     }
     
     public func cachedImage(identifier: String) async -> ProcessedImageData? {
@@ -70,128 +82,205 @@ public actor ImageDataManager: ImageDataManagerType {
     
     // MARK: - Internal Functions
 
-    private func processSourceOnQueue(_ dataSource: DataSource) async -> ProcessedImageData? {
-        return await withCheckedContinuation { continuation in
-            processingQueue.async {
-                switch dataSource {
-                    /// If we were given a direct `UIImage` value then use it
-                    case .image(_, let maybeImage):
-                        guard let image: UIImage = maybeImage else {
-                            return continuation.resume(returning: nil)
-                        }
-                        
-                        let processedData: ProcessedImageData = ProcessedImageData(
-                            type: .staticImage(image)
-                        )
-                        continuation.resume(returning: processedData)
-                        return
+    private static func processSource(_ dataSource: DataSource) async -> ProcessedImageData? {
+        switch dataSource {
+            /// If we were given a direct `UIImage` value then use it
+            case .image(_, let maybeImage):
+                guard let image: UIImage = maybeImage else { return nil }
+                
+                return ProcessedImageData(
+                    type: .staticImage(image)
+                )
+            
+            /// Custom handle `videoUrl` values since it requires thumbnail generation
+            case .videoUrl(let url, let mimeType, let sourceFilename, let thumbnailManager):
+                /// If we had already generated a thumbnail then use that
+                if let existingThumbnail: UIImage = thumbnailManager.existingThumbnailImage(url: url, size: .large) {
+                    let decodedImage: UIImage = (existingThumbnail.predecodedImage() ?? existingThumbnail)
+                    let processedData: ProcessedImageData = ProcessedImageData(
+                        type: .staticImage(decodedImage)
+                    )
                     
-                    /// Custom handle `videoUrl` values since it requires thumbnail generation
-                    case .videoUrl(let url):
-                        let asset: AVURLAsset = AVURLAsset(url: url, options: nil)
-                        
-                        guard asset.isValidVideo else { return continuation.resume(returning: nil) }
-                        
-                        let time: CMTime = CMTimeMake(value: 1, timescale: 60)
-                        let generator: AVAssetImageGenerator = AVAssetImageGenerator(asset: asset)
-                        generator.appliesPreferredTrackTransform = true
-                        
-                        guard
-                            let cgImage: CGImage = try? generator.copyCGImage(at: time, actualTime: nil)
-                        else { return continuation.resume(returning: nil) }
-                        
-                        let image: UIImage = UIImage(cgImage: cgImage)
-                        let decodedImage: UIImage = (image.predecodedImage() ?? image)
-                        let processedData: ProcessedImageData = ProcessedImageData(
-                            type: .staticImage(decodedImage)
-                        )
-                        continuation.resume(returning: processedData)
-                        return
-                        
-                    default: break
+                    return processedData
                 }
                 
-                /// Otherwise load the data as either a static or animated image (do quick validation checks here - other checks
-                /// require loading the image source anyway so don't bother to include them)
+                /// Otherwise we need to generate a new one
+                let assetInfo: (asset: AVURLAsset, cleanup: () -> Void)? = SNUIKit.asset(
+                    for: url.path,
+                    mimeType: mimeType,
+                    sourceFilename: sourceFilename
+                )
+                
                 guard
-                    let imageData: Data = dataSource.imageData,
-                    let imageFormat: SUIKImageFormat = imageData.suiKitGuessedImageFormat.nullIfUnknown,
-                    (imageFormat != .gif || imageData.suiKitHasValidGifSize),
-                    let source: CGImageSource = CGImageSourceCreateWithData(imageData as CFData, nil),
-                    CGImageSourceGetCount(source) > 0
-                else { return continuation.resume(returning: nil) }
+                    let asset: AVURLAsset = assetInfo?.asset,
+                    asset.isValidVideo
+                else { return nil }
                 
-                let count: Int = CGImageSourceGetCount(source)
+                let time: CMTime = CMTimeMake(value: 1, timescale: 60)
+                let generator: AVAssetImageGenerator = AVAssetImageGenerator(asset: asset)
+                generator.appliesPreferredTrackTransform = true
                 
-                switch count {
-                    /// Invalid image
-                    case ..<1: return continuation.resume(returning: nil)
-                        
-                    /// Static image
-                    case 1:
-                        guard let cgImage: CGImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
-                            return continuation.resume(returning: nil)
-                        }
-                        
-                        /// Extract image orientation if present
-                        var orientation: UIImage.Orientation = .up
-                        
-                        if
-                            let imageProperties: [CFString: Any] = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
-                            let rawCgOrientation: UInt32 = imageProperties[kCGImagePropertyOrientation] as? UInt32,
-                            let cgOrientation: CGImagePropertyOrientation = CGImagePropertyOrientation(rawValue: rawCgOrientation)
-                        {
-                            orientation = UIImage.Orientation(cgOrientation)
-                        }
-                        
-                        let image: UIImage = UIImage(cgImage: cgImage, scale: 1, orientation: orientation)
-                        let decodedImage: UIImage = (image.predecodedImage() ?? image)
-                        let processedData: ProcessedImageData = ProcessedImageData(
-                            type: .staticImage(decodedImage)
-                        )
-                        continuation.resume(returning: processedData)
-                        return
-                        
-                    /// Animated Image
-                    default:
-                        var framesArray: [UIImage] = []
-                        var durationsArray: [TimeInterval] = []
-                        
-                        for i in 0..<count {
-                            guard let cgImage: CGImage = CGImageSourceCreateImageAtIndex(source, i, nil) else {
-                                /// If a frame fails then use the previous frame as a fallback, otherwise fail as it was the first frame
-                                /// which failed
-                                guard
-                                    let lastFrame: UIImage = framesArray.last,
-                                    let lastDuration: TimeInterval = durationsArray.last
-                                else { return continuation.resume(returning: nil) }
-                                
-                                framesArray.append(lastFrame)
-                                durationsArray.append(lastDuration)
-                                continue
-                            }
-                            
-                            let image: UIImage = UIImage(cgImage: cgImage)
-                            let decodedImage: UIImage = (image.predecodedImage() ?? image)
-                            let duration: TimeInterval = ImageDataManager.getFrameDuration(from: source, at: i)
-                            
-                            framesArray.append(decodedImage)
-                            durationsArray.append(duration)
-                        }
-                        
-                        guard !framesArray.isEmpty else {
-                            return continuation.resume(returning: nil)
-                        }
-                        
-                        let animatedData: ProcessedImageData = ProcessedImageData(
-                            type: .animatedImage(
-                                frames: framesArray,
-                                frameDurations: durationsArray
-                            )
-                        )
-                        continuation.resume(returning: animatedData)
+                guard let cgImage: CGImage = try? generator.copyCGImage(at: time, actualTime: nil) else {
+                    return nil
                 }
-            }
+                
+                let image: UIImage = UIImage(cgImage: cgImage)
+                let decodedImage: UIImage = (image.predecodedImage() ?? image)
+                let processedData: ProcessedImageData = ProcessedImageData(
+                    type: .staticImage(decodedImage)
+                )
+                assetInfo?.cleanup()
+                
+                /// Since we generated a new thumbnail we should save it to disk
+                saveThumbnailToDisk(
+                    image: decodedImage,
+                    url: url,
+                    size: .large,
+                    thumbnailManager: thumbnailManager
+                )
+                
+                return processedData
+                
+            /// Custom handle `urlThumbnail` generation
+            case .urlThumbnail(let url, let size, let thumbnailManager):
+                /// If we had already generated a thumbnail then use that
+                if let existingThumbnail: UIImage = thumbnailManager.existingThumbnailImage(url: url, size: .large) {
+                    let decodedImage: UIImage = (existingThumbnail.predecodedImage() ?? existingThumbnail)
+                    let processedData: ProcessedImageData = ProcessedImageData(
+                        type: .staticImage(decodedImage)
+                    )
+                    
+                    return processedData
+                }
+                
+                /// Otherwise we need to generate a new one
+                let maxDimensionInPixels: CGFloat = await size.pixelDimension()
+                let options: [CFString: Any] = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                    kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
+                ]
+
+                guard
+                    let format: SUIKImageFormat = dataSource.dataForGuessingImageFormat?.suiKitGuessedImageFormat,
+                    format != .unknown,
+                    let imageSource: CGImageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
+                    let thumbnail: CGImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary)
+                else { return nil }
+                
+                let image: UIImage = UIImage(cgImage: thumbnail)
+                let decodedImage: UIImage = (image.predecodedImage() ?? image)
+                
+                /// Since we generated a new thumbnail we should save it to disk
+                saveThumbnailToDisk(
+                    image: decodedImage,
+                    url: url,
+                    size: size,
+                    thumbnailManager: thumbnailManager
+                )
+                
+                return ProcessedImageData(
+                    type: .staticImage(decodedImage)
+                )
+                
+            case .closureThumbnail(_, _, let imageRetrier):
+                guard let image: UIImage = await imageRetrier() else { return nil }
+                
+                /// Since there is likely custom (external) logic used to retrieve this thumbnail we don't save it to disk as there
+                /// is no way to know if it _should_ change between generations/launches or not
+                let decodedImage: UIImage = (image.predecodedImage() ?? image)
+                
+                return ProcessedImageData(
+                    type: .staticImage(decodedImage)
+                )
+                
+            /// Custom handle `placeholderIcon` generation
+            case .placeholderIcon(let seed, let text, let size):
+                let image: UIImage = PlaceholderIcon.generate(seed: seed, text: text, size: size)
+                let decodedImage: UIImage = (image.predecodedImage() ?? image)
+                
+                return ProcessedImageData(
+                    type: .staticImage(decodedImage)
+                )
+                
+            default: break
+        }
+        
+        /// Otherwise load the data as either a static or animated image (do quick validation checks here - other checks
+        /// require loading the image source anyway so don't bother to include them)
+        guard
+            let imageData: Data = dataSource.imageData,
+            let imageFormat: SUIKImageFormat = imageData.suiKitGuessedImageFormat.nullIfUnknown,
+            (imageFormat != .gif || imageData.suiKitHasValidGifSize),
+            let source: CGImageSource = CGImageSourceCreateWithData(imageData as CFData, nil),
+            CGImageSourceGetCount(source) > 0
+        else { return nil }
+        
+        let count: Int = CGImageSourceGetCount(source)
+        
+        switch count {
+            /// Invalid image
+            case ..<1: return nil
+                
+            /// Static image
+            case 1:
+                guard let cgImage: CGImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+                    return nil
+                }
+                
+                /// Extract image orientation if present
+                var orientation: UIImage.Orientation = .up
+                
+                if
+                    let imageProperties: [CFString: Any] = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+                    let rawCgOrientation: UInt32 = imageProperties[kCGImagePropertyOrientation] as? UInt32,
+                    let cgOrientation: CGImagePropertyOrientation = CGImagePropertyOrientation(rawValue: rawCgOrientation)
+                {
+                    orientation = UIImage.Orientation(cgOrientation)
+                }
+                
+                let image: UIImage = UIImage(cgImage: cgImage, scale: 1, orientation: orientation)
+                let decodedImage: UIImage = (image.predecodedImage() ?? image)
+                
+                return ProcessedImageData(
+                    type: .staticImage(decodedImage)
+                )
+                
+            /// Animated Image
+            default:
+                var framesArray: [UIImage] = []
+                var durationsArray: [TimeInterval] = []
+                
+                for i in 0..<count {
+                    guard let cgImage: CGImage = CGImageSourceCreateImageAtIndex(source, i, nil) else {
+                        /// If a frame fails then use the previous frame as a fallback, otherwise fail as it was the first frame
+                        /// which failed
+                        guard
+                            let lastFrame: UIImage = framesArray.last,
+                            let lastDuration: TimeInterval = durationsArray.last
+                        else { return nil }
+                        
+                        framesArray.append(lastFrame)
+                        durationsArray.append(lastDuration)
+                        continue
+                    }
+                    
+                    let image: UIImage = UIImage(cgImage: cgImage)
+                    let decodedImage: UIImage = (image.predecodedImage() ?? image)
+                    let duration: TimeInterval = ImageDataManager.getFrameDuration(from: source, at: i)
+                    
+                    framesArray.append(decodedImage)
+                    durationsArray.append(duration)
+                }
+                
+                guard !framesArray.isEmpty else { return nil }
+                
+                return ProcessedImageData(
+                    type: .animatedImage(
+                        frames: framesArray,
+                        frameDurations: durationsArray
+                    )
+                )
         }
     }
     
@@ -238,6 +327,20 @@ public actor ImageDataManager: ImageDataManagerType {
         
         return 0.1  /// Fallback
     }
+    
+    private static func saveThumbnailToDisk(
+        image: UIImage,
+        url: URL,
+        size: ImageDataManager.ThumbnailSize,
+        thumbnailManager: ThumbnailManager
+    ) {
+        /// Don't want to block updating the UI so detatch this task
+        Task.detached(priority: .background) {
+            guard let data: Data = image.jpegData(compressionQuality: 0.85) else { return }
+            
+            thumbnailManager.saveThumbnail(data: data, size: size, url: url)
+        }
+    }
 }
 
 // MARK: - ImageDataManager.DataSource
@@ -245,18 +348,67 @@ public actor ImageDataManager: ImageDataManagerType {
 public extension ImageDataManager {
     enum DataSource: Sendable, Equatable, Hashable {
         case url(URL)
-        case data(Data)
+        case data(String, Data)
         case image(String, UIImage?)
-        case videoUrl(URL)
-        case closure(@Sendable () -> Data?)
+        case videoUrl(URL, String, String?, ThumbnailManager)
+        case urlThumbnail(URL, ImageDataManager.ThumbnailSize, ThumbnailManager)
+        case closureThumbnail(String, ImageDataManager.ThumbnailSize, @Sendable () async -> UIImage?)
+        case placeholderIcon(seed: String, text: String, size: CGFloat)
+        
+        @available(*, deprecated, message: "This DataSource has been deprecated and will be removed in a future release. Use an altername DataSource instead.")
+        case closure(String, @Sendable () -> Data?)
+        
+        public var identifier: String {
+            switch self {
+                case .url(let url): return url.absoluteString
+                case .data(let identifier, _): return identifier
+                case .image(let identifier, _): return identifier
+                case .videoUrl(let url, _, _, _): return url.absoluteString
+                case .urlThumbnail(let url, let size, _):
+                    return "\(url.absoluteString)-\(size)"
+                
+                case .closureThumbnail(let identifier, let size, _):
+                    return "\(identifier)-\(size)"
+                
+                case .placeholderIcon(let seed, let text, let size):
+                    let content: (intSeed: Int, initials: String) = PlaceholderIcon.content(
+                        seed: seed,
+                        text: text
+                    )
+                    
+                    return "\(seed)-\(content.initials)-\(Int(floor(size)))"
+                    
+                case .closure(let identifier, _): return identifier
+            }
+        }
         
         public var imageData: Data? {
             switch self {
                 case .url(let url): return try? Data(contentsOf: url, options: [.dataReadingMapped])
-                case .data(let data): return data
+                case .data(_, let data): return data
                 case .image(_, let image): return image?.pngData()
                 case .videoUrl: return nil
-                case .closure(let dataRetriever): return dataRetriever()
+                case .urlThumbnail: return nil
+                case .closureThumbnail: return nil
+                case .placeholderIcon: return nil
+                    
+                case .closure(_, let dataRetriever): return dataRetriever()
+            }
+        }
+        
+        public var dataForGuessingImageFormat: Data? {
+            switch self {
+                case .url(let url), .urlThumbnail(let url, _, _):
+                    guard let fileHandle: FileHandle = try? FileHandle(forReadingFrom: url) else {
+                        return nil
+                    }
+                    
+                    defer { fileHandle.closeFile() }
+                    return fileHandle.readData(ofLength: 12)
+                    
+                case .data(_, let data): return data
+                case .image, .videoUrl, .closureThumbnail, .placeholderIcon: return nil
+                case .closure: return nil
             }
         }
         
@@ -270,27 +422,78 @@ public extension ImageDataManager {
         public static func == (lhs: DataSource, rhs: DataSource) -> Bool {
             switch (lhs, rhs) {
                 case (.url(let lhsUrl), .url(let rhsUrl)): return (lhsUrl == rhsUrl)
-                case (.data(let lhsData), .data(let rhsData)): return (lhsData == rhsData)
+                case (.data(let lhsIdentifier, let lhsData), .data(let rhsIdentifier, let rhsData)):
+                    return (
+                        lhsIdentifier == rhsIdentifier &&
+                        lhsData == rhsData
+                    )
                 case (.image(let lhsIdentifier, _), .image(let rhsIdentifier, _)):
                     /// `UIImage` is not _really_ equatable so we need to use a separate identifier to use instead
                     return (lhsIdentifier == rhsIdentifier)
                     
-                case (.videoUrl(let lhsUrl), .videoUrl(let rhsUrl)): return (lhsUrl == rhsUrl)
-                case (.closure, .closure): return false
+                case (.videoUrl(let lhsUrl, let lhsMimeType, let lhsSourceFilename, _), .videoUrl(let rhsUrl, let rhsMimeType, let rhsSourceFilename, _)):
+                    return (
+                        lhsUrl == rhsUrl &&
+                        lhsMimeType == rhsMimeType &&
+                        lhsSourceFilename == rhsSourceFilename
+                    )
+                    
+                case (.urlThumbnail(let lhsUrl, let lhsSize, _), .urlThumbnail(let rhsUrl, let rhsSize, _)):
+                    return (
+                        lhsUrl == rhsUrl &&
+                        lhsSize == rhsSize
+                    )
+                    
+                case (.closureThumbnail(let lhsIdentifier, let lhsSize, _), .closureThumbnail(let rhsIdentifier, let rhsSize, _)):
+                    return (
+                        lhsIdentifier == rhsIdentifier &&
+                        lhsSize == rhsSize
+                    )
+                    
+                case (.placeholderIcon(let lhsSeed, let lhsText, let lhsSize), .placeholderIcon(let rhsSeed, let rhsText, let rhsSize)):
+                    return (
+                        lhsSeed == rhsSeed &&
+                        lhsText == rhsText &&
+                        lhsSize == rhsSize
+                    )
+                    
+                case (.closure(let lhsIdentifier, _), .closure(let rhsIdentifier, _)): return (lhsIdentifier == rhsIdentifier)
+                    
                 default: return false
             }
         }
         
         public func hash(into hasher: inout Hasher) {
             switch self {
-                case .url(let url): return url.hash(into: &hasher)
-                case .data(let data): return data.hash(into: &hasher)
+                case .url(let url): url.hash(into: &hasher)
+                case .data(let identifier, let data):
+                    identifier.hash(into: &hasher)
+                    data.hash(into: &hasher)
+                    
                 case .image(let identifier, _):
                     /// `UIImage` is not actually hashable so we need to provide a separate identifier to use instead
-                    return identifier.hash(into: &hasher)
+                    identifier.hash(into: &hasher)
                     
-                case .videoUrl(let url): return url.hash(into: &hasher)
-                case .closure: break
+                case .videoUrl(let url, let mimeType, let sourceFilename, _):
+                    url.hash(into: &hasher)
+                    mimeType.hash(into: &hasher)
+                    sourceFilename.hash(into: &hasher)
+                    
+                case .urlThumbnail(let url, let size, _):
+                    url.hash(into: &hasher)
+                    size.hash(into: &hasher)
+                    
+                case .closureThumbnail(let identifier, let size, _):
+                    identifier.hash(into: &hasher)
+                    size.hash(into: &hasher)
+                    
+                case .placeholderIcon(let seed, let text, let size):
+                    seed.hash(into: &hasher)
+                    text.hash(into: &hasher)
+                    size.hash(into: &hasher)
+                    
+                case .closure(let identifier, _):
+                    identifier.hash(into: &hasher)
             }
         }
     }
@@ -403,7 +606,28 @@ extension AVAsset {
 }
 
 public extension ImageDataManager.DataSource {
+    @MainActor
     var sizeFromMetadata: CGSize? {
+        /// There are a number of types which have fixed sizes, in those cases we should return the target size rather than try to
+        /// read it from data so we doncan avoid processing
+        switch self {
+            case .image(_, let image):
+                guard let image: UIImage = image else { break }
+                
+                return image.size
+                
+            case .urlThumbnail(_, let size, _), .closureThumbnail(_, let size, _):
+                let dimension: CGFloat = size.pixelDimension()
+                return CGSize(width: dimension, height: dimension)
+                
+            case .placeholderIcon(_, _, let size): return CGSize(width: size, height: size)
+                
+            case .url, .data, .videoUrl: break
+                
+            case .closure: break
+        }
+        
+        /// Since we don't have a direct size, try to extract it from the data
         guard
             let imageData: Data = imageData,
             let imageFormat: SUIKImageFormat = imageData.suiKitGuessedImageFormat.nullIfUnknown
@@ -430,16 +654,47 @@ public extension ImageDataManager.DataSource {
     }
 }
 
+// MARK: - ImageDataManager.ThumbnailSize
+
+public extension ImageDataManager {
+    enum ThumbnailSize: String, Sendable {
+        case small
+        case medium
+        case large
+        
+        @MainActor public func pixelDimension() -> CGFloat {
+            let scale: CGFloat = UIScreen.main.scale
+            
+            switch self {
+                case .small: return floor(200 * scale)
+                case .medium: return floor(450 * scale)
+                case .large:
+                    /// This size is large enough to render full screen
+                    let screenSizePoints: CGSize = UIScreen.main.bounds.size
+                    
+                    return floor(max(screenSizePoints.width, screenSizePoints.height) * scale)
+            }
+        }
+    }
+}
+
 // MARK: - ImageDataManagerType
 
 public protocol ImageDataManagerType {
-    @discardableResult func loadImageData(
-        identifier: String,
-        source: ImageDataManager.DataSource
-    ) async -> ImageDataManager.ProcessedImageData?
+    @discardableResult func load(_ source: ImageDataManager.DataSource) async -> ImageDataManager.ProcessedImageData?
+    nonisolated func load(
+        _ source: ImageDataManager.DataSource,
+        onComplete: @escaping (ImageDataManager.ProcessedImageData?) -> Void
+    )
     
-    func cacheImage(_ image: UIImage, for identifier: String) async
     func cachedImage(identifier: String) async -> ImageDataManager.ProcessedImageData?
     func removeImage(identifier: String) async
     func clearCache() async
+}
+
+// MARK: - ThumbnailManager
+
+public protocol ThumbnailManager: Sendable {
+    func existingThumbnailImage(url: URL, size: ImageDataManager.ThumbnailSize) -> UIImage?
+    func saveThumbnail(data: Data, size: ImageDataManager.ThumbnailSize, url: URL)
 }

--- a/SessionUIKit/Utilities/SwiftUI+Utilities.swift
+++ b/SessionUIKit/Utilities/SwiftUI+Utilities.swift
@@ -8,7 +8,7 @@ struct ViewControllerHolder {
 }
 
 struct ViewControllerKey: EnvironmentKey {
-    static var defaultValue: ViewControllerHolder {
+    @MainActor static var defaultValue: ViewControllerHolder {
         return ViewControllerHolder(value: SNUIKit.mainWindow?.rootViewController)
     }
 }

--- a/SessionUtilitiesKit/General/AppContext.swift
+++ b/SessionUtilitiesKit/General/AppContext.swift
@@ -24,7 +24,7 @@ public protocol AppContext: AnyObject {
     var frontMostViewController: UIViewController? { get }
     var backgroundTimeRemaining: TimeInterval { get }
     
-    func setMainWindow(_ mainWindow: UIWindow)
+    @MainActor func setMainWindow(_ mainWindow: UIWindow)
     func ensureSleepBlocking(_ shouldBeBlocking: Bool, blockingObjects: [Any])
     func beginBackgroundTask(expirationHandler: @escaping () -> ()) -> UIBackgroundTaskIdentifier
     func endBackgroundTask(_ backgroundTaskIdentifier: UIBackgroundTaskIdentifier)

--- a/SessionUtilitiesKit/Media/UTType+Utilities.swift
+++ b/SessionUtilitiesKit/Media/UTType+Utilities.swift
@@ -106,6 +106,15 @@ public extension UTType {
     var isText: Bool { UTType.supportedTextTypes.contains(self) }
     var isMicrosoftDoc: Bool { UTType.supportedMicrosoftDocTypes.contains(self) }
     var isVisualMedia: Bool { isImage || isVideo || isAnimated }
+    var sessionMimeType: String? {
+        guard
+            let mimeType: String = preferredMIMEType,
+            let fileExtension: String = UTType.genericMimeTypesToExtensionTypes[mimeType],
+            let targetMimeType: String = UTType.genericExtensionTypesToMimeTypes[fileExtension]
+        else { return preferredMIMEType }
+        
+        return targetMimeType
+    }
     
     // MARK: - Initialization
     

--- a/SessionUtilitiesKit/Utilities/AVURLAsset+Utilities.swift
+++ b/SessionUtilitiesKit/Utilities/AVURLAsset+Utilities.swift
@@ -1,0 +1,71 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import AVFoundation
+
+public extension AVURLAsset {
+    static func asset(for path: String, mimeType: String?, sourceFilename: String?, using dependencies: Dependencies) -> (asset: AVURLAsset, cleanup: () -> Void)? {
+        if #available(iOS 17.0, *) {
+            /// Since `mimeType` can be null we need to try to resolve it to a value
+            let finalMimeType: String
+            
+            switch (mimeType, sourceFilename) {
+                case (.none, .none): return nil
+                case (.some(let mimeType), _): finalMimeType = mimeType
+                case (.none, .some(let sourceFilename)):
+                    guard
+                        let type: UTType = UTType(
+                            sessionFileExtension: URL(fileURLWithPath: sourceFilename).pathExtension
+                        ),
+                        let mimeType: String = type.sessionMimeType
+                    else { return nil }
+                    
+                    finalMimeType = mimeType
+            }
+            
+            return (
+                AVURLAsset(
+                    url: URL(fileURLWithPath: path),
+                    options: [AVURLAssetOverrideMIMETypeKey: finalMimeType]
+                ),
+                {}
+            )
+        }
+        else {
+            /// Since `mimeType` and/or `sourceFilename` can be null we need to try to resolve them both to values
+            let finalExtension: String
+            
+            switch (mimeType, sourceFilename) {
+                case (.none, .none): return nil
+                case (.none, .some(let sourceFilename)):
+                    guard
+                        let type: UTType = UTType(
+                            sessionFileExtension: URL(fileURLWithPath: sourceFilename).pathExtension
+                        ),
+                        let fileExtension: String = type.sessionFileExtension(sourceFilename: sourceFilename)
+                    else { return nil }
+                    
+                    finalExtension = fileExtension
+                    
+                case (.some(let mimeType), let sourceFilename):
+                    guard
+                        let fileExtension: String = UTType(sessionMimeType: mimeType)?
+                            .sessionFileExtension(sourceFilename: sourceFilename)
+                    else { return nil }
+                    
+                    finalExtension = fileExtension
+            }
+            
+            let tmpPath: String = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(URL(fileURLWithPath: path).lastPathComponent)
+                .appendingPathExtension(finalExtension)
+                .path
+            
+            try? dependencies[singleton: .fileManager].copyItem(atPath: path, toPath: tmpPath)
+            
+            return (
+                AVURLAsset(url: URL(fileURLWithPath: tmpPath), options: nil),
+                { [dependencies] in try? dependencies[singleton: .fileManager].removeItem(atPath: tmpPath) }
+            )
+        }
+    }
+}

--- a/SignalUtilitiesKit/Media Viewing & Editing/MediaMessageView.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/MediaMessageView.swift
@@ -142,7 +142,7 @@ public class MediaMessageView: UIView {
             if let imageData: Data = validImageData, let dataUrl: URL = attachment.dataUrl {
                 view.layer.minificationFilter = .trilinear
                 view.layer.magnificationFilter = .trilinear
-                view.loadImage(identifier: dataUrl.absoluteString, from: imageData)
+                view.loadImage(.data(dataUrl.absoluteString, imageData))
             }
             else {
                 view.contentMode = .scaleAspectFit


### PR DESCRIPTION
- Added the SwiftUI `SessionAsyncImage` (SwiftUI version of the `SessionImageView`)
- Removed some redundant theme logic from the share extension
- Updated the placeholder icon to use the `ImageDataManager`
- Marked a bunch of functions and closures which should always run on the main thread as `@MainActor`
- Fixed a bug where the CallVC would load display pictures
- Fixed a crash when accessing the nav stack too early
