### PR TITLE
Fixed a couple of cases where we were incorrectly resolving colors

### DIFF
--- a/SessionUIKit/Style Guide/ThemeManager.swift
+++ b/SessionUIKit/Style Guide/ThemeManager.swift
@@ -234,14 +234,19 @@ public enum ThemeManager {
         with primaryColor: Theme.PrimaryColor
     ) -> T? {
         switch value {
-            case .value(let value, let alpha): return T.resolve(value, for: theme)?.alpha(alpha)
+            case .value(let value, let alpha):
+                let color: T? = color(for: value, in: theme, with: primaryColor)
+                return color?.alpha(alpha)
+                
             case .primary: return T.resolve(primaryColor)
             case .explicitPrimary(let explicitPrimary): return T.resolve(explicitPrimary)
             
             case .highlighted(let value, let alwaysDarken):
+                let color: T? = color(for: value, in: theme, with: primaryColor)!
+                
                 switch (currentTheme.interfaceStyle, alwaysDarken) {
-                    case (.light, _), (_, true): return T.resolve(value, for: theme)?.brighten(-0.06)
-                    default: return T.resolve(value, for: theme)?.brighten(0.08)
+                    case (.light, _), (_, true): return color?.brighten(-0.06)
+                    default: return color?.brighten(0.08)
                 }
                 
             case .dynamicForInterfaceStyle(let light, let dark):


### PR DESCRIPTION
Fixed an issue where some colour resolution logic wasn't recursing correctly which would result in the "invalid" color being used:

<img width="172" height="137" alt="Screenshot 2025-08-11 at 9 38 47 am" src="https://github.com/user-attachments/assets/524ea83b-5c57-46a2-af62-125212bb3002" />
<img width="172" height="110" alt="Screenshot 2025-08-11 at 9 39 02 am" src="https://github.com/user-attachments/assets/8ec2555d-e201-4663-9802-3e790755f2e7" />
