### PR TITLE
Removed camera permission request on call start

### DIFF
--- a/Session/Settings/PrivacySettingsViewModel.swift
+++ b/Session/Settings/PrivacySettingsViewModel.swift
@@ -233,7 +233,9 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                     ),
                     confirmationInfo: ConfirmationModal.Info(
                         title: "callsVoiceAndVideoBeta".localized(),
-                        body: .text("callsVoiceAndVideoModalDescription".localized()),
+                        body: .text("callsVoiceAndVideoModalDescription"
+                            .put(key: "session_foundation", value: Constants.session_foundation)
+                            .localized()),
                         showCondition: .disabled,
                         confirmTitle: "theContinue".localized(),
                         confirmStyle: .danger,


### PR DESCRIPTION
### Description
- Removed camera permission on call initialization
- Camera access request only when needed during the call
- Fix missing text parameter on settings privacy dialog
