### PR TITLE
Fix unresponsive textfield due to small hit area

### DIFF
--- a/SessionUIKit/Components/SwiftUI/SessionTextField.swift
+++ b/SessionUIKit/Components/SwiftUI/SessionTextField.swift
@@ -11,6 +11,8 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
     @State var textThemeColor: ThemeValue = .textPrimary
     @State fileprivate var textChanged: ((String) -> Void)?
     
+    @FocusState private var isFirstResponder: Bool
+    
     public enum SessionTextFieldType {
         case thin
         case normal
@@ -83,6 +85,8 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
                     .font(font)
                     .foregroundColor(themeColor: textThemeColor)
                     .accessibility(self.accessibility)
+                    .focused($isFirstResponder)
+                    
                 } else {
                     ZStack {
                         TextEditor(text: $text)
@@ -92,6 +96,7 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
                         .accessibility(self.accessibility)
                         .frame(maxHeight: self.height)
                         .padding(.all, -4)
+                        .focused($isFirstResponder)
                         
                         // FIXME: This is a workaround for dynamic height of the TextEditor.
                         Text(text.isEmpty ? placeholder : text)
@@ -117,6 +122,8 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
                 RoundedRectangle(cornerRadius: self.cornerRadius)
                     .stroke(themeColor: isErrorMode ? .danger : .borderSeparator)
             )
+            .contentShape(RoundedRectangle(cornerRadius: self.cornerRadius))
+            .onTapGesture { isFirstResponder = !isFirstResponder } // Added hit test to launch keyboard, currently textfield's hit area is too small
             .onChange(of: text) { newText in
                 error = inputChecker?(newText)
                 textThemeColor = ((newText == lastErroredText || error?.isEmpty == false) ? .danger : .textPrimary)
@@ -127,7 +134,7 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
                     textThemeColor = .danger
                 }
             }
-            
+
             // Error message
             switch self.type {
                 case .thin:

--- a/SessionUIKit/Components/SwiftUI/SessionTextField.swift
+++ b/SessionUIKit/Components/SwiftUI/SessionTextField.swift
@@ -74,6 +74,7 @@ public struct SessionTextField<ExplanationView>: View where ExplanationView: Vie
                     Text(placeholder)
                         .font(.system(size: Values.smallFontSize))
                         .foregroundColor(themeColor: .textSecondary)
+                        .allowsHitTesting(false)
                 }
                 
                 if #available(iOS 16.0, *) {


### PR DESCRIPTION
### Description
PR fixes issue with textfield being unresponsive, Issue was due to small hit or touch area in the textfield  so keyboard is not triggered.
