### PR TITLE
Fix issue on some device long delete message is not wrapping

### DIFF
--- a/Session/Conversations/Message Cells/Content Views/DeletedMessageView.swift
+++ b/Session/Conversations/Message Cells/Content Views/DeletedMessageView.swift
@@ -33,7 +33,7 @@ final class DeletedMessageView: UIView {
         let imageContainerView: UIView = UIView()
         imageContainerView.set(.width, to: DeletedMessageView.iconImageViewSize)
         imageContainerView.set(.height, to: DeletedMessageView.iconImageViewSize)
-        
+
         let imageView = UIImageView(image: Lucide.image(icon: .trash2, size: DeletedMessageView.iconSize)?.withRenderingMode(.alwaysTemplate))
         imageView.themeTintColor = textColor
         imageView.contentMode = .scaleAspectFit
@@ -45,7 +45,6 @@ final class DeletedMessageView: UIView {
         // Body label
         let titleLabel = UILabel()
         titleLabel.setContentHuggingPriority(.required, for: .vertical)
-        titleLabel.preferredMaxLayoutWidth = maxWidth - 6   // `6` for the `stackView.layoutMargins`
         titleLabel.font = .systemFont(ofSize: Values.smallFontSize)
         titleLabel.text = {
             switch variant {
@@ -69,6 +68,6 @@ final class DeletedMessageView: UIView {
         
         let calculatedSize: CGSize = stackView.systemLayoutSizeFitting(CGSize(width: maxWidth, height: 999))
         stackView.pin(to: self, withInset: Values.smallSpacing)
-        stackView.set(.height, to: calculatedSize.height)
+        stackView.set(.height, greaterThanOrEqualTo: calculatedSize.height)
     }
 }


### PR DESCRIPTION
### Description

PR fixes issue with the delete message bubble not wrapping on some device models. Removed the `preferredMaxLayoutWidth` since it's already in a stack view with a layout margin.

<img width="300" height="87" alt="Screenshot 2025-08-27 at 10 42 29 AM" src="https://github.com/user-attachments/assets/81a40ed1-437e-47fc-9b02-e6eb7656b4fd" />