### PR TITLE
Fix accessory labels expansion causing squashed content

### DIFF
--- a/Session/Shared/Views/SessionCell+AccessoryView.swift
+++ b/Session/Shared/Views/SessionCell+AccessoryView.swift
@@ -397,6 +397,7 @@ extension SessionCell {
             label.themeTextColor = .textPrimary
             label.setContentHugging(to: .required)
             label.setCompressionResistance(to: .required)
+            label.numberOfLines = 0
             
             result.addArrangedSubview(imageView)
             result.addArrangedSubview(label)

--- a/Session/Shared/Views/SessionCell.swift
+++ b/Session/Shared/Views/SessionCell.swift
@@ -221,6 +221,9 @@ public class SessionCell: UITableViewCell {
         botSeparatorTrailingConstraint = botSeparator.pin(.trailing, to: .trailing, of: cellBackgroundView)
         botSeparator.pin(.bottom, to: .bottom, of: cellBackgroundView)
         
+        // Limit accessory views horizontal expansion to 40% of the container
+        trailingAccessoryView.set(.width, lessThanOrEqualTo: .width, of: contentView, multiplier: 0.40)
+        
         // Explicitly call this to ensure we have initialised the constraints before we initially
         // layout (if we don't do this then some constraints get created for the first time when
         // updating the cell before the `isActive` value gets set, resulting in breaking constriants)

--- a/Session/Shared/Views/SessionHighlightingBackgroundLabel.swift
+++ b/Session/Shared/Views/SessionHighlightingBackgroundLabel.swift
@@ -24,6 +24,7 @@ public class SessionHighlightingBackgroundLabel: UIView {
         result.themeTextColor = .textPrimary
         result.setContentHugging(to: .required)
         result.setCompressionResistance(to: .required)
+        result.numberOfLines = 0
         
         return result
     }()


### PR DESCRIPTION
### Description

PR fixes the issue where accessory labels are squashing the main content due to it's long text, added a expansion limit (40%) to handle the issue.


<img width="366" height="325" alt="Screenshot 2025-08-15 at 11 55 42 AM" src="https://github.com/user-attachments/assets/ce979505-61d9-4014-98d6-17711ccacd85" />
<img width="397" height="374" alt="Screenshot 2025-08-15 at 11 55 53 AM" src="https://github.com/user-attachments/assets/e6f75578-b517-48b4-88d5-1e2f0f49b0d9" />
