### PR TITLE
Fix join community tabbar spacing

### DIFF
--- a/Session/Open Groups/JoinOpenGroupVC.swift
+++ b/Session/Open Groups/JoinOpenGroupVC.swift
@@ -76,7 +76,17 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
         
         setNavBarTitle("communityJoin".localized())
         view.themeBackgroundColor = .backgroundSecondary
-        let navBarHeight: CGFloat = (navigationController?.navigationBar.frame.size.height ?? 0)
+        
+        // Only account for navigation header when view controller
+        // presentation type is `fullScreen`
+        var navBarHeight: CGFloat {
+            switch modalPresentationStyle {
+            case .fullScreen:
+                return navigationController?.navigationBar.frame.size.height ?? 0
+            default:
+                return 0
+            }
+        }
         
         let closeButton = UIBarButtonItem(image: #imageLiteral(resourceName: "X"), style: .plain, target: self, action: #selector(close))
         closeButton.themeTintColor = .textPrimary


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 (Simulator), iOS 18.6
 * iPhone 16 Pro (Simulator), iOS 18.6

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

PR fixes the issue with the Join Community page where navigation and tab bar has too much space between them.

<img width="452" height="856" alt="Screenshot 2025-08-11 at 10 53 17 AM" src="https://github.com/user-attachments/assets/a9628ddb-1b42-4b5c-bb53-bea1303dad20" />


