### PR TITLE
Updated disabled conversation input buttons colors

### DIFF
--- a/Session/Conversations/Input View/InputView.swift
+++ b/Session/Conversations/Input View/InputView.swift
@@ -475,8 +475,13 @@ final class InputView: UIView, InputViewButtonDelegate, InputTextViewDelegate, M
 
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.bottomStackView?.arrangedSubviews.forEach { $0.alpha = (updatedInputState.allowedInputTypes != .none ? 1 : 0) }
+            
             self?.attachmentsButton.alpha = (updatedInputState.allowedInputTypes == .all ? 1 : 0.4)
+            self?.attachmentsButton.mainButton.updateAppearance(isEnabled: updatedInputState.allowedInputTypes == .all)
+            
             self?.voiceMessageButton.alpha =  (updatedInputState.allowedInputTypes == .all ? 1 : 0.4)
+            self?.voiceMessageButton.updateAppearance(isEnabled: updatedInputState.allowedInputTypes == .all)
+            
             self?.disabledInputLabel.alpha = (updatedInputState.allowedInputTypes != .none ? 0 : Values.mediumOpacity)
         }
     }

--- a/SessionUIKit/Components/Input View/InputViewButton.swift
+++ b/SessionUIKit/Components/Input View/InputViewButton.swift
@@ -136,6 +136,11 @@ public final class InputViewButton: UIView {
         )
     }
     
+    public func updateAppearance(isEnabled: Bool) {
+        iconImageView.themeTintColor = isEnabled ? .textPrimary : .disabled
+        backgroundView.themeBackgroundColor = isEnabled ? .inputButton_background : .disabled
+    }
+    
     // MARK: - Interaction
     
     // We want to detect both taps and long presses


### PR DESCRIPTION
### Description
- Updated disabled input view buttons color

| Before | After |
|--------|-------|
| ![Before screenshot](https://github.com/user-attachments/assets/b338f0b5-4266-41f6-bef0-96d01f362df2) | ![After screenshot](https://github.com/user-attachments/assets/2e19cceb-c0a1-4dc4-8d48-072210745780) |

| Old disabled state | Updated disabled state |


