### PR TITLE
Fix missing `session_foundation` value for voice call dialog

### DIFF
--- a/Session/Settings/PrivacySettingsViewModel.swift
+++ b/Session/Settings/PrivacySettingsViewModel.swift
@@ -233,7 +233,9 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                     ),
                     confirmationInfo: ConfirmationModal.Info(
                         title: "callsVoiceAndVideoBeta".localized(),
-                        body: .text("callsVoiceAndVideoModalDescription".localized()),
+                        body: .text("callsVoiceAndVideoModalDescription"
+                            .put(key: "session_foundation", value: Constants.session_foundation)
+                            .localized()),
                         showCondition: .disabled,
                         confirmTitle: "theContinue".localized(),
                         confirmStyle: .danger,


### PR DESCRIPTION
### Description

- Added missing `session_foundation` value for the call and voice permission request dialog description

![IMG_4AC7463FD053-1](https://github.com/user-attachments/assets/1ce19a84-b5c8-4741-afc2-b568b47a1e71)
