### PR TITLE
Updated expiresStartedAtMs when message has been sent successfully

### DIFF
--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -10,7 +10,6 @@ extension ContextMenuVC {
     struct ExpirationInfo {
         let expiresStartedAtMs: Double?
         let expiresInSeconds: TimeInterval?
-        let canCountdown: Bool
     }
     
     struct Action {
@@ -104,16 +103,12 @@ extension ContextMenuVC {
         }
 
         static func delete(_ cellViewModel: MessageViewModel, _ delegate: ContextMenuActionDelegate?) -> Action {
-            
-            let canCountdown: Bool  = (!cellViewModel.variant.isOutgoing || ![.sending, .failed].contains(cellViewModel.state))
-            
             return Action(
                 icon: Lucide.image(icon: .trash2, size: 24),
                 title: "delete".localized(),
                 expirationInfo: ExpirationInfo(
                     expiresStartedAtMs: cellViewModel.expiresStartedAtMs,
-                    expiresInSeconds: cellViewModel.expiresInSeconds,
-                    canCountdown: canCountdown
+                    expiresInSeconds: cellViewModel.expiresInSeconds
                 ),
                 themeColor: .danger,
                 shouldDismissInfoScreen: true,

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -10,6 +10,7 @@ extension ContextMenuVC {
     struct ExpirationInfo {
         let expiresStartedAtMs: Double?
         let expiresInSeconds: TimeInterval?
+        let canCountdown: Bool
     }
     
     struct Action {
@@ -103,12 +104,21 @@ extension ContextMenuVC {
         }
 
         static func delete(_ cellViewModel: MessageViewModel, _ delegate: ContextMenuActionDelegate?) -> Action {
+            
+            let canCountdown: Bool = {
+                guard cellViewModel.variant.isOutgoing else { return true }
+                    
+                let state = cellViewModel.state
+                return state != .sending && state != .failed
+            }()
+            
             return Action(
                 icon: Lucide.image(icon: .trash2, size: 24),
                 title: "delete".localized(),
                 expirationInfo: ExpirationInfo(
                     expiresStartedAtMs: cellViewModel.expiresStartedAtMs,
-                    expiresInSeconds: cellViewModel.expiresInSeconds
+                    expiresInSeconds: cellViewModel.expiresInSeconds,
+                    canCountdown: canCountdown
                 ),
                 themeColor: .danger,
                 shouldDismissInfoScreen: true,

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -105,12 +105,7 @@ extension ContextMenuVC {
 
         static func delete(_ cellViewModel: MessageViewModel, _ delegate: ContextMenuActionDelegate?) -> Action {
             
-            let canCountdown: Bool = {
-                guard cellViewModel.variant.isOutgoing else { return true }
-                    
-                let state = cellViewModel.state
-                return state != .sending && state != .failed
-            }()
+            let canCountdown: Bool  = (!cellViewModel.variant.isOutgoing || ![.sending, .failed].contains(cellViewModel.state))
             
             return Action(
                 icon: Lucide.image(icon: .trash2, size: 24),

--- a/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
@@ -119,9 +119,10 @@ extension ContextMenuVC {
         }
         
         private func setUpSubtitle() {
-            guard 
-                let expiresInSeconds = self.action.expirationInfo?.expiresInSeconds,
-                let expiresStartedAtMs = self.action.expirationInfo?.expiresStartedAtMs
+            guard
+                let expirationInfo = self.action.expirationInfo,
+                let expiresInSeconds = expirationInfo.expiresInSeconds,
+                let expiresStartedAtMs = expirationInfo.expiresStartedAtMs
             else {
                 subtitleLabel.isHidden = true
                 subtitleWidthConstraint.isActive = false
@@ -130,11 +131,22 @@ extension ContextMenuVC {
             
             subtitleLabel.isHidden = false
             subtitleWidthConstraint.isActive = true
+            
             // To prevent a negative timer
-            let timeToExpireInSeconds: TimeInterval =  max(0, (expiresStartedAtMs + expiresInSeconds * 1000 - dependencies[cache: .snodeAPI].currentOffsetTimestampMs()) / 1000)
+            var timeToExpireInSeconds: TimeInterval {
+                // If canCountdown = false, use base expiration timer value
+                guard expirationInfo.canCountdown else {
+                    return expiresInSeconds
+                }
+                
+                return max(0, (expiresStartedAtMs + expiresInSeconds * 1000 - dependencies[cache: .snodeAPI].currentOffsetTimestampMs()) / 1000)
+            }
+            
             subtitleLabel.text = "disappearingMessagesCountdownBigMobile"
-                .put(key: "time_large", value: timeToExpireInSeconds.formatted(format: .twoUnits))
+                .put(key: "time_large", value: timeToExpireInSeconds.formatted(format: .twoUnits, minimumUnit:  expirationInfo.canCountdown ? .second : .minute))
                 .localized()
+            
+            guard expirationInfo.canCountdown else { return }
             
             timer = Timer.scheduledTimerOnMainThread(withTimeInterval: 1, repeats: true, using: dependencies, block: { [weak self, dependencies] _ in
                 let timeToExpireInSeconds: TimeInterval =  (expiresStartedAtMs + expiresInSeconds * 1000 - dependencies[cache: .snodeAPI].currentOffsetTimestampMs()) / 1000

--- a/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
@@ -121,8 +121,8 @@ extension ContextMenuVC {
         private func setUpSubtitle() {
             guard
                 let expirationInfo = self.action.expirationInfo,
-                let expiresInSeconds = expirationInfo.expiresInSeconds,
-                let expiresStartedAtMs = expirationInfo.expiresStartedAtMs
+                let expiresStartedAtMs = expirationInfo.expiresStartedAtMs,
+                let expiresInSeconds = expirationInfo.expiresInSeconds
             else {
                 subtitleLabel.isHidden = true
                 subtitleWidthConstraint.isActive = false
@@ -133,20 +133,11 @@ extension ContextMenuVC {
             subtitleWidthConstraint.isActive = true
             
             // To prevent a negative timer
-            var timeToExpireInSeconds: TimeInterval {
-                // If canCountdown = false, use base expiration timer value
-                guard expirationInfo.canCountdown else {
-                    return expiresInSeconds
-                }
-                
-                return max(0, (expiresStartedAtMs + expiresInSeconds * 1000 - dependencies[cache: .snodeAPI].currentOffsetTimestampMs()) / 1000)
-            }
+            let timeToExpireInSeconds = max(0, (expiresStartedAtMs + expiresInSeconds * 1000 - dependencies[cache: .snodeAPI].currentOffsetTimestampMs()) / 1000)
             
             subtitleLabel.text = "disappearingMessagesCountdownBigMobile"
-                .put(key: "time_large", value: timeToExpireInSeconds.formatted(format: .twoUnits, minimumUnit:  expirationInfo.canCountdown ? .second : .minute))
+                .put(key: "time_large", value: timeToExpireInSeconds.formatted(format: .twoUnits, minimumUnit: .second))
                 .localized()
-            
-            guard expirationInfo.canCountdown else { return }
             
             timer = Timer.scheduledTimerOnMainThread(withTimeInterval: 1, repeats: true, using: dependencies, block: { [weak self, dependencies] _ in
                 let timeToExpireInSeconds: TimeInterval =  (expiresStartedAtMs + expiresInSeconds * 1000 - dependencies[cache: .snodeAPI].currentOffsetTimestampMs()) / 1000

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -741,9 +741,6 @@ public class ConversationViewModel: OWSAudioPlayerDelegate, NavigatableStateHold
                 body: text
             ),
             expiresInSeconds: threadData.disappearingMessagesConfiguration?.expiresInSeconds(),
-            expiresStartedAtMs: threadData.disappearingMessagesConfiguration?.initialExpiresStartedAtMs(
-                sentTimestampMs: Double(sentTimestampMs)
-            ),
             linkPreviewUrl: linkPreviewDraft?.urlString,
             isProMessage: dependencies[cache: .libSession].isSessionPro,
             using: dependencies

--- a/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
@@ -214,8 +214,8 @@ extension MessageSender {
                         // from the correct time.
                         var scheduledTimestampForDeletion: Double? {
                             guard interaction.isExpiringMessage else { return nil }
-                            let sentTimestampMs: Int64 = dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
-                            return Double(sentTimestampMs)
+                            let sentTimestampMs: Double = dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
+                            return sentTimestampMs
                         }
                     
                         try interaction.with(

--- a/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
@@ -209,6 +209,15 @@ extension MessageSender {
                         try interaction.with(state: .sent).update(db)
                     
                     case (true, .syncMessage), (_, .contact), (_, .closedGroup), (_, .openGroup), (_, .openGroupInbox):
+                        // The timestamp to use for scheduling message deletion. This is generated
+                        // when the message is successfully sent to ensure the deletion timer starts
+                        // from the correct time.
+                        var scheduledTimestampForDeletion: Double? {
+                            guard interaction.isExpiringMessage else { return nil }
+                            let sentTimestampMs: Int64 = dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
+                            return Double(sentTimestampMs)
+                        }
+                    
                         try interaction.with(
                             serverHash: message.serverHash,
                             // Track the open group server message ID and update server timestamp (use server
@@ -218,6 +227,7 @@ extension MessageSender {
                                 nil :
                                 serverTimestampMs.map { Int64($0) }
                             ),
+                            expiresStartedAtMs: scheduledTimestampForDeletion, // Updates the expiresStartedAtMs value when message is marked as sent
                             openGroupServerMessageId: message.openGroupServerMessageId.map { Int64($0) },
                             state: .sent
                         ).update(db)
@@ -240,7 +250,7 @@ extension MessageSender {
                         
                             if
                                 case .syncMessage = destination,
-                                let startedAtMs: Double = interaction.expiresStartedAtMs,
+                                let startedAtMs: Double = scheduledTimestampForDeletion,
                                 let expiresInSeconds: TimeInterval = interaction.expiresInSeconds,
                                 let serverHash: String = message.serverHash
                             {


### PR DESCRIPTION
### Description

PR handles the scenario where expired timer runs even if message has not been sent yet. Expiration timer now only runs when outgoing message is sent successfully
