### PR TITLE
Added skip authentication flags for some group api calls

### DIFF
--- a/SessionMessagingKit/Jobs/DisplayPictureDownloadJob.swift
+++ b/SessionMessagingKit/Jobs/DisplayPictureDownloadJob.swift
@@ -58,8 +58,8 @@ public enum DisplayPictureDownloadJob: JobExecutor {
                             fileId: fileId,
                             roomToken: roomToken,
                             authMethod: Authentication.community(info: info),
-                            using: dependencies,
-                            skipAuthentication: skipAuthentication
+                            skipAuthentication: skipAuthentication,
+                            using: dependencies
                         )
                 }
             }

--- a/SessionMessagingKit/Jobs/DisplayPictureDownloadJob.swift
+++ b/SessionMessagingKit/Jobs/DisplayPictureDownloadJob.swift
@@ -48,7 +48,7 @@ public enum DisplayPictureDownloadJob: JobExecutor {
                             using: dependencies
                         )
                         
-                    case .community(let fileId, let roomToken, let server):
+                    case .community(let fileId, let roomToken, let server, let skipAuthentication):
                         guard
                             let info: LibSession.OpenGroupCapabilityInfo = try? LibSession.OpenGroupCapabilityInfo
                                 .fetchOne(db, id: OpenGroup.idFor(roomToken: roomToken, server: server))
@@ -58,7 +58,8 @@ public enum DisplayPictureDownloadJob: JobExecutor {
                             fileId: fileId,
                             roomToken: roomToken,
                             authMethod: Authentication.community(info: info),
-                            using: dependencies
+                            using: dependencies,
+                            skipAuthentication: skipAuthentication
                         )
                 }
             }
@@ -206,7 +207,7 @@ public enum DisplayPictureDownloadJob: JobExecutor {
                     )
                 db.addConversationEvent(id: id, type: .updated(.displayPictureUrl(url)))
                 
