### PR TITLE
Shifted dedupe file writing off the database thread

### DIFF
--- a/SessionMessagingKit/Database/Models/MessageDeduplication.swift
+++ b/SessionMessagingKit/Database/Models/MessageDeduplication.swift
@@ -38,7 +38,6 @@ public extension MessageDeduplication {
         threadId: String,
         threadVariant: SessionThread.Variant?,
         uniqueIdentifier: String?,
-        legacyIdentifier: String? = nil,
         message: Message?,
         serverExpirationTimestamp: TimeInterval?,
         ignoreDedupeFiles: Bool,
@@ -54,7 +53,6 @@ public extension MessageDeduplication {
             try ensureMessageIsNotADuplicate(
                 threadId: threadId,
                 uniqueIdentifier: uniqueIdentifier,
-                legacyIdentifier: legacyIdentifier,
                 using: dependencies
             )
             
@@ -99,14 +97,6 @@ public extension MessageDeduplication {
             shouldDeleteWhenDeletingThread: shouldDeleteWhenDeletingThread
         ).insert(db)
         
-        /// Create the replicated file in the 'AppGroup' so that the PN extension is able to dedupe messages
-        try createDedupeFile(
-            threadId: threadId,
-            uniqueIdentifier: uniqueIdentifier,
-            legacyIdentifier: legacyIdentifier,
-            using: dependencies
-        )
-        
         /// Insert & create special call-specific dedupe records
         try insertCallDedupeRecordsIfNeeded(
             db,
@@ -117,16 +107,18 @@ public extension MessageDeduplication {
             using: dependencies
         )
         
-        /// Create a legacy dedupe record
-        try createLegacyDeduplicationRecord(
-            db,
+        /// Register dedupe files to be written
+        dependencies[singleton: .messageDeduplicationBatchFileWriter].addPendingWrite(
             threadId: threadId,
-            legacyIdentifier: legacyIdentifier,
-            legacyVariant: getLegacyVariant(for: message.map { Message.Variant(from: $0) }),
-            timestampMs: message?.sentTimestampMs.map { Int64($0) },
-            serverExpirationTimestamp: serverExpirationTimestamp,
-            using: dependencies
+            uniqueIdentifier: uniqueIdentifier,
+            callMessage: message as? CallMessage
         )
+        
+        db.afterCommit(dedupeId: BatchFileWriter.dedupeId) {
+            Task(priority: .utility) {
+                await dependencies[singleton: .messageDeduplicationBatchFileWriter].processPendingWrites()
+            }
+        }
     }
     
     static func deleteIfNeeded(
@@ -188,20 +180,11 @@ public extension MessageDeduplication {
     static func createDedupeFile(
         threadId: String,
         uniqueIdentifier: String,
-        legacyIdentifier: String? = nil,
         using dependencies: Dependencies
     ) throws {
         try dependencies[singleton: .extensionHelper].createDedupeRecord(
             threadId: threadId,
             uniqueIdentifier: uniqueIdentifier
-        )
-        
-        /// Also create a dedupe file for the legacy identifier if provided
-        guard let legacyIdentifier: String = legacyIdentifier else { return }
-        
-        try dependencies[singleton: .extensionHelper].createDedupeRecord(
-            threadId: threadId,
-            uniqueIdentifier: legacyIdentifier
         )
     }
     
@@ -213,7 +196,6 @@ public extension MessageDeduplication {
         try ensureMessageIsNotADuplicate(
             threadId: processedMessage.threadId,
             uniqueIdentifier: processedMessage.uniqueIdentifier,
-            legacyIdentifier: getLegacyIdentifier(for: processedMessage),
             using: dependencies
         )
     }
@@ -221,22 +203,11 @@ public extension MessageDeduplication {
     static func ensureMessageIsNotADuplicate(
         threadId: String,
         uniqueIdentifier: String,
-        legacyIdentifier: String? = nil,
         using dependencies: Dependencies
     ) throws {
         if dependencies[singleton: .extensionHelper].dedupeRecordExists(
             threadId: threadId,
             uniqueIdentifier: uniqueIdentifier
-        ) {
-            throw MessageError.duplicateMessage
-        }
-        
-        /// Also check for a dedupe file using the legacy identifier
-        guard let legacyIdentifier: String = legacyIdentifier else { return }
-        
-        if dependencies[singleton: .extensionHelper].dedupeRecordExists(
-            threadId: threadId,
-            uniqueIdentifier: legacyIdentifier
         ) {
             throw MessageError.duplicateMessage
         }
@@ -246,7 +217,7 @@ public extension MessageDeduplication {
 // MARK: - CallMessage Convenience
 
 public extension MessageDeduplication {
-    static func insertCallDedupeRecordsIfNeeded(
+    private static func insertCallDedupeRecordsIfNeeded(
         _ db: ObservingDatabase,
         threadId: String,
         callMessage: CallMessage?,
@@ -278,13 +249,6 @@ public extension MessageDeduplication {
             /// For any other combinations we don't want to deduplicate messages (as they are needed to keep the call going)
             default: break
         }
-        
-        /// Create the replicated file in the 'AppGroup' so that the PN extension is able to dedupe call messages
-        try createCallDedupeFilesIfNeeded(
-            threadId: threadId,
-            callMessage: callMessage,
-            using: dependencies
-        )
     }
     
     static func createCallDedupeFilesIfNeeded(
@@ -361,7 +325,6 @@ public extension MessageDeduplication {
                     threadId: processedMessage.threadId,
                     threadVariant: threadVariant,
                     uniqueIdentifier: processedMessage.uniqueIdentifier,
-                    legacyIdentifier: getLegacyIdentifier(for: processedMessage),
                     message: messageInfo.message,
                     serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                     ignoreDedupeFiles: ignoreDedupeFiles,
@@ -382,122 +345,8 @@ public extension MessageDeduplication {
                 try createDedupeFile(
                     threadId: processedMessage.threadId,
                     uniqueIdentifier: processedMessage.uniqueIdentifier,
-                    legacyIdentifier: getLegacyIdentifier(for: processedMessage),
                     using: dependencies
                 )
-        }
-    }
-}
-
-// MARK: - Legacy Dedupe Records
-
-public extension MessageDeduplication {
-    @available(*, deprecated, message: "⚠️ Remove this code once once enough time has passed since it's release (at least 1 month)")
-    static let doesCreateLegacyRecords: Bool = true
-}
-
-private extension MessageDeduplication {
-    @available(*, deprecated, message: "⚠️ Remove this code once once enough time has passed since it's release (at least 1 month)")
-    private static func createLegacyDeduplicationRecord(
-        _ db: ObservingDatabase,
-        threadId: String,
-        legacyIdentifier: String?,
-        legacyVariant: _040_MessageDeduplicationTable.ControlMessageProcessRecordVariant?,
-        timestampMs: Int64?,
-        serverExpirationTimestamp: TimeInterval?,
-        using dependencies: Dependencies
-    ) throws {
-        typealias Variant = _040_MessageDeduplicationTable.ControlMessageProcessRecordVariant
-        guard
-            let legacyIdentifier: String = legacyIdentifier,
-            let legacyVariant: Variant = legacyVariant,
-            let timestampMs: Int64 = timestampMs
-        else { return }
-        
-        let expirationTimestampSeconds: Int64? = {
-            /// If we have a server expiration for the hash then we should use that value as the priority
-            if let serverExpirationTimestamp: TimeInterval = serverExpirationTimestamp {
-                return Int64(serverExpirationTimestamp)
-            }
-            
-            /// If we got here then it means we have no way to know when the message should expire but messages stored on
-            /// a snode as well as outgoing blinded message reuqests stored on a SOGS both have a similar default expiration
-            /// so create one manually by using `SnodeReceivedMessage.defaultExpirationMs`
-            ///
-            /// For a `contact` conversation at the time of writing this migration there _shouldn't_ be any type of message
-            /// which never expires or has it's TTL extended (outside of config messages)
-            ///
-            /// If we have a `timestampMs` then base our custom expiration on that
-            return ((timestampMs + SnodeReceivedMessage.defaultExpirationMs) / 1000)
-        }()
-        
-        /// Add `(SnodeReceivedMessage.serverClockToleranceMs * 2)` to `expirationTimestampSeconds`
-        /// in order to try to ensure that our deduplication record outlasts the message lifetime on the storage server
-        let finalExpiryTimestampSeconds: Int64? = expirationTimestampSeconds
-            .map { $0 + ((SnodeReceivedMessage.serverClockToleranceMs * 2) / 1000) }
-        
-        /// When we delete a `contact` conversation we want to keep the dedupe records around because, if we don't, the
-        /// conversation will just reappear (this isn't an issue for `legacyGroup` conversations because they no longer poll)
-        ///
-        /// For `community` conversations we only poll while the conversation exists and have a `seqNo` to poll from in order
-        /// to prevent retrieving old messages
-        ///
-        /// Updated `group` conversations are a bit special because we want to delete _most_ records, but there are a few that
-        /// can cause issues if we process them again so we hold on to those just in case
-        let shouldDeleteWhenDeletingThread: Bool = {
-            switch legacyVariant {
-                case .groupUpdateInvite, .groupUpdatePromote, .groupUpdateMemberLeft,
-                    .groupUpdateInviteResponse:
-                    return false
-                default: return true
-            }
-        }()
-        
-        /// Add the record
-        _ = try MessageDeduplication(
-            threadId: threadId,
-            uniqueIdentifier: legacyIdentifier,
-            expirationTimestampSeconds: finalExpiryTimestampSeconds,
-            shouldDeleteWhenDeletingThread: shouldDeleteWhenDeletingThread
-        ).insert(db)
-    }
-    
-    @available(*, deprecated, message: "⚠️ Remove this code once once enough time has passed since it's release (at least 1 month)")
-    static func getLegacyVariant(for variant: Message.Variant?) -> _040_MessageDeduplicationTable.ControlMessageProcessRecordVariant? {
-        guard let variant: Message.Variant = variant else { return nil }
-        
-        switch variant {
-            case .visibleMessage: return .visibleMessageDedupe
-            case .readReceipt: return .readReceipt
-            case .typingIndicator: return .typingIndicator
-            case .unsendRequest: return .unsendRequest
-            case .dataExtractionNotification: return .dataExtractionNotification
-            case .expirationTimerUpdate: return .expirationTimerUpdate
-            case .messageRequestResponse: return .messageRequestResponse
-            case .callMessage: return .call
-            case .groupUpdateInvite, .groupUpdateMemberChange, .groupUpdatePromote:
-                return .groupUpdateMemberChange
-            case .groupUpdateInfoChange: return .groupUpdateInfoChange
-            case .groupUpdateMemberLeft: return .groupUpdateMemberLeft
-            case .groupUpdateMemberLeftNotification: return .groupUpdateMemberLeftNotification
-            case .groupUpdateInviteResponse: return .groupUpdateInviteResponse
-            case .groupUpdateDeleteMemberContent: return .groupUpdateDeleteMemberContent
-                
-            case .libSessionMessage: return nil
-        }
-    }
-        
-    @available(*, deprecated, message: "⚠️ Remove this code once once enough time has passed since it's release (at least 1 month)")
-    static func getLegacyIdentifier(for processedMessage: ProcessedMessage) -> String? {
-        switch processedMessage {
-            case .config: return nil
-            case .standard(_, _, let messageInfo, _):
-                guard
-                    let timestampMs: UInt64 = messageInfo.message.sentTimestampMs,
-                    let variant: _040_MessageDeduplicationTable.ControlMessageProcessRecordVariant = getLegacyVariant(for: Message.Variant(from: messageInfo.message))
-                else { return nil }
-                
-                return "LegacyRecord-\(variant.rawValue)-\(timestampMs)" // stringlint:ignore
         }
     }
 }
@@ -506,3 +355,102 @@ public extension CallMessage {
     var preOfferDedupeIdentifier: String { "\(uuid)-preOffer" }
 }
 
+// MARK: - MessageDeduplication BatchFileWriter
+
+private extension MessageDeduplication {
+    private struct PendingWrite {
+        let threadId: String
+        let uniqueIdentifier: String
+        let callMessage: CallMessage?
+    }
+    
+    actor BatchFileWriter: MessageDeduplicationBatchFileWriterType {
+        fileprivate static let dedupeId: String = "BatchFileWriteDedupeId"
+        
+        private let dependencies: Dependencies
+        nonisolated private let syncState: BatchFileWriterSyncState = BatchFileWriterSyncState()
+        
+        // MARK: - Initialiation
+        
+        init(using dependencies: Dependencies) {
+            self.dependencies = dependencies
+        }
+        
+        // MARK: - Functions
+        
+        nonisolated public func addPendingWrite(
+            threadId: String,
+            uniqueIdentifier: String,
+            callMessage: CallMessage?
+        ) {
+            syncState.addPendingWrite(
+                PendingWrite(
+                    threadId: threadId,
+                    uniqueIdentifier: uniqueIdentifier,
+                    callMessage: callMessage
+                )
+            )
+        }
+        
+        public func processPendingWrites() async {
+            let pendingWrites: [PendingWrite] = syncState.popAll()
+            
+            for pendingWrite in pendingWrites {
+                do {
+                    /// Create the replicated file in the 'AppGroup' so that the PN extension is able to dedupe messages
+                    try MessageDeduplication.createDedupeFile(
+                        threadId: pendingWrite.threadId,
+                        uniqueIdentifier: pendingWrite.uniqueIdentifier,
+                        using: dependencies
+                    )
+                    
+                    /// Create the replicated file in the 'AppGroup' so that the PN extension is able to dedupe call messages
+                    try createCallDedupeFilesIfNeeded(
+                        threadId: pendingWrite.threadId,
+                        callMessage: pendingWrite.callMessage,
+                        using: dependencies
+                    )
+                }
+                catch {
+                    Log.warn(.cat, "Failed to write dedupe file for \(pendingWrite.threadId) due to error: \(error).")
+                }
+            }
+            
+        }
+    }
+    
+    private final class BatchFileWriterSyncState {
+        private let lock: NSLock = NSLock()
+        private var _pendingWrites: [PendingWrite] = []
+        
+        fileprivate func addPendingWrite(_ pendingWrite: PendingWrite) {
+            lock.withLock { _pendingWrites.append(pendingWrite) }
+        }
+        
+        fileprivate func popAll() -> [PendingWrite] {
+            return lock.withLock {
+                let result: [PendingWrite] = _pendingWrites
+                _pendingWrites = []
+                return result
+            }
+        }
+    }
+}
+
+public extension Singleton {
+    static let messageDeduplicationBatchFileWriter: SingletonConfig<MessageDeduplicationBatchFileWriterType> = Dependencies.create(
+        identifier: "messageDeduplicationBatchFileWriter",
+        createInstance: { dependencies, _ in MessageDeduplication.BatchFileWriter(using: dependencies) }
+    )
+}
+
+// MARK: - MessageDeduplicationBatchFileWriterType
+
+public protocol MessageDeduplicationBatchFileWriterType: Actor {
+    nonisolated func addPendingWrite(
+        threadId: String,
+        uniqueIdentifier: String,
+        callMessage: CallMessage?
+    )
+    func processPendingWrites() async
+}

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -747,14 +747,10 @@ public class ExtensionHelper: ExtensionHelperType {
                             .appendingPathComponent(conversationHash)
                             .path
                     )
-                    let numConsideredeDedupeRecords: Int = (MessageDeduplication.doesCreateLegacyRecords ?
-                        (dedupeFileCreatedTimestamps.count / 2) :
-                        dedupeFileCreatedTimestamps.count
-                    )
                     
                     /// If the number of dedupe records don't match the number of unread messages (minus 1 to account for the stub
                     /// file) then the user has seen the message requests banner since they received the PN for this message request
-                    guard numConsideredeDedupeRecords == (unreadMessageHashes.count - 1) else {
+                    guard dedupeFileCreatedTimestamps.count == (unreadMessageHashes.count - 1) else {
                         return result
                     }
                     

--- a/SessionMessagingKitTests/Database/Models/MessageDeduplicationSpec.swift
+++ b/SessionMessagingKitTests/Database/Models/MessageDeduplicationSpec.swift
@@ -28,6 +28,7 @@ class MessageDeduplicationSpec: AsyncSpec {
             
             return result
         }()
+        @TestState var mockLogger: MockLogger! = MockLogger()
         
         beforeEach {
             dependencies.set(singleton: .storage, to: mockStorage)
@@ -53,6 +54,8 @@ class MessageDeduplicationSpec: AsyncSpec {
             try await mockExtensionHelper
                 .when { try $0.upsertLastClearedRecord(threadId: .any) }
                 .thenReturn(())
+            
+            Log.setup(with: mockLogger)
         }
         
         // MARK: - MessageDeduplication - Inserting
@@ -86,7 +89,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     expect(records?.first?.shouldDeleteWhenDeletingThread).to(beFalse())
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- checks that it is not a duplicate record
@@ -108,29 +111,6 @@ class MessageDeduplicationSpec: AsyncSpec {
                     
                     await mockExtensionHelper
                         .verify { $0.dedupeRecordExists(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
-                }
-                
-                // MARK: ---- creates a legacy record if needed
-                it("creates a legacy record if needed") {
-                    try await mockStorage.writeAsync { db in
-                        expect {
-                            try MessageDeduplication.insert(
-                                db,
-                                threadId: "testThreadId",
-                                threadVariant: .contact,
-                                uniqueIdentifier: "testId",
-                                legacyIdentifier: "testLegacyId",
-                                message: mockMessage,
-                                serverExpirationTimestamp: 1234567890,
-                                ignoreDedupeFiles: false,
-                                using: dependencies
-                            )
-                        }.toNot(throwError())
-                    }
-                    
-                    await mockExtensionHelper
-                        .verify { $0.dedupeRecordExists(threadId: "testThreadId", uniqueIdentifier: "testLegacyId") }
                         .wasCalled(exactly: 1)
                 }
                 
@@ -281,7 +261,6 @@ class MessageDeduplicationSpec: AsyncSpec {
                                 threadId: "testThreadId",
                                 threadVariant: .contact,
                                 uniqueIdentifier: nil,
-                                legacyIdentifier: "testLegacyId",
                                 message: mockMessage,
                                 serverExpirationTimestamp: 1234567890,
                                 ignoreDedupeFiles: false,
@@ -325,15 +304,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     }
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
-                    await mockExtensionHelper
-                        .verify {
-                            try $0.createDedupeRecord(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "LegacyRecord-1-12345678901234"
-                            )
-                        }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- does not create records for config ProcessedMessages
@@ -361,7 +332,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     expect(records).to(beEmpty())
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasNotCalled()
+                        .wasNotCalled(timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- throws if the message is a duplicate
@@ -377,7 +348,6 @@ class MessageDeduplicationSpec: AsyncSpec {
                                 threadId: "testThreadId",
                                 threadVariant: .contact,
                                 uniqueIdentifier: "testId",
-                                legacyIdentifier: "testLegacyId",
                                 message: mockMessage,
                                 serverExpirationTimestamp: 1234567890,
                                 ignoreDedupeFiles: false,
@@ -387,91 +357,44 @@ class MessageDeduplicationSpec: AsyncSpec {
                     }
                 }
                 
-                // MARK: ---- throws if the message is a legacy duplicate
-                it("throws if the message is a legacy duplicate") {
-                    try await mockExtensionHelper
-                        .when {
-                            $0.dedupeRecordExists(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testId"
-                            )
-                        }
-                        .thenReturn(false)
-                    try await mockExtensionHelper
-                        .when {
-                            $0.dedupeRecordExists(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testLegacyId"
-                            )
-                        }
-                        .thenReturn(true)
-                    
-                    try await mockStorage.writeAsync { db in
-                        expect {
-                            try MessageDeduplication.insert(
-                                db,
-                                threadId: "testThreadId",
-                                threadVariant: .contact,
-                                uniqueIdentifier: "testId",
-                                legacyIdentifier: "testLegacyId",
-                                message: mockMessage,
-                                serverExpirationTimestamp: 1234567890,
-                                ignoreDedupeFiles: false,
-                                using: dependencies
-                            )
-                        }.to(throwError(MessageError.duplicateMessage))
-                    }
-                }
-                
-                // MARK: ---- throws if it fails to create the dedupe file
-                it("throws if it fails to create the dedupe file") {
+                // MARK: ---- logs a warning if it fails to create the dedupe file
+                it("logs a warning if it fails to create the dedupe file") {
                     try await mockExtensionHelper
                         .when { try $0.createDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
                         .thenThrow(TestError.mock)
                     
                     try await mockStorage.writeAsync { db in
-                        expect {
-                            try MessageDeduplication.insert(
-                                db,
-                                threadId: "testThreadId",
-                                threadVariant: .contact,
-                                uniqueIdentifier: "testId",
-                                legacyIdentifier: "testLegacyId",
-                                message: mockMessage,
-                                serverExpirationTimestamp: 1234567890,
-                                ignoreDedupeFiles: false,
-                                using: dependencies
-                            )
-                        }.to(throwError(TestError.mock))
+                        try MessageDeduplication.insert(
+                            db,
+                            threadId: "testThreadId",
+                            threadVariant: .contact,
+                            uniqueIdentifier: "testId",
+                            message: mockMessage,
+                            serverExpirationTimestamp: 1234567890,
+                            ignoreDedupeFiles: false,
+                            using: dependencies
+                        )
                     }
-                }
-                
-                // MARK: ---- throws if it fails to create the legacy dedupe file
-                it("throws if it fails to create the legacy dedupe file") {
-                    try await mockExtensionHelper
-                        .when {
-                            try $0.createDedupeRecord(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testLegacyId"
-                            )
-                        }
-                        .thenThrow(TestError.mock)
                     
-                    try await mockStorage.writeAsync { db in
-                        expect {
-                            try MessageDeduplication.insert(
-                                db,
-                                threadId: "testThreadId",
-                                threadVariant: .contact,
-                                uniqueIdentifier: "testId",
-                                legacyIdentifier: "testLegacyId",
-                                message: mockMessage,
-                                serverExpirationTimestamp: 1234567890,
-                                ignoreDedupeFiles: false,
-                                using: dependencies
+                    await expect { await mockLogger.logs }.toEventually(
+                        contain(
+                            MockLogger.LogOutput(
+                                level: .warn,
+                                categories: [
+                                    Log.Category.create(
+                                        "MessageDeduplication",
+                                        group: nil,
+                                        customSuffix: "",
+                                        defaultLevel: .info
+                                    )
+                                ],
+                                message: "Failed to write dedupe file for testThreadId due to error: mock.",
+                                file: "SessionMessagingKit/MessageDeduplication.swift",
+                                function: "processPendingWrites()"
                             )
-                        }.to(throwError(TestError.mock))
-                    }
+                        ),
+                        timeout: .milliseconds(100)
+                    )
                 }
             }
             
@@ -481,91 +404,120 @@ class MessageDeduplicationSpec: AsyncSpec {
                 it("inserts a preOffer record correctly") {
                     try await mockStorage.writeAsync { db in
                         expect {
-                            try MessageDeduplication.insertCallDedupeRecordsIfNeeded(
+                            try MessageDeduplication.insert(
                                 db,
                                 threadId: "testThreadId",
-                                callMessage: CallMessage(
+                                threadVariant: .contact,
+                                uniqueIdentifier: "testId",
+                                message: CallMessage(
                                     uuid: "12345",
                                     kind: .preOffer,
                                     sdps: [],
                                     sentTimestampMs: 1234567890
                                 ),
-                                expirationTimestampSeconds: 1234567891,
-                                shouldDeleteWhenDeletingThread: false,
+                                serverExpirationTimestamp: 1234567891,
+                                ignoreDedupeFiles: true,
                                 using: dependencies
                             )
                         }.toNot(throwError())
                     }
                     
-                    let records: [MessageDeduplication]? = mockStorage
-                        .read { db in try MessageDeduplication.fetchAll(db) }
-                    expect(records?.count).to(equal(1))
-                    expect(records?.first?.threadId).to(equal("testThreadId"))
-                    expect(records?.first?.uniqueIdentifier).to(equal("12345-preOffer"))
-                    expect(records?.first?.expirationTimestampSeconds).to(equal(1234567891))
-                    expect(records?.first?.shouldDeleteWhenDeletingThread).to(beFalse())
+                    let records: [MessageDeduplication] = try await mockStorage
+                        .readAsync { db in try MessageDeduplication.fetchAll(db) }
+                    expect(records.count).to(equal(2))
+                    expect(records.map { $0.threadId }).to(equal(["testThreadId", "testThreadId"]))
+                    expect(records.map { $0.uniqueIdentifier }).to(equal(["testId", "12345-preOffer"]))
+                    expect(records.map { $0.expirationTimestampSeconds })
+                            .to(equal([1234568011, 1234568011]))
+                    expect(records.map { $0.shouldDeleteWhenDeletingThread }).to(equal([false, false]))
+                    await mockExtensionHelper
+                        .verify {
+                            try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId")
+                        }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                     await mockExtensionHelper
                         .verify {
                             try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "12345-preOffer")
                         }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- inserts a generic record correctly
                 it("inserts a generic record correctly") {
                     try await mockStorage.writeAsync { db in
                         expect {
-                            try MessageDeduplication.insertCallDedupeRecordsIfNeeded(
+                            try MessageDeduplication.insert(
                                 db,
                                 threadId: "testThreadId",
-                                callMessage: CallMessage(
+                                threadVariant: .contact,
+                                uniqueIdentifier: "testId",
+                                message: CallMessage(
                                     uuid: "12345",
                                     kind: .endCall,
                                     sdps: [],
                                     sentTimestampMs: 1234567890
                                 ),
-                                expirationTimestampSeconds: 1234567891,
-                                shouldDeleteWhenDeletingThread: false,
+                                serverExpirationTimestamp: 1234567891,
+                                ignoreDedupeFiles: true,
                                 using: dependencies
                             )
                         }.toNot(throwError())
                     }
                     
-                    let records: [MessageDeduplication]? = mockStorage
-                        .read { db in try MessageDeduplication.fetchAll(db) }
-                    expect(records?.count).to(equal(1))
-                    expect(records?.first?.threadId).to(equal("testThreadId"))
-                    expect(records?.first?.uniqueIdentifier).to(equal("12345"))
-                    expect(records?.first?.expirationTimestampSeconds).to(equal(1234567891))
-                    expect(records?.first?.shouldDeleteWhenDeletingThread).to(beFalse())
+                    let records: [MessageDeduplication] = try await mockStorage
+                        .readAsync { db in try MessageDeduplication.fetchAll(db) }
+                    expect(records.count).to(equal(2))
+                    expect(records.map { $0.threadId }).to(equal(["testThreadId", "testThreadId"]))
+                    expect(records.map { $0.uniqueIdentifier }).to(equal(["testId", "12345"]))
+                    expect(records.map { $0.expirationTimestampSeconds })
+                            .to(equal([1234568011, 1234568011]))
+                    expect(records.map { $0.shouldDeleteWhenDeletingThread }).to(equal([false, false]))
+                    await mockExtensionHelper
+                        .verify {
+                            try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId")
+                        }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                     await mockExtensionHelper
                         .verify {
                             try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "12345")
                         }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
-                // MARK: ---- does nothing if no call message is provided
-                it("does nothing if no call message is provided") {
+                // MARK: ---- does not insert a call dedupe record if no call message is provided
+                it("does not insert a call dedupe record if no call message is provided") {
                     try await mockStorage.writeAsync { db in
                         expect {
-                            try MessageDeduplication.insertCallDedupeRecordsIfNeeded(
+                            try MessageDeduplication.insert(
                                 db,
                                 threadId: "testThreadId",
-                                callMessage: nil,
-                                expirationTimestampSeconds: 1234567891,
-                                shouldDeleteWhenDeletingThread: false,
+                                threadVariant: .contact,
+                                uniqueIdentifier: "testId",
+                                message: nil,
+                                serverExpirationTimestamp: 1234567891,
+                                ignoreDedupeFiles: true,
                                 using: dependencies
                             )
                         }.toNot(throwError())
                     }
                     
-                    let records: [MessageDeduplication]? = mockStorage
-                        .read { db in try MessageDeduplication.fetchAll(db) }
-                    expect(records?.count).to(equal(0))
+                    let records: [MessageDeduplication] = try await mockStorage
+                        .readAsync { db in try MessageDeduplication.fetchAll(db) }
+                    expect(records.count).to(equal(1))
+                    expect(records.map { $0.threadId }).to(equal(["testThreadId"]))
+                    expect(records.map { $0.uniqueIdentifier }).to(equal(["testId"]))
+                    expect(records.map { $0.expirationTimestampSeconds }).to(equal([1234568011]))
+                    expect(records.map { $0.shouldDeleteWhenDeletingThread }).to(equal([false]))
+                    
+                    /// Only called once with the expected values
+                    await mockExtensionHelper
+                        .verify {
+                            try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId")
+                        }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
-                        .wasNotCalled()
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
             }
         }
@@ -801,30 +753,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     }.toNot(throwError())
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
-                }
-                
-                // MARK: ---- creates both the main file and a legacy file when needed
-                it("creates both the main file and a legacy file when needed") {
-                    expect {
-                        try MessageDeduplication.createDedupeFile(
-                            threadId: "testThreadId",
-                            uniqueIdentifier: "testId",
-                            legacyIdentifier: "testLegacyId",
-                            using: dependencies
-                        )
-                    }.toNot(throwError())
-                    await mockExtensionHelper
-                        .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
-                    await mockExtensionHelper
-                        .verify {
-                            try $0.createDedupeRecord(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testLegacyId"
-                            )
-                        }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- creates a file from a ProcessedMessage
@@ -853,7 +782,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     }.toNot(throwError())
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- throws when it fails to create the file
@@ -869,46 +798,6 @@ class MessageDeduplicationSpec: AsyncSpec {
                             using: dependencies
                         )
                     }.to(throwError(TestError.mock))
-                }
-                
-                // MARK: ---- throws when it fails to create the legacy file
-                it("throws when it fails to create the legacy file") {
-                    try await mockExtensionHelper
-                        .when {
-                            try $0.createDedupeRecord(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testId"
-                            )
-                        }
-                        .thenReturn(())
-                    try await mockExtensionHelper
-                        .when {
-                            try $0.createDedupeRecord(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testLegacyId"
-                            )
-                        }
-                        .thenThrow(TestError.mock)
-                    
-                    expect {
-                        try MessageDeduplication.createDedupeFile(
-                            threadId: "testThreadId",
-                            uniqueIdentifier: "testId",
-                            legacyIdentifier: "testLegacyId",
-                            using: dependencies
-                        )
-                    }.to(throwError(TestError.mock))
-                    await mockExtensionHelper
-                        .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
-                    await mockExtensionHelper
-                        .verify {
-                            try $0.createDedupeRecord(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testLegacyId"
-                            )
-                        }
-                        .wasCalled(exactly: 1)
                 }
             }
             
@@ -933,7 +822,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                         .verify {
                             try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "12345-preOffer")
                         }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- creates a generic file correctly
@@ -953,7 +842,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: "testThreadId", uniqueIdentifier: "12345") }
-                        .wasCalled(exactly: 1)
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
                 }
                 
                 // MARK: ---- creates a files for the correct call message kinds
@@ -1038,7 +927,7 @@ class MessageDeduplicationSpec: AsyncSpec {
                     
                     await mockExtensionHelper
                         .verify { try $0.createDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
-                        .wasNotCalled()
+                        .wasNotCalled(timeout: .milliseconds(100))
                 }
             }
         }
@@ -1053,18 +942,6 @@ class MessageDeduplicationSpec: AsyncSpec {
                         try MessageDeduplication.ensureMessageIsNotADuplicate(
                             threadId: "testThreadId",
                             uniqueIdentifier: "testId",
-                            using: dependencies
-                        )
-                    }.toNot(throwError())
-                }
-                
-                // MARK: ---- when ensuring a message is not a legacy duplicate
-                it("does not throw when not a legacy duplicate") {
-                    expect {
-                        try MessageDeduplication.ensureMessageIsNotADuplicate(
-                            threadId: "testThreadId",
-                            uniqueIdentifier: "testId",
-                            legacyIdentifier: "testLegacyId",
                             using: dependencies
                         )
                     }.toNot(throwError())
@@ -1109,41 +986,6 @@ class MessageDeduplicationSpec: AsyncSpec {
                             using: dependencies
                         )
                     }.to(throwError(MessageError.duplicateMessage))
-                }
-                
-                // MARK: ---- throws when the message is a legacy duplicate
-                it("throws when the message is a legacy duplicate") {
-                    try await mockExtensionHelper
-                        .when {
-                            $0.dedupeRecordExists(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testId"
-                            )
-                        }
-                        .thenReturn(false)
-                    try await mockExtensionHelper
-                        .when {
-                            $0.dedupeRecordExists(
-                                threadId: "testThreadId",
-                                uniqueIdentifier: "testLegacyId"
-                            )
-                        }
-                        .thenReturn(true)
-                    
-                    expect {
-                        try MessageDeduplication.ensureMessageIsNotADuplicate(
-                            threadId: "testThreadId",
-                            uniqueIdentifier: "testId",
-                            legacyIdentifier: "testLegacyId",
-                            using: dependencies
-                        )
-                    }.to(throwError(MessageError.duplicateMessage))
-                    await mockExtensionHelper
-                        .verify { $0.dedupeRecordExists(threadId: "testThreadId", uniqueIdentifier: "testId") }
-                        .wasCalled(exactly: 1)
-                    await mockExtensionHelper
-                        .verify { $0.dedupeRecordExists(threadId: "testThreadId", uniqueIdentifier: "testLegacyId") }
-                        .wasCalled(exactly: 1)
                 }
             }
             

--- a/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
+++ b/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
@@ -1795,7 +1795,7 @@ class ExtensionHelperSpec: AsyncSpec {
                                 atPath: "/test/extensionCache/conversations/a/dedupe"
                             )
                         }
-                        .thenReturn(["b1", "b1-legacy", "c1", "c1-legacy", "d1", "d1-legacy"])
+                        .thenReturn(["b1", "c1", "d1"])
                     try await mockCrypto
                         .when { $0.generate(.hash(message: Array("a".utf8) + Array("messageRequest".utf8))) }
                         .thenReturn([3, 4, 5])
@@ -1805,11 +1805,8 @@ class ExtensionHelperSpec: AsyncSpec {
                         "/test/extensionCache/conversations/a/unread/c",
                         "/test/extensionCache/conversations/a/unread/d",
                         "/test/extensionCache/conversations/a/dedupe/b1",
-                        "/test/extensionCache/conversations/a/dedupe/b1-legacy",
                         "/test/extensionCache/conversations/a/dedupe/c1",
-                        "/test/extensionCache/conversations/a/dedupe/c1-legacy",
-                        "/test/extensionCache/conversations/a/dedupe/d1",
-                        "/test/extensionCache/conversations/a/dedupe/d1-legacy"
+                        "/test/extensionCache/conversations/a/dedupe/d1"
                     ]
                     for path in validPaths  {
                         try await mockFileManager


### PR DESCRIPTION
- Updated the dedupe record file writing to happen after the database transaction (not on the database thread)
- Removed legacy dedupe record code (should have been long enough now)
