### PR TITLE
Fixed an issue where notification settings weren't being respected for PNs

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 		FD37EA1928AC5CCA003AE748 /* NotificationSoundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37EA1828AC5CCA003AE748 /* NotificationSoundViewModel.swift */; };
 		FD39352C28F382920084DADA /* VersionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD39352B28F382920084DADA /* VersionFooterView.swift */; };
 		FD39353628F7C3390084DADA /* _004_FlagMessageHashAsDeletedOrInvalid.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD39353528F7C3390084DADA /* _004_FlagMessageHashAsDeletedOrInvalid.swift */; };
+		FD3937082E4AD3FE00571F17 /* NoopDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3937072E4AD3F800571F17 /* NoopDependency.swift */; };
 		FD3AABE928306BBD00E5099A /* ThreadPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3AABE828306BBD00E5099A /* ThreadPickerViewModel.swift */; };
 		FD3C906727E416AF00CD579F /* BlindedIdLookupSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3C906627E416AF00CD579F /* BlindedIdLookupSpec.swift */; };
 		FD3E0C84283B5835002A425C /* SessionThreadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3E0C83283B5835002A425C /* SessionThreadViewModel.swift */; };
@@ -1983,6 +1984,7 @@
 		FD37EA1828AC5CCA003AE748 /* NotificationSoundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundViewModel.swift; sourceTree = "<group>"; };
 		FD39352B28F382920084DADA /* VersionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionFooterView.swift; sourceTree = "<group>"; };
 		FD39353528F7C3390084DADA /* _004_FlagMessageHashAsDeletedOrInvalid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _004_FlagMessageHashAsDeletedOrInvalid.swift; sourceTree = "<group>"; };
+		FD3937072E4AD3F800571F17 /* NoopDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoopDependency.swift; sourceTree = "<group>"; };
 		FD3AABE828306BBD00E5099A /* ThreadPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPickerViewModel.swift; sourceTree = "<group>"; };
 		FD3C906627E416AF00CD579F /* BlindedIdLookupSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlindedIdLookupSpec.swift; sourceTree = "<group>"; };
 		FD3E0C83283B5835002A425C /* SessionThreadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionThreadViewModel.swift; sourceTree = "<group>"; };
@@ -5012,6 +5014,7 @@
 		FDF01FAE2A9ED0C800CAF969 /* Dependency Injection */ = {
 			isa = PBXGroup;
 			children = (
+				FD3937072E4AD3F800571F17 /* NoopDependency.swift */,
 				FDE7551F2C9BC1A6002A2623 /* CacheConfig.swift */,
 				FDC6D75F2862B3F600B04575 /* Dependencies.swift */,
 				FD2272ED2C3521D6004D8A6C /* FeatureConfig.swift */,
@@ -6405,6 +6408,7 @@
 				FDAA16762AC28A3B00DDBF77 /* UserDefaultsType.swift in Sources */,
 				FDDF074429C3E3D000E5E8B5 /* FetchRequest+Utilities.swift in Sources */,
 				FD7F745B2BAAA35E006DDFD8 /* LibSession.swift in Sources */,
+				FD3937082E4AD3FE00571F17 /* NoopDependency.swift in Sources */,
 				FD74434A2D07CA9F00862443 /* Codable+Utilities.swift in Sources */,
 				FD0559562E026E1B00DC48CE /* ObservingDatabase.swift in Sources */,
 				FD74434B2D07CA9F00862443 /* CGFloat+Utilities.swift in Sources */,

--- a/Session/Notifications/NotificationPresenter.swift
+++ b/Session/Notifications/NotificationPresenter.swift
@@ -31,6 +31,12 @@ public class NotificationPresenter: NSObject, UNUserNotificationCenterDelegate, 
         
         /// Populate the notification settings from `libSession` and the database
         Task.detached(priority: .high) { [weak self] in
+            do { try await dependencies.waitUntilInitialised(cache: .libSession) }
+            catch {
+                Log.error("[NotificationPresenter] Failed to wait until libSession initialised: \(error)")
+                return
+            }
+            
             typealias GlobalSettings = (
                 sound: Preferences.Sound,
                 previewType: Preferences.NotificationPreviewType

--- a/SessionMessagingKit/Calls/NoopSessionCallManager.swift
+++ b/SessionMessagingKit/Calls/NoopSessionCallManager.swift
@@ -2,8 +2,9 @@
 
 import Foundation
 import CallKit
+import SessionUtilitiesKit
 
-internal struct NoopSessionCallManager: CallManagerProtocol {
+internal struct NoopSessionCallManager: CallManagerProtocol, NoopDependency {
     var currentCall: CurrentCallProtocol?
 
     func setCurrentCall(_ call: CurrentCallProtocol?) {}

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -1197,7 +1197,7 @@ public extension LibSessionCacheType {
     }
 }
 
-private final class NoopLibSessionCache: LibSessionCacheType {
+private final class NoopLibSessionCache: LibSessionCacheType, NoopDependency {
     let dependencies: Dependencies
     let userSessionId: SessionId = .invalid
     let isEmpty: Bool = true

--- a/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsManagerType.swift
@@ -413,7 +413,7 @@ public extension NotificationsManagerType {
 
 // MARK: - NoopNotificationsManager
 
-public struct NoopNotificationsManager: NotificationsManagerType {
+public struct NoopNotificationsManager: NotificationsManagerType, NoopDependency {
     public let dependencies: Dependencies
     
     public init(using dependencies: Dependencies) {

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -108,9 +108,6 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         )
         SNMessagingKit.configure(using: dependencies)
         
-        /// The `NotificationServiceExtension` needs custom behaviours for it's notification presenter so set it up here
-        dependencies.set(singleton: .notificationsManager, to: NSENotificationPresenter(using: dependencies))
-        
         /// Cache the users secret key
         dependencies.mutate(cache: .general) {
             $0.setSecretKey(ed25519SecretKey: userMetadata.ed25519SecretKey)
@@ -127,6 +124,12 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
             userEd25519SecretKey: userMetadata.ed25519SecretKey
         )
         dependencies.set(cache: .libSession, to: cache)
+        
+        /// The `NotificationServiceExtension` needs custom behaviours for it's notification presenter so set it up here
+        ///
+        /// **Note:** This **MUST** happen after we have loaded the `libSession` cache as the notification settings are
+        /// stored in there
+        dependencies.set(singleton: .notificationsManager, to: NSENotificationPresenter(using: dependencies))
         
         return userMetadata.unreadCount
     }

--- a/SessionSnodeKit/LibSession/LibSession+Networking.swift
+++ b/SessionSnodeKit/LibSession/LibSession+Networking.swift
@@ -917,7 +917,7 @@ public extension LibSession {
         func snodeCacheSize() -> Int
     }
     
-    class NoopNetworkCache: NetworkCacheType {
+    class NoopNetworkCache: NetworkCacheType, NoopDependency {
         public var isSuspended: Bool { return false }
         public var networkStatus: AnyPublisher<NetworkStatus, Never> {
             Just(NetworkStatus.unknown).eraseToAnyPublisher()

--- a/SessionUtilitiesKit/Dependency Injection/Dependencies.swift
+++ b/SessionUtilitiesKit/Dependency Injection/Dependencies.swift
@@ -40,8 +40,10 @@ public class Dependencies {
     
     // MARK: - Initialization
     
-    public static func createEmpty() -> Dependencies { return Dependencies() }
-    private init() {
+    public static func createEmpty() -> Dependencies { return Dependencies(forTesting: false) }
+    
+    /// This constructor should not be used directly (except for `TestDependencies`), use `Dependencies.createEmpty()` instead
+    internal init(forTesting: Bool) {
         let (stream, continuation) = AsyncStream.makeStream(of: DependencyChange.self)
         dependecyChangeStream = stream
         dependecyChangeContinuation = continuation

--- a/SessionUtilitiesKit/Dependency Injection/Dependencies.swift
+++ b/SessionUtilitiesKit/Dependency Injection/Dependencies.swift
@@ -13,6 +13,10 @@ public class Dependencies {
     @ThreadSafeObject private static var cachedIsRTLRetriever: (requiresMainThread: Bool, retriever: () -> Bool) = (false, { false })
     @ThreadSafeObject private var storage: DependencyStorage = DependencyStorage()
     
+    private typealias DependencyChange = (Dependencies.DependencyStorage.Key, DependencyStorage.Value?)
+    private let dependecyChangeStream: AsyncStream<DependencyChange>
+    private let dependecyChangeContinuation: AsyncStream<DependencyChange>.Continuation
+    
     // MARK: - Subscript Access
     
     public subscript<S>(singleton singleton: SingletonConfig<S>) -> S { getOrCreate(singleton) }
@@ -37,6 +41,11 @@ public class Dependencies {
     // MARK: - Initialization
     
     public static func createEmpty() -> Dependencies { return Dependencies() }
+    private init() {
+        let (stream, continuation) = AsyncStream.makeStream(of: DependencyChange.self)
+        dependecyChangeStream = stream
+        dependecyChangeContinuation = continuation
+    }
     
     // MARK: - Functions
     
@@ -112,7 +121,7 @@ public class Dependencies {
         return elements.popRandomElement()
     }
     
-    // MARK: - Instance replacing
+    // MARK: - Instance management
     
     public func warmCache<M, I>(cache: CacheConfig<M, I>) {
         _ = getOrCreate(cache)
@@ -133,6 +142,26 @@ public class Dependencies {
     
     public static func setIsRTLRetriever(requiresMainThread: Bool, isRTLRetriever: @escaping () -> Bool) {
         _cachedIsRTLRetriever.set(to: (requiresMainThread, isRTLRetriever))
+    }
+    
+    private func waitUntilInitialised(targetKey: Dependencies.DependencyStorage.Key) async throws {
+        /// If we already have an instance (which isn't a `NoopDependency`) then no need to observe the stream
+        guard !_storage.performMap({ $0.instances[targetKey]?.isNoop == false }) else { return }
+        
+        for await (key, instance) in dependecyChangeStream {
+            /// If the target instance has been set (and isn't a `NoopDependency`) then we can stop waiting (observing the stream)
+            if key == targetKey && instance?.isNoop == false {
+                break
+            }
+        }
+    }
+    
+    public func waitUntilInitialised<S>(singleton: SingletonConfig<S>) async throws {
+        try await waitUntilInitialised(targetKey: DependencyStorage.Key.Variant.singleton.key(singleton.identifier))
+    }
+    
+    public func waitUntilInitialised<M, I>(cache: CacheConfig<M, I>) async throws {
+        try await waitUntilInitialised(targetKey: DependencyStorage.Key.Variant.cache.key(cache.identifier))
     }
 }
 
@@ -196,6 +225,7 @@ public extension Dependencies {
         removeValue(feature.identifier, of: .feature)
         
         /// Notify observers
+        dependecyChangeContinuation.yield((key, nil))
         notifyAsync(events: [
             ObservedEvent(key: .feature(feature), value: nil),
             ObservedEvent(key: .featureGroup(feature), value: nil)
@@ -243,6 +273,15 @@ private extension Dependencies {
             case cache(ThreadSafeObject<MutableCacheType>)
             case userDefaults(UserDefaultsType)
             case feature(any FeatureType)
+            
+            var isNoop: Bool {
+                switch self {
+                    case .singleton(let value): return value is NoopDependency
+                    case .userDefaults(let value): return value is NoopDependency
+                    case .feature(let value): return value is NoopDependency
+                    case .cache(let value): return value.performMap { $0 is NoopDependency }
+                }
+            }
             
             func distinctKey(for identifier: String) -> Key {
                 switch self {
@@ -340,18 +379,30 @@ private extension Dependencies {
     
     /// Convenience method to store a dependency instance in memory in a thread-safe way
     @discardableResult private func setValue<T>(_ value: T, typedStorage: DependencyStorage.Value, key: String) -> T {
-        return _storage.performUpdateAndMap { storage in
-            storage.instances[typedStorage.distinctKey(for: key)] = typedStorage
+        let finalKey: DependencyStorage.Key = typedStorage.distinctKey(for: key)
+        let result: T = _storage.performUpdateAndMap { storage in
+            storage.instances[finalKey] = typedStorage
             return (storage, value)
         }
+        
+        /// We generally _shouldn't_ be setting a dependency to a no-op value so log a warning when we do so
+        if typedStorage.isNoop {
+            Log.warn("Setting noop dependency for \(key)")
+        }
+        
+        dependecyChangeContinuation.yield((finalKey, typedStorage))
+        return result
     }
     
     /// Convenience method to remove a dependency instance from memory in a thread-safe way
     private func removeValue(_ key: String, of variant: DependencyStorage.Key.Variant) {
+        let finalKey: DependencyStorage.Key = variant.key(key)
         _storage.performUpdate { storage in
-            storage.instances.removeValue(forKey: variant.key(key))
+            storage.instances.removeValue(forKey: finalKey)
             return storage
         }
+        
+        dependecyChangeContinuation.yield((finalKey, nil))
     }
 }
  

--- a/SessionUtilitiesKit/Dependency Injection/NoopDependency.swift
+++ b/SessionUtilitiesKit/Dependency Injection/NoopDependency.swift
@@ -1,0 +1,5 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+
+public protocol NoopDependency {}

--- a/SessionUtilitiesKit/General/AppContext.swift
+++ b/SessionUtilitiesKit/General/AppContext.swift
@@ -54,7 +54,7 @@ public extension AppContext {
     func endBackgroundTask(_ backgroundTaskIdentifier: UIBackgroundTaskIdentifier) {}
 }
 
-private final class NoopAppContext: AppContext {
+private final class NoopAppContext: AppContext, NoopDependency {
     let mainWindow: UIWindow? = nil
     let frontMostViewController: UIViewController? = nil
     

--- a/_SharedTestUtilities/TestDependencies.swift
+++ b/_SharedTestUtilities/TestDependencies.swift
@@ -105,7 +105,7 @@ public class TestDependencies: Dependencies {
     // MARK: - Initialization
     
     public init(initialState: ((TestDependencies) -> ())? = nil) {
-        super.init()
+        super.init(forTesting: true)
         
         initialState?(self)
     }


### PR DESCRIPTION
Looks like we had an order-of-execution issue where we tried to retrieve settings from `libSession` before it had be properly initialised, testing the fix for this uncovered a few other issues where we were trying to use dependencies before they had been set, these cases have also been addressed

Changes include:
- Added a mechanism to wait for a dependency to be set
- Added a warning log when a dependency gets set to a no-op instance
- Fixed an issue where the `NSENotificationPresenter` would be setup before the `libSession` cache was loaded, resulting in the notification settings always using the default values
- Fixed an issue where the `NotificationPresenter` would be setup before the `libSession` cache was loaded, resulting in incorrect notification settings being stored in the cache
- Fixed an issue where the `NotificationsManager` delegate wouldn't be set on initial launch
- Fixed an issue where we wouldn't check the local network permission on launch because the libSession cache wouldn't have been initialised yet