### PR TITLE
Centralised message deletion logic

### DIFF
--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -2991,10 +2991,11 @@ extension ConversationVC {
                     .writePublisher { [dependencies = viewModel.dependencies] db in
                         /// Remove any existing `infoGroupInfoInvited` interactions from the group (don't want to have a
                         /// duplicate one from inside the group history)
-                        _ = try Interaction
-                            .filter(Interaction.Columns.threadId == group.id)
+                        try Interaction.deleteWhere(
+                            db,
+                            .filter(Interaction.Columns.threadId == group.id),
                             .filter(Interaction.Columns.variant == Interaction.Variant.infoGroupInfoInvited)
-                            .deleteAll(db)
+                        )
                         
                         /// Optimistically insert a `standard` member for the current user in this group (it'll be update to the correct
                         /// one once we receive the first `GROUP_MEMBERS` config message but adding it here means the `canWrite`

--- a/Session/Media Viewing & Editing/MediaPageViewController.swift
+++ b/Session/Media Viewing & Editing/MediaPageViewController.swift
@@ -592,10 +592,11 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
                 )
                 
                 // Delete any interactions which had all of their attachments removed
-                _ = try Interaction
-                    .filter(id: itemToDelete.interactionId)
-                    .having(Interaction.interactionAttachments.isEmpty)
-                    .deleteAll(db)
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(Interaction.Columns.id == itemToDelete.interactionId),
+                    .hasAttachments(false)
+                )
             }
         }
         actionSheet.addAction(UIAlertAction(title: "cancel".localized(), style: .cancel))

--- a/Session/Media Viewing & Editing/MediaTileViewController.swift
+++ b/Session/Media Viewing & Editing/MediaTileViewController.swift
@@ -733,16 +733,12 @@ public class MediaTileViewController: UIViewController, UICollectionViewDataSour
                 )
                 
                 // Delete any interactions which had all of their attachments removed
-                try items.forEach { item in
-                    let remainingAttachmentCount: Int = try InteractionAttachment
-                        .filter(InteractionAttachment.Columns.interactionId == item.interactionId)
-                        .fetchCount(db)
-                    
-                    if remainingAttachmentCount == 0 {
-                        _ = try Interaction.deleteOne(db, id: item.interactionId)
-                        db.addMessageEvent(id: item.interactionId, threadId: threadId, type: .deleted)
-                    }
-                }
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(items.map { $0.interactionId }.contains(Interaction.Columns.id)),
+                    .filter(Interaction.Columns.threadId == threadId),
+                    .hasAttachments(false)
+                )
             }
             
             self?.endSelectMode()

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -463,7 +463,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         /// We need to do a clean up for disappear after send messages that are received by push notifications before
         /// the app set up the main screen and load initial data to prevent a case when the PagedDatabaseObserver
         /// hasn't been setup yet then the conversation screen can show stale (ie. deleted) interactions incorrectly
-        DisappearingMessagesJob.cleanExpiredMessagesOnLaunch(using: dependencies)
+        DisappearingMessagesJob.cleanExpiredMessagesOnResume(using: dependencies)
         
         /// Now that the database is setup we can load in any messages which were processed by the extensions (flag that we will load
         /// them in this thread and create a task to _actually_ load them asynchronously

