### PR TITLE
Added checking if message has attachment before showing delete dialog

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -1164,6 +1164,7 @@
 		FDFE75B42ABD46B600655640 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD83B9D127D59495005E1583 /* MockUserDefaults.swift */; };
 		FDFE75B52ABD46B700655640 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD83B9D127D59495005E1583 /* MockUserDefaults.swift */; };
 		FDFF9FDF2A787F57005E0628 /* JSONEncoder+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFF9FDE2A787F57005E0628 /* JSONEncoder+Utilities.swift */; };
+		FE4234C92E9CDECD00F2C9F7 /* AttachmentManager+AttachmentDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4234C82E9CDECD00F2C9F7 /* AttachmentManager+AttachmentDeleter.swift */; };
 		FED288F32E4C28CF00C31171 /* AppReviewPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED288F22E4C28CF00C31171 /* AppReviewPromptDialog.swift */; };
 		FED288F82E4C3BE100C31171 /* AppReviewPromptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED288F72E4C3BE100C31171 /* AppReviewPromptModel.swift */; };
 /* End PBXBuildFile section */
@@ -2450,6 +2451,7 @@
 		FDFDE129282D056B0098B17F /* MediaZoomAnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaZoomAnimationController.swift; sourceTree = "<group>"; };
 		FDFE75B02ABD2D2400655640 /* _030_MakeBrokenProfileTimestampsNullable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _030_MakeBrokenProfileTimestampsNullable.swift; sourceTree = "<group>"; };
 		FDFF9FDE2A787F57005E0628 /* JSONEncoder+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+Utilities.swift"; sourceTree = "<group>"; };
+		FE4234C82E9CDECD00F2C9F7 /* AttachmentManager+AttachmentDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttachmentManager+AttachmentDeleter.swift"; sourceTree = "<group>"; };
 		FED288F22E4C28CF00C31171 /* AppReviewPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReviewPromptDialog.swift; sourceTree = "<group>"; };
 		FED288F72E4C3BE100C31171 /* AppReviewPromptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReviewPromptModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -3213,6 +3215,7 @@
 				FD7115EA28C5D78E00B47552 /* ThreadSettingsViewModel.swift */,
 				9479981B2DD44AC5008F5CD5 /* ThreadNotificationSettingsViewModel.swift */,
 				FD7115F328C71EB200B47552 /* ThreadDisappearingMessagesSettingsViewModel.swift */,
+				FE4234C82E9CDECD00F2C9F7 /* AttachmentManager+AttachmentDeleter.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -7033,6 +7036,7 @@
 				7B0EFDF0275084AA00FFAAE7 /* CallMessageCell.swift in Sources */,
 				C3AAFFF225AE99710089E6DD /* AppDelegate.swift in Sources */,
 				FD10AF0C2AF32B9A007709E5 /* SessionListViewModel.swift in Sources */,
+				FE4234C92E9CDECD00F2C9F7 /* AttachmentManager+AttachmentDeleter.swift in Sources */,
 				942256822C23F8BB00C0FDBF /* InviteAFriendScreen.swift in Sources */,
 				B8BB82A5238F627000BA5194 /* HomeVC.swift in Sources */,
 				4521C3C01F59F3BA00B4C582 /* TextFieldHelper.swift in Sources */,

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -557,6 +557,11 @@ final class ConversationVC: BaseVC, LibSessionRespondingViewController, Conversa
         // conversation settings then we don't need to worry about the conversation getting marked as
         // when when the user returns back through this view controller
         self.viewModel.markAsRead(target: .thread, timestampMs: nil)
