### PR TITLE
Stopped some message types making conversations become visible

### DIFF
--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -400,9 +400,9 @@ public enum MessageReceiver {
         // visible (the only other spot this flag gets set is when sending messages)
         let shouldBecomeVisible: Bool = {
             switch message {
-                case is ReadReceipt: return true
-                case is TypingIndicator: return true
-                case is UnsendRequest: return true
+                case is ReadReceipt: return false
+                case is TypingIndicator: return false
+                case is UnsendRequest: return false
                 case is CallMessage: return (threadId != dependencies[cache: .general].sessionId.hexString)
                     
                 /// These are sent to the one-to-one conversation so they shouldn't make that visible


### PR DESCRIPTION
Looks like there was a bug introduced in the Groups Rebuild release where we unintentionally started making conversations visible after handling these message types where we didn't in the past