-            case .community(_, let roomToken, let server):
+            case .community(_, let roomToken, let server, _):
                 _ = try? OpenGroup
                     .filter(id: OpenGroup.idFor(roomToken: roomToken, server: server))
                     .updateAllAndConfig(
@@ -228,7 +229,7 @@ extension DisplayPictureDownloadJob {
     public enum Target: Codable, Hashable, CustomStringConvertible {
         case profile(id: String, url: String, encryptionKey: Data)
         case group(id: String, url: String, encryptionKey: Data)
-        case community(imageId: String, roomToken: String, server: String)
+        case community(imageId: String, roomToken: String, server: String, skipAuthentication: Bool = false)
         
         var isValid: Bool {
             switch self {
@@ -239,7 +240,7 @@ extension DisplayPictureDownloadJob {
                         encryptionKey.count == DisplayPictureManager.aes256KeyByteLength
                     )
                     
-                case .community(let imageId, _, _): return !imageId.isEmpty
+                case .community(let imageId, _, _, _): return !imageId.isEmpty
             }
         }
         
@@ -249,7 +250,7 @@ extension DisplayPictureDownloadJob {
             switch self {
                 case .profile(let id, _, _): return "profile: \(id)"
                 case .group(let id, _, _): return "group: \(id)"
-                case .community(_, let roomToken, let server): return "room: \(roomToken) on server: \(server)"
+                case .community(_, let roomToken, let server, _): return "room: \(roomToken) on server: \(server)"
             }
         }
     }
@@ -274,11 +275,12 @@ extension DisplayPictureDownloadJob {
             
             self.target = {
                 switch target {
-                    case .community(let imageId, let roomToken, let server):
+                    case .community(let imageId, let roomToken, let server, let skipAuthentication):
                         return .community(
                             imageId: imageId,
                             roomToken: roomToken,
-                            server: server.lowercased()   // Always in lowercase on `OpenGroup`
+                            server: server.lowercased(),   // Always in lowercase on `OpenGroup`
+                            skipAuthentication: skipAuthentication
                         )
                         
                     default: return target
@@ -358,7 +360,7 @@ extension DisplayPictureDownloadJob {
                     
                     return (url == latestDisplayPictureUrl)
                     
-                case .community(let imageId, let roomToken, let server):
+                case .community(let imageId, let roomToken, let server, _):
                     guard
                         let latestImageId: String = try? OpenGroup
                             .select(.imageId)

--- a/SessionMessagingKit/Jobs/RetrieveDefaultOpenGroupRoomsJob.swift
+++ b/SessionMessagingKit/Jobs/RetrieveDefaultOpenGroupRoomsJob.swift
@@ -72,7 +72,8 @@ public enum RetrieveDefaultOpenGroupRoomsJob: JobExecutor {
             .tryFlatMap { [dependencies] authMethod -> AnyPublisher<(ResponseInfoType, OpenGroupAPI.CapabilitiesAndRoomsResponse), Error> in
                 try OpenGroupAPI.preparedCapabilitiesAndRooms(
                     authMethod: authMethod,
-                    using: dependencies
+                    using: dependencies,
+                    skipAuthentication: true
                 ).send(using: dependencies)
             }
             .subscribe(on: scheduler, using: dependencies)
@@ -157,7 +158,8 @@ public enum RetrieveDefaultOpenGroupRoomsJob: JobExecutor {
                                         target: .community(
                                             imageId: imageId,
                                             roomToken: room.token,
-                                            server: OpenGroupAPI.defaultServer
+                                            server: OpenGroupAPI.defaultServer,
+                                            skipAuthentication: true
                                         ),
                                         timestamp: (dependencies[cache: .snodeAPI].currentOffsetTimestampMs() / 1000)
                                     )

--- a/SessionMessagingKit/Jobs/RetrieveDefaultOpenGroupRoomsJob.swift
+++ b/SessionMessagingKit/Jobs/RetrieveDefaultOpenGroupRoomsJob.swift
@@ -72,8 +72,8 @@ public enum RetrieveDefaultOpenGroupRoomsJob: JobExecutor {
             .tryFlatMap { [dependencies] authMethod -> AnyPublisher<(ResponseInfoType, OpenGroupAPI.CapabilitiesAndRoomsResponse), Error> in
                 try OpenGroupAPI.preparedCapabilitiesAndRooms(
                     authMethod: authMethod,
-                    using: dependencies,
-                    skipAuthentication: true
+                    skipAuthentication: true,
+                    using: dependencies
                 ).send(using: dependencies)
             }
             .subscribe(on: scheduler, using: dependencies)

--- a/SessionMessagingKit/Open Groups/OpenGroupAPI.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupAPI.swift
@@ -165,8 +165,8 @@ public enum OpenGroupAPI {
     private static func preparedSequence(
         requests: [any ErasedPreparedRequest],
         authMethod: AuthenticationMethod,
-        using dependencies: Dependencies,
-        skipAuthentication: Bool = false
+        skipAuthentication: Bool = false,
+        using dependencies: Dependencies
     ) throws -> Network.PreparedRequest<Network.BatchResponseMap<Endpoint>> {
         let preparedRequest = try Network.PreparedRequest(
             request: Request(
@@ -193,8 +193,8 @@ public enum OpenGroupAPI {
     /// could return: `{"capabilities": ["sogs", "batch"], "missing": ["magic"]}`
     public static func preparedCapabilities(
         authMethod: AuthenticationMethod,
-        using dependencies: Dependencies,
-        skipAuthentication: Bool = false
+        skipAuthentication: Bool = false,
+        using dependencies: Dependencies
     ) throws -> Network.PreparedRequest<Capabilities> {
         let preparedRequest = try Network.PreparedRequest(
             request: Request<NoBody, Endpoint>(
@@ -215,8 +215,8 @@ public enum OpenGroupAPI {
     /// Rooms to which the user does not have access (e.g. because they are banned, or the room has restricted access permissions) are not included
     public static func preparedRooms(
         authMethod: AuthenticationMethod,
-        using dependencies: Dependencies,
-        skipAuthentication: Bool = false
+        skipAuthentication: Bool = false,
+        using dependencies: Dependencies
     ) throws -> Network.PreparedRequest<[Room]> {
         let preparedRequest = try Network.PreparedRequest(
             request: Request<NoBody, Endpoint>(
@@ -329,20 +329,20 @@ public enum OpenGroupAPI {
     /// methods for the documented behaviour of each method
     public static func preparedCapabilitiesAndRooms(
         authMethod: AuthenticationMethod,
-        using dependencies: Dependencies,
-        skipAuthentication: Bool = false
+        skipAuthentication: Bool = false,
+        using dependencies: Dependencies
     ) throws -> Network.PreparedRequest<CapabilitiesAndRoomsResponse> {
         let preparedRequest = try OpenGroupAPI
             .preparedSequence(
                 requests: [
                     // Get the latest capabilities for the server (in case it's a new server or the
                     // cached ones are stale)
-                    preparedCapabilities(authMethod: authMethod, using: dependencies, skipAuthentication: skipAuthentication),
-                    preparedRooms(authMethod: authMethod, using: dependencies, skipAuthentication: skipAuthentication)
+                    preparedCapabilities(authMethod: authMethod, skipAuthentication: skipAuthentication, using: dependencies),
+                    preparedRooms(authMethod: authMethod, skipAuthentication: skipAuthentication, using: dependencies)
                 ],
                 authMethod: authMethod,
-                using: dependencies,
-                skipAuthentication: skipAuthentication
+                skipAuthentication: skipAuthentication,
+                using: dependencies
             )
 
         let finalRequest = skipAuthentication ? preparedRequest : try preparedRequest.signed(with: OpenGroupAPI.signRequest, using: dependencies)
@@ -372,7 +372,7 @@ public enum OpenGroupAPI {
                     capabilities: (info: capabilitiesInfo, data: capabilities),
                     rooms: (info: roomsInfo, data: (roomsResponse.body ?? []))
                 )
-        }
+            }
     }
     
     // MARK: - Messages
@@ -847,8 +847,8 @@ public enum OpenGroupAPI {
         fileId: String,
         roomToken: String,
         authMethod: AuthenticationMethod,
-        using dependencies: Dependencies,
-        skipAuthentication: Bool = false
+        skipAuthentication: Bool = false,
+        using dependencies: Dependencies
     ) throws -> Network.PreparedRequest<Data> {
         let preparedRequest = try Network.PreparedRequest(
             request: Request<NoBody, Endpoint>(

--- a/SessionMessagingKitTests/Jobs/RetrieveDefaultOpenGroupRoomsJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/RetrieveDefaultOpenGroupRoomsJobSpec.swift
@@ -263,6 +263,7 @@ class RetrieveDefaultOpenGroupRoomsJobSpec: QuickSpec {
                             ),
                             forceBlinded: false
                         ),
+                        skipAuthentication: true,
                         using: dependencies
                     )
                 }
@@ -284,6 +285,8 @@ class RetrieveDefaultOpenGroupRoomsJobSpec: QuickSpec {
                             requestAndPathBuildTimeout: expectedRequest.requestAndPathBuildTimeout
                         )
                     })
+                
+                expect(expectedRequest?.headers).to(beEmpty())
             }
             
             // MARK: -- will retry 8 times before it fails

--- a/SessionMessagingKitTests/Jobs/RetrieveDefaultOpenGroupRoomsJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/RetrieveDefaultOpenGroupRoomsJobSpec.swift
@@ -438,7 +438,8 @@ class RetrieveDefaultOpenGroupRoomsJobSpec: QuickSpec {
                                     target: .community(
                                         imageId: "12",
                                         roomToken: "testRoom2",
-                                        server: OpenGroupAPI.defaultServer
+                                        server: OpenGroupAPI.defaultServer,
+                                        skipAuthentication: true
                                     ),
                                     timestamp: 1234567890
                                 )
@@ -485,7 +486,8 @@ class RetrieveDefaultOpenGroupRoomsJobSpec: QuickSpec {
                                     target: .community(
                                         imageId: "12",
                                         roomToken: "testRoom2",
-                                        server: OpenGroupAPI.defaultServer
+                                        server: OpenGroupAPI.defaultServer,
+                                        skipAuthentication: true
                                     ),
                                     timestamp: 1234567890
                                 )

--- a/SessionMessagingKitTests/Open Groups/OpenGroupAPISpec.swift
+++ b/SessionMessagingKitTests/Open Groups/OpenGroupAPISpec.swift
@@ -770,6 +770,44 @@ class OpenGroupAPISpec: QuickSpec {
                     
                     expect(preparedRequest?.path).to(equal("/sequence"))
                     expect(preparedRequest?.method.rawValue).to(equal("POST"))
+                    
+                    expect(preparedRequest?.headers).toNot(beEmpty())
+                    expect(preparedRequest?.headers).to(equal([
+                        HTTPHeader.sogsNonce: "pK6YRtQApl4NhECGizF0Cg==",
+                        HTTPHeader.sogsTimestamp: "1234567890",
+                        HTTPHeader.sogsSignature: "VGVzdFNvZ3NTaWduYXR1cmU=",
+                        HTTPHeader.sogsPubKey: "1588672ccb97f40bb57238989226cf429b575ba355443f47bc76c5ab144a96c65b"
+                    ]))
+                }
+                
+                // MARK: ---- generates the request correctly and skips adding request headers
+                it("generates the request correctly and skips adding request headers") {
+                    expect {
+                        preparedRequest = try OpenGroupAPI.preparedCapabilitiesAndRooms(
+                            authMethod: Authentication.community(
+                                info: LibSession.OpenGroupCapabilityInfo(
+                                    roomToken: "",
+                                    server: "testserver",
+                                    publicKey: TestConstants.publicKey,
+                                    capabilities: []
+                                ),
+                                forceBlinded: false
+                            ),
+                            skipAuthentication: true,
+                            using: dependencies
+                        )
+                    }.toNot(throwError())
+                    
+                    expect(preparedRequest?.batchEndpoints.count).to(equal(2))
+                    expect(preparedRequest?.batchEndpoints[test: 0].asType(OpenGroupAPI.Endpoint.self))
+                        .to(equal(.capabilities))
+                    expect(preparedRequest?.batchEndpoints[test: 1].asType(OpenGroupAPI.Endpoint.self))
+                        .to(equal(.rooms))
+                    
+                    expect(preparedRequest?.path).to(equal("/sequence"))
+                    expect(preparedRequest?.method.rawValue).to(equal("POST"))
+                    
+                    expect(preparedRequest?.headers).to(beEmpty())
                 }
                 
                 // MARK: ---- processes a valid response correctly
@@ -1626,6 +1664,31 @@ class OpenGroupAPISpec: QuickSpec {
                     ]))
                 }
                 
+                // MARK: ---- generates the download destination correctly when given an id and skips adding request headers
+                it("generates the download destination correctly when given an id and skips adding request headers") {
+                    expect {
+                        preparedRequest = try OpenGroupAPI.preparedDownload(
+                            fileId: "1",
+                            roomToken: "roomToken",
+                            authMethod: Authentication.community(
+                                info: LibSession.OpenGroupCapabilityInfo(
+                                    roomToken: "",
+                                    server: "testserver",
+                                    publicKey: TestConstants.publicKey,
+                                    capabilities: []
+                                ),
+                                forceBlinded: false
+                            ),
+                            skipAuthentication: true,
+                            using: dependencies
+                        )
+                    }.toNot(throwError())
+                    
+                    expect(preparedRequest?.path).to(equal("/room/roomToken/file/1"))
+                    expect(preparedRequest?.method.rawValue).to(equal("GET"))
+                    expect(preparedRequest?.headers).to(beEmpty())
+                }
+                
                 // MARK: ---- generates the download request correctly when given a URL
                 it("generates the download request correctly when given a URL") {
                     expect {
@@ -2274,6 +2337,40 @@ class OpenGroupAPISpec: QuickSpec {
                         .handleEvents(receiveOutput: { result in response = result })
                         .mapError { error.setting(to: $0) }
                         .sinkAndStore(in: &disposables)
+                    
+                    expect(preparedRequest?.headers).toNot(beEmpty())
+
+                    expect(response).toNot(beNil())
+                    expect(error).to(beNil())
+                }
+                
+                // MARK: ---- triggers sending correctly without headers
+                it("triggers sending correctly without headers") {
+                    var response: (info: ResponseInfoType, data: [OpenGroupAPI.Room])?
+                    
+                    expect {
+                        preparedRequest = try OpenGroupAPI.preparedRooms(
+                            authMethod: Authentication.community(
+                                info: LibSession.OpenGroupCapabilityInfo(
+                                    roomToken: "",
+                                    server: "testserver",
+                                    publicKey: TestConstants.publicKey,
+                                    capabilities: []
+                                ),
+                                forceBlinded: false
+                            ),
+                            skipAuthentication: true,
+                            using: dependencies
+                        )
+                    }.toNot(throwError())
+                    
+                    preparedRequest?
+                        .send(using: dependencies)
+                        .handleEvents(receiveOutput: { result in response = result })
+                        .mapError { error.setting(to: $0) }
+                        .sinkAndStore(in: &disposables)
+                    
+                    expect(preparedRequest?.headers).to(beEmpty())
 
                     expect(response).toNot(beNil())
                     expect(error).to(beNil())


### PR DESCRIPTION
### Description

- Added `skipAuthentication` argument to skip authentication when fetching default rooms and capabilities
- Added `skipAuthentication` argument on default room downloads
- `skipAuthentication == true` will now skip `signed(with:using:)` during request