+        
+        // Message deletion
+        self.viewModel.dependencies[singleton: .attachmentManager].willTriggerDeleteOption = { [weak self] (items, completion) in
+            self?.deleteAttachments(items, completion: completion)
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Session/Conversations/Settings/AttachmentManager+AttachmentDeleter.swift
+++ b/Session/Conversations/Settings/AttachmentManager+AttachmentDeleter.swift
@@ -1,0 +1,16 @@
+// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import SessionUtilitiesKit
+import SessionMessagingKit
+
+extension AttachmentManager {
+    // Reusable delete function for all the media preview instances
+    public func deleteAttachments(_ items: [MediaGalleryViewModel.Item], completion: @escaping () -> Void) {
+        let desiredIDSet: Set<Int64> = Set(items.map { $0.interactionId })
+        
+        willTriggerDeleteOption?(desiredIDSet) {
+            completion()
+        }
+    }
+}

--- a/Session/Media Viewing & Editing/AllMediaViewController.swift
+++ b/Session/Media Viewing & Editing/AllMediaViewController.swift
@@ -231,6 +231,8 @@ extension AllMediaViewController: MediaTileViewControllerDelegate {
             )
         }
         else {
+            self.navigationItem.hidesBackButton = false
+            
             self.navigationItem.rightBarButtonItem = UIBarButtonItem(
                 title: "select".localized(),
                 style: .plain,

--- a/SessionMessagingKit/Shared Models/MessageViewModel+DeletionActions.swift
+++ b/SessionMessagingKit/Shared Models/MessageViewModel+DeletionActions.swift
@@ -171,32 +171,6 @@ public extension MessageViewModel.DeletionBehaviours {
                     }
                 }()
                 
-                var alertContentForDeletion: (title: String, body: String) {
-                    // Get only attachments with associated message
-                    let attachments = cellViewModels.filter { $0.attachments != nil && $0.body?.isEmpty == false }
-                    
-                    if !attachments.isEmpty && attachments.count == cellViewModels.count {
-                        return (
-                            "deleteAttachments"
-                                .putNumber(attachments.count)
-                                .localized(),
-                            "deleteAttachmentsDescription"
-                                .putNumber(attachments.count)
-                                .localized(),
-                        )
-                    }
-                    
-                    // If items to delete contains other messages aside from attachments w/ message
-                    return (
-                        "deleteMessage"
-                            .putNumber(cellViewModels.count)
-                            .localized(),
-                        "deleteMessageConfirm"
-                            .putNumber(cellViewModels.count)
-                            .localized(),
-                    )
-                }
-                
                 switch (state, isAdmin) {
                     /// User selects messages including a control, pending or “deleted” message
                     case (.containsLocalOnlyMessages, _):
@@ -261,9 +235,13 @@ public extension MessageViewModel.DeletionBehaviours {
                     /// User selects messages including only their own messages
                     case (.outgoingOnly, _):
                         return MessageViewModel.DeletionBehaviours(
-                            title: alertContentForDeletion.title,
+                            title: "deleteMessage"
+                                .putNumber(cellViewModels.count)
+                                .localized(),
                             warning: nil,
-                            body: alertContentForDeletion.body,
+                            body: "deleteMessageConfirm"
+                                .putNumber(cellViewModels.count)
+                                .localized(),
                             actions: [
                                 NamedAction(
                                     title: "deleteMessageDeviceOnly".localized(),
@@ -300,11 +278,15 @@ public extension MessageViewModel.DeletionBehaviours {
                     /// User selects messages including ones from other users
                     case (.containsIncoming, false):
                         return MessageViewModel.DeletionBehaviours(
-                            title: alertContentForDeletion.title,
+                            title: "deleteMessage"
+                                .putNumber(cellViewModels.count)
+                                .localized(),
                             warning: "deleteMessageWarning"
                                 .putNumber(cellViewModels.count)
                                 .localized(),
-                            body: alertContentForDeletion.body,
+                            body: "deleteMessageDescriptionDevice"
+                                .putNumber(cellViewModels.count)
+                                .localized(),
                             actions: [
                                 NamedAction(
                                     title: "deleteMessageDeviceOnly".localized(),
@@ -331,9 +313,13 @@ public extension MessageViewModel.DeletionBehaviours {
                     /// Admin can multi-select their own messages and messages from other users
                     case (.containsIncoming, true):
                         return MessageViewModel.DeletionBehaviours(
-                            title: alertContentForDeletion.title,
+                            title: "deleteMessage"
+                                .putNumber(cellViewModels.count)
+                                .localized(),
                             warning: nil,
-                            body: alertContentForDeletion.body,
+                            body: "deleteMessageConfirm"
+                                .putNumber(cellViewModels.count)
+                                .localized(),
                             actions: [
                                 NamedAction(
                                     title: "deleteMessageDeviceOnly".localized(),

--- a/SessionMessagingKit/Shared Models/MessageViewModel+DeletionActions.swift
+++ b/SessionMessagingKit/Shared Models/MessageViewModel+DeletionActions.swift
@@ -171,6 +171,32 @@ public extension MessageViewModel.DeletionBehaviours {
                     }
                 }()
                 
+                var alertContentForDeletion: (title: String, body: String) {
+                    // Get only attachments with associated message
+                    let attachments = cellViewModels.filter { $0.attachments != nil && $0.body?.isEmpty == false }
+                    
+                    if !attachments.isEmpty && attachments.count == cellViewModels.count {
+                        return (
+                            "deleteAttachments"
+                                .putNumber(attachments.count)
+                                .localized(),
+                            "deleteAttachmentsDescription"
+                                .putNumber(attachments.count)
+                                .localized(),
+                        )
+                    }
+                    
+                    // If items to delete contains other messages aside from attachments w/ message
+                    return (
+                        "deleteMessage"
+                            .putNumber(cellViewModels.count)
+                            .localized(),
+                        "deleteMessageConfirm"
+                            .putNumber(cellViewModels.count)
+                            .localized(),
+                    )
+                }
+                
                 switch (state, isAdmin) {
                     /// User selects messages including a control, pending or “deleted” message
                     case (.containsLocalOnlyMessages, _):
@@ -235,13 +261,9 @@ public extension MessageViewModel.DeletionBehaviours {
                     /// User selects messages including only their own messages
                     case (.outgoingOnly, _):
                         return MessageViewModel.DeletionBehaviours(
-                            title: "deleteMessage"
-                                .putNumber(cellViewModels.count)
-                                .localized(),
+                            title: alertContentForDeletion.title,
                             warning: nil,
-                            body: "deleteMessageConfirm"
-                                .putNumber(cellViewModels.count)
-                                .localized(),
+                            body: alertContentForDeletion.body,
                             actions: [
                                 NamedAction(
                                     title: "deleteMessageDeviceOnly".localized(),
@@ -278,15 +300,11 @@ public extension MessageViewModel.DeletionBehaviours {
                     /// User selects messages including ones from other users
                     case (.containsIncoming, false):
                         return MessageViewModel.DeletionBehaviours(
-                            title: "deleteMessage"
-                                .putNumber(cellViewModels.count)
-                                .localized(),
+                            title: alertContentForDeletion.title,
                             warning: "deleteMessageWarning"
                                 .putNumber(cellViewModels.count)
                                 .localized(),
-                            body: "deleteMessageDescriptionDevice"
-                                .putNumber(cellViewModels.count)
-                                .localized(),
+                            body: alertContentForDeletion.body,
                             actions: [
                                 NamedAction(
                                     title: "deleteMessageDeviceOnly".localized(),
@@ -313,13 +331,9 @@ public extension MessageViewModel.DeletionBehaviours {
                     /// Admin can multi-select their own messages and messages from other users
                     case (.containsIncoming, true):
                         return MessageViewModel.DeletionBehaviours(
-                            title: "deleteMessage"
-                                .putNumber(cellViewModels.count)
-                                .localized(),
+                            title: alertContentForDeletion.title,
                             warning: nil,
-                            body: "deleteMessageConfirm"
-                                .putNumber(cellViewModels.count)
-                                .localized(),
+                            body: alertContentForDeletion.body,
                             actions: [
                                 NamedAction(
                                     title: "deleteMessageDeviceOnly".localized(),

--- a/SessionMessagingKit/Utilities/AttachmentManager.swift
+++ b/SessionMessagingKit/Utilities/AttachmentManager.swift
@@ -30,6 +30,9 @@ public extension Log.Category {
 public final class AttachmentManager: Sendable, ThumbnailManager {
     private let dependencies: Dependencies
     
+    // Hook for the listener class
+    public var willTriggerDeleteOption: ((Set<Int64>, @escaping () -> Void) -> Void)? = nil
+    
     // MARK: - Initalization
     
     init(using dependencies: Dependencies) {


### PR DESCRIPTION
### Description
- Changed delete alert dialog title and body when message selected has an attachment.

<img width="408" height="340" alt="Screenshot 2025-10-07 at 2 17 12 PM" src="https://github.com/user-attachments/assets/612dce04-146e-45d3-adcd-ea4bc60ba3a4" />


https://www.figma.com/design/kau6LggVcMMWmZRMibEo8F/Standardise-Message-Deletion?node-id=1134-930&m=dev