### PR TITLE
Fixed an issue with the home screen empty state and MR banner

### DIFF
--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -363,7 +363,7 @@ public class HomeViewModel: NavigatableStateHolder {
         
         /// Generate the new state
         return State(
-            viewState: (loadResult.info.totalCount == 0 ?
+            viewState: (loadResult.info.totalCount == 0 && unreadMessageRequestThreadCount == 0 ?
                 .empty(isNewUser: (startedAsNewUser && !hasSavedThread && !hasSavedMessage)) :
                 .loaded
             ),


### PR DESCRIPTION
Looks like we weren't taking the message requests banner into account when determining whether the home screen should be in it's empty state - this PR fixes that issue

**Before:**
<img width="250" height="445" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-08-25 at 14 11 06" src="https://github.com/user-attachments/assets/a7160135-57a9-4e2e-9e9b-271cd4c1862b" />

**After**
<img width="250" height="445" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-08-25 at 14 10 31" src="https://github.com/user-attachments/assets/f2b9e917-518d-4c04-8e4b-d8a34e207b93" />