--- a/SessionMessagingKit/Database/Models/ClosedGroup.swift
+++ b/SessionMessagingKit/Database/Models/ClosedGroup.swift
@@ -334,19 +334,7 @@ public extension ClosedGroup {
         }
         
         if dataToRemove.contains(.messages) {
-            struct InteractionThreadInfo: Codable, FetchableRecord, Hashable {
-                let id: Int64
-                let threadId: String
-            }
-            
-            let interactionInfo: Set<InteractionThreadInfo> = try Interaction
-                .select(.id, .threadId)
-                .filter(threadIds.contains(Interaction.Columns.threadId))
-                .asRequest(of: InteractionThreadInfo.self)
-                .fetchSet(db)
-            try Interaction.deleteAll(db, ids: interactionInfo.map { $0.id })
-            
-            interactionInfo.forEach { db.addMessageEvent(id: $0.id, threadId: $0.threadId, type: .deleted) }
+            try Interaction.deleteWhere(db, .filter(threadIds.contains(Interaction.Columns.threadId)))
             
             /// Delete any `MessageDeduplication` entries that we want to reprocess if the member gets
             /// re-invited to the group with historic access (these are repeatable records so won't cause issues if we re-run them)
@@ -381,6 +369,7 @@ public extension ClosedGroup {
         }
         
         if dataToRemove.contains(.thread) {
+            try Interaction.deleteWhere(db, .filter(threadIds.contains(Interaction.Columns.threadId)))
             try SessionThread   // Intentionally use `deleteAll` here as this gets triggered via `deleteOrLeave`
                 .filter(ids: threadIds)
                 .deleteAll(db)

--- a/SessionMessagingKit/Database/Models/DisappearingMessageConfiguration.swift
+++ b/SessionMessagingKit/Database/Models/DisappearingMessageConfiguration.swift
@@ -266,7 +266,7 @@ public extension DisappearingMessagesConfiguration {
                     .filter(Interaction.Columns.threadId == threadId),
                     .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
                     .filter(Interaction.Columns.authorId == userSessionId.hexString),
-                    .filter(Interaction.Columns.expiresInSeconds != 0),
+                    .filter(Interaction.Columns.expiresInSeconds != 0)
                 )
                 
             case (true, .disappearAfterRead):
@@ -322,7 +322,7 @@ public extension DisappearingMessagesConfiguration {
                 try Interaction.deleteWhere(
                     db,
                     .filter(Interaction.Columns.threadId == threadId),
-                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
+                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
                 )
             case .community: break
         }

--- a/SessionMessagingKit/Database/Models/DisappearingMessageConfiguration.swift
+++ b/SessionMessagingKit/Database/Models/DisappearingMessageConfiguration.swift
@@ -248,11 +248,12 @@ public extension DisappearingMessagesConfiguration {
         using dependencies: Dependencies
     ) throws {
         guard threadVariant == .contact else {
-            try Interaction
-                .filter(Interaction.Columns.threadId == self.threadId)
-                .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
+            try Interaction.deleteWhere(
+                db,
+                .filter(Interaction.Columns.threadId == threadId),
+                .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
                 .filter(Interaction.Columns.expiresInSeconds != self.durationSeconds)
-                .deleteAll(db)
+            )
             return
         }
         
@@ -260,28 +261,41 @@ public extension DisappearingMessagesConfiguration {
         
         switch (self.isEnabled, self.type) {
             case (false, _):
-                try Interaction
-                    .filter(Interaction.Columns.threadId == self.threadId)
-                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
-                    .filter(Interaction.Columns.authorId == userSessionId.hexString)
-                    .filter(Interaction.Columns.expiresInSeconds != 0)
-                    .deleteAll(db)
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(Interaction.Columns.threadId == threadId),
+                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
+                    .filter(Interaction.Columns.authorId == userSessionId.hexString),
+                    .filter(Interaction.Columns.expiresInSeconds != 0),
+                )
                 
             case (true, .disappearAfterRead):
-                try Interaction
-                    .filter(Interaction.Columns.threadId == self.threadId)
-                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
-                    .filter(Interaction.Columns.authorId == userSessionId.hexString)
-                    .filter(!(Interaction.Columns.expiresInSeconds == self.durationSeconds && Interaction.Columns.expiresStartedAtMs != Interaction.Columns.timestampMs))
-                    .deleteAll(db)
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(Interaction.Columns.threadId == threadId),
+                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
+                    .filter(Interaction.Columns.authorId == userSessionId.hexString),
+                    .filter(
+                        !(
+                            Interaction.Columns.expiresInSeconds == self.durationSeconds &&
+                            Interaction.Columns.expiresStartedAtMs != Interaction.Columns.timestampMs
+                        )
+                    )
+                )
             
             case (true, .disappearAfterSend):
-                try Interaction
-                    .filter(Interaction.Columns.threadId == self.threadId)
-                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
-                    .filter(Interaction.Columns.authorId == userSessionId.hexString)
-                    .filter(!(Interaction.Columns.expiresInSeconds == self.durationSeconds && Interaction.Columns.expiresStartedAtMs == Interaction.Columns.timestampMs))
-                    .deleteAll(db)
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(Interaction.Columns.threadId == threadId),
+                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
+                    .filter(Interaction.Columns.authorId == userSessionId.hexString),
+                    .filter(
+                        !(
+                            Interaction.Columns.expiresInSeconds == self.durationSeconds &&
+                            Interaction.Columns.expiresStartedAtMs == Interaction.Columns.timestampMs
+                        )
+                    )
+                )
                 
             default: break
         }
@@ -298,16 +312,18 @@ public extension DisappearingMessagesConfiguration {
     ) throws -> MessageReceiver.InsertedInteractionInfo? {
         switch threadVariant {
             case .contact:
-                _ = try Interaction
-                    .filter(Interaction.Columns.threadId == threadId)
-                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(Interaction.Columns.threadId == threadId),
+                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
                     .filter(Interaction.Columns.authorId == authorId)
-                    .deleteAll(db)
+                )
             case .legacyGroup, .group:
-                _ = try Interaction
-                    .filter(Interaction.Columns.threadId == threadId)
-                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate)
-                    .deleteAll(db)
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(Interaction.Columns.threadId == threadId),
+                    .filter(Interaction.Columns.variant == Interaction.Variant.infoDisappearingMessagesUpdate),
+                )
             case .community: break
         }
         

