### PR TITLE
Fix hash id displayed instead of contact name in apple watch call

### DIFF
--- a/Session/Calls/Call Management/SessionCallManager+CXCallController.swift
+++ b/Session/Calls/Call Management/SessionCallManager+CXCallController.swift
@@ -16,7 +16,8 @@ extension SessionCallManager {
         reportOutgoingCall(call)
         
         if callController != nil {
-            let handle = CXHandle(type: .generic, value: call.sessionId)
+            // Show contact name opening outgoing call in apple watch
+            let handle = CXHandle(type: .generic, value: call.contactName)
             let startCallAction = CXStartCallAction(call: call.callId, handle: handle)
             
             startCallAction.isVideo = false

--- a/Session/Calls/Call Management/SessionCallManager+CXCallController.swift
+++ b/Session/Calls/Call Management/SessionCallManager+CXCallController.swift
@@ -16,8 +16,10 @@ extension SessionCallManager {
         reportOutgoingCall(call)
         
         if callController != nil {
-            // Show contact name opening outgoing call in apple watch
-            let handle = CXHandle(type: .generic, value: call.contactName)
+            // Show contact name + session id (truncated...) opening outgoing call in apple watch
+            let callDisplay = generateDisplayForCall(call)
+            
+            let handle = CXHandle(type: .generic, value: callDisplay)
             let startCallAction = CXStartCallAction(call: call.callId, handle: handle)
             
             startCallAction.isVideo = false

--- a/Session/Calls/Call Management/SessionCallManager.swift
+++ b/Session/Calls/Call Management/SessionCallManager.swift
@@ -114,10 +114,13 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
             return
         }
         
+        // Show contact name + session id (truncated...) opening outgoing call in apple watch
+        let callDisplay = generateDisplayForCall(call)
+        
         // Construct a CXCallUpdate describing the incoming call, including the caller.
         let update = CXCallUpdate()
         update.localizedCallerName = callerName
-        update.remoteHandle = CXHandle(type: .generic, value: call.sessionId)
+        update.remoteHandle = CXHandle(type: .generic, value: callDisplay)
         update.hasVideo = false
 
         disableUnsupportedFeatures(callUpdate: update)
@@ -295,5 +298,21 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
             }
             Log.flush()
         }
+    }
+    
+    func generateDisplayForCall(_ call: CurrentCallProtocol) -> String {
+        guard
+            let sessionCall = call as? SessionCall,
+            sessionCall.contactName.isEmpty == false
+        else {
+            /// When contact name is empty display
+            /// ex. 1234...7890
+            return call.sessionId.truncated(prefix: 4, suffix: 4)
+        }
+
+        /// Display contact name + truncated session id prefix 4
+        /// ex. John 1234...
+        let truncatedSessionId = sessionCall.sessionId.truncated(prefix: 4, suffix: 0)
+        return "\(sessionCall.contactName) \(truncatedSessionId)"
     }
 }


### PR DESCRIPTION
### Description
PR fixes the issue where calls transferred to an apple watch does not display the contacts name

<img width="368" height="448" alt="incoming-FA6F57A3-6027-4CAD-B5C9-A7AC3E8A1F2D" src="https://github.com/user-attachments/assets/06bb07ae-04c6-44a6-ae4c-c810f9ed793c" />
