### PR TITLE
Fixed an IP2Country crash on launch

### DIFF
--- a/Session/Home/HomeVC.swift
+++ b/Session/Home/HomeVC.swift
@@ -355,7 +355,9 @@ public final class HomeVC: BaseVC, LibSessionRespondingViewController, UITableVi
         }
         
         // Onion request path countries cache
-        viewModel.dependencies.warmCache(cache: .ip2Country)
+        Task.detached(priority: .background) { [dependencies = viewModel.dependencies] in
+            dependencies.warmCache(cache: .ip2Country)
+        }
         
         // Bind the UI to the view model
         bindViewModel()


### PR DESCRIPTION
Fixed a crash which could occur on launch due to the IP2Country warming running on the main thread and taking too long