--- a/SessionMessagingKit/Database/Models/SessionThread.swift
+++ b/SessionMessagingKit/Database/Models/SessionThread.swift
@@ -582,9 +582,10 @@ public extension SessionThread {
                 
             case .hideContactConversationAndDeleteContentDirectly:
                 // Clear any interactions for the deleted thread
-                _ = try Interaction
+                try Interaction.deleteWhere(
+                    db,
                     .filter(threadIds.contains(Interaction.Columns.threadId))
-                    .deleteAll(db)
+                )
                 
                 // Hide the threads
                 try SessionThread.updateVisibility(
@@ -598,7 +599,13 @@ public extension SessionThread {
                 try MessageDeduplication.deleteIfNeeded(db, threadIds: threadIds, using: dependencies)
             
             case .deleteContactConversationAndMarkHidden:
-                _ = try SessionThread
+                // Clear any interactions for the deleted thread
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(remainingThreadIds.contains(Interaction.Columns.threadId))
+                )
+                
+                try SessionThread
                     .filter(ids: remainingThreadIds)
                     .deleteAll(db)
                 
@@ -620,9 +627,10 @@ public extension SessionThread {
                 // hidden locally rather than deleted)
                 if threadIds.contains(userSessionId.hexString) {
                     // Clear any interactions for the deleted thread
-                    _ = try Interaction
+                    try Interaction.deleteWhere(
+                        db,
                         .filter(Interaction.Columns.threadId == userSessionId.hexString)
-                        .deleteAll(db)
+                    )
                     
                     try SessionThread.updateVisibility(
                         db,
@@ -643,15 +651,20 @@ public extension SessionThread {
                 // custom data for this contact)
                 try LibSession.remove(db, contactIds: Array(remainingThreadIds), using: dependencies)
                 
-                _ = try Profile
+                try Profile
                     .filter(ids: remainingThreadIds)
                     .updateAll(db, Profile.Columns.nickname.set(to: nil))
                 
-                _ = try Contact
+                try Contact
                     .filter(ids: remainingThreadIds)
                     .deleteAll(db)
                 
-                _ = try SessionThread
+                try Interaction.deleteWhere(
+                    db,
+                    .filter(remainingThreadIds.contains(Interaction.Columns.threadId))
+                )
+                
+                try SessionThread
                     .filter(ids: remainingThreadIds)
                     .deleteAll(db)
                 

--- a/SessionMessagingKit/Jobs/DisappearingMessagesJob.swift
+++ b/SessionMessagingKit/Jobs/DisappearingMessagesJob.swift
@@ -35,19 +35,11 @@ public enum DisappearingMessagesJob: JobExecutor {
         var numDeleted: Int = -1
         
         let updatedJob: Job? = dependencies[singleton: .storage].write { db in
-            let interactionInfo: Set<InteractionThreadInfo> = try Interaction
-                .select(.id, .threadId)
-                .filter(Interaction.Columns.expiresStartedAtMs != nil)
+            numDeleted = try Interaction.deleteWhere(
+                db,
+                .filter(Interaction.Columns.expiresStartedAtMs != nil),
                 .filter((Interaction.Columns.expiresStartedAtMs + (Interaction.Columns.expiresInSeconds * 1000)) <= timestampNowMs)
-                .asRequest(of: InteractionThreadInfo.self)
-                .fetchSet(db)
-            try Interaction.filter(interactionInfo.map { $0.id }.contains(Interaction.Columns.id)).deleteAll(db)
-            numDeleted = interactionInfo.count
-            
-            // Notify of the deletion
-            interactionInfo.forEach { info in
-                db.addMessageEvent(id: info.id, threadId: info.threadId, type: .deleted)
-            }
+            )
             
             // Update the next run timestamp for the DisappearingMessagesJob (if the call
             // to 'updateNextRunIfNeeded' returns 'nil' then it doesn't need to re-run so
@@ -73,20 +65,21 @@ private struct InteractionThreadInfo: Codable, FetchableRecord, Hashable {
 // MARK: - Clean expired messages on app launch
 
 public extension DisappearingMessagesJob {
-    static func cleanExpiredMessagesOnLaunch(using dependencies: Dependencies) {
+    static func cleanExpiredMessagesOnResume(using dependencies: Dependencies) {
         guard dependencies[cache: .general].userExists else { return }
         
         let timestampNowMs: Double = dependencies[cache: .snodeAPI].currentOffsetTimestampMs()
         var numDeleted: Int = -1
         
         dependencies[singleton: .storage].write { db in
-            numDeleted = try Interaction
-                .filter(Interaction.Columns.expiresStartedAtMs != nil)
+            numDeleted = try Interaction.deleteWhere(
+                db,
+                .filter(Interaction.Columns.expiresStartedAtMs != nil),
                 .filter((Interaction.Columns.expiresStartedAtMs + (Interaction.Columns.expiresInSeconds * 1000)) <= timestampNowMs)
-                .deleteAll(db)
+            )
         }
         
-        Log.info(.cat, "Deleted \(numDeleted) expired messages on app launch.")
+        Log.info(.cat, "Deleted \(numDeleted) expired messages on app resume.")
     }
 }
 

--- a/SessionMessagingKit/Jobs/GarbageCollectionJob.swift
+++ b/SessionMessagingKit/Jobs/GarbageCollectionJob.swift
@@ -309,11 +309,12 @@ public enum GarbageCollectionJob: JobExecutor {
                 
                 /// Remove interactions which should be disappearing after read but never be read within 14 days
                 if finalTypesToCollect.contains(.expiredUnreadDisappearingMessages) {
-                    _ = try Interaction
-                        .filter(Interaction.Columns.expiresInSeconds != 0)
-                        .filter(Interaction.Columns.expiresStartedAtMs == nil)
+                    try Interaction.deleteWhere(
+                        db,
+                        .filter(Interaction.Columns.expiresInSeconds != 0),
+                        .filter(Interaction.Columns.expiresStartedAtMs == nil),
                         .filter(Interaction.Columns.timestampMs < (timestampNow - fourteenDaysInSeconds) * 1000)
-                        .deleteAll(db)
+                    )
                 }
 
                 if finalTypesToCollect.contains(.expiredPendingReadReceipts) {

--- a/SessionMessagingKit/Jobs/GetExpirationJob.swift
+++ b/SessionMessagingKit/Jobs/GetExpirationJob.swift
@@ -90,9 +90,10 @@ public enum GetExpirationJob: JobExecutor {
                         hashesWithNoExiprationInfo = hashesWithNoExiprationInfo.subtracting(inferredExpiredMessageHashes)
                         
                         if !inferredExpiredMessageHashes.isEmpty {
-                            try Interaction
+                            try Interaction.deleteWhere(
+                                db,
                                 .filter(inferredExpiredMessageHashes.contains(Interaction.Columns.serverHash))
-                                .deleteAll(db)
+                            )
                         }
                         
                         try Interaction

--- a/SessionMessagingKit/Open Groups/OpenGroupManager.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupManager.swift
@@ -323,6 +323,7 @@ public final class OpenGroupManager {
         }
         
         // Remove all the data (everything should cascade delete)
+        _ = try? Interaction.deleteWhere(db, .filter(Interaction.Columns.threadId == openGroupId))
         _ = try? SessionThread
             .filter(id: openGroupId)
             .deleteAll(db)
@@ -656,10 +657,11 @@ public final class OpenGroupManager {
         // Handle any deletions that are needed
         if !messageServerInfoToRemove.isEmpty {
             let messageServerIdsToRemove: [Int64] = messageServerInfoToRemove.map { $0.id }
-            _ = try? Interaction
-                .filter(Interaction.Columns.threadId == openGroup.threadId)
+            _ = try? Interaction.deleteWhere(
+                db,
+                .filter(Interaction.Columns.threadId == openGroup.threadId),
                 .filter(messageServerIdsToRemove.contains(Interaction.Columns.openGroupServerMessageId))
-                .deleteAll(db)
+            )
             
             // Update the seqNo for deletions
             largestValidSeqNo = max(largestValidSeqNo, (messageServerInfoToRemove.map({ $0.seqNo }).max() ?? 0))

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Groups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Groups.swift
@@ -472,10 +472,11 @@ extension MessageReceiver {
         /// If the message is about adding the current user then we should remove any existing `infoGroupInfoInvited` interactions
         /// from the group (don't want to have two different messages indicating the current user was added to the group)
         if messageContainsCurrentUser && message.changeType == .added {
-            _ = try Interaction
-                .filter(Interaction.Columns.threadId == groupSessionId.hexString)
+            try Interaction.deleteWhere(
+                db,
+                .filter(Interaction.Columns.threadId == groupSessionId.hexString),
                 .filter(Interaction.Columns.variant == Interaction.Variant.infoGroupInfoInvited)
-                .deleteAll(db)
+            )
         }
         
         switch messageInfo.infoString(using: dependencies) {
@@ -943,10 +944,11 @@ extension MessageReceiver {
         
         /// Remove any existing `infoGroupInfoInvited` interactions from the group (don't want to have a duplicate one in case
         /// the group was created via a `USER_GROUPS` config when syncing a new device)
-        _ = try Interaction
-            .filter(Interaction.Columns.threadId == groupSessionId.hexString)
+        try Interaction.deleteWhere(
+            db,
+            .filter(Interaction.Columns.threadId == groupSessionId.hexString),
             .filter(Interaction.Columns.variant == Interaction.Variant.infoGroupInfoInvited)
-            .deleteAll(db)
+        )
         
         /// Unline most control messages we don't bother setting expiration values for this message, this is because we won't actually
         /// have the current disappearing messages config as we won't have polled the group yet (and the settings are stored in the

--- a/SessionMessagingKit/Shared Models/MessageViewModel+DeletionActions.swift
+++ b/SessionMessagingKit/Shared Models/MessageViewModel+DeletionActions.swift
@@ -11,7 +11,7 @@ public extension MessageViewModel {
     struct DeletionBehaviours {
         public enum Behaviour {
             case markAsDeleted(ids: [Int64], options: Interaction.DeletionOption, threadId: String, threadVariant: SessionThread.Variant)
-            case deleteFromDatabase(ids: [Int64], threadId: String)
+            case deleteFromDatabase([Int64])
             case cancelPendingSendJobs([Int64])
             case preparedRequest(Network.PreparedRequest<Void>)
         }
@@ -97,14 +97,9 @@ public extension MessageViewModel {
                             )
                         }
                         
-                    case .deleteFromDatabase(let ids, let threadId):
+                    case .deleteFromDatabase(let ids):
                         result = result.flatMapStorageWritePublisher(using: dependencies) { db, _ in
-                            _ = try Interaction
-                                .filter(ids: ids)
-                                .deleteAll(db)
-                            ids.forEach { id in
-                                db.addMessageEvent(id: id, threadId: threadId, type: .deleted)
-                            }
+                            try Interaction.deleteWhere(db, .filter(ids.contains(Interaction.Columns.id)))
                         }
                         
                     case .preparedRequest(let preparedRequest):
@@ -203,13 +198,12 @@ public extension MessageViewModel.DeletionBehaviours {
                                         
                                         /// Control messages and deleted messages should be immediately deleted from the database
                                         .deleteFromDatabase(
-                                            ids: cellViewModels
+                                            cellViewModels
                                                 .filter { viewModel in
                                                     viewModel.variant.isInfoMessage ||
                                                     viewModel.variant.isDeletedMessage
                                                 }
-                                                .map { $0.id },
-                                            threadId: threadData.threadId
+                                                .map { $0.id }
                                         ),
                                         
                                         /// Other message types should only be marked as deleted
@@ -447,10 +441,7 @@ public extension MessageViewModel.DeletionBehaviours {
                     )
                     .appending(threadData.threadIsNoteToSelf ?
                         /// If it's the `Note to Self`conversation then we want to just delete the interaction
-                        .deleteFromDatabase(
-                            ids: cellViewModels.map { $0.id },
-                            threadId: threadData.threadId
-                        ) :
+                        .deleteFromDatabase(cellViewModels.map { $0.id }) :
                         .markAsDeleted(
                             ids: targetViewModels.map { $0.id },
                             options: [.local, .network],
@@ -693,10 +684,7 @@ public extension MessageViewModel.DeletionBehaviours {
                             }
                     )
                     .appending(
-                        .deleteFromDatabase(
-                            ids: cellViewModels.map { $0.id },
-                            threadId: threadData.threadId
-                        )
+                        .deleteFromDatabase(cellViewModels.map { $0.id })
                     )
         }
     }

--- a/SessionMessagingKitTests/Open Groups/OpenGroupManagerSpec.swift
+++ b/SessionMessagingKitTests/Open Groups/OpenGroupManagerSpec.swift
@@ -854,7 +854,7 @@ class OpenGroupManagerSpec: QuickSpec {
             context("when deleting") {
                 beforeEach {
                     mockStorage.write { db in
-                        try Interaction.deleteAll(db)
+                        try Interaction.deleteWhere(db, .deleteAll)
                         try SessionThread.deleteAll(db)
                         
                         try testGroupThread.insert(db)
@@ -1759,7 +1759,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 // MARK: ---- ignores a message with no sender
                 it("ignores a message with no sender") {
                     mockStorage.write { db in
-                        try Interaction.deleteAll(db)
+                        try Interaction.deleteWhere(db, .deleteAll)
                     }
                     
                     mockStorage.write { db in
@@ -1793,7 +1793,7 @@ class OpenGroupManagerSpec: QuickSpec {
                 // MARK: ---- ignores a message with invalid data
                 it("ignores a message with invalid data") {
                     mockStorage.write { db in
-                        try Interaction.deleteAll(db)
+                        try Interaction.deleteWhere(db, .deleteAll)
                     }
                     
                     mockStorage.write { db in


### PR DESCRIPTION
There was a bug where disappearing messages that disappeared while the app was in the background wouldn't trigger a conversation list update. After debugging I found it was because that case wasn't sending a "messageDeleted" event and, after doing a quick search, I found there were a bunch of cases where it wasn't being sent

As a result this PR centralises the message deletion logic and adds a log (and `fatalError` in debug) if the incorrect deletion function is used to prevent this from occurring again in the future

**Note:** In the future we may want to do something similar for all objects which should send CRUD events - now that all database operations are routed via `ObservableDatabase` we actually have hooks into these operations so we could do so (though if the goal is to eventually shift the database into `libSession` then it may not be worth the effort)