### PR TITLE
Fixed an issue where the unread count could incorrectly get reset

### DIFF
--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -62,6 +62,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         
         do {
             let mainAppUnreadCount: Int = try performSetup(notificationInfo)
+            notificationInfo = notificationInfo.with(mainAppUnreadCount: mainAppUnreadCount)
             notificationInfo = try extractNotificationInfo(notificationInfo, mainAppUnreadCount)
             try setupGroupIfNeeded(notificationInfo)
             
@@ -1287,7 +1288,8 @@ private extension NotificationServiceExtension {
             requestId: String? = nil,
             content: UNMutableNotificationContent? = nil,
             contentHandler: ((UNNotificationContent) -> Void)? = nil,
-            metadata: PushNotificationAPI.NotificationMetadata? = nil
+            metadata: PushNotificationAPI.NotificationMetadata? = nil,
+            mainAppUnreadCount: Int? = nil
         ) -> NotificationInfo {
             return NotificationInfo(
                 content: (content ?? self.content),
@@ -1295,7 +1297,7 @@ private extension NotificationServiceExtension {
                 contentHandler: (contentHandler ?? self.contentHandler),
                 metadata: (metadata ?? self.metadata),
                 data: data,
-                mainAppUnreadCount: mainAppUnreadCount
+                mainAppUnreadCount: (mainAppUnreadCount ?? self.mainAppUnreadCount)
             )
         }
     }

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -63,7 +63,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         do {
             let mainAppUnreadCount: Int = try performSetup(notificationInfo)
             notificationInfo = notificationInfo.with(mainAppUnreadCount: mainAppUnreadCount)
-            notificationInfo = try extractNotificationInfo(notificationInfo, mainAppUnreadCount)
+            notificationInfo = try extractNotificationInfo(notificationInfo)
             try setupGroupIfNeeded(notificationInfo)
             
             processedNotification = try processNotification(notificationInfo)
@@ -152,7 +152,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
     
     // MARK: - Notification Handling
     
-    private func extractNotificationInfo(_ info: NotificationInfo, _ mainAppUnreadCount: Int) throws -> NotificationInfo {
+    private func extractNotificationInfo(_ info: NotificationInfo) throws -> NotificationInfo {
         let (maybeData, metadata, result) = PushNotificationAPI.processNotification(
             notificationContent: info.content,
             using: dependencies
@@ -170,7 +170,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                     contentHandler: info.contentHandler,
                     metadata: metadata,
                     data: data,
-                    mainAppUnreadCount: mainAppUnreadCount
+                    mainAppUnreadCount: info.mainAppUnreadCount
                 )
                 
             default: throw NotificationError.processingError(result, metadata)


### PR DESCRIPTION
When receiving a message which was too large we were throwing an error which would result in `completeSilently` getting called, but in this case we hadn't set the `NotificationInfo.mainAppUnreadCount` value yet which would result in it being the default `0` value (so the app badge would end up being reset, or incorrect)

The fix is to set `NotificationInfo.mainAppUnreadCount` immediately before trying to extract the rest of the notification info since we actually have it before that point