### PR TITLE
Update message request delete action

### DIFF
--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -649,7 +649,7 @@ public extension UIContextualAction {
                                 guard !isMessageRequest else {
                                     switch threadViewModel.threadVariant {
                                         case .group: return ThemedAttributedString(string: "groupInviteDelete".localized())
-                                        default: return ThemedAttributedString(string: "messageRequestsDelete".localized())
+                                        default: return ThemedAttributedString(string: "messageRequestsContactDelete".localized())
                                     }
                                 }
                                 
@@ -692,7 +692,7 @@ public extension UIContextualAction {
                                                     return .deleteGroupAndContent
                                                 case (.group, _, _): return .leaveGroupAsync
                                                 
-                                                case (.contact, _, _): return .deleteContactConversationAndMarkHidden
+                                                case (.contact, _, _): return .deleteContactConversationAndContact
                                             }
                                         }()
                                         


### PR DESCRIPTION
### Description
- Updated the `Delete` functionality for 1on1 message requests so that it deletes the contact instead of only removing the conversation.
- Updated 1 on 1 delete message request confirmation dialog