### PR TITLE
Fixed an issue where attachments would be incorrectly scaled down

### DIFF
--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -1175,42 +1175,39 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
         
         guard
             let firstAttachment: Attachment = mediaAttachments.first,
-            var width: CGFloat = firstAttachment.width.map({ CGFloat($0) }),
-            var height: CGFloat = firstAttachment.height.map({ CGFloat($0) }),
+            let originalWidth: CGFloat = firstAttachment.width.map({ CGFloat($0) }),
+            let originalHeight: CGFloat = firstAttachment.height.map({ CGFloat($0) }),
             mediaAttachments.count == 1,
-            width > 0,
-            height > 0
+            originalWidth > 0,
+            originalHeight > 0
         else { return defaultSize }
         
         // Honor the content aspect ratio for single media
-        let size: CGSize = CGSize(width: width, height: height)
-        var aspectRatio = (size.width / size.height)
+        let originalSize: CGSize = CGSize(width: originalWidth, height: originalHeight)
+        var aspectRatio = (originalSize.width / originalSize.height)
+        
         // Clamp the aspect ratio so that very thin/wide content still looks alright
         let minAspectRatio: CGFloat = 0.35
         let maxAspectRatio = 1 / minAspectRatio
-        let maxSize = CGSize(width: maxMessageWidth, height: maxMessageWidth)
         aspectRatio = aspectRatio.clamp(minAspectRatio, maxAspectRatio)
         
+        // Constraint the image
+        let constraintWidth = min(maxMessageWidth, originalSize.width)
+        let constraintHeight = min(maxMessageWidth, originalSize.height)
+        
+        var finalWidth: CGFloat
+        var finalHeight: CGFloat
+        
         if aspectRatio > 1 {
-            width = maxSize.width
-            height = width / aspectRatio
+            finalWidth = constraintWidth
+            finalHeight = finalWidth / aspectRatio
         }
         else {
-            height = maxSize.height
-            width = height * aspectRatio
+            finalHeight = constraintHeight
+            finalWidth = finalHeight * aspectRatio
         }
         
-        // Don't blow up small images unnecessarily
-        let minSize: CGFloat = 150
-        let shortSourceDimension = min(size.width, size.height)
-        let shortDestinationDimension = min(width, height)
-        
-        if shortDestinationDimension > minSize && shortDestinationDimension > shortSourceDimension {
-            let factor = minSize / shortDestinationDimension
-            width *= factor; height *= factor
-        }
-        
-        return CGSize(width: width, height: height)
+        return CGSize(width: finalWidth, height: finalHeight)
     }
 
     static func getMaxWidth(for cellViewModel: MessageViewModel, includingOppositeGutter: Bool = true) -> CGFloat {


### PR DESCRIPTION
Looks like there is currently a bug where we incorrectly scale images down if their sizes happen to fall between an arbitrary min size (`150px`) and the max message bubble size (`~324px`) - this change fixes the logic to use the provided size instead

<img width="426" height="770" alt="Screenshot 2025-08-11 at 3 40 54 pm" src="https://github.com/user-attachments/assets/ae7232bf-b4f4-4313-a865-68bf295014ba" />
<img width="426" height="721" alt="Screenshot 2025-08-11 at 3 44 33 pm" src="https://github.com/user-attachments/assets/276e4ce4-d70c-49d8-a964-b361aa5e2946" />
