### PR TITLE
[Automated] Update fallback static snode list

### DIFF
--- a/Session/Meta/service-nodes-cache.json
+++ b/Session/Meta/service-nodes-cache.json
@@ -5,10935 +5,21813 @@
       "storage_port": 22100,
       "pubkey_ed25519": "00000000c9b1ef4599f86182d6905963a72f6a9f50849e1263b4384df8600091",
       "pubkey_x25519": "1eb93ed1f33f5adcbda13c5e984515f273394bbda656c827c8bbc319826d6f55",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22109,
       "pubkey_ed25519": "001ab2324517aa4aa7501782dd986c76288a3d3f7474a534e0f5497b32b6aee9",
       "pubkey_x25519": "22f02827866ae814c43ba726196d2e79b598fce4c67f39c01c561824f74f363c",
-      "requested_unlock_height": 2059300
+      "requested_unlock_height": 2059300,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "209.141.32.170",
       "storage_port": 22021,
       "pubkey_ed25519": "00a36a9c0f82d10ef82451c2856fb8ed781b00a0d786a33fa796e4f0cea527cb",
       "pubkey_x25519": "16576ef8ef4f6e4332cc0b1d5a53b61e1c6d12c89b3fe4bef4f1e12f33b2a268",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "94.237.91.42",
       "storage_port": 22021,
       "pubkey_ed25519": "00b4c93c08e44a14485ee2ec9e72e1e0acff1707c07f08884875b68730d69f69",
       "pubkey_x25519": "8ed66b9fdcca690542bdff7a3038ef6a78a6ef48cd16d778bf946a4f03614a25",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22143,
       "pubkey_ed25519": "00b8b3856f6f4ce0547ba495fc66c833b30a7b0e3b0310150000671e6274d8dc",
       "pubkey_x25519": "28d4aac9e2ae60bb426bac17b6d70b969f2900cc6e92bbc8f36c16d4d3accd28",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20243,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "145.239.82.149",
       "storage_port": 22021,
       "pubkey_ed25519": "00cba58ba274780d6314742b73a511aa19a37610e101c93c8eb510851dc57fde",
       "pubkey_x25519": "1c784309947a7f83a9f339e76d18baaceea78bd6c26c406371aba1941f0d4d3c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "53ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22136,
       "pubkey_ed25519": "00d2971121a55b9c023b2e8b03ea5c1af4d256ecf7528f311524fc5d0eea621d",
       "pubkey_x25519": "0dc73bb26715f373d232c54462606895fa75c30ef7af4ed90bb88632b1315719",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20236,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "199.195.254.208",
       "storage_port": 22021,
       "pubkey_ed25519": "015a6fbcc24ef876cbd5c417791e4b6f37a16885cd074764e30aae388a81110f",
       "pubkey_x25519": "5e517af33a4edcc4ea7bf4147ef06dc56dcd296cc996e29fe7d7d656dc770800",
-      "requested_unlock_height": 2056299
+      "requested_unlock_height": 2056299,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "102.208.228.250",
       "storage_port": 22101,
       "pubkey_ed25519": "019b5782c2fd8327187aa8722dc9258b38da8b871cfdf6e906b9c6e136db9551",
       "pubkey_x25519": "abe40c04c6731b03f8e934b4c189e728d47f19ca15904244782acd4168e55c2b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "164.68.125.151",
       "storage_port": 22021,
       "pubkey_ed25519": "01b2d3a58ed4a10eaed8b7450de21bb0b63abd37b9862caaa188a36093099b66",
       "pubkey_x25519": "bbd68b82f24404d4c22cb5eb2939f1cdb2d638dd683d13d1036975e5e6ba980f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "184.107.141.171",
       "storage_port": 22021,
       "pubkey_ed25519": "0216a30633cc87446b3beebaf30280e031c17cd7831a46781a3274cf1b143ebe",
       "pubkey_x25519": "c554199d33c25b6ccc6993425e6c7ca2e69cb05a7b89560786ce49e0beb1bd14",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "149.56.46.30",
       "storage_port": 22021,
       "pubkey_ed25519": "0260e90222f61dae1f82d62fc6ed566591c0936ffaab1669d1b5d68f8e9cd9d6",
       "pubkey_x25519": "cfbec1c6189e2f99343a652fda642b0abdbd73e9e2591f89b6d556e749b58c10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "66.175.222.15",
       "storage_port": 22021,
       "pubkey_ed25519": "02769c6698a3142b568bf0d420a98cfadb8c2676212042bad3313411e7cef96a",
       "pubkey_x25519": "be067338b38ae4ae823583502654d02ec1008269278b254459e01c34caa3562f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "102.208.228.249",
       "storage_port": 22101,
       "pubkey_ed25519": "02aba91de5b54501895677632509a405ae6ccd0f0607a932efe3053844931618",
       "pubkey_x25519": "479725c6bfc0c102fa3f25c6249611ea40190111fe845e26cfebc4ba13adab79",
-      "requested_unlock_height": 2059021
+      "requested_unlock_height": 2059021,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22108,
       "pubkey_ed25519": "02c29484abbf83f2efec44c59ea22992a7f22cd068ede29914dd81a239d8addc",
       "pubkey_x25519": "c75fe06d11224128e48dda42f3446ddea821e0c3fac47d39fa70587baf789240",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "165.22.195.5",
       "storage_port": 22021,
       "pubkey_ed25519": "02d103800d67b39c50dbceb7c1953cb82e324d0c963516b46509ccd11e600185",
       "pubkey_x25519": "224fecf4aac5651914d2f10865cc21513cb8c6027abc02c712b17c1d1268f41a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22103,
       "pubkey_ed25519": "02d51ac0ff375b638c96481d78eba46b5b962c77fcb0f4daa19d9a331049d84a",
       "pubkey_x25519": "f2c015516a79bf155b41e1609c2f93f951ba89550d9f4f526843431a55e83f47",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "205.185.117.229",
       "storage_port": 22021,
       "pubkey_ed25519": "02d6e520d3f525d0a7e3672abd0ebdcd152a25c23467935554dc4289f7240396",
       "pubkey_x25519": "54588338bfcc54eefa4ce34aa2c8f24eac216d7b7d9bb869b4bc376c8528de66",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22105,
       "pubkey_ed25519": "02f0c05842d4e32a91c7832c63b7f4ca6f45af280bcfbf143e8b68f4719f4e0a",
       "pubkey_x25519": "0eae2afbaff9a2b0c030949c3c1bc99b2324b4d02845eee86eed3a9758816e6d",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "79.143.190.38",
       "storage_port": 22021,
       "pubkey_ed25519": "032f54b2558819cb61597b99f5bb3dd3c38596c45ef134520939735db1bfd1a2",
       "pubkey_x25519": "43f0cf4be932a1ff17362fd5f6cb919c2b8d0ece3a9f51d5a0768bc0126a0b12",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "affffffffffffff"
     },
     {
       "public_ip": "5.189.184.134",
       "storage_port": 22021,
       "pubkey_ed25519": "0347e64297a989848f0c5e06cfbc08b48030eb37bcb59435a057cdf62fe4c21e",
       "pubkey_x25519": "66097d9f33bf06b4b6e62bc79a22599ec02df1907d4b27108680eb8769cb2446",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.32",
       "storage_port": 22021,
       "pubkey_ed25519": "03b1ffb823dd8cecbb70a2586332e657d7aa6ae22478b51429fe6d12c7af893c",
       "pubkey_x25519": "28141ae61331d9249fcd282ca1adab2adf8f5cf321fb88a31e55982e51eaba02",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "144.172.110.88",
       "storage_port": 22021,
       "pubkey_ed25519": "03db3754a432b305d980b6644bdefa9af72675ecbd90b257d92e925402ec3c00",
       "pubkey_x25519": "df4a6a515c35d261f696a7e0184bb037722090128b5b47cdfe1f1367e9afac25",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
       "storage_port": 22104,
       "pubkey_ed25519": "0420004ea489cd7c1cf07902194eea77f6a1f71ae2acca814bd46aeb3a808c04",
       "pubkey_x25519": "5a60042515a1bde7cee40dd93e3f20fa74282f68e69fc5f0a3cbb06dea513f60",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
       "storage_port": 22101,
       "pubkey_ed25519": "0420006992769849ccf8ee7c5cb83305bf843d732d15852bc7a3cdaaa4573601",
       "pubkey_x25519": "c6d0d936f0598b2494845b3e46f4cd94242254ea312bfcf43a0cf67a0e96004e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "89ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
       "storage_port": 22102,
       "pubkey_ed25519": "0420007cccde5cef12776bb6f7a4ee97135e74dddd627875eeb1177e6ecefc02",
       "pubkey_x25519": "da718373b9e74c6f5423ba34a8ff0d76ba2159a426d045ca7ac1252a651aac70",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
       "storage_port": 22105,
       "pubkey_ed25519": "042000ad62a7f8bc7b458dbd952bacc467d1348f4836e3beb6623fb1bb99a605",
       "pubkey_x25519": "8a2f20319ae94ff1f19677f20fab84a2942c7fee006296a5f5fd3ab837fcd57d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
       "storage_port": 22103,
       "pubkey_ed25519": "042000d385bf799647d92120416b4dcff66cf5f79dae1404395c0b8ccd02f903",
       "pubkey_x25519": "e3137fb6910a77c61a535dccebb574a0c5109764c945f01535c9b18750c3b550",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "213.171.214.124",
       "storage_port": 22021,
       "pubkey_ed25519": "044aad9c1ba9acb340075e575eab1d2f940e52c60895bb5f7ea541310b4b989d",
       "pubkey_x25519": "889945afd29c963295b1a922719a9af8cb346e37996f6481ab0b38039d67321b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "107.174.102.142",
       "storage_port": 22021,
       "pubkey_ed25519": "04732ca016ab612f00c98bf5716b59ddfe4c683ab7eb7158090b573274f1660a",
       "pubkey_x25519": "ce597e20cba3193dc897d0fbc2e200faa90a53a614ba93eb962e9d101e85161d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "164.68.101.39",
       "storage_port": 22021,
       "pubkey_ed25519": "04cd78d5cf6b615aa33505797d163ed55a739d6b6989e5737cdf5c7c13d52bde",
       "pubkey_x25519": "c359717548ef06f57609f11d8033feab4ba9e45b70fb0465adaa83f6eee4c75b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "150.230.150.46",
       "storage_port": 22101,
       "pubkey_ed25519": "04ea9eb5eeb7114329118dfbd5f7cb3b1f8681272edc327bc137e86017e59024",
       "pubkey_x25519": "b15a909f06b860eb11bf2a66089e93bd8601b7ada2cd1b1fd5dde319fcd82a3f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "45.33.48.115",
       "storage_port": 22021,
       "pubkey_ed25519": "0522c4b58689080190ee7cd4dd29b587d1483a851033edb5fb0ac4e1d5d821b1",
       "pubkey_x25519": "c106403b2545b48ea1d310318183090da9a1cbd06ee70499b4cf926e4d05504c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "31.22.111.229",
       "storage_port": 22021,
       "pubkey_ed25519": "05272906543a9cb53a6fab6585dafe5f6f29dda44b847bd90000138b5f4df378",
       "pubkey_x25519": "97405551f5af15a0b01afed91ffe8cb4718a5c088eeaf64e998edc45c07aa532",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "89ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22130,
       "pubkey_ed25519": "0529c957a46d55c52e764d55e18bfb89e3f9a1b560f608e90c88b7d1836b375e",
       "pubkey_x25519": "c5ebd60c431503417992d0d1400a599fb08be3e7b679e06fdf5c8b7eeb7c9d73",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20230,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "23.239.0.240",
       "storage_port": 22021,
       "pubkey_ed25519": "052adabebcf34ebebf46b3668fda1652dc047f883883c0081f29d4649b078129",
       "pubkey_x25519": "9961918a64cbcd79dbef35915ca54b5071b2dd7357f8556d84bdc79ce82ecf39",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22105,
       "pubkey_ed25519": "05633a9ea32f03e2fd2782839efd0c4b7bfb0cec2e661e99a6b7e644ac68a985",
       "pubkey_x25519": "828d0a44bdb350072e49afc437426dc0439b4d8beda849a87ca259e9a8b65862",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "53ffffffffffffff"
     },
     {
       "public_ip": "157.180.78.109",
       "storage_port": 22021,
       "pubkey_ed25519": "05710220ea9c4bf526b46289df01d69f8dcba9aaace7c99fea799affc6971830",
       "pubkey_x25519": "96a0316f9438b95e4eb0c0ab9d582b54378c8e6e27ceb8bc645d3e497bdf4745",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "387fffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22105,
       "pubkey_ed25519": "0573143e0290cee1891edaacfb461861662fb9358504d950c971b61e3f0bee62",
       "pubkey_x25519": "d654a347cfaf332af91530de7607afe747c6ab33dee7b1d985e711e1b049d65a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "145.239.89.180",
       "storage_port": 22021,
       "pubkey_ed25519": "058be550f28e57b13fbb961acb49b2f945c995121f38a4ddff68336b81bb950d",
       "pubkey_x25519": "4019a8ee100e35452c1e30c49183f680b496973215d6126e9d5f023957d74d4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "247fffffffffffff"
     },
     {
       "public_ip": "116.203.91.99",
       "storage_port": 22021,
       "pubkey_ed25519": "059078ddf563e94964a7165f3571d3cf4244c0abe433ab538fc34cfe0f166951",
       "pubkey_x25519": "bf1f00960bb0e0fc460bf12f30e246a039726260c8532903aab580575c090e3c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
       "storage_port": 22112,
       "pubkey_ed25519": "05ce9a2d3686470eb1262eca95fd28deb0dbd17259d0ca12a1896a78afc66b7c",
       "pubkey_x25519": "576da53e3501be7127ed22dc93353f650ee24191d77de1b448be081ff6cc024d",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "64.235.33.114",
       "storage_port": 22021,
       "pubkey_ed25519": "05e0e8c4f1a8cff3753412810d9033268bc339f76f159d8ccc95de1ed2666aa4",
       "pubkey_x25519": "8945073c7a0a28e82dc117611415d5871f3409232ac682089da7122689459127",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "164.90.199.112",
       "storage_port": 22021,
       "pubkey_ed25519": "0607deb29b2f20248ca87a6f5058b9d3dca0e799703288472b4df639631b6ef4",
       "pubkey_x25519": "c973a9d48d1cec6fff2b9319aaaba9c5cc369bfd5d92711ea87a366d1f7dcf76",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "164.68.101.53",
       "storage_port": 22021,
       "pubkey_ed25519": "0625c01f284086f659e9a2ba4b94d2b6eec4ddcd971fedffa858d2c2d833fa1e",
       "pubkey_x25519": "00ff7385815ff0753bdae126a5028d90f6bc2cc94b942a7635fb25c2dd3a986e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "82.115.220.46",
       "storage_port": 22021,
       "pubkey_ed25519": "062f39ae96b406d1f841a05c047eb6f74e968b79da4f81edf1464fd4b0e0febc",
       "pubkey_x25519": "94a1dcfa74d99b2cdf30686e54144c51c92bd02158dfc22ce020d4998767b477",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "173.255.248.132",
       "storage_port": 22021,
       "pubkey_ed25519": "0647dcafb31273cc4d00e1955da3afd601e80841771b29b9aede716115f7a867",
       "pubkey_x25519": "f85f3a1e386725e1052001fe6c98c5d5af0e58dab54832d07b74d59063e4c127",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6cffffffffffffff"
     },
     {
       "public_ip": "138.201.195.125",
       "storage_port": 22021,
       "pubkey_ed25519": "0657d81272e010def2ea9bcdf4112e24962fc5b5957e5291888a07c6b940d856",
       "pubkey_x25519": "4567ac5332303201ff58461136874ed0c5a4ef9df967bb1d279c42b1efa33c26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "149.102.144.201",
       "storage_port": 22021,
       "pubkey_ed25519": "06623be5bcfa9c4100f40a3c6355fe77d2c9336fb1360950d2ca93a4c55bf79b",
       "pubkey_x25519": "aff8f62367b245005927607c71ffff901c1da749e9038b6f8976d53cad54a83b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "104.244.78.225",
       "storage_port": 22021,
       "pubkey_ed25519": "072e7ec13a4a5e5b92370c38e55d01d9cb57143ddc88232a4a48f35dcfa91528",
       "pubkey_x25519": "0b4e0dc632505ff2a17253b672055ab6c1676d58cc3c70ae96ac0a854e07e741",
-      "requested_unlock_height": 2063714
+      "requested_unlock_height": 2063714,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "128.140.43.94",
       "storage_port": 22021,
       "pubkey_ed25519": "0747f60da7fd230067e7f2de67f088cb05db60485b1cb543945fbc57a21c94a1",
       "pubkey_x25519": "db6cbfe06e2ddb2fedbfcdc2c860a634546eb33846b1a495c6a4debc21536a35",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1f7fffffffffffff"
     },
     {
       "public_ip": "75.119.157.196",
       "storage_port": 22021,
       "pubkey_ed25519": "075b6bf20378700da29067cae04e40137b512c7f01b73ed6b9fbfbbd28ade7a2",
       "pubkey_x25519": "7d047d3646a3f9c8e1a0062a8128d72ffedaf78ab0ed991153b8fe68be54ff0b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22115,
       "pubkey_ed25519": "07675c83ec30537c296f622cf38b8df50f2a4bbb11daa8a65ce562930a680e97",
       "pubkey_x25519": "a927c2abcfe231926b5bd0fd5294b716bc577a3bdf1be5fd3a93743c95d9ae6f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "194.26.213.177",
       "storage_port": 22021,
       "pubkey_ed25519": "0769651a82b2a900d440e3cb8fd450b8896ede2552393c65bf64a4e4b0701d9b",
       "pubkey_x25519": "34848f772954ec58718d72aa4b62d8aaf59816ba084a3bd348eb8f5fbf3f1c7e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "38ffffffffffffff"
     },
     {
       "public_ip": "207.180.201.59",
       "storage_port": 22021,
       "pubkey_ed25519": "07ad3ce46d0a87255011798c636406681a092d72885adc6b10517d5050253b77",
       "pubkey_x25519": "88faeab5dc8358e29b4199d1c01d2545735a629fa11c54c5bb581b7673cf7c13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "164.68.98.8",
       "storage_port": 22021,
       "pubkey_ed25519": "07c6170434e3a96512288d8a2fb3246afe2e58292b413421930de463352dd3c0",
       "pubkey_x25519": "692d7b2c95c6354c5e6021e5e214829355b2ae0960f25514908fe8dd8f1c1344",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "188.166.57.188",
       "storage_port": 22021,
       "pubkey_ed25519": "07c6636d3e42955cea5d49ff0e1501275873b1d193f1fc210ab29e6a4fba136d",
       "pubkey_x25519": "6c9dc772694939bdba2535864fa819f45df2b82d60676cd8750f4638b976ae2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "54.38.65.27",
       "storage_port": 22021,
       "pubkey_ed25519": "08000370a3ec0118daa3b8252d79c8040ffdaeae99fe392a923608d10810e851",
       "pubkey_x25519": "f10a695eec5ea4e3f456be67f01625a3699dcaf060b56ee89480362dc32e4e78",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "152.89.29.35",
       "storage_port": 22021,
       "pubkey_ed25519": "081bb1e49ac39cc7c05a7d1d3f89948c3305d6a05eda07e0568826891fa6d379",
       "pubkey_x25519": "80f1aa56523955043dd409633e376cd71d370ac85dfa9be76c96921db1a9a420",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c6ffffffffffffff"
+    },
+    {
+      "public_ip": "95.216.223.93",
+      "storage_port": 22108,
+      "pubkey_ed25519": "081c6d44c7a10ff80b86037d6de0adbb5ca911cb8db93831a0dd484d1f387572",
+      "pubkey_x25519": "04385e377449f5ccd9f2acaa542024fb5dd5bc474524f96065bcf775381f8650",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22408,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.9",
       "storage_port": 22021,
       "pubkey_ed25519": "084a2d45603ac18b1f1f10c547d85c6a140271366500f34be361577d54bc6411",
       "pubkey_x25519": "823f5eb1d57769c452cf7f3135185df70065bd69e85c987892d66a0f5557990b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "62.72.45.244",
       "storage_port": 22021,
       "pubkey_ed25519": "087b62c32ef17c79f627fc25536d76201eb8ac174ec2aa191a452e09658404ee",
       "pubkey_x25519": "0c6f007eb8300397eef8b885573c02cb87e6fa1e38d78b6594c6bc75b816a175",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22108,
       "pubkey_ed25519": "08c5f20aa9be8a0470926225a73c565d8d140b306826f2cd36483f0abab49752",
       "pubkey_x25519": "7a076e4ff4e31f4be973f9e5de363346bcc2d6c51034ebc0b703ce09c1e25e6d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22101,
       "pubkey_ed25519": "08ff8a8bf860aee0aeba6c5ebf5f7ca0e0480228f5ff50b70f2e04916c176739",
       "pubkey_x25519": "be0ecef4b2996cc4027de95945cc2b299da465c0473b7e40673f80343444b72e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "198.98.52.68",
       "storage_port": 22021,
       "pubkey_ed25519": "091546ffcfeefec168488f80ae5a79c6b896dce0a6e4600c971f9333b559157f",
       "pubkey_x25519": "b69ae3b0119f4dcb4bbed5e9a073f21e27f79b9613ca74509f3e6fb9fe0b4e45",
-      "requested_unlock_height": 2056568
+      "requested_unlock_height": 2056568,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22105,
       "pubkey_ed25519": "0918aa5f3b181aa20ce69e60837a28f89b6618b062d64b54f5af3c3ca6e7fc2d",
       "pubkey_x25519": "0b18a585db56a51cbef994151bda86506b9c0838f340174071c9d365c3c1ed13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22107,
       "pubkey_ed25519": "0935646d07ac65020a45e1ca1b09cea44dbb8ca5064d16f7311c5616a58191ce",
       "pubkey_x25519": "76f505ca264c3ae31b8e1e1356e2a9f486b688c2143a72cec3a640d8ccbd3609",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22407,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22102,
       "pubkey_ed25519": "094a13930303fd8403cca54a7df979ce5cada6e3302e0f5a2c2edd6e274ffff4",
       "pubkey_x25519": "dda327c89668a64fd2be25a80e799a4eded52cf67f9a216045f5eafdf3f50514",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "62.72.42.149",
       "storage_port": 22021,
       "pubkey_ed25519": "096ea812834d10406d788cfa78a6a86f1770535327aa646b200be358e4b49c06",
       "pubkey_x25519": "a9e841c77e795f0827e0598d676d793a0d58c54ee02ef7012d77d53ec3d9d667",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "15.204.247.48",
       "storage_port": 22021,
       "pubkey_ed25519": "0994beae91a5a60dabdd3d3fb4e1575a503d8d4846f3ddeddd5d1c1908fe9b80",
       "pubkey_x25519": "366f44a2c641826d876cf4cee0f0ab2e22e880aa03832c5b48d9c4ebd5b37f1c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "154.38.180.45",
       "storage_port": 22021,
       "pubkey_ed25519": "09e62f283d614ff88506b6c5c830ea3ae9e6a65ff60d1606b1f6714476133d23",
       "pubkey_x25519": "839cf6f87d9021355b1c13f985ffab276118817bcdd5e679aebe0f5a628bed24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22114,
       "pubkey_ed25519": "0aa5bc282f724ddc55e172618f17e2adc6f3cbc0097863934989813ddabd57a5",
       "pubkey_x25519": "54702be33281f8211119cb3498bf51a7c69bbcdf65559008f68cfb6254f5be71",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "164.68.126.130",
       "storage_port": 22021,
       "pubkey_ed25519": "0ad04d2e4d73382336cedda832e86cffa1235342a534d775e6191e292b4c31d6",
       "pubkey_x25519": "ce707b65f6440c1af8666844b910596a2f35003ae4718afc1ee57e761457e703",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "144.91.76.172",
       "storage_port": 22021,
       "pubkey_ed25519": "0ad6d50b6cc25ec48e1322b2806978c517c4b012dc6fb8cfeea2801f7efec0ed",
       "pubkey_x25519": "33b29cd764290467a946d3b1829b8ebd6ae56efc68ab956a18f2f9de5eebea6f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "109.123.247.227",
       "storage_port": 22021,
       "pubkey_ed25519": "0adb3942aca18d7321dda2ebf8f07303a1247d30d537ae6aef5bd2b453ccb30d",
       "pubkey_x25519": "60c604e7bfe76ea150998cda60e2cb99828e8d36c543c4ad53d60ab704d3972b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "5.78.45.225",
       "storage_port": 22021,
       "pubkey_ed25519": "0b2a63306e330415aab9f281931f6544a67748d9103d03533110c68af53cc4ac",
       "pubkey_x25519": "fae9b64e26873908f526554fe89067563220a1caa172d3664841a12c7fb7252e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22111,
       "pubkey_ed25519": "0b5e1b69725af866240d1ba59a39220a8bb176f04715d73ace35b6894b50ca30",
       "pubkey_x25519": "743902fb0212e41d78fe66ab29e22864e3505f4cbe5940ff3c8bb586e170fb69",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "89.58.30.52",
       "storage_port": 22021,
       "pubkey_ed25519": "0bc0ff22113bb03d521eb0a60aed7f1dc5b2866a9a04590f66dea9592825139c",
       "pubkey_x25519": "7f0c508e9a3ba19f0ae1669c094515b59042bda9c6fbaabc7e7cf3ec29293916",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "135.181.153.185",
       "storage_port": 22021,
       "pubkey_ed25519": "0bc9eae31da3ae1949e2d6af39214442873fbbddd391b5f8f938698db43e1c89",
       "pubkey_x25519": "5bd3725ae72f4c231f925e65dbe959d7899fe80eec9422c6d4eee4b68c64675c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "51.161.134.230",
       "storage_port": 22021,
       "pubkey_ed25519": "0c137d05b3ddf88d61ac6cc2850ed81f79dfda1cc75e86ec54594031a2bf8431",
       "pubkey_x25519": "c79924b0b02934f730fb5f5cee7b2db348a4d72417a33449c7ec4c8f582b655c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "45.79.66.109",
       "storage_port": 22021,
       "pubkey_ed25519": "0c6fff265cda975399ca2bdbca92454b8fde4beb265ef00fd6851e16903e58d3",
       "pubkey_x25519": "024d5577dd76d53714e8484587fdb8c0f3ebaa404e95a206744fac5adeda275d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "59ffffffffffffff"
     },
     {
       "public_ip": "49.12.96.107",
       "storage_port": 22021,
       "pubkey_ed25519": "0cb4dc9f2208c614e7809ea74566d660b9eb7317ddb86ceea43e9fd8c3f5aff1",
       "pubkey_x25519": "3abaf580feb7f430788561bd8d3801d3c61c7b66f1d01857e1aecbf8cf8a5d29",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "affffffffffffff"
     },
     {
       "public_ip": "107.189.13.56",
       "storage_port": 22021,
       "pubkey_ed25519": "0ce4ff11f13d000697b9543d1cbd8c757673a76683c99993add2717fd5726d34",
       "pubkey_x25519": "1ea3ce87ad63fc7cd038c57d6626c17c4152ce7228185fa4b413956665ed7d49",
-      "requested_unlock_height": 2064051
+      "requested_unlock_height": 2064051,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c6ffffffffffffff"
     },
     {
       "public_ip": "104.218.100.6",
       "storage_port": 22021,
       "pubkey_ed25519": "0cf0d9581388fca85566ccd6f40de93f14521f01bb41b841337b662ee633a3f3",
       "pubkey_x25519": "fc0052ebb9a44f03f3c21e249b7aebd3412b0530dfd40d37e2c8a6150b3c7a58",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22101,
       "pubkey_ed25519": "0d04257018b89e991b5a27848bd2a6e9574981e5c244c317f8661733f300f099",
       "pubkey_x25519": "9b74721df1dcae71d15f2561a76b5714f8d5984b955d68962acba36672543c18",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "154.53.62.195",
       "storage_port": 22021,
       "pubkey_ed25519": "0d08373838d99fd08603bd38f813203772a415b61ece78efdf0abd2cc85ed831",
       "pubkey_x25519": "933d3f4c2593bb225a17c87212e6ac0fce77ef37e9b9f85d4c79c65f5fef3077",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67ffffffffffffff"
     },
     {
       "public_ip": "164.68.97.254",
       "storage_port": 22021,
       "pubkey_ed25519": "0d56fb3e3a0239a54c48b40f42e64a2d7b7d6043cbc7a7ecc768fc15a3fcbfd3",
       "pubkey_x25519": "eb191d7eeb84300dc5c7f2cf621490f8bcd66614ca62205b068e92e974c7d20d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "139.99.133.148",
       "storage_port": 22021,
       "pubkey_ed25519": "0da6da6bcd8a6c56bd38d93428abcabb3b1eeb5594d10477dad0362c3aef59ee",
       "pubkey_x25519": "7c82e580c3b91faeafa7b56939f14ec66f6cf782aef783f4cff5a05ead3deb24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6cffffffffffffff"
     },
     {
       "public_ip": "5.22.219.119",
       "storage_port": 22021,
       "pubkey_ed25519": "0da720a2bb5d9a896c665c19a0bf2f3dbd8dc9ea70173b985d1f0aa21a1f36eb",
       "pubkey_x25519": "14f75e01812fd2c888c04cea4284be6ec430da2202c6edf3187a8a9e3b60a94c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "147fffffffffffff"
     },
     {
       "public_ip": "51.81.34.178",
       "storage_port": 22021,
       "pubkey_ed25519": "0ded13763b02fe06237a0c6da10ce380d985f5adebe5a46afaa438784578685a",
       "pubkey_x25519": "f21700da347f9cb91896b424265e3cc9d8ef0b94a0a342c8ddf5c72ccfdd822c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "139.99.6.204",
       "storage_port": 22021,
       "pubkey_ed25519": "0df0a6c1f387bebcb2967edc7e0254670ad777f220044b2b6300216c207056a2",
       "pubkey_x25519": "f845f7e9d13a94b27ff31108ae289ecb6e1c18c0b2a44bbbb01c5169d2426a6c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2f7fffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
       "storage_port": 22105,
       "pubkey_ed25519": "0e113e0a8199ad4fe7a3cae13df4ab238b49c1a31037a3f50b7b7ab31798903a",
       "pubkey_x25519": "cc88e63260553d2bfd21aec7a7ff8788bf3bcccd8c661a92ada4a929029a922a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "192.3.211.92",
       "storage_port": 22021,
       "pubkey_ed25519": "0e334283dedccde8aaf6c0633497bdeeb21c7e7c13ad45c9077d62de450d14a3",
       "pubkey_x25519": "65e510461497689b0ae36ffa2fd41e8821875b1477fe94c6a7e12778bf1c4609",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "39ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22117,
       "pubkey_ed25519": "0e3b2c5bc03e0a42c16f2930f7a4b1e5a2885d5ba7025648d7e0aec08a0b7930",
       "pubkey_x25519": "e2c22fe6cc5556432a49c55dac93e15dbc0cf7cc1a88ae9b7be06b5d1963592d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "77.74.199.109",
       "storage_port": 22021,
       "pubkey_ed25519": "0e48a182ee2670f3f078911288286e6d9141e02c6d845668181d28c0456c0111",
       "pubkey_x25519": "0e0171ce4b0a5ebe5063a6221510c2493085ce7d105e6c60e592bf6c5490c321",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "96ffffffffffffff"
     },
     {
       "public_ip": "100.42.178.63",
       "storage_port": 22021,
       "pubkey_ed25519": "0e89abd7ee561131be4e52539da9134d4b3d3faa5798e2b1975db002bfc0b2c7",
       "pubkey_x25519": "dfff5e78a86586074316bd05a873650aa87b639c1a80358b3dcd21ad4f59427d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22102,
       "pubkey_ed25519": "0eb20b4ccda995691578eb2294804dfa23b4ea83ccad1345da2b32d9beca8a17",
       "pubkey_x25519": "bb06d5d7aff9122ea4e67a9d3c351882e1a2bbac136f9d5e3d76f48124e74857",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "20ffffffffffffff"
     },
     {
       "public_ip": "198.98.48.221",
       "storage_port": 22021,
       "pubkey_ed25519": "0ebdb5e13a0458ef6cda459c4f6110cfec03b6f352fccf32d17af10f27a76d13",
       "pubkey_x25519": "abe2a0a3451a102eb65581adc0d7778bf14d7e321471492d7af24b451a2b4a61",
-      "requested_unlock_height": 2056295
+      "requested_unlock_height": 2056295,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "327fffffffffffff"
     },
     {
       "public_ip": "104.248.196.63",
       "storage_port": 22021,
       "pubkey_ed25519": "0ecd1c85a5fa50092f202d7ca243dc4353861c6da90e0a8f5ec709996502c8c4",
       "pubkey_x25519": "96c17c9d71ba15957075f19c47f57ec678666283134c6545f2110d3df43fa152",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "142.91.105.124",
       "storage_port": 22021,
       "pubkey_ed25519": "0ed0ca5dd6e1cec903f590d352a6f6888d956015afd764b42ef654d702a1610f",
       "pubkey_x25519": "0d10ff619093a9fd9a0380ce0c9ec57be09af8f0197db974b2004aae0b47e521",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
       "storage_port": 22120,
       "pubkey_ed25519": "0edf48cfbce29f71da6ba60b213c89dc1d44703fa69949c66e31b664e37942a2",
       "pubkey_x25519": "b057a4fd95d172583776fa362de9ea51e2349fe78d59fd673f398257a8b0824e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c8ffffffffffffff"
     },
     {
       "public_ip": "164.68.126.26",
       "storage_port": 22021,
       "pubkey_ed25519": "0f19d169658d7b3ab8e417332a48abe5edfc0e34352d002c04dec8a4be49c8cd",
       "pubkey_x25519": "57348059d7706b4d81aaeb3cb19cd0c86239ee4dec327621b9fb207f2ea34f2b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "154.12.235.135",
       "storage_port": 22021,
       "pubkey_ed25519": "0f366f78ee4fe0f0a9a0b029f5730eea53dc84989604f1e327212e36495d192f",
       "pubkey_x25519": "4f987e735190fe2eca5ed2d55ce9442687768ed478224dceb0917bf98224c162",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "91.99.186.114",
       "storage_port": 22021,
       "pubkey_ed25519": "0fd6b23d93f4c7b95e5a1333deb5f5994a22797e77ac5f38701c2a0aa113a2e3",
       "pubkey_x25519": "f5f6bc83bf3899673426a80dd5047f94457ad834a487d7346327a36879f53e4a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22102,
       "pubkey_ed25519": "0fdd51f8a5eb7509ea3c093191516a7ddc485d61c63831d02259e76783ebd0c2",
       "pubkey_x25519": "4fd4178848883fcb649a4639232fc88cf5d1b1a6439e82ce2739c723f3183328",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22135,
       "pubkey_ed25519": "104b26541826a2fdb4ee22d5feffe7b69e9b4e6e0bcd03b7651b0538aa686cea",
       "pubkey_x25519": "ad792ccf84ad0ca2d48c3cd4d97ab27293d9552fa9d4f141a459982638101a68",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20235,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.224",
       "storage_port": 22021,
       "pubkey_ed25519": "1058661e1a5595c2eecf3a8f83dc58b83d1f3139f5b6bc10e2840dc8662d74db",
       "pubkey_x25519": "5157ff751d8b8b20ed156b9cbcf9716f43160581f7014a6ea95eb5dab0df370a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c8ffffffffffffff"
     },
     {
       "public_ip": "86.48.5.122",
       "storage_port": 22021,
       "pubkey_ed25519": "1076f78be9331b56f9ddaa082a9b145febb58c29c6c1836c8f4fda110804e650",
       "pubkey_x25519": "ebb6db0f0f491ebc2b8c4b3b398578be11bf77183d9bdda75977b52e41148f4f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "158.69.223.154",
       "storage_port": 22021,
       "pubkey_ed25519": "10840dbcbbafd24f3410a005af241419cf9af23db60885c7b3904b67611f58f6",
       "pubkey_x25519": "5d2d38d49f14d4f77c43597e378e6b69c2f3c77c7cbfad2b998faf59b7fb7874",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d8ffffffffffffff"
     },
     {
       "public_ip": "92.112.124.193",
       "storage_port": 22021,
       "pubkey_ed25519": "108748eb93664bdde601589137cd7c3ecece96bb18336abc0beac4adac6d577f",
       "pubkey_x25519": "923bbba01eebc53fe7eac39c409562088802f5d90a69d2a2b154dd082ad54d2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22131,
       "pubkey_ed25519": "10a4d8acf7e3ad406d91555b26016f0fa4f032ef5f40be33f72aa7662407c161",
       "pubkey_x25519": "a82887fbb40f980b4960acf27be1b03b442078c7d3a64b11012f62a889088f74",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20231,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "23ffffffffffffff"
     },
     {
       "public_ip": "51.79.161.81",
       "storage_port": 22021,
       "pubkey_ed25519": "1106d6cefb5df5192a43751bb0fc5e885e6a8067a598e6cc33fd6c7f4cfb5934",
       "pubkey_x25519": "24309a1efbbc4bff663fae8e597b6cdcc0b0ae76560adc8b66866341aacd2271",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "86.107.168.151",
       "storage_port": 22021,
       "pubkey_ed25519": "11444fd6b1aa725a9d975571eb26804626e6ab8640e7e3fb2a8516cb327b0414",
       "pubkey_x25519": "422021db6824aa39f0d9f0fada5a54bd13d6f8ba692237707204d9f55cfae639",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "affffffffffffff"
     },
     {
       "public_ip": "51.79.85.184",
       "storage_port": 22021,
       "pubkey_ed25519": "11525f4493e01f1ccc840a3afe9cfb3240d25737473e0c4b412c52d1262439e2",
       "pubkey_x25519": "d879b768ab46c9b0f4c0b02808cd6f3576f4d0fd0ffdb6ddddac413defa5ac45",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "138.197.206.211",
       "storage_port": 22021,
       "pubkey_ed25519": "115328323408bc4526ae86a5c042b6a336213260743af1e221aeafa7bf9ba3ca",
       "pubkey_x25519": "725c723f38ce2529217a88e18abd37ccfcd16eb596d06dd4c45f9285a8eabf51",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "185.217.125.45",
       "storage_port": 22021,
       "pubkey_ed25519": "116d7be19b97674e108cecbfaa23657b17c02ea72bd8d751ee66c922137620f8",
       "pubkey_x25519": "d149f0a504f5f4a72c6c8c5acc5395923922b7555de189ffe8ade5593ba91f0c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "91.98.16.40",
       "storage_port": 22021,
       "pubkey_ed25519": "117e28bd98ccafe9b6de035c8e1391d2ec88416b7755c2d6555b0ccde57b0a15",
       "pubkey_x25519": "e3034128782cc6530ceadc2e03534a39449dddee7967750b6f970683f4ff875a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "38.242.141.83",
       "storage_port": 22021,
       "pubkey_ed25519": "1193cc9e86deaa057ec3d127725df49ae13135338e3a78e26b13dc244f2e4c0e",
       "pubkey_x25519": "8ab4551df73227ab1b3e3a907a5a9ee07302723707b287adefa65994290e9604",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "96ffffffffffffff"
     },
     {
       "public_ip": "45.154.197.46",
       "storage_port": 22021,
       "pubkey_ed25519": "11a1a75139c82c7e903fe0dfd63561992714b3bbc700310d4c3feee0ead8838f",
       "pubkey_x25519": "cf34538a2863a7000451783304b07991b3a052b43394ae270e1139f1559a9822",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "3.215.58.127",
       "storage_port": 22021,
       "pubkey_ed25519": "11ab4e1e14271f3760b9e6ddc445a4e37d78b4e9ab7be8618e557b8d4eb5e487",
       "pubkey_x25519": "6aee149dbb9420e35d3ea25b5d868b97a1ead8abba10d0d08f34f6175a146a18",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "147fffffffffffff"
     },
     {
       "public_ip": "164.68.125.218",
       "storage_port": 22021,
       "pubkey_ed25519": "11ad1ed83f3904d8594bb41b7cf8de6aaa6b1ccf8eb5719d2addcbb0efc2ae5c",
       "pubkey_x25519": "7cca5e137e0bf98ee0841e365561977c93605d359c3dee84e656ae53aef7d12f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "91.231.182.75",
       "storage_port": 22021,
       "pubkey_ed25519": "11b5e9ac538c4663b1db96b7d7059eefcd50f9ad84789cce3fb3ab391724b7c7",
       "pubkey_x25519": "c572890b9aa69647a5031460c0e768c204475b5c6d23d616422b226b88bd206e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "139.185.46.77",
       "storage_port": 22102,
       "pubkey_ed25519": "11d6e04e3bfe5591d98966962aae348bd020989f361b22223bfa2db0e1f05939",
       "pubkey_x25519": "877d41b484bcb205950f5548174f07a36ec77f1fc487b0088c49a1aa2dfb6816",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "5.22.222.67",
       "storage_port": 22021,
       "pubkey_ed25519": "1215398eec834be85b46455d7daf064e3732adf5eefeb91ac57fa06dfe577f89",
       "pubkey_x25519": "8051df31ff70d672b2c3d7e983e1b7ffcd5155cc273f4ead90dd6eff8c7b3743",
-      "requested_unlock_height": 2056356
+      "requested_unlock_height": 2056356,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "158.178.195.222",
       "storage_port": 22021,
       "pubkey_ed25519": "121ff61a485e45ea87ae135314ed37abca0bd98eb4dafb3f1e7967f5b96cbf39",
       "pubkey_x25519": "32586e97ebe6f14c91551527fcf9fd705055c59b8c5cf249eeaae922f6002d41",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22106,
       "pubkey_ed25519": "1351d3fdc0777ab0c7230db8c2c574bba4610888816ef3b088dcd84dbab9f7b1",
       "pubkey_x25519": "bb2700b8bba417cc5cc4d3c86e5365b6743c390140b54293ac11942e270f393d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "35.236.80.3",
       "storage_port": 22021,
       "pubkey_ed25519": "135f3fc6d653d316e68f7c164b2fc4e577b8dbca2cfb2be570403a6688978c03",
       "pubkey_x25519": "6391710b466ca3b9ba9c236badb0815bf635069c7bb2ee095e8456e4d6f84c65",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "136.144.244.103",
       "storage_port": 22021,
       "pubkey_ed25519": "1372cf1968a7e3115f3db1a202be83a18b9f225d24d7ac7bae064b1ff6ae0bd6",
       "pubkey_x25519": "37f526e2c5ad7f4e2f5893a93527602898784e588dc69064fbae4d3aad5bda02",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "5.223.66.134",
       "storage_port": 22021,
       "pubkey_ed25519": "141d831ee76d49df0f35b9e5d01ad967ad444537b78b11f7958e4a68e99fa414",
       "pubkey_x25519": "9ee7b80b2632a7c70609e0c6705df82eaa359bfdd9da1ac99e3b843a92508836",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a8ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.167",
       "storage_port": 22021,
       "pubkey_ed25519": "1439c118e7726865a3efc2141b443d5e05a2b2e03f37a74403c1144752001acd",
       "pubkey_x25519": "13487305ef955acd111483f22ebe16c2eb50cfa65a102e3fa8203cfdbd39a920",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "327fffffffffffff"
     },
     {
       "public_ip": "82.223.70.189",
       "storage_port": 22021,
       "pubkey_ed25519": "14f1bfe3ce366d30c94ef71a8137720cac6079183c5110bdb9b2162df5efb9d4",
       "pubkey_x25519": "3276e7bfb184cdc18057091b367477f7931e8193966943a42684103facd0191b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "91.99.10.205",
       "storage_port": 22021,
       "pubkey_ed25519": "152a2b3e74a7759c23558d7c0646f333bb30f9f75cbc3ebbea6f8ad9966fb127",
       "pubkey_x25519": "3d825f82f773441ac852de5db4f56a1f8cf18db5236ef7512eb402300347fd18",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "164.68.114.12",
       "storage_port": 22021,
       "pubkey_ed25519": "1554eb566edb0c1d4423d35ee20a5ab173f43a2d2d8a5334b61ea9f5723cdea2",
       "pubkey_x25519": "d956e6aea43065a3384dfff86efc82e75bfa6ac8625842babe574e8b1b50e179",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "146.71.85.145",
       "storage_port": 22021,
       "pubkey_ed25519": "1585a27d5bbf761cc11b6e3c13afd5e96d1402826fd07f343ec9a6e517630e8f",
       "pubkey_x25519": "5190274d83dbefa7ae48b662a07a8fdf42fc2904fc3c2cc899eabc39a99dc372",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22104,
       "pubkey_ed25519": "15ad47847fe129ae40d0676fc74ba9ea6bffcac0c6dbcaf27154be682b132b8d",
       "pubkey_x25519": "003229a12f3f7e889d933ce5b8546e845be245fed2c3cbf80b63130842bfe26f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e5ffffffffffffff"
     },
     {
       "public_ip": "51.79.173.182",
       "storage_port": 22021,
       "pubkey_ed25519": "15c457c08e7fb855b596e06081a1c7006b2de0c872ccfb1201c14b1a03757adb",
       "pubkey_x25519": "8235dc89edf0f2b5de6c1114a3c852f53dcf3ca029d8a0c1311668e7d2cc1627",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "95.217.218.66",
       "storage_port": 22101,
       "pubkey_ed25519": "15d5aff81157128e0a5d9c3dc278c0b8c23f5ad734b3627a15d708e9bd50eb21",
       "pubkey_x25519": "d4620c192bb23eea61d64451b59ecf10a8f17fd32240dca030a76d2a6acdf56f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "198.98.54.28",
       "storage_port": 22021,
       "pubkey_ed25519": "15d848d64c5eeac37618849c8b6885115fefa79f79e3d42653da8e056717a143",
       "pubkey_x25519": "cef178a49e34afe37745c15aa5795ce27ff9b7078573be8e96241943d5674a1e",
-      "requested_unlock_height": 2056294
+      "requested_unlock_height": 2056294,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "205.185.124.31",
       "storage_port": 22021,
       "pubkey_ed25519": "162d570c061db82091db04ec531426f7765b9aea500100e7774b07e31561ec0f",
       "pubkey_x25519": "87325f5f358b594d59ec244cded81763c73afaa24790b01faadad9d6a7d08b53",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "164.68.101.46",
       "storage_port": 22021,
       "pubkey_ed25519": "1636d40eea2639088b11affaed8ddcf8650377019d4385559cd6f205e645ea33",
       "pubkey_x25519": "8d3c61bcc0d7f23c21ccf35efe9551612e30b0d54bca3aa26207b55c84b82a08",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "38.60.156.237",
       "storage_port": 22021,
       "pubkey_ed25519": "16481769aa4e9aeaf9b016402d7c12518558b28c79bc28b9973db971618a4b50",
       "pubkey_x25519": "102c7ddf875811990184c44d03631ac5364235dfba21593bcd1a0a44f718bd19",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "147fffffffffffff"
     },
     {
       "public_ip": "185.45.113.185",
       "storage_port": 22021,
       "pubkey_ed25519": "165b15e05cbe2cf946c45222f8ab65006043b3586faf6d0f648651a2b3ff059c",
       "pubkey_x25519": "e78c268b5ec7a37792acc8884ba92cbfb558e9062306290733b7de3e7a1d703a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "198.98.59.173",
       "storage_port": 22021,
       "pubkey_ed25519": "17421ce31a6b6aa8c2c7cdffe35d0794565fa7520c4ba3911897ea138ff837fd",
       "pubkey_x25519": "9877a7d4b0a412125e5febb41d75bf3002ea5e3be8365992d2c76739550e4e7c",
-      "requested_unlock_height": 2056569
+      "requested_unlock_height": 2056569,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "51.222.107.179",
       "storage_port": 22021,
       "pubkey_ed25519": "174f0f9b5e4d913269c76b9dd3b51d5245ff69f081a4fa275a68f18e284d6e70",
       "pubkey_x25519": "c3ac9d1564505aac4b5fc4ffc014d8857d647a36e73c985d98ad14dcb7a33920",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "afffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22106,
       "pubkey_ed25519": "177615ced0287372cf0158c83def2971f2bef0f2aebf3b17ec2af5008fc56852",
       "pubkey_x25519": "5dfbc547ed14ec33c8033556556ba900b38d76a4f33d88c27f9e37b77cd75d00",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "164.68.114.10",
       "storage_port": 22021,
       "pubkey_ed25519": "178a0447573738dea4e83a1897292b2d711072aad6d44bc39565ce791efcefa3",
       "pubkey_x25519": "c90c18bc6f778fdf8128cc781afdcaf5585cc86dd0816f942485fe91b4c86163",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "164.68.114.40",
       "storage_port": 22021,
       "pubkey_ed25519": "179042eb07305f608bbd3a371067593aecd77d1fb3da9fd551ecfc58f6066421",
       "pubkey_x25519": "1c220712693c434832d03f5f8c516a2215db7abd33818d60b3416cd2fba1c735",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "173.249.30.151",
       "storage_port": 22021,
       "pubkey_ed25519": "18074a5068e15e1289e6279d13fa0d0aa6d1e055b5956c829671eb887c2aef34",
       "pubkey_x25519": "6332a8d1994f205662881354b487932b6f3a8f29ec76387ee0fcfbd16682de5f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "45.88.188.183",
       "storage_port": 22021,
       "pubkey_ed25519": "1812103cfa87f63f5cee3d1f731ed12e8c2d2810c0bfd927990e4c474bc80909",
       "pubkey_x25519": "f8b934ef918bd080de946d5335a8f23507da86caaf597a9f08dc5c2809b0fe6f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "51.195.117.60",
       "storage_port": 22021,
       "pubkey_ed25519": "18157415e8cbce21b21e781913a8a69502e6d32a2578315ade1ac21b1ccbab2a",
       "pubkey_x25519": "2abfa04ffaf1ce515eea68cf743cdc10b29ce01331c708b7f14f1d18edc42804",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "85.9.208.51",
       "storage_port": 22021,
       "pubkey_ed25519": "187f643e572dbd5babdb713825f13048950d11be71d38e79ab2c80031f57ba65",
       "pubkey_x25519": "3de19cd48c19eb9cfef61dff5840694e85f16068fe6567b9f3c184b8fd236a1b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "141.145.218.202",
       "storage_port": 22021,
       "pubkey_ed25519": "1880c36b3e5689d4e067d98ea8678597b0912bf9023d1761165490b778a51bf2",
       "pubkey_x25519": "06f018f48812f44e37043f6864fb687b6d0327a446d9e141b1d8d124d0647a61",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "45.79.65.63",
       "storage_port": 22021,
       "pubkey_ed25519": "1886478e919569e22854d20a5fd858ea06e4965af98e44dab1cf6da9b7fef474",
       "pubkey_x25519": "6b1d2b9d1a1de3dadf56dcd7e5d95cd7a87b69aed0462eefc1824151f300256b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "159.195.84.13",
       "storage_port": 22021,
       "pubkey_ed25519": "18e50a127bc94a3b3bd89c61258cb5469473d6e9b327e95ce09781198e720f91",
       "pubkey_x25519": "147cb685c85e4d9eaca49fa789a0a25836c52ab4ce4eecefd8360f55fe9a3861",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22101,
       "pubkey_ed25519": "191c854219fba4405c244c7c750fff910f6ce669b0e72c444b8912a29cac1806",
       "pubkey_x25519": "67c85b06822a12526bf484b77b0ddfc54415bf74e314f7d0549fb9f97516496a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22102,
       "pubkey_ed25519": "194196e47fda040fb328762981d162a604ef283b348d17bbe877d1bd876c8f9a",
       "pubkey_x25519": "a48b0cddfd4b5795a8833ee8347a61d7c55110822286f4a3d5f49eba9e964520",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "64.44.168.82",
       "storage_port": 22021,
       "pubkey_ed25519": "19bae8ba0ba256f2e4b5863cfe75424ab5450191c5b905e59649acbdd63fc596",
       "pubkey_x25519": "c11ec5fa69afc2053810e9fb590fb1320bd494a8ea774aedc9e28e1c5c004126",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22116,
       "pubkey_ed25519": "19c03fffa95753fda1b41bfb226ac47f4ad3788fa5472157e798015edc042042",
       "pubkey_x25519": "23a9bb5a1233dd1e0529f9ba3a697e8f402c1d5f1c2cb880c07e0ac3c0b88061",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "185.45.114.9",
       "storage_port": 22021,
       "pubkey_ed25519": "19e50188acb58de0ba43e1ff2f2eb8381f964718e327d8b591eb8fde413ea296",
       "pubkey_x25519": "85b430a9f8f0c174e8b0579fe860b96b08db580c96e9be9112b6c0510695ca0d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "487fffffffffffff"
     },
     {
       "public_ip": "104.244.79.204",
       "storage_port": 22021,
       "pubkey_ed25519": "1a2f0d7a1e3e7f3a8d12ea131fe09d547cfa6bb9d533a99dd544e0e63f556a12",
       "pubkey_x25519": "d635083bc38c0152b3e66687202d4f0c3835c5c86d514b04de3bcb6492185d27",
-      "requested_unlock_height": 2063712
+      "requested_unlock_height": 2063712,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22123,
       "pubkey_ed25519": "1a855224581cb9634cedc0c1dad96141234a989788d9e2d7dfe3a10908960df3",
       "pubkey_x25519": "1c83e8531163c567dfcab0deb7cda07d74ef2238eedc21a978fb8edce78ff456",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20223,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "141.95.149.172",
       "storage_port": 22021,
       "pubkey_ed25519": "1a89189d0a0b5ebedc5f5a948bfdadfa6da005a231b6a09a1a6ca43761db5297",
       "pubkey_x25519": "95064705ab5928ab351ffbf7676da99c09be24c0972e1b9550821e2b8388bd05",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "94.237.121.135",
       "storage_port": 22021,
       "pubkey_ed25519": "1aa4c4dd41766b0bcfc2667f346806078fc2394873ba779093e3c06b6a81264a",
       "pubkey_x25519": "9eac24b77e93e33579fa79f4806ed5018386cbd95b9035881888179d28fc3347",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "107.189.2.83",
       "storage_port": 22021,
       "pubkey_ed25519": "1abf17efe0021bb50da0ddfb469ee3a4333da5e2549ce281e082440e4375dbbc",
       "pubkey_x25519": "0c103488d3dd88a772818ebddae34e629667d18d8301a28d8c3463b76fdab529",
-      "requested_unlock_height": 2064049
+      "requested_unlock_height": 2064049,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "5.78.41.67",
       "storage_port": 22021,
       "pubkey_ed25519": "1ad52a6c993ad15a58e5fd8297e794f91fc7a63d3ee4144b4480ee906d6638aa",
       "pubkey_x25519": "9f590093f4029c0ff9d58e17b3d08a92cc631f20304cf2d0b120a67d0c0eb930",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "184.107.141.170",
       "storage_port": 22021,
       "pubkey_ed25519": "1b331088cb13056ab285793c370c607e0755e8bd96fc7c8c7c5fd74d679840d2",
       "pubkey_x25519": "6c7c78e6f01108a3c4ba65befaea8b7f813dfc6d3c6643005962c92fc9c7fd5d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20603,
       "pubkey_ed25519": "1b77bc44b0c948a89cd8c45d76626a97431cdae29cce63fbefaeca24e24529bc",
       "pubkey_x25519": "390daab0c87f2f4d1dbc4940ff67af9f7cc909cdbcacf3432b719879f7767550",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20903,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22120,
       "pubkey_ed25519": "1ba159a878cfcc649f7118783ab45b819da125037490934f744dc7d2da8e8fe3",
       "pubkey_x25519": "b4b1b0b93e38d33097cafe0b1896fdea350b0325c4d491e423f43d81f08bcc26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22126,
       "pubkey_ed25519": "1bb14ffc2555df6fc581828df1f0c4ed9aa45605c7b0b72b97a4bfcdddc4d7f8",
       "pubkey_x25519": "8a311da8c8bce17b25ae22a5cee37e0a3ce1f3d9f3c31cfff8b3317894c2636f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20226,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "84.247.128.37",
       "storage_port": 22021,
       "pubkey_ed25519": "1bc939df19403acbb796ccbf18c0f96a97b931074e2d3fc81494a318c04df794",
       "pubkey_x25519": "3a67ac7f8073a93f79dc9a0505d4d8b0bbf4241e9c70b392aabc8a03ad017850",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "205.185.123.63",
       "storage_port": 22021,
       "pubkey_ed25519": "1bdf4a89266e3695f51187e6606454cf8850c9217005df1fa2f115742ea25537",
       "pubkey_x25519": "c7a650e72553e078ee07527fcfe6aebf9d87f62b0e9ff4c2ae3692c270023261",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22102,
       "pubkey_ed25519": "1c0d8f50a45f05dc7af22a66e45e16d403d571d26a669f5dc04f34255fde2c1c",
       "pubkey_x25519": "92a1992cf7b92a8d741c8b27cac2e28925a391ecea58d4c8f1b6cb7ba389614c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22107,
       "pubkey_ed25519": "1c94dff689af043df1baeea6cb007b6d89689a8e1897e2023ccabdc33e20c7e1",
       "pubkey_x25519": "50e5f22ceaeacf4ad2e4dd3dd295072a3cb6e3ef48a7f64dfe952b40dbbe2c22",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "93.115.20.135",
       "storage_port": 22021,
       "pubkey_ed25519": "1cc8ff8cec0a588ea7488a14c879d2d3b14ce1226761b6325d8fe580a786de62",
       "pubkey_x25519": "1224851d2d29f0f436aec84dd29c81f6ac60b6e481e2451abc1b884dba974f2c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4effffffffffffff"
     },
     {
       "public_ip": "130.162.189.88",
       "storage_port": 22103,
       "pubkey_ed25519": "1ce3eb7795f71bcdadc4b5d884bfe8a51ddc6edfa79f243c32a3d286da8589c9",
       "pubkey_x25519": "4782ce88ceaafc1f30547df7038427358c2aadabeb7353b9e8bf3478809e3f3f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22101,
       "pubkey_ed25519": "1d14e842190f9aadc61b6ca531caa67b06441c092674e38826d8c119a41d309b",
       "pubkey_x25519": "2219b5c73d4b10abc947ba4a9b53db3298b9b7a1a2e2286ac9acad9e8c5ba953",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "23.137.248.143",
       "storage_port": 22021,
       "pubkey_ed25519": "1d1fffa3ff915362c5f82e294397ca365b19f413d46223a667305fda78d66332",
       "pubkey_x25519": "69f71c493c1fb30fab81f5f568ef29fbc6da13d6de21c5b32de521d470beb237",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.228",
       "storage_port": 22021,
       "pubkey_ed25519": "1d20519e4f82b156a37d9e0fb8f4d3806568312491198f908f659e22c969c09f",
       "pubkey_x25519": "02f0020d30156935de0c4c4dfc41db18f6c19e2c2c9e063eb642d0f0fa901d1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "159.69.27.54",
       "storage_port": 22021,
       "pubkey_ed25519": "1d7b5f82e0c06673945ae609dfb88fc4ec39343b121ac7b1d43f69d3075b36e3",
       "pubkey_x25519": "0b2f1934ae5c34a403e255f29a9f7734996bc94fdef14d8fbb6621b4e42a1d1b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22102,
       "pubkey_ed25519": "1d8ae98bdb603edc55f1b39af84e8a2f0fc776fdec4e501783513ad4f12c77cb",
       "pubkey_x25519": "1f000e20c69bafd68b34460de78d58055477a326a6cd6cd8e128f13ee4bf7639",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "52ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22105,
       "pubkey_ed25519": "1ddf6fbcd0e53e62b89ee0c7b07d3485e9d8eefa87802e18fb002c3b7a25f100",
       "pubkey_x25519": "453288e608615475e40a38a87a894c4650ed3689b8d764e71877184799165f52",
-      "requested_unlock_height": 2059466
+      "requested_unlock_height": 2059466,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "164.68.104.12",
       "storage_port": 22021,
       "pubkey_ed25519": "1de39c84ec9dbbb00ed47034b24d93a76f171c7ea0339b769d62e0d21e0b2691",
       "pubkey_x25519": "0a7ab47efc9653f7659c813fddfd137a5094ab0e44ba249decfaa98d47205b54",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22100,
       "pubkey_ed25519": "1e01d3e756fccd9aec0f2cad477547cb09bd58d2707c251aab15587bffedce46",
       "pubkey_x25519": "0087048a1929e7989ada5cba3e3cba5dc65a8b822d919f5cb2a69af0c70dd649",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "5.255.121.55",
       "storage_port": 22021,
       "pubkey_ed25519": "1e1c913cbfc98f052328391fd59c136ed72fccd9ba715814dd7f389647087695",
       "pubkey_x25519": "c373a094a4482b1ff35ac0f7d43cd42112d2c58a63e296dd66ceef7b7feed90b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "152.89.29.28",
       "storage_port": 22021,
       "pubkey_ed25519": "1e36e971dcd0ce9b913706e59a7c9f34d96f8a6d710b9019763b265f72a804dd",
       "pubkey_x25519": "75698b5cfa0777258b1861e093b2c5f7ab1507107676f836ebeae74b7a35d43e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "135.181.38.28",
       "storage_port": 22021,
       "pubkey_ed25519": "1e4d90d3520964828ff03617f0bef200c2d6704ddcfa33556454a7da75c0a6c6",
       "pubkey_x25519": "4219f5313954d77d2918bd322d711404c048ed72d73f5b9e5c47def8c73e1c00",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
       "storage_port": 22104,
       "pubkey_ed25519": "1e5a03126a3cb174e5fc25ba1f734e89bc2ad4a4af254de885d5d4a1827797de",
       "pubkey_x25519": "23f0b7d4c8a72a8575b3e788431ad10da2a6b8b0c2f4949ba6cea26443a1ad19",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "157.180.92.87",
       "storage_port": 22021,
       "pubkey_ed25519": "1e5c4f86d16ca72e173d1cf7478eede99a4ae702a0e03e8c6fa8857d559d47d7",
       "pubkey_x25519": "5c530e6383bacb5a58c7fc7561d576a6b9dbda7454f1129337093554b50e9125",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20602,
       "pubkey_ed25519": "1e814ff394791263e86d25c0161723451ee8d877abe55f1ba5cf7c244d5b5e23",
       "pubkey_x25519": "f8407941098a1fd7436a208cd9d5e604e04cde33e049269bf54695699d180f6e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20902,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "5.189.153.18",
       "storage_port": 22021,
       "pubkey_ed25519": "1ee6bf85168b76cbd20a563ebdb142c73e92a2ec4123a8dc8a3837b4b928b7ef",
       "pubkey_x25519": "51cecb0465fba1ac8362c97a57a4d6d134f07df497512ffc9f313dbfcf1c6905",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22100,
       "pubkey_ed25519": "1f000f09a7b07828dcb72af7cd16857050c10c02bd58afb0e38111fb6cda1fef",
       "pubkey_x25519": "be83fe1221fdd85e4d9d2b62e2a34ba82eaf73da45700185d25aff4575ec6018",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22101,
       "pubkey_ed25519": "1f001f03f837d01baa809a3c345cfa076103aebc47f53ec79ee314bc33baa6a7",
       "pubkey_x25519": "26b7c9a3c39d0c2a7e8a2310fcae542e553fb8af90cfdb4860d1d31241a5a77b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2fffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22102,
       "pubkey_ed25519": "1f002f0d39343febcb29f1e9e5d725104bd24f8abfaab2269394c05cb38557f5",
       "pubkey_x25519": "9d23eedb4d8544cce603875344cba404a471e9c0d4175431c5ce56174ed9e003",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22103,
       "pubkey_ed25519": "1f003f0b6544c1050c9a052deafdb8cd1b4d2fbbf1dfb9d80f47ee2a0c316112",
       "pubkey_x25519": "7726dc89ce371d41761d47547559848da637ff65ea40dc05979747624cdef560",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22104,
       "pubkey_ed25519": "1f004f0208edb179ac116ebd288967b88e7f54574d2134c1b3f6387f00c6852a",
       "pubkey_x25519": "b392bd8d25d46e054ba666dc9cdabd4692be175f107064168908c1c8e30cac24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22105,
       "pubkey_ed25519": "1f005f0b9f6200b2692d809b38b330b7014a1d56e429af0f4603cd9b1fbb5062",
       "pubkey_x25519": "759600dc48f29c60984ec685391ff6db6c3f0b7d7f2370ac0b39fa11a92f1c37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22106,
       "pubkey_ed25519": "1f006f31d5892f4e202e0e7c19547ed4dd0510dceb74364fe5546841e5d82e87",
       "pubkey_x25519": "51ee1744569d96b2312edd0e00e7cd95406bbb389040d23821e34396e1ce155e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "52ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22107,
       "pubkey_ed25519": "1f007f0a87188aae68a7071e80d515b47444a461d734709b806cae4db58eba56",
       "pubkey_x25519": "4d8680f814c1ae3671194146818c942727f91c06201b4f66c13bed5a76d1794e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22108,
       "pubkey_ed25519": "1f008f109386e922d11ec95b4c2ae8ae449712f85cf3d70e63bce7c69b314723",
       "pubkey_x25519": "16f856612a2268678a0d850d63d3903f2d9c911e0bb77c746e13810056029654",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "30ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22109,
       "pubkey_ed25519": "1f009f0297320b32cac3e090556ce8a8cdeefba430e080575aff3d6864c07675",
       "pubkey_x25519": "1092c5ac79e76f693f2e6c8b883685eedd42e27a578be8ea814364c61399be23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "23ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22110,
       "pubkey_ed25519": "1f010f01f6d2a9e18268d77b25662de6f86800aa6c4f29057c97bda0c908daf1",
       "pubkey_x25519": "0240d6ef8194edb9e52f005a092785df314e72fcf17e34aaeb7d10c6ec913d00",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "327fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22111,
       "pubkey_ed25519": "1f011f10c02d469b92f143f8466454f86df1c7f1c7581a3e92cb4245b72c000e",
       "pubkey_x25519": "d3c0a3587699d4860d1e29b99e5a306ac0c5e9b17a01537a7b16e30455036367",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "96ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22112,
       "pubkey_ed25519": "1f012f27608d68905876d3adcf02786f27eef6dcf7a0a858c3863bac0ec8c158",
       "pubkey_x25519": "fb010706c22cc7a329d999c3a1b2ad489d34bb19c0d46ce72e48dc590243b619",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22113,
       "pubkey_ed25519": "1f013f0df7b1e4d4eb11b2b51ec983554af9506f637b93f4ec41627c22c48d92",
       "pubkey_x25519": "ac502b701160f4f1553aa80fd7bdc282f1bf226572a1e72123aa20cbe7e4cb3b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22114,
       "pubkey_ed25519": "1f014f0bb8181eeea993f0335edd8843f09ea28e6f254b78adc9d83e79795fa0",
       "pubkey_x25519": "605c8e6b77cad6d8977ca9c9ddaf950489e69afd42b30d7e3f1bbf0bf531f873",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22115,
       "pubkey_ed25519": "1f015f2ce89643d07a4cd5a6bea8efc22062931f566a4035cdacb6c72422ccb9",
       "pubkey_x25519": "011b311e028859727a8e52199a1ca9c93b0368d43f25ae36447e78eba9dddc1c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9affffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22116,
       "pubkey_ed25519": "1f016f2682df03c3cacfc06f53c6f67dae2910295953e9723eaab0bd2c82edc1",
       "pubkey_x25519": "b0fabcfdf63da3acf02228244565a248ae1a41675579573bed9da04923d7af44",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22117,
       "pubkey_ed25519": "1f017f00fa5a1c1254b3bc49513df1663760e99c146f230b717b54878e09f8ca",
       "pubkey_x25519": "7e209986c78b812fac7f5ea28c9a59a5e3444afd4cb017904dab12a8c021e458",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22118,
       "pubkey_ed25519": "1f018f03a75ad874f747ce6e050fdae903275346211c6207d62ecfa98bcd856e",
       "pubkey_x25519": "390d71229b5fbe782264bf1528c58de07a14624faed344085cc15b3a17d4cf49",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "afffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22119,
       "pubkey_ed25519": "1f019f0ebab510ddb5a6530db7d4b114b8bc20a683cbb61647bcfa81edd57c34",
       "pubkey_x25519": "a8dc6e31d86995da839e93c791b8437042fd394f7bcf3c4ea3f12c4b4f21e937",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22120,
       "pubkey_ed25519": "1f020f21f921303e2c982be1f1429555c2232ee0e5b30539dbe222f1340d09dc",
       "pubkey_x25519": "5b035c8589d41d41e880719d9d7da4a06192d611e673b5a0a04b56cd0ffc0621",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22121,
       "pubkey_ed25519": "1f021f0742add530dcc48c57cc7ab7d48b54f6a1e63b5123e41c07a0fce4522e",
       "pubkey_x25519": "a634fd24e360bf074af87e33323b92c0a0461bb40ef9c673aee87f7a1cddd66d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22122,
       "pubkey_ed25519": "1f022f08ecb801299cb43fafba721dfb7d9deb10a7734951f46b9c7c8ec1c274",
       "pubkey_x25519": "b90c0ce5849765d4ac3c577a7fca2144c0d70ef8b413f037be0e38324ec93a17",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22123,
       "pubkey_ed25519": "1f023f1281bca38542ef0bd1ebbc5967d2ac6d0fb03f7ebf0faeab8da5573c97",
       "pubkey_x25519": "308372fb39db13cd81ab0075305d6561f59218c3d4d798ecf9e860de561e3323",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20223,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22124,
       "pubkey_ed25519": "1f024f1c31257f3b9c935ccf01c5aa4e75e26234c406c91eb801a60577841235",
       "pubkey_x25519": "6c76e7b04ed81d0d84b8de5a73cdf4f7550fb1f0b873d8089572f20ddb647e4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20224,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22125,
       "pubkey_ed25519": "1f025f038b085d7fc3ba11b40e7d49032ae5f4fb88cd1cc8a0645652b0ba39dc",
       "pubkey_x25519": "02294e42f6aec8382a5ce836dbaa2803c481ecd2a8a707a72ba97a73cb675556",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20225,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22126,
       "pubkey_ed25519": "1f026f07c8a223fd1afe02e98bf0a205240b99b0fc5da2a8fc4f18bb9ce8dc39",
       "pubkey_x25519": "32087485380d4017a3c0d8726d1532d1098a1ca88e932a7b1604cdb8da04040f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20226,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22127,
       "pubkey_ed25519": "1f027f30bcc9b5bd7d046605586a00e645513245cab5a7344bfadca85482cbff",
       "pubkey_x25519": "0650c30076d7835435680d3aa14ab29c006b39cd0f607ccccf03674706e39e7d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20227,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22128,
       "pubkey_ed25519": "1f028f03e419c2485f289908e61fabc7cf87ec62f8047913470a9d9c2aaf277b",
       "pubkey_x25519": "9212b94f753bea70e42cab67b976347c0e8d35662a95ca0726415843866a223f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20228,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
       "storage_port": 22129,
       "pubkey_ed25519": "1f029f3987216b0053f5e6f2a0bf9bbca04193c662083d682357714b693f311e",
       "pubkey_x25519": "84e87a4c2190919c6de8cb101b0702ebce4b5b9bed9a95571e17d33dff642a3c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20229,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22100,
       "pubkey_ed25519": "1f100f1a23bf3a2de81487cc07dfff5b28027541c2903f53c55a2d138104fc7b",
       "pubkey_x25519": "82225f5d8f169b502f56e7a08240ce4e8081e05be2399149c1b9b394eefe231e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22101,
       "pubkey_ed25519": "1f101f0acee4db6f31aaa8b4df134e85ca8a4878efaef7f971e88ab144c1a7ce",
       "pubkey_x25519": "05c8c236cf6c4013b8ca930a343fdc62c413ba038a16bb12e75632e0179d404a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22102,
       "pubkey_ed25519": "1f102f0494e1727722b710b151753a8cb1fc1c71f8a678119449d064a9f831db",
       "pubkey_x25519": "cc3f8deb33c960b45da510a1561fc895b04e744ed14de56751b7e130e6b6d44b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22103,
       "pubkey_ed25519": "1f103f0900883f659b9281ec4a4fef81bb835d25b9793fefd142b1a8d7bde731",
       "pubkey_x25519": "d9f6c8c4819a59c896a1a6e31a8f5c1f6bf1ded5fd8252b1632a792c35a57e16",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22104,
       "pubkey_ed25519": "1f104f051472131b3c938c1c86d1c98ff3815ff7fa9ba6068e4121d8477f4413",
       "pubkey_x25519": "75cb8a1dacc73a78cafc9b6b7b64b8ca198154baa49f23bfbd18e66fdabf842e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "17ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22105,
       "pubkey_ed25519": "1f105f4c20a6f770b56ac306e3bb8431d7d5f5f99c1425b4a697d9c8656faf03",
       "pubkey_x25519": "ef02b089181bab53c757fa581b61868872af614e8f80be021f40f2da0fb90d01",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22106,
       "pubkey_ed25519": "1f106f0c8d25fc530c62a7b09431b66517948f6e97cfadbce0bbda75bdf2601c",
       "pubkey_x25519": "97769a052d6765ba5a3590337d5d1ed8952a7a33aef83eee37ea438107137020",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22107,
       "pubkey_ed25519": "1f107f2b38e8246b644f917c7f8d226ff5ab9fb416d5647f74b80f833c179aca",
       "pubkey_x25519": "b9236ac972dde9a769c7cd44917287690ca2e49c805790293d81c20959c87f64",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22108,
       "pubkey_ed25519": "1f108f099c330950ba1520ee450b602fbff0c8b8ab8e0664d6e11e1694bb4f7d",
       "pubkey_x25519": "8432aae407a690a82348e97208fbcde0b6cac09f88da65ece8ab6094347c0b6a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22109,
       "pubkey_ed25519": "1f109f290db89defbc5a39669e49df9481fbb0be19385ef662da3e17f95d071a",
       "pubkey_x25519": "df2eb49aee935e77f485629fee335ef4f253a3e5aff05bf8a24ec83ad8fd5468",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22110,
       "pubkey_ed25519": "1f110f22f007c262da290d816fe06bdf746fb993a6a0a1f968088ecadcff9587",
       "pubkey_x25519": "01cc793f2af7e9a92bca37ed2bc70980581ff4d8576ea3645a39938916434c22",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "39ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22111,
       "pubkey_ed25519": "1f111f33e983f4c461ba7982b878e0067e817d785638001814bc8d8be68b3220",
       "pubkey_x25519": "b86dd72c7dc76eb2f6367780ce77d78769e9f2d1119e045a9e02b54d0213e054",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22112,
       "pubkey_ed25519": "1f112f65ce6ef96d335f2dc2be059e316753b9e472eaa538fbce633e63ba8b9a",
       "pubkey_x25519": "f819463a4738b8dfa1c47559cf1c532e97f8ed0ef76bff599495a0ac18376731",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22113,
       "pubkey_ed25519": "1f113f1ff165aa1ec6c01c82f4e144f710fbb6a4bb9ef4d92f17c84a2d936c26",
       "pubkey_x25519": "462126c4c23843945e890884237898bb77bd31566f5749e55b31dfc91e1e447d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22114,
       "pubkey_ed25519": "1f114f3c0582f4c7b28f50680ddf67f9fb843333752485a29cfec9b87180b4d1",
       "pubkey_x25519": "0fb58e373cd75224dfbadd06f4f951ab7b2ff7a87d2b3a0465a6a2bacff07e0a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22115,
       "pubkey_ed25519": "1f115f1abb04b6bb462332d04de8034f2aa77f1725fcc4d2a1c57c9837508d94",
       "pubkey_x25519": "e7a254ae2395a1135db42ff9cf23724e02282ccad28c8ae7e33fbb59bac3801a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22116,
       "pubkey_ed25519": "1f116f0743aef838407c21658ce02b75585f13b01d44d4bc3510e9a9f11c80fe",
       "pubkey_x25519": "a9ec5dc734204499070e85aeaa3df30f9dd0f3a9008f953e2e99619d48747912",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22117,
       "pubkey_ed25519": "1f117f140a6e32b502ee914cb1f5a1b3412fbf59649c1ad15153ac9531995719",
       "pubkey_x25519": "a903f83792eecea8325ca3653508ffb402158db5551bada9284f71282f916d39",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
       "storage_port": 22118,
       "pubkey_ed25519": "1f118f04d79899b137e0497858bbbdd20f69693b38b0633879e62b2bcb9e306f",
       "pubkey_x25519": "23693ba239777b5d76a3c09c085460ada4b2b15c1af22620f28e17bf7bc1797f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "487fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22100,
       "pubkey_ed25519": "1f200f483f5df9f5fc9909ae0e6146869f9d5b81b75ccba1b39bbaab9d0d88d4",
       "pubkey_x25519": "694fb645e6a84798d7bf3b45243690da4a181d6154f95b40f84a4c7ac06a845c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22101,
       "pubkey_ed25519": "1f201f2d608d88d2c7e403014d6e87990c3eb944052a1f8562ad7ed4c92e9ee6",
       "pubkey_x25519": "7423d295414a620fef6d2685640f08831b1964b19cbc90c3a0ffbd1221209a46",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22102,
       "pubkey_ed25519": "1f202f00f4d2d4acc01e20773999a291cf3e3136c325474d159814e06199919f",
       "pubkey_x25519": "22ced8efd4e5faf15531e9b9244b2c1de299342892b97d19268c4db69ab6350f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22103,
       "pubkey_ed25519": "1f203f36faecd16d1c1c9514143d4a6715be1b16e160760f57942ab6da3e4ed5",
       "pubkey_x25519": "457b528b43ca36dac0c1bed7e3ba68d30f299f65b6c57fdcc9350280febf4e5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22104,
       "pubkey_ed25519": "1f204f0196fa42cc178bb318b76879e1c97e9b1b9d9ca85b224c985ea9b3631d",
       "pubkey_x25519": "cf8a2c8e007633842c6814d0e59bd91c13192c19e740f2798151293671428642",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22105,
       "pubkey_ed25519": "1f205f043d639bcde0634b408612c35e8ff94a56e5680548315d15b29e20f5c3",
       "pubkey_x25519": "8e69d4127aaca7cda1545fa00c9d6f1f9db869a34a250df4ad4dc1751ef9472f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a8ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22106,
       "pubkey_ed25519": "1f206f30807b43b9b8b55e6e61f4faa227043d12c4225b4fcba807052b7f6411",
       "pubkey_x25519": "65d76772f7fa74ee398dc4b2e96039c76ba1e44e0f54625f64878f91806d5013",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22107,
       "pubkey_ed25519": "1f207f10af677d19935176956fae173f2db654333474893ac2924a895126b701",
       "pubkey_x25519": "ce322e439d182f6634f214ba7da1188216d8d52ab6a464d34ae372842dad5c37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22108,
       "pubkey_ed25519": "1f208f04407a183ca87ec918297d5828d56e53be17ad5c701ed2935977c1b166",
       "pubkey_x25519": "c31de4e82d1563bda75169c9b6f52ed3bd0fbf1998668dba7d130f0c00303d4f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22109,
       "pubkey_ed25519": "1f209f1617e556288fdde09ea130ec846cabc32cae0a74789eacf3ff539d3d73",
       "pubkey_x25519": "140f0dac0f45ed12d66a30f5b4cb9acae33d12c7ca3eaca15cef8eeed6c34056",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "467fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22110,
       "pubkey_ed25519": "1f210f35a00346ad641710952f7f0d85e2c40f565a9bf44b283f8edf82a0eedc",
       "pubkey_x25519": "86febd7322e44b03e1d2a30602f7e41293f8b7706e987b650110cad4fe267240",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22111,
       "pubkey_ed25519": "1f211f31bd3f810fa0f993c4826cf99a275233114d95b551087965d0c93b1881",
       "pubkey_x25519": "f1a95bba7e06abf1a690e58ceeedf9aa59712165f11c2503d540c15e69e79c55",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22112,
       "pubkey_ed25519": "1f212f001791d0d737aff1920f10b724b010d14f184d55b41820a31d162f2c82",
       "pubkey_x25519": "3dd280eda55ef8e76d2924c7dbbddcdd6c58655fdcdc1fd29b58afdcf150ac62",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22113,
       "pubkey_ed25519": "1f213f1f2ee4e804e057e361bff86ee30e1efccbb79c4f1b6039a4565a69489c",
       "pubkey_x25519": "4c54c3c09272a337c2361dd25d9647c01e5c4ccb31738e77c662cf73ad1dcd15",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
       "storage_port": 22114,
       "pubkey_ed25519": "1f214f205a51da18f024809c8a62afba8687a6fd9c663f0684bb4f6aece0ab86",
       "pubkey_x25519": "3944512d5256dab783271e6769bd681512f4488bd5988e1dc81c83fdf3e4ba60",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22118,
       "pubkey_ed25519": "1f218f0d2969b23bc915c95947c0a3e402c946e1ebbb45eb73be5febcae6b680",
       "pubkey_x25519": "d857460e871cfa6ed943d7d3aabe4139f78067a9ea1fd0d2deb8029afb7f6040",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22119,
       "pubkey_ed25519": "1f219f19459d7e2268f3c451368d954ff52d1375a43a4a84eed245e2903bae7c",
       "pubkey_x25519": "955ada5f930b7946409c789c281d3826d7eeb1b0ebc84df44acb5789516f2174",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e5ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22120,
       "pubkey_ed25519": "1f220f04dfb38f449bd65d2a1b123810141fc9e08a627f8a2fba9e9fffd2d62d",
       "pubkey_x25519": "d873fb36454114353076e57cb232b0d1dbc259e3ae6a341040e5e7d2b61f773b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22121,
       "pubkey_ed25519": "1f221f054cacb5b19837099ae8b588748d088c467fa42a4282e99eb06b79a180",
       "pubkey_x25519": "5ff59bddf01fa6682517d0730a27eba20cd94a9e0cfb6d52ee01a88fcd7cf107",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22122,
       "pubkey_ed25519": "1f222f1f093d789d23eb3e9985925a44da66af41d04de6abb87e9788cc285c4b",
       "pubkey_x25519": "63e8d8a3257234eea747a5f61d7afa637a1399e36456d211e0b6dd34800c8654",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22123,
       "pubkey_ed25519": "1f223f457fb02ef0a849ae197d0cf187aba38c2fab1be5f8ede12c7aa5482e59",
       "pubkey_x25519": "aa64685b22a2c9a596c89c7b0bee3c7cb332465cadc9e2422e7e93307772600a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20223,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22124,
       "pubkey_ed25519": "1f224f70ed03568b270c812afc1a3760d71f34f26583270012ce5e6b50af3e9b",
       "pubkey_x25519": "fe8f49e858b30718af85a4a0c82dc986caaa1ed64d8c1928509e3c57e7d82b13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20224,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "96ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
       "storage_port": 22125,
       "pubkey_ed25519": "1f225f1a9b2d2cfc31555d08d64603daf5838019fd21a9c31a24483da856ec60",
       "pubkey_x25519": "2128fb312fe0a0ab6426e6cba49487fbf9bb63e169258a399834a3e03dd50416",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20225,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22114,
       "pubkey_ed25519": "1f29f96c16d6c81431868627a061752d733544fbab7f741c7397d4f3750b460e",
       "pubkey_x25519": "b0640ac745e0795dcbbff0df442f3a27f3b536e4367018600879417bad3bc10a",
-      "requested_unlock_height": 2059467
+      "requested_unlock_height": 2059467,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22100,
       "pubkey_ed25519": "1f300f2ef3d24a7c4bea552837e2c8ddaadce8a4aeee118ba4f29a03466a6a98",
       "pubkey_x25519": "897cdca96164759ec68a27114fa6b4f89b044705fdd296a2a6d9923fc4838d56",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22101,
       "pubkey_ed25519": "1f301f21400a69a43286b8f5add7faec26b948de2862a745f71eab822ccd7b1c",
       "pubkey_x25519": "09385c93bc86635b5d29951ea53024f6f7fd3bb63fc86e4cd3b561c7ec2f8541",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22102,
       "pubkey_ed25519": "1f302f0dbbe571f3f1c26bb9fbea0fd6206c8ff7e9570e4a4f434fe8260dab7e",
       "pubkey_x25519": "ee57488206578a1e50c0514c5ef34809a113867af7272980f006e1647215f007",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22103,
       "pubkey_ed25519": "1f303f1d7523c46fa5398826740d13282d26b5de90fbae5749442f66afb6d78b",
       "pubkey_x25519": "330ad0d67b58f39a6f46fbeaf5c3622860dfa584e9d787f70c3702031712767a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22104,
       "pubkey_ed25519": "1f304f0363497181679aad55d6122924be7a54a08d5610ce7be651d3f935d0f1",
       "pubkey_x25519": "dd39037dc2d28ee482aa1d52bc04ea27533e6f347a195662d3fbcc2e0eddea04",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22105,
       "pubkey_ed25519": "1f305f11a7129e9c6173beb6332bfd22d73fa983cfca3c1c097076b4f9f0e3dd",
       "pubkey_x25519": "1fef1d4624bbaef9974e773c0eedaf39b2432f9edd0890570c8e3972f871ac7d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22106,
       "pubkey_ed25519": "1f306f0c6d67465adbf4d378857348327eea700734953dc22be51c651441b7a7",
       "pubkey_x25519": "edd6fe362c013a2f539279d052320af151c8cd2fdffb43f180a959feeb567504",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22107,
       "pubkey_ed25519": "1f307f24e1b16f3fb1e8e2feee0f1ba46f2c7efa0b01f96572708192c82ff800",
       "pubkey_x25519": "1e0d4b6030e15602753c9fbe6f406a34d1309c546835353a00030fddf9274d2a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22108,
       "pubkey_ed25519": "1f308f0bb7c4fb144b6b8b2f8331d03fffc098710354bf7b517f37f23a78b23b",
       "pubkey_x25519": "0196673ff195f5edf038f4945bb0079f9bd1954b6254cee06ee0e328fa7d7d10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22109,
       "pubkey_ed25519": "1f309f07379b2e3fb7792e9b38381bd9c2fabb47f6c4d9e5a360505ab922107c",
       "pubkey_x25519": "96ac44a6ffea0e2044cd839574ab735119160572d8995ae5d92cbb1cd3388520",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22110,
       "pubkey_ed25519": "1f310f26871003349ede2448aaf57c52c50844af7d187be3b173e7c6765a9434",
       "pubkey_x25519": "e9c996ee7c0148f943ba074cc4c49daadeaa05d948b4c8f86bf4b6d92c060125",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22111,
       "pubkey_ed25519": "1f311f601ae85ca0d86857408173fa687f9d01ac496f07ed767908baac7d9fa2",
       "pubkey_x25519": "4d57fcf51c147a324d834b8b624acd8fd00d5270c9e6c8a909dc26b9224a9f50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22112,
       "pubkey_ed25519": "1f312f021c915443c5a76c2089c85dfc158efd6842746e1cbec0e33d3b3b8657",
       "pubkey_x25519": "6770759f7fa235f1dd341a8e172e62d720fe9a431771089d90cc3991283cd60f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22113,
       "pubkey_ed25519": "1f313f0c2acd37a645150020d517f3e6ea5c617914411d4a9dc0cab987333517",
       "pubkey_x25519": "c9e93ad78db7003577660f1a2658a2bd340142f9fd16ad4c58beb6518e5d0719",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22114,
       "pubkey_ed25519": "1f314f1273f14afd6f32bcb8bc7a4125faf253094f41fa2ecba4d8d588b5567a",
       "pubkey_x25519": "4f1b491794d1df95213fb89fa5ec09643970dcf888deacfacb7eec5394604827",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22115,
       "pubkey_ed25519": "1f315f322bdd54ea6940e95b710b2a7e88ed9a218d1f4a1801458311e954e64f",
       "pubkey_x25519": "342578458951f6400bfefb33599d591850eb7f4dc4f6ecfc9db15b8e5267ed3a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22116,
       "pubkey_ed25519": "1f316f3f580f8f779644d27eb54c92529c3987356db0a769e752fa92d6a321ca",
       "pubkey_x25519": "d075be37d3cad3df6d6c9cc65244056ebafaeb176e4602804f9b7bce5829e044",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22117,
       "pubkey_ed25519": "1f317f063c277637e074d281a5f51276d6cd0a6618393b1dda01cee1ce322239",
       "pubkey_x25519": "45baeb67162aaaf5f6c5979387bc0d316a2133514aac068fd47f444f5a2e580c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22118,
       "pubkey_ed25519": "1f318f03e88a09af39953ccf3bccadb59ac13da07dba8f5d3d83e460005208a0",
       "pubkey_x25519": "09cf91c00ee0174a7be107d1756c4d778ce46d350946baaab412c3a322c02b56",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22119,
       "pubkey_ed25519": "1f319f3877d6cd0339d83e2be25832ebba2d26f494094130835db79403c9b462",
       "pubkey_x25519": "370825a7bfc7a1bc41a7e3086b18e0fe1a6f0f39cee900a2d6eca67731d76672",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22120,
       "pubkey_ed25519": "1f320f12429bbf697ba95df9fe1e35d9675cef0c3e3d11f0e586d1c771db70c4",
       "pubkey_x25519": "4b96fedbd82ed83dc48a182107bbbb3d0dbca9983679f91e0761257ec0609b2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22121,
       "pubkey_ed25519": "1f321f0b064541bdee014a234745d5fafe0e5731360ab6e769f83d7c45c4d08e",
       "pubkey_x25519": "6d7f16680e6030c78625b13a16e4ba7c484abdd2558d23d2204a628d772f9a52",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22122,
       "pubkey_ed25519": "1f322f1aab63d371a238971b5cb6729283f5e24e0142ed35558448b088e23ac7",
       "pubkey_x25519": "0aaaf0d7876e67c11ffac1c5b73930685152387ca6b1b6dc9010caeb84f44452",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22123,
       "pubkey_ed25519": "1f323f140c5b6c45db805c005b8956330e21425cd252ac9ca1b0e939bcf2fef6",
       "pubkey_x25519": "98c7b0d35e93be0ff7e2b8bc4a6aa0ca0d95c9c73518bc492c98e8a8deac9927",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20223,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22124,
       "pubkey_ed25519": "1f324f04de177ba006351d65a3c27cb2e559834280702c0eac9327dad9a84848",
       "pubkey_x25519": "c549c8854b801d83bf01647c5c3c635e14e70aad90ff84aaf994658fd6fab821",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20224,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22125,
       "pubkey_ed25519": "1f325f0634e7d5c42d7a980c54f6d6a1eb0dc73b2fca664b2b5340afaa82a2c2",
       "pubkey_x25519": "15a0343633e3674c9751eb43fc1b72c425c4b499f2911bcc87906cbf90702254",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20225,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22126,
       "pubkey_ed25519": "1f326f0745eca28676d6a616649e87086351fbf9ee9cdd5c519d03b07791078e",
       "pubkey_x25519": "53a4c19a177aac96f3e722ed4c4370ebc8b32443b3ce6ac68bc005124c7ebd68",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20226,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22127,
       "pubkey_ed25519": "1f327f0729a0d613039515e6525fcdbfd416712ea04f944fec0ad94dcb62879d",
       "pubkey_x25519": "6cbbe93cd49c43c642321f38ad7ac7c0ecc6c9312f8340dea2f07d0226da4d4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20227,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
       "storage_port": 22128,
       "pubkey_ed25519": "1f328f11cde9b55d44ce4113714bbc01c629f56fe46e2ee1bed60677e293492d",
       "pubkey_x25519": "807773cb46bb90a29b18db6452579bb8b9790f77a90c1167cab96007f004ee1c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20228,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "107.175.39.131",
       "storage_port": 22021,
       "pubkey_ed25519": "1f342e94214bcdefca880d6172ec2618f47ed826898b61bc3932cd1b35c28721",
       "pubkey_x25519": "2b3b7352adca324f426092ab83284af1faeae512aad828e3429e365c3d4d681e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "91.99.120.185",
       "storage_port": 22103,
       "pubkey_ed25519": "1f3c49b0b3a3cf092bc37131aab2d49eee526aa9c05b7e9de82c43134bdf1517",
       "pubkey_x25519": "9bf08c20691ce35a5bb519be7a3d36a694d461c828fec9830caf41dbfdb71a4a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22100,
       "pubkey_ed25519": "1f400f199a4d0242a05a26e952264042646bbbe0333ddbb4aac1628512f44558",
       "pubkey_x25519": "77eb13516e0efbfb7baf60d27e5cfb6b7c5b8f03ffdb64881fcf93493f759b58",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22101,
       "pubkey_ed25519": "1f401f2773e8bdf07cf14b4f57adf58a63e63a98b14033ebebd4e0b635035f67",
       "pubkey_x25519": "1e2ad5a2d031815ae56bb684f049d284834e4a6bf9e3df0cb11c75ac912a5218",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22102,
       "pubkey_ed25519": "1f402f0373679c687e9a1ef4f38e113e8a16392677629da2d8bf6fd4874fb897",
       "pubkey_x25519": "af024db1ae94ef750bd0f250c86f76ba0b75c49ffa57015e9c4429d9da573873",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "467fffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22103,
       "pubkey_ed25519": "1f403f10a864e3e08b14412b5cef75b2f682b38bf9894a9f26fd4210785d4f7c",
       "pubkey_x25519": "216740f91b74d7357f9acbdb850cf12f664aabdd965b6aa99f0fd661d00aed08",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22104,
       "pubkey_ed25519": "1f404f113d471d0b89369fc27a9edf1831c6f83d9ed7ad7bf9c7f66c88b77d4b",
       "pubkey_x25519": "c264bdd1102a0bcbc3f0339f35292c19cd6a1da9df7f432cc55956929c38ab49",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "487fffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22105,
       "pubkey_ed25519": "1f405f0060d775717a1343db333847de070d0779b85e1e0a4115e41ffae59ef9",
       "pubkey_x25519": "eab1c2dc9d52babadacc80c30a30e9c072b9eb5a06b5f86f596fba5e10e75f53",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "59ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22106,
       "pubkey_ed25519": "1f406f26f2e3382043eda8a2ba163182a38812f4f7d04dc31599701367860dde",
       "pubkey_x25519": "4af54f327a65c35882be6b6ba5ef6f279c54a576c0055a25d692a5015369bc37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "0"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22107,
       "pubkey_ed25519": "1f407f10dac4c058703b56549e9bd7c6abb45406d74cff31727f5e5aafa7d91e",
       "pubkey_x25519": "d283377ad1ef7c8de630ecdf2355c43719a6a8880814fb68721985e2351d476a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22108,
       "pubkey_ed25519": "1f408f02f1dae7bf8cbd705f4f9747e09b5bb852d78abdc7f0afbc965fd9f7b0",
       "pubkey_x25519": "b9699f825a1b725b204ea2615f7e0f36ade14765eab379088c123876746f5944",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22109,
       "pubkey_ed25519": "1f409f1fec6878e234d7f15af4e6953c4ab3719ed83b9b465dc26b5ef62b212b",
       "pubkey_x25519": "b77e7a8440f3bde1fce62cab308e00a6c4da1969d50aa3ed8685e3a800e54c4d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22110,
       "pubkey_ed25519": "1f410f0adb541dca82692af066c4b306c77f7b120c572c23ebf554d762122ce1",
       "pubkey_x25519": "86c17d9a95428baf320e427bc9889cacada078f77b79c74314569af01f7b690c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22111,
       "pubkey_ed25519": "1f411f0db9b2cce68de7de4d9138dca01b749fd51a9eb092c1b92b886a1d6fa7",
       "pubkey_x25519": "0781a80b42e20b3c5601a40314a8dd673daabc01699fc7afeb200c6ac9d9a15f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22112,
       "pubkey_ed25519": "1f412f05fef2b20621e6a00a021ea7c1f9515c79cb6baf0481f100fa15441ff3",
       "pubkey_x25519": "197976f7601c65d97400d3775b7f3315f98662a625c6f700b9aaf18d6f0e8154",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22113,
       "pubkey_ed25519": "1f413f009b489ae560dbcdca23659690b962fe40169d928dc2a1ca8611339730",
       "pubkey_x25519": "5cf4c32454fbda9fe78fc853e6941fdb0d45e094374c87cf37b059702be8b27a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "205.209.114.66",
       "storage_port": 22114,
       "pubkey_ed25519": "1f414f02e4e3ef85c517c81afb0402a980f937a5b43a686aba502d7bc6728976",
       "pubkey_x25519": "12e2f86e9adc980c64029cb544fec9f4a1ef3347502c5f6113b7987ad5198909",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22100,
       "pubkey_ed25519": "1f500f17d77c1972d08a0afbc35b558b2c39276258ad67204a27373e7d6a0ecd",
       "pubkey_x25519": "0ec7f814ed101ab9ed10d22f4fa8d94241071994f9a682a40b973978820bc128",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22101,
       "pubkey_ed25519": "1f501f07d319e5c2e768e90ffb5e9e3aab0264f49d14317ea90442f3a85f73e7",
       "pubkey_x25519": "799a99c59d3e6cc35d2bfa81a52d74e06667faa97ac1784ee8d7a4f349af7d03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4effffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22102,
       "pubkey_ed25519": "1f502f096353bf0fc8c00979f3f87e12280b05d753e46225368f3fbf656c2a66",
       "pubkey_x25519": "28a6bcf53a579c586003c1937a57cb1f6f6dff06fc11889bc4f2b2923c24974c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22103,
       "pubkey_ed25519": "1f503f0fa2d5bc61a8b054e039409e6d97f87c7d4f883ae4e00a3a175561a46a",
       "pubkey_x25519": "cfd8ace973c0fc27cd8bcf2f33143ed1b56fdfd6aeb27446a5eea7ddcd256337",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22104,
       "pubkey_ed25519": "1f504f00d83b8fba9f85f181faf3a78d5a2536802472c7f0c6abd7120aefb4b7",
       "pubkey_x25519": "bab0e8e906a8a72e0c789b42236bb29dd7348a455dc776e8f963d13296ed635a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22105,
       "pubkey_ed25519": "1f505f01413bb25b1a0b44a71cc8a197546629730732e6212eff29ec73a4b091",
       "pubkey_x25519": "0130bd84b3b756b04fddeca5e70eca344dc199261d80351cb29bec64537acd52",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22106,
       "pubkey_ed25519": "1f506f0d8c48b911ec933e9036dc8d3f61332da42b35a665ee7bf094948c7715",
       "pubkey_x25519": "c17339e8f3260930cd6237b6558cd46eca3171800f48a33fbc4ed8a54f26510e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22107,
       "pubkey_ed25519": "1f507f05e8e71473e1b7b735c4f18cb22230094e927510cca06ad76b5b7dafa2",
       "pubkey_x25519": "d5dcc437f5dbf90fddcbc0a078afe4e4a4d471b79b281fa9c9b204fae41d1762",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22108,
       "pubkey_ed25519": "1f508f1249c851afbbe5331bb791bd87f560f1e62fc55d26e85d10efc4cbf03e",
       "pubkey_x25519": "010780978da0683a33d7c154cd93a9ffc0bea446937cb0dbb646f428a6ba0032",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "247fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22109,
       "pubkey_ed25519": "1f509f05c49da0478818ee5772c6e15b457b0923ece38d034d9d4f601a161419",
       "pubkey_x25519": "275a84609bf6bdbb9dd730783a44af18d1836656fd4ae9aac21703cca4592d36",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22110,
       "pubkey_ed25519": "1f510f028c7fa4dcd2fbfe897bb9d0aa6135f9e2bcd8997c1797984bfa68b41d",
       "pubkey_x25519": "6f5d87c6ae3f936775c1449311f14b182e3162498bd60845833132c601636328",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "247fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22111,
       "pubkey_ed25519": "1f511f573239555f2a142eff16b3f30205ff29686771c2731d711c9835787a8e",
       "pubkey_x25519": "5321a1d73899dbb336572b177f0d51f3a486ba7724d3c621bfb27e4d18b4fd2f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22112,
       "pubkey_ed25519": "1f512f14d8a238301be69f26762bad25633b7121db8444104da3bb7595a88d0d",
       "pubkey_x25519": "277284ea6cf13584c14ae95408b2228e07fff8398b77192d277f46b59ea50869",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22113,
       "pubkey_ed25519": "1f513f003e401837ce3fe8ce31f3c8f3ebc18dc24cbe91c22d4d20753aaa5b1a",
       "pubkey_x25519": "9ddf002200bcb0b5ea18e201c21365f1cb1733e3e7a8496991772c4dfe65295d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22114,
       "pubkey_ed25519": "1f514f10c189447af83dd44200344fe59dd857b8b566179027c7f02532eb2c90",
       "pubkey_x25519": "d3c6a2b9f6d602736dfbe75b58f42cb88e8e68ed50f86663dad35d76ad37607a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22115,
       "pubkey_ed25519": "1f515f2776f6ddf826715f8d7a3e54de65ad1b1e2f29ab3dee4f536f69aa637e",
       "pubkey_x25519": "3a03530090426934c5821d2823f64d1f8ec447a813f3f1c4a5fc5464a964bb0b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22116,
       "pubkey_ed25519": "1f516f08372bf86ece83576b95f9de98ff6f690b60ad670f6ec48dc587669abb",
       "pubkey_x25519": "96f65582fc02309dd747a782f801ba10a9712871a464de36217e3c1a77544134",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22117,
       "pubkey_ed25519": "1f517f0ebd15701f4b9750ffbe8a6740aeb925ccb5c7ca2e0f4e15f60bad8686",
       "pubkey_x25519": "c3ead8dc68b35b56c6876409700b2e9beb1ca4cb7881e9eac4d6a883de5d221f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22118,
       "pubkey_ed25519": "1f518f086948a4bf179452d464537e7d38daf9fb2e55c04db81a19b9688acb14",
       "pubkey_x25519": "88b5e3f253e238638d55dc408e60a8eff51944086ef900ee3f6715aaf593ee62",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22119,
       "pubkey_ed25519": "1f519f0ae51880f62cd35a3bdaeb7f100708e8c6778b22be6d5bc71e94f429fa",
       "pubkey_x25519": "bb712153f43e1b54d5d9d026406af8bfbd612ad4cbf8f075304404517db87e5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22120,
       "pubkey_ed25519": "1f520f16a7dcd23a4a4d97fb2bd557606599889f62c75e93c4f6279eb4cb324a",
       "pubkey_x25519": "2ab59209eb8c2c9fb7638dc1998a80a0128eea49566e90b70774adf6c02ca96b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22121,
       "pubkey_ed25519": "1f521f2654b0c6632fc8ffcb21f0a9c29e2241c0e5b57c87277011d3f3a38d0d",
       "pubkey_x25519": "7847bde8bc44e15021d7b8cec97335d56ef36d9a9eb14aad414e5a789a00407c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
       "storage_port": 22122,
       "pubkey_ed25519": "1f522f0cd02dac3a0bc8b6b8132e171d30076925892585ae5838979f304f183a",
       "pubkey_x25519": "2908e34ddb432528e009de44af1b7b9e99406cb9b91318a9c3014245b7aae854",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22100,
       "pubkey_ed25519": "1f600f3c6d2e81171cf9007394348212a1a04344f2a4747dee37f219d4742e03",
       "pubkey_x25519": "ef9405877bdc990ff08d1630d300d4838f8cc7ae97dca4f438e6669192d46414",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22101,
       "pubkey_ed25519": "1f601f14d48f8793582e4d706df05e839d0de1ceb6e84c9230a981203bc2ce2c",
       "pubkey_x25519": "bec481474d156b9116358ef48762639fffce5f15f6321c2ba10b51ce26b0ed7a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22102,
       "pubkey_ed25519": "1f602f45297b941ac17d36e30a96716f6f606bf1288369ea7dd03b87c0fad744",
       "pubkey_x25519": "6e6a42b8edea7c877997a7701c32dc978bc33f4345c0ccde299d7c56edbb3a1a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22103,
       "pubkey_ed25519": "1f603f176ddd928c6abbc26c5ec42e7d7d61e580af69e2e83390ba2001fb8480",
       "pubkey_x25519": "fda7f5267de6ffc97687b38d617a49ed87f61a8c66c66ca409d9b26309339c40",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22104,
       "pubkey_ed25519": "1f604f1c858a121a681d8f9b470ef72e6946ee1b9c5ad15a35e16b50c28db7b0",
       "pubkey_x25519": "929c5fc60efa1834a2d4a77a4a33387c1c3d5afc2b192c2ba0e040b29388b216",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22105,
       "pubkey_ed25519": "1f605f18f0ad8408387db7a8867d2b833e61debfbaf8877dcf61b4c2cf3fc0f2",
       "pubkey_x25519": "4306e5525af2e571a849fb6334ccdd741aca3362f167bc5cebf343117a3f841a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22106,
       "pubkey_ed25519": "1f606f110bfbb7c7a9816c2de596c70eb53175ea600dd5a16f0b9b706c72f9d1",
       "pubkey_x25519": "f21cf40445f84a64869e6d3015d0addf7ffa077e0b5e52770edf9e763bfd5f21",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22107,
       "pubkey_ed25519": "1f607f0906b937936c30a7f7aed363ccbc817a2d240acb7e8fe34b6796fc0987",
       "pubkey_x25519": "67cba94390cf0df3c6375a1423dcc2bbc4ace36f1003f7c948399abd6a164a13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22108,
       "pubkey_ed25519": "1f608f147643e2f9196a93c17626d417061b250c1a854f66de9cfc273f3eb3ff",
       "pubkey_x25519": "370fcbbb6366d8b0afa165e544c1a365ab18cb29175d30cd994f8e7480598d49",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22109,
       "pubkey_ed25519": "1f609f0e08cc03595f2e6393388f3f2d8b5b97aa460704e22c602722cd4c2cfc",
       "pubkey_x25519": "c0818f8160c208a58ad7081914d36041c8cea325d470c12f8dc537caa47ff27e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22110,
       "pubkey_ed25519": "1f610f1ff695848d39fbe3be1aab36b1dd86fd90055bee33174f2f046b45bfff",
       "pubkey_x25519": "f88032ded21be69045181acd4dd3865f397e482eaa4991b2aafe966e8bc3ed28",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22111,
       "pubkey_ed25519": "1f611f055e72fc57c2f1f9a2e5ea66d0f407bd1e5ddfbfb2d7605321e72d2453",
       "pubkey_x25519": "704f863d47eb5e6ba1d309d33a1c544c03e8e10c67e3f71f6d779353822c7879",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22112,
       "pubkey_ed25519": "1f612f18ff7a4a73dd624445b31509974b0bc1344eeb3673d92893a41cc3ab34",
       "pubkey_x25519": "48ea379e50ff25295930562e85cb702c7ab28e73928d359387a812ed4690dd47",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22113,
       "pubkey_ed25519": "1f613f17fab237d3b8f48cd21780b8f8af011088e2c2f0f12e4588e175508eb2",
       "pubkey_x25519": "ac1645dc98f259a9f382abb3fa8200eb2fa00079cb3b55d7c5c048608bf60759",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
       "storage_port": 22114,
       "pubkey_ed25519": "1f614f0042604a5c206fa3153e9bd256247cdeac0076b083d2004c13e63dc70e",
       "pubkey_x25519": "a8d80cd802fd4130e26ab453ebefebb210e942e29a443eb33703452b56306c3b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "247fffffffffffff"
     },
     {
       "public_ip": "80.83.124.173",
       "storage_port": 22021,
       "pubkey_ed25519": "1f69a9e69725c552d6c4d43406321597c7bae52b7dbf2745d7160085ae5d787b",
       "pubkey_x25519": "46af3e8f16b69d4f6cb9e95714a4f00f7c3d01b5e36f726a3383c35db6564b45",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22110,
       "pubkey_ed25519": "1f7501cd50c6face6d9aa72e816af36fcd6ce5bb145d0f532524963ff5ebfc77",
       "pubkey_x25519": "de49da0caf6e48aed9741a4eae002e5be200964721e58a22ae8f61315fac1f7e",
-      "requested_unlock_height": 2059467
+      "requested_unlock_height": 2059467,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22109,
       "pubkey_ed25519": "1fa297a6245a59ac093eaed4bc3add6491e902d81d695535d2d7fcc157b83f9a",
       "pubkey_x25519": "ff037b72bf6dfecc9be9a8428c9b79dbc7d0324a5c3754b1e872d4b79f81b85f",
-      "requested_unlock_height": 2062111
+      "requested_unlock_height": 2062111,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "195.200.17.130",
       "storage_port": 22021,
       "pubkey_ed25519": "201e0b7855c076227c6c47919ed4544d9a5d64e0aa35d6cde048d8458c23ff99",
       "pubkey_x25519": "ba2d8e8a9535e376aaa9c43eb8b3b5ec18a2b753e14b31509973411d6d208814",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "161.35.151.220",
       "storage_port": 22021,
       "pubkey_ed25519": "202b3d43eead2479ed1bfc269b3013487f69471c25e9aeb9002954067024b44b",
       "pubkey_x25519": "a8dd870968fdafe938ba1c966b1647daeaf5df91440d17656f9e7934c69ab419",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.232",
       "storage_port": 22021,
       "pubkey_ed25519": "2031cde9c462205c7cfe7a876db11c060ee12fe3f78e73b52fa42dbe405cf62f",
       "pubkey_x25519": "c4d20ff5068efe2161e68140f55a2d17475ce8f4036c969bab9a21cb16cf474a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "467fffffffffffff"
     },
     {
       "public_ip": "50.114.206.167",
       "storage_port": 22021,
       "pubkey_ed25519": "2080fb3ed7662aa7efceff772f4c61bdcb66ac7e4ebd8b0125fb3e4d56b8ed5e",
       "pubkey_x25519": "3f79c124011249351aa04a1a3c43ea8fd4c3c2c6c0d7b34cf43c31eafcb1e24b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "193.22.147.127",
       "storage_port": 22021,
       "pubkey_ed25519": "209aa14eb13bdf97155a6b0141affad8b081761a67184791889ef0112a5960d1",
       "pubkey_x25519": "bc78be47e82a71ada8b47298329daf86474df716dba2008143c57fa27f8da348",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22111,
       "pubkey_ed25519": "209afbcc7c730a8a56dfd2b349e6d4c0dff29135711f1ea6273d41abae3adf35",
       "pubkey_x25519": "3b24253907b84b2782d1a9d58bde65f05ed649555e11ddb311a6b8fe36c46858",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "167.114.129.231",
       "storage_port": 22021,
       "pubkey_ed25519": "20a761c9d553bdfe1688a1e8ba495023b831dd0c2faeea4b029a5a818219bb0e",
       "pubkey_x25519": "c5c790efab0cbe82f5e4688782adcb00c52870e467e2d69f65b1b5e3c0efa257",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "38.45.67.62",
       "storage_port": 22021,
       "pubkey_ed25519": "20ea27207edcd4f409c5d3d44a48478d7302f96c2654704ff766c800974e1568",
       "pubkey_x25519": "cfb9307a3611bda6854977712939851c2b5b31b2ac107a1928b1af175473ca7c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22104,
       "pubkey_ed25519": "2116858003285e5a996361d903944c73f94774a2fa12956e8fb902d4949d54aa",
       "pubkey_x25519": "7a5d812dbf9e314fc04f38ebe23b4f903f8f1f1b44be372c97ab346d79770b44",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22103,
       "pubkey_ed25519": "21255829a52faf4fc85e02b8b95dfc5b12a168fa5119c86b6b3774e325bf321e",
       "pubkey_x25519": "dc5cfad8c96a2ac9bac0d488ee2ea615848d243b3d5b25773d891ab7630f237c",
-      "requested_unlock_height": 2059022
+      "requested_unlock_height": 2059022,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "94.177.9.86",
       "storage_port": 22021,
       "pubkey_ed25519": "2141f276d1ea0cc312d193ce040738db362ed7cc11c9d4653f0f3336d7d9f635",
       "pubkey_x25519": "b17bd16061306906112db8297e8acbadeae9863afc16d9cc022e13a1cda37708",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "147.135.208.118",
       "storage_port": 22021,
       "pubkey_ed25519": "214c77122474bebeac79d2ba4f97f8abb267236a34bd887b1e7088c5f8c48fd3",
       "pubkey_x25519": "0047fe4a3a7cf5205ce9796ceccea62f435c7afbaa99ddcab818d519d0ae291a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "66.179.243.81",
       "storage_port": 22021,
       "pubkey_ed25519": "21d0ba87a6d1b4ef8c26bfd0a21d32e526a12ba12e8a04aa95a843cc2afd186f",
       "pubkey_x25519": "1ee96e21b7a944dea960d64e8823f0e1afe04a2e9837bc6552f12c56f0d8e864",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "139.99.238.151",
       "storage_port": 22021,
       "pubkey_ed25519": "22512d7d1de402a8f50a439f686af663f207becbea8a44ddbe84440c35ca1e14",
       "pubkey_x25519": "8b34b85a9f2d5b7d6970a5815e5c76c531678b45ded2a8ba823c296ff34ab135",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "198.98.53.227",
       "storage_port": 22021,
       "pubkey_ed25519": "22a0a525f400b989547884f409db1e0755e493a5ced313e3e8889868486b4e91",
       "pubkey_x25519": "5a22ab07dee000e489d110dcc6eafef075f6098c605d53d1c72af05d601ff321",
-      "requested_unlock_height": 2056300
+      "requested_unlock_height": 2056300,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "50.114.206.219",
       "storage_port": 22021,
       "pubkey_ed25519": "22c52f8bc17befaa4e841171cc639b733991767be7a03b5e2572c6df94f1dda3",
       "pubkey_x25519": "96883ab11199c0d7e948af9a6ec86200316e915660fb53e8be936b89052b0579",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22103,
       "pubkey_ed25519": "23200c094e1776548f521e7a183fbec5198b352b02696d502bc26fcdaec9263f",
       "pubkey_x25519": "0c7295d58a94d3ce08fa858426293c25831894668f481d4c4ba3b17742fc5050",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "198.98.60.131",
       "storage_port": 22021,
       "pubkey_ed25519": "237604e4cf5f77156817a1ae9bed3fa6570fe54bf632cca87369a940471e0c9d",
       "pubkey_x25519": "c098b599b0e1874e506a72f9474b963e163213b1b1692ca7284226fc19da9f7c",
-      "requested_unlock_height": 2056567
+      "requested_unlock_height": 2056567,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22121,
       "pubkey_ed25519": "2378e991e294cc80594b761390f7b0157b831d402f3c24d7cd7f9cbb3d93c4a5",
       "pubkey_x25519": "a94656b5ced27067d161deb5271bdeb6642653fd430db57e4a52ab5a8a660871",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "172.93.167.92",
       "storage_port": 22021,
       "pubkey_ed25519": "237fadadf715673ef4ba4c08bdabdfc8473ff451d315385eb7db35b6f877dbb7",
       "pubkey_x25519": "a772f687fabc87e9ff6a127794af6f9ad820f4ab40b2863bf3a9f92021cdfa67",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "77.74.199.94",
       "storage_port": 22021,
       "pubkey_ed25519": "23830b819f995ad8e3a2ae272c9ff3badbb4b261794610b2cf408058a4e0cabc",
       "pubkey_x25519": "c00c5298d75fd3d4a46f1773c152bbb5de9362a7c12a3320812a4961eafe6353",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "94.237.45.1",
       "storage_port": 22021,
       "pubkey_ed25519": "23944ff096299ae3b343126fab9f591c215fc32d42c87c62f888bd804b5fc7e7",
       "pubkey_x25519": "02ac96aa0877e56c3ec0dcecd56444d53fba80b288fafde61871c25386f8f33d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "95.111.238.80",
       "storage_port": 22021,
       "pubkey_ed25519": "23bf357027a42a8ad426bdc0350413d002338d0532d8d93ebaedcb6490bd2da9",
       "pubkey_x25519": "dbd07f991ddd04b481c5ee7c316dd7a25b6bbd8d81d32e37b6a10e3434ac6a5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22100,
       "pubkey_ed25519": "23c572c4bb4c5d2eea42cedc85cc14d1e7fecfaafc554c6181915e1437f209b9",
       "pubkey_x25519": "c831d002abeeda491a36bfbe95f75262456cc4afe9fba43b1250bb8693ad4b39",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22116,
       "pubkey_ed25519": "23c89d932e1fea811e7b33ab88956f8550ede291596fac160504771e8a479aab",
       "pubkey_x25519": "2650029714955e63fa2326fe6b32a3beef72e8e264790a3e822d9cc772d56530",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "209.141.62.119",
       "storage_port": 22021,
       "pubkey_ed25519": "23d37590ee47ee1197254051ec209c4afb2e2970f0a791270dba1c5882fa83b2",
       "pubkey_x25519": "f96e6fb9139112cb77deeb4ab08a6dc2163b9adfcd4e81ad552b223962a9e022",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "38ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.209",
       "storage_port": 22021,
       "pubkey_ed25519": "23fd4abe81af81d62f60f896de730903daeb5a81bbda2ad4f587b2fc9f22def2",
       "pubkey_x25519": "dd159e8dd55cdc60265fde71c472ea6ec14f127fdb0ed25c6f81bac3c087fb22",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22107,
       "pubkey_ed25519": "24184a93ff28ac6a6adb7238e7d88fd9296a54b9aaac8de62a4bc0a9fc8d1af9",
       "pubkey_x25519": "1e83a6b3752cc04f4f7c526b1dc890faefc8958059c911bd3d56589c783c3b30",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "64.235.37.141",
       "storage_port": 22021,
       "pubkey_ed25519": "241f3fe710d4c73a1c5b5ca47ebb35a2b71f9ff6fecab68e13688d9945f550ed",
       "pubkey_x25519": "6ced6bf53bdddc402c135a0a69bd8fb15ffd3635b06000925f1ea6b8a86ada1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2affffffffffffff"
     },
     {
       "public_ip": "91.98.20.46",
       "storage_port": 22021,
       "pubkey_ed25519": "2420b9467d24570e5097b4eadb1cd4efbc21682b616e062950010668c6f5f152",
       "pubkey_x25519": "2110955757edbcc35b12b1e93d66ba0980f92d626ac14f1a53b306070690b147",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22100,
       "pubkey_ed25519": "243a9ee2a38e533ae6fca0abf08527e38d6f43bf71e23c4786311505a2e3d859",
       "pubkey_x25519": "8c408c4a77875f04904fbc65efab10181e255fb6b4d3a428ed6616d132a7706e",
-      "requested_unlock_height": 0
-    },
-    {
-      "public_ip": "62.3.32.104",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2478a7abe756d10b3c9a4f3d873b44f453c0682352d3450d32ae865cbc8d514a",
-      "pubkey_x25519": "d4635e6e6a0bf4debe9f641ec88ca8e30de0b627a49dd933b9e50eeccda3c272",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "104.244.74.160",
       "storage_port": 22021,
       "pubkey_ed25519": "24c175f77a2a7785e3832afc63f0ed28d4a671bbafe6b3b5fdf18794f1f54a82",
       "pubkey_x25519": "1eba10da263cc79196a5053710554469acf92576f61bce816a7efee46a11a73c",
-      "requested_unlock_height": 2063709
+      "requested_unlock_height": 2063709,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "affffffffffffff"
     },
     {
       "public_ip": "158.69.206.52",
       "storage_port": 22021,
       "pubkey_ed25519": "24c1bc136ff9f34dc862fccece6e04462c311024e8dd27f953dd40f714d40e70",
       "pubkey_x25519": "caff26d74142c45d30e7b67a32b6670f691a256acd8ee6fc16b496efb6f1384e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "107.189.3.102",
       "storage_port": 22021,
       "pubkey_ed25519": "2501f18db49af68bcb105dabf1ff73a5dc287a1f0ce11c441785382d074f72ce",
       "pubkey_x25519": "c5b71121feda39d68e1ce52ec0c8d2c3313ef8df0601785b1ccbeabc0d59dc49",
-      "requested_unlock_height": 2064051
+      "requested_unlock_height": 2064051,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "107.189.13.183",
       "storage_port": 22021,
       "pubkey_ed25519": "252f44c955f6e6a925eaecca2931df97648c17868ce6e0c6b773e605f85e3a1b",
       "pubkey_x25519": "9a49654b530eecd48323665eaebde57a13f619ca4ebd601000e2fb889829fe5e",
-      "requested_unlock_height": 2064046
+      "requested_unlock_height": 2064046,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "102.208.228.248",
       "storage_port": 22101,
       "pubkey_ed25519": "2550e0143a328dfe6dbc10ac09c6adbb736ff6dce02c577f2b432459c5f871f4",
       "pubkey_x25519": "eb62025f02682042da42caf190e15a69b0c7b997c3b360ece741c5273dff592c",
-      "requested_unlock_height": 2059021
+      "requested_unlock_height": 2059021,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "194.62.96.16",
       "storage_port": 22021,
       "pubkey_ed25519": "25d223ca4629c883f0612a956ee7684a5cfa2a5beb06755ba109362e150efb70",
       "pubkey_x25519": "327a233eeac9d047a587978918fac97c4b1e05791f12558be69928678ae7ef16",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22102,
       "pubkey_ed25519": "25e010d78a9d97d3590342ce7dec98a88ec3549747927f911a6b1242ff066758",
       "pubkey_x25519": "70a46e498a896f5e7ce973eff16399cd8006a6867af1ef5b5f4cb02eb778ff71",
-      "requested_unlock_height": 2056796
+      "requested_unlock_height": 2056796,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22110,
       "pubkey_ed25519": "25fa58b2fb5dfbbbbaf67af4f72bfe9d8dd755de5a0787fccdce8c7f128e77c8",
       "pubkey_x25519": "217bf21ef1f16f262b9d80c263f61df4a48b58f7dcb1e689f9a7471fd2f3c45d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22111,
       "pubkey_ed25519": "266b2090e79d6e3fac09a385e92683a81577f1daed006f5432e689f6757657c1",
       "pubkey_x25519": "9eab3ad0bf47d5b11188f5e7e273108cef0986bb2b69237f6bd5194fc9cc5e44",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "198.98.61.136",
       "storage_port": 22021,
       "pubkey_ed25519": "26ecdc506756016df50a9902b21a8a59ddfad5d365f9dbcb435da1450a17d305",
       "pubkey_x25519": "824feab290bb561eceecab99e8ab0bd59ef647910a55498ed02708d2a5a39b2b",
-      "requested_unlock_height": 2056571
+      "requested_unlock_height": 2056571,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "49.13.13.128",
       "storage_port": 22021,
       "pubkey_ed25519": "27026c1091ed8e8daab05614af1b5027a6e26004cd25555d9a0b649214743a1b",
       "pubkey_x25519": "7ffe0c534d85e71dede1e830b143a6377e17adb2bd52928b7d249ab81e808466",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "164.68.107.170",
       "storage_port": 22021,
       "pubkey_ed25519": "271b7a41f97804ac0fea0ddf9bd80156e383aae90e36190e4bffd59688d66aef",
       "pubkey_x25519": "a822c34f2212db3c61646c3f9cee1823d083b832fc7e260b9419a9bea144b103",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "86.106.182.17",
       "storage_port": 22021,
       "pubkey_ed25519": "27dae0e56f2caff4519bff5de4c1161fd027ea80505a4fc622932af46edb9be9",
       "pubkey_x25519": "83806dd728f4af6871bff03a15e5df5b23ef6186e2d69977813449a2abd1e15a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "104.225.220.121",
       "storage_port": 22021,
       "pubkey_ed25519": "2808df9ae7d8600fb422348687ffc1c9f4a1d6fae482e78cbab39413fbf5ee37",
       "pubkey_x25519": "1a984349c60bf1290c3a32442a0fe50b92a851b336f23b0c92619c1a57176d4d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22100,
       "pubkey_ed25519": "282358b3517b1839a9b9d4c751832fd18689b4b2a8e91b38cc7c16fdc25ec196",
       "pubkey_x25519": "396c09d2441dec7a0c81de3f2e90b0c045dd8958307a6aa423e589e49a87bd1e",
-      "requested_unlock_height": 2059467
+      "requested_unlock_height": 2059467,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "199.195.249.188",
       "storage_port": 22021,
       "pubkey_ed25519": "2855feb745c807371ce2035867eba01543dc60bf274a97554b63989d01bcd41d",
       "pubkey_x25519": "87007ef78827fd93f2187ae9cdceaa4bedcf60fe66bdb6d0d83f754f7ff7c101",
-      "requested_unlock_height": 2056299
+      "requested_unlock_height": 2056299,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22124,
       "pubkey_ed25519": "288bd454a590ee935cef7843108ab0ac0c821eedca04e2df95b394d9abf8d2d8",
       "pubkey_x25519": "451133762c1a1a706472bfdc66e1eb8ea53b3050688dc0458d4c2d6bd2a8cc65",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20224,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "178.62.253.44",
       "storage_port": 22021,
       "pubkey_ed25519": "28c1157788669b7e80d0a3f05566bdea97e1596f25d06c040be5021c834556eb",
       "pubkey_x25519": "8ee50a868c5399b6ee8f5f70b8287a54a3d3b929828937ed746d3d2fd8febc01",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2affffffffffffff"
     },
     {
       "public_ip": "51.68.137.38",
       "storage_port": 22021,
       "pubkey_ed25519": "28c710aeeb4233186234189c6f6f1df1677537ba4fadf6d06b28eee6429a917d",
       "pubkey_x25519": "90d8b4406f8c16c50765de5b866e96376b89a255539ebc026e6d9c78f470082f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f7ffffffffffffff"
     },
     {
       "public_ip": "194.107.126.33",
       "storage_port": 22021,
       "pubkey_ed25519": "28d5f02b1e548c757281cce744671156062dda35f30cb17598b999f65d475751",
       "pubkey_x25519": "9bbb833bbfc1f34f43f96b4a73c95e16ac65ae5ea430211ef1d349ec1e90690e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "96.9.215.215",
       "storage_port": 22102,
       "pubkey_ed25519": "28e9fe70f9d86bfa1b146898e53c167fafc1b8f694f0551257f0a3a9b079b110",
       "pubkey_x25519": "986e9691341e6c2cce1a07e577769bbdb9b52d2f3d8608f201320ef12b97a627",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
       "storage_port": 22140,
       "pubkey_ed25519": "29071ff562b42881d6cc1d3a904fefbf8f94d2358228589febfe646eedaf5c17",
       "pubkey_x25519": "9485d4f1ad6c5160c7b254ca8a32870141905be5490a25053c90ec0c721bd00c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20240,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "206.189.109.173",
       "storage_port": 22021,
       "pubkey_ed25519": "291788c52c713eb7f6ecbb70a0683b8cc4a2d8e2ce1805261392b48af562c2b8",
       "pubkey_x25519": "11e9506436ffe090935d40ebecf841df676843cb519dac2e6155e731bbfb171a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "5.161.114.96",
       "storage_port": 22021,
       "pubkey_ed25519": "2937611edd054931f4206d8313a7c1268c42dff3aef0d2c1473c35edee08b795",
       "pubkey_x25519": "58469f254ff8e4449d8f34a90b975b0c0ee587358430ec4fc349d9bc58a52b34",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "49.13.9.201",
       "storage_port": 22021,
       "pubkey_ed25519": "2962b67fbf23c7330899b110ecdc88c0e81660a9e5bdda463dccb8fba005fafc",
       "pubkey_x25519": "355da68b1c91f81e9db3571de825df8b93ae10aace92e76f4931786ea6b4f714",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "194.32.77.75",
       "storage_port": 22021,
       "pubkey_ed25519": "298fb59e547e1e9fdbe6355b15f6937e84143248f66ef6d612ffe3fd7a9ed813",
       "pubkey_x25519": "2b314f5eed8622207ae0f3b2bc5ed75a3ac10f47fe201e747cb35f07fd321600",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22115,
       "pubkey_ed25519": "29d5fb74d3126042c8dab58525f4ef57529c054ed10484e411b5131e9e7cad78",
       "pubkey_x25519": "9eba5dc959b6ebcb4d2b18a1e80137c40d8d40ae4fd4cb29315ee8f28c2d9f43",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "212.56.45.2",
       "storage_port": 22021,
       "pubkey_ed25519": "29ea7c458ffee249178431a22353b76da73eded11d3fac5735cfdf88305bbff8",
       "pubkey_x25519": "74032af37c64a141e36f7db9ad36c86ce8ff57f77c53c75720b17ec2f735c364",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "95.111.245.253",
       "storage_port": 22021,
       "pubkey_ed25519": "29ffe3d2634afbaa718d1c06200151006c25fc9c8c392da67b253aa4fac6ca55",
       "pubkey_x25519": "87885313872cd2e16e468c46b1dacb7ba5b606d270037ec467bf332210fe7f18",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "141.105.130.4",
       "storage_port": 22021,
       "pubkey_ed25519": "2a0a80eedde0ee2f0b5c619d4d3d7ea0304e1e987344a5e425696cab7cea1432",
       "pubkey_x25519": "feaaea1d69018de889fcde963e9c2ff595eab0e2787a1547cedbc0052bdae27d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "185.243.214.22",
       "storage_port": 22021,
       "pubkey_ed25519": "2a4939cb2f27adc01a73f439fa05f18ef3e4098bf0782ff7b4e9d24121139dc9",
       "pubkey_x25519": "9375e902dd3912efdc67e59fd5f4a8e51befa2b4edb255ef06377a218de3007e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "65.109.1.140",
       "storage_port": 22021,
       "pubkey_ed25519": "2a5a1b874217893eb387a30031cc306e0502682d0998849aa6d0bba8e97f67f2",
       "pubkey_x25519": "22209778f4842cbef49f885ff8876168b6eae391f549d7a44bac04436744b075",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "178.128.121.1",
       "storage_port": 22021,
       "pubkey_ed25519": "2a693ca959597b9509860f818362ab4ec1b2630646cacb5a71e18fcc645a4782",
       "pubkey_x25519": "8c0118d59b1fda98575eaf545610c3d026cf60ce36c55bb37596a0ca8d2df77f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22106,
       "pubkey_ed25519": "2a6eadce8cccd1b4cbddfe337986554a8bef52b964c1c0853a47dd37932e5271",
       "pubkey_x25519": "14d110262914e349a0daa6a2d8fcb3ca5e5f68dd25beba5c5f6edd5d515c316e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "185.173.235.108",
       "storage_port": 22021,
       "pubkey_ed25519": "2aaa88518c19d08723397fd06627544c68ca5fdd2bbff31f5a87022b7948233a",
       "pubkey_x25519": "77d2c5adb175ba519c08475dec9414b2d051f1f8556950bc3acd3c7b3d37a971",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "91.231.182.72",
       "storage_port": 22021,
       "pubkey_ed25519": "2b15f7759564d0a2c7d60b04f8c7b5604b793cdd570fd0754a38d5738e919dad",
       "pubkey_x25519": "7a5f703c2b1f078e729330e2824f02503434a1adf0d32c2276a1d7f2aa637e66",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5bffffffffffffff"
+    },
+    {
+      "public_ip": "95.217.218.66",
+      "storage_port": 22104,
+      "pubkey_ed25519": "2b3afbb02ac99ef0bec69aa23c3086263b80a255e81853b257d9355376a2ab67",
+      "pubkey_x25519": "226dfab4897a5fc8802d3c6e27e55938d3a320c1126c7f1c4e82ba9771cedd29",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "185.70.198.105",
       "storage_port": 22021,
       "pubkey_ed25519": "2b4018d37b2bff2ae0b417b2175ac56a2e59b13ce78e46d1a7ae5455311b5b1e",
       "pubkey_x25519": "0caec3f41e88a30eae3ca746cf2838897b5fbcbf6af65c32f1e61a0699580348",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.175",
       "storage_port": 22021,
       "pubkey_ed25519": "2b8da85d063ee397d5a8fb37b8508652d5178f95873b4e59fb52eda467650f9a",
       "pubkey_x25519": "795ed210d269745e8812359655774c9ac21e17d0a05a01059b44b37f19f0f828",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "167.86.119.129",
       "storage_port": 22021,
       "pubkey_ed25519": "2b9fa075f00a1625df989e6e803bb61d68f43bf78b84a4a52cc16dae5436cbf1",
       "pubkey_x25519": "d1362142f5c04cfa92ae3618437e692094de67e7c924a0362a1a9cda776e0e4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "199.195.254.118",
       "storage_port": 22021,
       "pubkey_ed25519": "2bc1eb54ecdb1193678cabdc8724194c2a3bdd25d568164958a21b33b7880ad5",
       "pubkey_x25519": "0ac6d777f7cf8f2396fe59482ce116f094a7f50412bf995867623d1f81da325d",
-      "requested_unlock_height": 2056296
+      "requested_unlock_height": 2056296,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "164.68.104.164",
       "storage_port": 22021,
       "pubkey_ed25519": "2bc44824399be5323296534ead917cfde0a47911ecc9d81571a3f7496566d064",
       "pubkey_x25519": "b65fd9d9320d93493a033d5166b33d924cb750a069bfc9622ceb2d098db36450",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "217.156.50.127",
       "storage_port": 22021,
       "pubkey_ed25519": "2c28c8698e15684885eabcb4520481735089ba6a42f31c087d0892938e5737fa",
       "pubkey_x25519": "1ec4e32809898005a334e2cc127ff38e5c1d66d1a8a53e2c7241d2b25da92953",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22101,
       "pubkey_ed25519": "2c64ff33d4ab2a04d3e5fa90371c7617db22e9b77688cee7453859004be429d2",
       "pubkey_x25519": "952817f0e3c5e00906056a28ca7ff5b2f99ed7f42a4bf1ce7ee94fac8a7f3e7b",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "141.105.130.184",
       "storage_port": 22021,
       "pubkey_ed25519": "2d9baeac32d5930a00a1037a7e678cfae9419057427e82e7eb218b421d33863b",
       "pubkey_x25519": "005b4d282ba7435b6adc3c88811533db3946dc9038e787ddcace4a9002d89437",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "84.247.128.59",
       "storage_port": 22021,
       "pubkey_ed25519": "2da7e93a82f751bff4d57c7e22530828de181717172ab0f9c89862cfb105046e",
       "pubkey_x25519": "c4798a461fcb4f7badb45bae73a769dd511316b9923d124addd97731b75b5f05",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "213.199.41.115",
       "storage_port": 22021,
       "pubkey_ed25519": "2def1586a8af7996626d92b4b84917500523059a1b6d85d78d0013fd05c3725a",
       "pubkey_x25519": "cfa1ecdb120eef33c1f708a3227ee7db48ae2fc4d59fa070b92e673059b5ca1e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "198.98.48.12",
       "storage_port": 22021,
       "pubkey_ed25519": "2e2af8881670c1dca91073af7c3f0705c8922a55f0273bdcb1c5d5b33029820b",
       "pubkey_x25519": "00a1836c44f0283b26250ed094b233982ceebd2f1ac9fc04aa816cd8bd8c1151",
-      "requested_unlock_height": 2056569
+      "requested_unlock_height": 2056569,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22119,
       "pubkey_ed25519": "2e2f73e3d12ca86981fa2621b54222d7bb47f1bd0a2c66314684b00394f1a14c",
       "pubkey_x25519": "185ca1221f3136f8ace71352a4b502b1dad2d2daf7208fae43613fe35e69cc26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "157.254.221.25",
       "storage_port": 22021,
       "pubkey_ed25519": "2ed012dc966fed576b8b59c2c96c7e257bb1dea5fd9ae707167721fee3189957",
       "pubkey_x25519": "60e6ea7387e7c551e92e1fbce5276a94444912c078837e3dcaffad54fe1c024b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22132,
       "pubkey_ed25519": "2f11e443d4a5122393d3b0f25c952028a40a03fd120b4fdebf7380cef72c742e",
       "pubkey_x25519": "49e0b2461dc1f7a97991bece0e012dbc321209b6f9de900daa40a18d0e665361",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20232,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "38ffffffffffffff"
     },
     {
       "public_ip": "209.145.54.198",
       "storage_port": 22021,
       "pubkey_ed25519": "2f55897e0cc1982dbc8ed2a281ef11f6bed9826ddf2b9d883071ad6f5a2930e6",
       "pubkey_x25519": "c848d01edcc01eb41d82af743bcf668f6cddbc7935a8d4ee2748959bdd99836a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22120,
       "pubkey_ed25519": "2f617b7a434ae3d76878864920310ef0d3563ff259ade25c4cb9721b0af9c7ee",
       "pubkey_x25519": "71a69cdd70d440255a00143b6129cf7507fa0ed0bba8d0c2184634186abbdc37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "130.255.77.179",
       "storage_port": 22021,
       "pubkey_ed25519": "2f6b05d12ceddae4e68c6a1a5056b13e72538d94b801487e1c5132280f1c7ffd",
       "pubkey_x25519": "269bbb978a0e856acb9f63a9e66df14252667d1640814b85827f55dd33e3e11f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "51.195.252.72",
       "storage_port": 22021,
       "pubkey_ed25519": "2fa7c2eea39e41920c805b59e97fff20f8ea675c9489f738686aafe832c0f02d",
       "pubkey_x25519": "34901b66e2f40fc44eb763d0a1f2cdfea2b024c32066e90b36bc76cc97aead01",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.243",
       "storage_port": 22021,
       "pubkey_ed25519": "300a0c4fb1c23f8506b531a905948ef3b9ce8a799ecbad864c7ea40294c4f1b7",
       "pubkey_x25519": "0e8bb99b51caecc1131aaf3082e47ef4e7dab5e94c63d72ed8145dda339ced39",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "0"
     },
     {
       "public_ip": "38.242.142.248",
       "storage_port": 22021,
       "pubkey_ed25519": "3054360a0fd2ba7a61d35d7360666602b029e98b9cca070b8e5089cdcefd2815",
       "pubkey_x25519": "f3b143d07a31229a3f2e09d17564b9654e04fcca232988d0ab847266a9bf1e12",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "184.174.38.202",
       "storage_port": 22021,
       "pubkey_ed25519": "306ab0f5cfd7230a17b015f8dfccb0263efb423d51278a2f3dddf42af86203d8",
       "pubkey_x25519": "461f3fd9b0c9d5761135b776f18a54b8966abd258b8f324271fdc84b91101449",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "95.111.204.25",
       "storage_port": 22021,
       "pubkey_ed25519": "306f6824f908b16687f04a799a0e9e0c31a76aeef1f48a530d386fb56bcc8408",
       "pubkey_x25519": "1e1f5a0a3bb19aa6235d7ed269cfc0252dceedd19b2d660d43826081bba5d762",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "51.81.187.85",
       "storage_port": 22021,
       "pubkey_ed25519": "30954b725ed8232e4a46d375d1055a0cc3ff888aff0f7396886562a11dfc74b0",
       "pubkey_x25519": "5a7cb771a9cd72153f0437d93aa2316d249c9a7c27eb1893edd303868272a66e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2f7fffffffffffff"
     },
     {
       "public_ip": "185.132.36.125",
       "storage_port": 22021,
       "pubkey_ed25519": "30b9bb55dad81da39f4d4ace65b102fffd14aa896acc7b58ef1a27ef9996b0ef",
       "pubkey_x25519": "a994f3d3cac6b5b4e69ee9f3802e3943bdb68166140ff18f6168c1633294d275",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "95.216.196.246",
       "storage_port": 22021,
       "pubkey_ed25519": "30c10f9e118ba68945c2473748b9e67e715ba53e9edddd4dc3c0b69e285c6fa0",
       "pubkey_x25519": "f6ba804b0bf483c395025f9688602e4873b7e923a8fa2b28a0621cbd686e7b37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2d7fffffffffffff"
     },
     {
       "public_ip": "209.126.77.237",
       "storage_port": 22021,
       "pubkey_ed25519": "30e74a81afbd87caf57138cf72be6e7b709462f1e863a6253d107a0ea4f23fb4",
       "pubkey_x25519": "4a13b775f3709710f7303c1c8eaf297b36d5ec4c70ad215ea5f4a939be2cfa60",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "141.105.130.127",
       "storage_port": 22021,
       "pubkey_ed25519": "316097df512640737bb5c840daa632a0a8f32ba96c4bf816e59ad5fa4e8f3dc4",
       "pubkey_x25519": "74b79188ace989064e90af63e29dec88b7e5fa81c760cf6fd097034b041f1813",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "51.38.125.80",
       "storage_port": 22021,
       "pubkey_ed25519": "31a7ce4a541c4d8483dabc5c8dff2756c08fc7faecb52256e01c04b6c719bcfe",
       "pubkey_x25519": "e0b516f91ab8c3138a8c9587f88f2b687702db673a44fc9c9b3a2077cd45fe58",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "109.199.100.173",
       "storage_port": 22021,
       "pubkey_ed25519": "31cd2530efcbbf199a12c614b914510bce5aa83974ae25e512dc00c34c51de5d",
       "pubkey_x25519": "9f9b90e67b67fa3819f52fefc1b38d168bc68a4a6f413b514b6e49c30803b178",
-      "requested_unlock_height": 2055170
+      "requested_unlock_height": 2055170,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "164.68.125.235",
       "storage_port": 22021,
       "pubkey_ed25519": "31f4bb3a2baf824481db2429303ce38ff89bdf9a4a44dc2c532428c466796f44",
       "pubkey_x25519": "39f4f5787b0a68b3b423c4bcc730e408d866073fbdcb3c42c03edab1b484ae13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "104.243.34.25",
       "storage_port": 22104,
       "pubkey_ed25519": "3234bdcbca860cfb704eca2578dc9fe228906a490e82e444001e320b937b21a6",
       "pubkey_x25519": "8d258d8c3f67f23a17bb3be13bdf3f9265db072429d136c870f20c7c31f8cb1c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4cffffffffffffff"
     },
     {
       "public_ip": "82.223.118.211",
       "storage_port": 22021,
       "pubkey_ed25519": "3244bdaa442dda8587279d0fb05e8e441685ac3309c500d9157d5b261742fde2",
       "pubkey_x25519": "1c74522bbc4a1d7de1e181e5e0d1a5d46b42d7a17524232eff3a730b190e964d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22117,
       "pubkey_ed25519": "3249dc023773ec1cec8d7eb84b591b04965a59b41c300b40d702ee14a9d7dde8",
       "pubkey_x25519": "086700ac027423c8844fa586a24af7d81ec7ae9072cc0fa852dfadb6d998ac04",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "141.105.130.62",
       "storage_port": 22021,
       "pubkey_ed25519": "32e023dadaaf3bc03ad02d272916192936c19f7540975c3f71a8932679a7facd",
       "pubkey_x25519": "7226125d1287a61ccb98354e6418e023c38fbe76cda136b6aed487a6dc1fab10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.141",
       "storage_port": 22021,
       "pubkey_ed25519": "32ee60f5827e3045311a70ab4aa2c3452e866aba8aa76a1e41bd9de1dfcaf700",
       "pubkey_x25519": "fe3f29034196e03ce34437f179dbcc69f8f2d4c761fc2b9ab769024a34ad945a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "164.68.104.184",
       "storage_port": 22021,
       "pubkey_ed25519": "32f244d823356bf9dbffc85c83f530dfd6f1f3f26ef572410452d390927b7f8b",
       "pubkey_x25519": "abc49d581d5f5b9413f1f4fa1244bbb3c5c172b184ae80e4a29a9ebf6c2eda47",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22105,
       "pubkey_ed25519": "32f66a2d247defad21c80b060eab3df2f65334042c5521a1ece0396ab55edace",
       "pubkey_x25519": "c62de254c1af75fb49bfbe6d5fbda7a6a97e9b6f63d22b5993bebacf5ed19a66",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "52ffffffffffffff"
     },
     {
       "public_ip": "45.154.197.40",
       "storage_port": 22021,
       "pubkey_ed25519": "3304b076517b6021243f0157adf45735dac47f933be5ca90d5686465814ec0e1",
       "pubkey_x25519": "db9c7dcd3d4158759c56203b18d99bd5e8a44dc70b0ca5293785a12bdb2ec25a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "146.59.3.229",
       "storage_port": 22021,
       "pubkey_ed25519": "330a27c90766fa3a3e75e5550d46036ce56d17610119ea559e98b865a9cbe2e2",
       "pubkey_x25519": "bc72a6dc452d9562cd3989a48ef813616a0d76f18692c332c6a00222c0d30a1b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22126,
       "pubkey_ed25519": "338ab9f6005b211a036684f620a605ea171f40ff73a6a56ae1910e64bb8497db",
       "pubkey_x25519": "7372c84ee9264e7f69ddbcfc42baa3c2a64b244d345c4c7dceec57be246cea5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20226,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "198.98.49.206",
       "storage_port": 22021,
       "pubkey_ed25519": "3440684d377a7a04409bb125f6dca7512fc5c3ecdecaec6016a75124c8965b1b",
       "pubkey_x25519": "cd4bac01bc5fa64819a00a8441f093fd52a97d6ac070e10a5c1da8ae00851b4d",
-      "requested_unlock_height": 2056298
+      "requested_unlock_height": 2056298,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2fffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22104,
       "pubkey_ed25519": "347bd683e8adbf5f6968e7d6bb1f20725621779374f86a44553af3ecbddbde9e",
       "pubkey_x25519": "7ff974740bb08bff2fd582169a49bf8a15152e9917202d9c0785a3f976b63a54",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "164.68.117.25",
       "storage_port": 22021,
       "pubkey_ed25519": "34a6b321c62f466224f1cad153915daff8075d8b339e7fa47712b311f1509567",
       "pubkey_x25519": "b4d71359920c827836a378d147e2c09c94d0456c24f973472e15b76a06e2f625",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "144.91.77.90",
       "storage_port": 22021,
       "pubkey_ed25519": "34af438910a54fcac12ae70efb92a609434cc2793638ae81767e2b08f82da57d",
       "pubkey_x25519": "a4a35ccc8a0f85071171a822e25ed04527f6cf62d5f7c13229698a6e6e840357",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "207.180.241.240",
       "storage_port": 22021,
       "pubkey_ed25519": "34b3593e399ea88aa8a9de3b87f7218a9ba375d464b07a3ae1770e5509beae5e",
       "pubkey_x25519": "b6ef5c8657a3daace844c9ee00089856492c389aa89ef053f6d2085b5c51cc31",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "51.83.187.20",
       "storage_port": 22021,
       "pubkey_ed25519": "35159cdcafafc13adde7ffe91d6d07e0643a34d2750ea016c5ac6f6bdbc6cbd6",
       "pubkey_x25519": "f006c587a74f0bbf560496572a81b46e76c2fa08520308817601a8dd8bd24654",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "afffffffffffffff"
     },
     {
       "public_ip": "198.7.127.225",
       "storage_port": 22021,
       "pubkey_ed25519": "352338af9f1bcc3c0edc92cfe647cf211041d7cbd654a0115f3a0fc757ce86ba",
       "pubkey_x25519": "8c223e5633a3347f77b2cb24fe4984aa7b857962be7c8d15824c3ee7376bdc13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "91.107.206.183",
       "storage_port": 22021,
       "pubkey_ed25519": "353c2c4f5d3dab317094a87c178c16aa93c1d829aeca025996e394680d5f0805",
       "pubkey_x25519": "60fc225f9e5f6dbe934a8c3dd8fd565e3af3bb46076779397eee90c63ea46c03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "74.207.241.22",
       "storage_port": 22021,
       "pubkey_ed25519": "3548aaf4a4a527eea4a5375b85e714b8995702df973cd7748d6530586639eb84",
       "pubkey_x25519": "2484d7071ed3c8bc482b2cdb296e282c8aac776838c86b485cafddc19ae0821a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
       "storage_port": 22113,
       "pubkey_ed25519": "3552ee17e117eedd44711f6907653fb5b2d5fbf56f7d5118ffa56016a99a9d98",
       "pubkey_x25519": "fc89c0e47b87adb1403c2a2cc9d47632888ef0b55aeaa35eafa43c11766caa40",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "167.114.128.82",
       "storage_port": 22021,
       "pubkey_ed25519": "358fd188973b053c04aca0b689ef4c11417ce4e66473afe4c492463c2da7b101",
       "pubkey_x25519": "4cf6b7ca7c336b1718897d2c4d36bbc6b5cd8e8d530682cc815c48d63003a25d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "198.98.61.177",
       "storage_port": 22021,
       "pubkey_ed25519": "35a44177058d70d2a5cceca7397070ef21f1c03af57df9e302ca4fbbb4091c6d",
       "pubkey_x25519": "2f380783abe306f0ec3c2012186f379b95aea8162bd75220bb154838e25ec534",
-      "requested_unlock_height": 2056298
+      "requested_unlock_height": 2056298,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "89.168.85.187",
       "storage_port": 22101,
       "pubkey_ed25519": "35c56544d3cbf310891bc8f3bdbb1e210d6314c7c1c749106b3048120b1a7094",
       "pubkey_x25519": "74569e6e93a501ffef93e407fb1027f21297058b89462ee24ebb871f02328710",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "104.237.158.114",
       "storage_port": 22021,
       "pubkey_ed25519": "35db987f1e16c26a479ffa16e474e4a2d4c9bb021b918ed4ff0158b24444c478",
       "pubkey_x25519": "fa9867b738563159ffe7bf26e97c4795c90f64d144ddaf31739a30abee1c9f03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "199.195.248.217",
       "storage_port": 22021,
       "pubkey_ed25519": "35eb2772eaaaf4423d8a40825a6c9a7f5f06fd62ef886c636e20fd705f4f795f",
       "pubkey_x25519": "be02872795dea00a12b1e4524b87b7fb46ffb714cc392f5481c223254a9e6a17",
-      "requested_unlock_height": 2056294
+      "requested_unlock_height": 2056294,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "143.198.238.21",
       "storage_port": 22021,
       "pubkey_ed25519": "3602143131036abd581a3bcd2faed275d437c5c8307ba44faaf288072ccd1da0",
       "pubkey_x25519": "e675c6d09e85d86b40e92f32a8fba2a578d30fa43eca0c28abdc59a24da6c778",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2d7fffffffffffff"
     },
     {
       "public_ip": "209.222.103.98",
       "storage_port": 22110,
       "pubkey_ed25519": "3658bd502598f2cc458967b3e3b5a5c340b5a2becad9f2ec79cd9b4ed4692fd4",
       "pubkey_x25519": "a962614250c38adb055bb7445c296e170fac0b687bc81bb41efc00aaab379c30",
-      "requested_unlock_height": 2059300
+      "requested_unlock_height": 2059300,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "173.249.193.95",
       "storage_port": 22021,
       "pubkey_ed25519": "368215a3027a3ce78d3c51d09d37adcb39efc00804b297865393d828fbbfb872",
       "pubkey_x25519": "1887099b8f7acda328fc77d21d8ae65b1276de157257ed7535d9411bd4c42739",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "51.83.69.65",
       "storage_port": 22021,
       "pubkey_ed25519": "36a37f35c0b790ccaa6b0e20e95d196b3abb0284706e796cd46122b518efbe53",
       "pubkey_x25519": "0404e848b9c6c28368102268775b4f5ae9df8741a7d49b63e3745ac52b24a413",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "193.160.96.222",
       "storage_port": 22021,
       "pubkey_ed25519": "36b2c982ae93d92dd059971bbf236f19333fb1f1efcde82c074bd8b703315c9b",
       "pubkey_x25519": "fb6db1874c349ada87c6bb9637bd1af5d6da50c4793048cdb86cc8aecbf65365",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22129,
       "pubkey_ed25519": "36c5f6af0c769a5f35ea2f89a62c8bcc879ba656bd6b2a23477a100c2a292fb0",
       "pubkey_x25519": "9d78254dabe7df8979eb4b87178b62a19469e1fbc395faebd28ad0d27c08dd25",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20229,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "46.225.78.111",
       "storage_port": 22021,
       "pubkey_ed25519": "36ca3e9680e66c2966c062c9cb6883bb192cc62878860824f7cdd94710fbc8e0",
       "pubkey_x25519": "be50753eff2b356e51bf8b67acace22bc04ef4d5316e74d07aac0f15ca3b9d78",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "192.9.182.60",
       "storage_port": 22102,
       "pubkey_ed25519": "36da0a69008a6cc9be515b88e61219addffddc7dbad7050d7aa2ad71501e41b6",
       "pubkey_x25519": "42b7397ceebc43ba0103b0b26cc854a6ae7f29773fd4fff9192f717527b3d640",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "167.99.46.232",
       "storage_port": 22021,
       "pubkey_ed25519": "373099eb46419e13300f3f3c48f96d2865e9afd621e18ce0c086445491f96e35",
       "pubkey_x25519": "09afb72d962cfa4d4f887dcdd6a5511dbc128c02cff3691e9a8a97864fd9d077",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "199.195.251.163",
       "storage_port": 22021,
       "pubkey_ed25519": "373773ffdeee58dc4771ffc899f8bf5d3465f6515fce6a69d9a37703702078e0",
       "pubkey_x25519": "13e17f861b4d558500cf04342ffccf9676f2840d37e4ec0ef168101b3157a74d",
-      "requested_unlock_height": 2056296
+      "requested_unlock_height": 2056296,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "207.180.205.249",
       "storage_port": 22021,
       "pubkey_ed25519": "373a589468bb62daaed1475a9eb041c99d962a9d272fd5dc3f15d718b6c70e58",
       "pubkey_x25519": "7791f2cd4a1fa58a65232eb8c2ad7b794111ad686f657093391d06460e7fb628",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "164.68.126.229",
       "storage_port": 22021,
       "pubkey_ed25519": "3741de3e63c724cf9d809370dd080b5e7363ff3fc7a5866581bf19d7178e4f8b",
       "pubkey_x25519": "8c1130fd882a4280561000a339166dcd99b50519d9ab8146e757942a90038058",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "86.107.168.156",
       "storage_port": 22021,
       "pubkey_ed25519": "37613127a287e0de9aaf9eb1e0947b406eef3546c9387c6200e0c80ef33ec090",
       "pubkey_x25519": "3aa3678fc25c293ae976c3c803fb46212860b859475a4ffcf3a7ec1ef7cfc43b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "164.90.200.74",
       "storage_port": 22021,
       "pubkey_ed25519": "37681c2bf8f7845c2683eab2fe68fb33c031618d861d990286dc77579d4ddf00",
       "pubkey_x25519": "e54faed443627ca05956be2b5395ebcb7084dc609e066165123704e342e8d077",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "0"
     },
     {
       "public_ip": "107.189.6.53",
       "storage_port": 22021,
       "pubkey_ed25519": "37b733e56f3f670a57052c610403547fb317af86c252f0b68bd1ddf8d293e70f",
       "pubkey_x25519": "34028d5615db02a820df158c608afc99effd4fa196f8b683c565e667bbd80375",
-      "requested_unlock_height": 2064050
+      "requested_unlock_height": 2064050,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22107,
       "pubkey_ed25519": "37cba182243cd8aecffbfe5db7d61a8625d5eebbee068746b03bc5452e7876a0",
       "pubkey_x25519": "040c07df12782f8a5090e183ab5f6dfb2f48a7f7eac6c2a091805fa339afcc2a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22407,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22103,
       "pubkey_ed25519": "37ff021b553b234865bd9988a57f989adc672cd25ebc4d34a167e929342822af",
       "pubkey_x25519": "61eff4c2606646e081d6259a723f3065726e4dc276c5ce1550dbecb24a6fb248",
-      "requested_unlock_height": 2059300
+      "requested_unlock_height": 2059300,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "185.245.83.77",
       "storage_port": 22021,
       "pubkey_ed25519": "380c39fa75062a73127c9687630713210efaddc3a39b760dc47bc573a02f8aec",
       "pubkey_x25519": "89fb640efb6a3da1e1521e1040cd2f32cfe7cb47d93c2fe89307a468a0b46736",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "38.45.67.245",
       "storage_port": 22021,
       "pubkey_ed25519": "3843c70c6c95e93197303222c6accbc3a3961e559b6457f83044d57b68540335",
       "pubkey_x25519": "c93e9d705cf9b83ada3c361c84cc91a41564f1e2951fd679858709ec16b62e5a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "46.250.249.103",
       "storage_port": 22021,
       "pubkey_ed25519": "384c8abf99e596fff41e0e0efa34baa96b0cf6a39fc0c953437cfc9205baed53",
       "pubkey_x25519": "260c029aeb0b39a73db660aee9919c087e7e83de32e2f3bf9be78a3b15c36328",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "387fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22129,
       "pubkey_ed25519": "3866a53df944880e84d8d99b42d9a37b227674f0cb00fe7dc61198b0a25922bb",
       "pubkey_x25519": "c945f03d6ec6fbb043418aa6dc16872487219414b78415c71f32e9f3b2b8cc23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20229,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "164.68.126.100",
       "storage_port": 22021,
       "pubkey_ed25519": "386fff69caf0102034063bb1f6ee4e86a919266964a5027bb4c1e3d8f3e701f5",
       "pubkey_x25519": "6c52330ebd889c924e7bd8ca9b82d3b0c312beb17a746c121d9eaf50152f7c7a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22107,
       "pubkey_ed25519": "3897ffeea34ed9ec1ca80253868a896743b45b6bcf096fb46a541b498630b7f5",
       "pubkey_x25519": "33e1bb55458664668fd33d451de5c2eda5984325f0c3a5bae646f9df4ee35a4f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22407,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "167.86.69.151",
       "storage_port": 22021,
       "pubkey_ed25519": "3929fbed3469b68e0ea4f5ec3dd0412f9de3c55c8a03b44f0d994560005a19d6",
       "pubkey_x25519": "772f7e0e3bc4cf26aab70f90e51b8349c31a09dd188417f0354637c7316f8d7d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "205.185.121.209",
       "storage_port": 22021,
       "pubkey_ed25519": "3a0e1c131606f7b18a191485810b3eafdf093dfd5de83586c4d6256b3003f3a9",
       "pubkey_x25519": "f4c76fa89b052d2a3e36c7a2ce6ccffc9b09a18113a8e7e48bde684ce82df874",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22105,
       "pubkey_ed25519": "3a0e99d7a7ffcf1c00dfd61277b1461f8c06ade1a5b41f9bd116ba9f73d5e2ad",
       "pubkey_x25519": "ff5d13e42517d82368ee5cb1b9e23011dc4575973ec4d43fadf2643f1f007b5a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "185.188.249.168",
       "storage_port": 22021,
       "pubkey_ed25519": "3a2881c7d7674f07719a79442e7b894b5961fbdb27919fff02a2b42b70dc3c5e",
       "pubkey_x25519": "e42dabaa117420e38ac5a5300f45f8acd3fe8dc9be648be9f8c56aeafad41363",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20605,
       "pubkey_ed25519": "3a830c260d8045dbea6bc4cbc94ef1410edc6469c4228cf407a5a5203ed779e7",
       "pubkey_x25519": "42fe2c446ad96da5601dc37eca35995c0db3ad4cc3e20afc1e65f73644739933",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20905,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "96ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22113,
       "pubkey_ed25519": "3aea158387f81dec94ef9ce47c16333bd2061d15eb72a5edc57692ad084fc4e9",
       "pubkey_x25519": "a2b8d52e719be904e8c4d2bf3e1c00a1289b7f26d570c1df64322cd60eaed048",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "173.249.195.109",
       "storage_port": 22104,
       "pubkey_ed25519": "3af4a69fd764b3bf2c22ada8931975b8c7cb94568f3ee8d28c74023a1e57658f",
       "pubkey_x25519": "b7017dfe27ea6d5fcf56b3d8a0b6e007dd232700b762f0480adcf48e29d48a2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "96.9.215.215",
       "storage_port": 22103,
       "pubkey_ed25519": "3b11f1a0b1c39ac2f3d197d63c5eab8157e1ae380831b8bf3f6cd3bf62ebca27",
       "pubkey_x25519": "5b2e70445510215b4380650ba11e2779bc62faa5d606a06ca5058dbe3610cd2b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "209.141.42.118",
       "storage_port": 22021,
       "pubkey_ed25519": "3b6679361b2fdcb059a2ad8919d00c273c6f8cdbb7c46eae61e7f0f5cd050277",
       "pubkey_x25519": "108d65887fc4e9b0dce1eee379666b1be9736c3260ae619b315c9970600efc73",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "141.145.193.90",
       "storage_port": 22021,
       "pubkey_ed25519": "3b79f809059cec8ef5f080429573ceab670ececac9299832fb46b8ca2b71ac59",
       "pubkey_x25519": "01d9764da257de7ee910002cf76ee64395786b084531f7ab7abec91405bf4203",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22123,
       "pubkey_ed25519": "3c3e35c2fdb0a55863d7b87ad0b0a4e546ddb67bd281dc0f82e8368b4c302929",
       "pubkey_x25519": "4e38bce3434c5517debdd49e49ae90cf3f717627b636a7d0b91b404cf3c47354",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20223,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1f7fffffffffffff"
     },
     {
       "public_ip": "45.79.83.44",
       "storage_port": 22021,
       "pubkey_ed25519": "3c658e7f88877159750967c046aa180694dd90acfe9dfcc9ce9231996aac9469",
       "pubkey_x25519": "d5253675b2b62de8cfe6d86b9d9e84f67c03b66b73428056d5c46a997f9fff06",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22117,
       "pubkey_ed25519": "3c835b74f025cb47a86640eee50d986b8955f7a7e75c0104925ee1005f026ed3",
       "pubkey_x25519": "e36b651d834d7205a86c3199aeefe3bc12f0c9708db17bcb3ba5562d0ff5ea09",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "74.50.123.173",
       "storage_port": 22021,
       "pubkey_ed25519": "3c91e4300084de95863a7e37df69de0d1abc936b35bb9e162824bc29b04c29a5",
       "pubkey_x25519": "304e99ba102024086a9d303b790a40779a9b6dc1f168edc390adf9636de0d024",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "107.189.12.253",
       "storage_port": 22021,
       "pubkey_ed25519": "3cab940bf5682de76590ac97ca6f2d26ae3426aa795703901663f8da51d592e4",
       "pubkey_x25519": "8edabcc5617146894a8a6378c2588b14e1192704bb7a466e6275562524d3265b",
-      "requested_unlock_height": 2064048
+      "requested_unlock_height": 2064048,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22118,
       "pubkey_ed25519": "3cc5dc7270e47461955f60e43fa08c671705d03289b68ac4a000f3a652aae430",
       "pubkey_x25519": "a8eb55062d8769aea7909d2c9e733fa5c7a5a024df9026bc6ea8194dbf27f76d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "95.111.246.120",
       "storage_port": 22021,
       "pubkey_ed25519": "3cd52992fbf62ee50538e6412b1cf414061d30eefc8abcdf8cabdae2c3107212",
       "pubkey_x25519": "9466147f641ad373d2b8e76a7c550e7a6d0254f65c2085ef63cc31fc6b088b23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "91.231.182.167",
       "storage_port": 22021,
       "pubkey_ed25519": "3cfaaea93870c694a9dda0d2ecb3ae436a8339e766c9f4a6b58d0800380eb25b",
       "pubkey_x25519": "71385973a488ea6fd924e540340ee23e0e8c2f381d5dc6525c600afb02f59035",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "51.79.173.171",
       "storage_port": 22021,
       "pubkey_ed25519": "3d00c00397e9653e35af80bc42f0ce9e86e413f6902788ba9051d05adf74273b",
       "pubkey_x25519": "0204d34bde0b5d4f5eb526ce67eb3d6efe5c48099e23df1d6f2119427e3ab374",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "147fffffffffffff"
     },
     {
       "public_ip": "154.12.242.153",
       "storage_port": 22021,
       "pubkey_ed25519": "3d653841350d8131adab92025f22612e51997e86b3fed536df91cf06f5f455f7",
       "pubkey_x25519": "d50dee6e8ff3f0ed1dd8623fae830cfd846dd1a7ac283d95265dfcc364f1aa7e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "53ffffffffffffff"
     },
     {
       "public_ip": "107.173.168.10",
       "storage_port": 22021,
       "pubkey_ed25519": "3d6ac7d7395434d57b852c3b5ffdbb4be57932e847229b463bb355b5b42a3b30",
       "pubkey_x25519": "b6fb2c2671ee81d79a7755f237ce68dd2a66199ae56cc03a67b321c9a253357c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "159.223.2.72",
       "storage_port": 22021,
       "pubkey_ed25519": "3d880954f635adfa331c66044145451679f51251650fa5cbd66a10a83af6fafa",
       "pubkey_x25519": "e3e58aee9523c5a309fd05e2ee9e8283fe53ceeec2fab07a50d694c56c8ce946",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22127,
       "pubkey_ed25519": "3d940eb1f9384984541045253b0e1786c1a99dddfaff384f9497766889f5bd1f",
       "pubkey_x25519": "0214af794c1aeaf01c1ba7c4d77dafb234d43d55f849b557c107010fd0fe8f5a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20227,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "38.242.155.130",
       "storage_port": 22021,
       "pubkey_ed25519": "3dc89e34b4f6f0f219d6d0cdd0411d7a91ab4a13440de3a0ef620f362fce0b6f",
       "pubkey_x25519": "169c157f3aa3d771c69a3437c932e53b8a2976be746458eae65a8528ea615159",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22107,
       "pubkey_ed25519": "3df57dd30732957c5826bda84a653c6dc5695613e031ba30642ba5d1480c1279",
       "pubkey_x25519": "eae611e8e3645b684f250c6224a14827503a3ec75c75f8e5b27b26fe36334e30",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "164.68.98.83",
       "storage_port": 22021,
       "pubkey_ed25519": "3e45521c1dc8f9ad3f7d09db98d0454608c441985747f6144058da1d0e9053db",
       "pubkey_x25519": "4a427f84971b41ecd56260e80db959670223714402f75d2fb5c4c8fc7ab03805",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "152.53.207.147",
       "storage_port": 22021,
       "pubkey_ed25519": "3e6974b216498ac13e8d75dbb687805816aac6043230c6a5485df03045d289bb",
       "pubkey_x25519": "cc1a69b65e625641ae6c3afe28b4aed07d4f8001e8f282f70dfbc2d71027de3a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22107,
       "pubkey_ed25519": "3e6a169bdd87f1249f97fc1a43d996c147569a4a831e9dcc17843185d7c07ff7",
       "pubkey_x25519": "f7c156f6b11d0f09a27300e4d05a75adedf5308c8ef852a060feb7f2556f2648",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "45.33.57.4",
       "storage_port": 22021,
       "pubkey_ed25519": "3e7266c30e7f1f50815466b7bb60974fa9b1351c19083939731e475a390db7c3",
       "pubkey_x25519": "f208fdaea7de5e4b7d965f19986458f1b9e3e77e23655ee8ee54601268c8fe26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "38.54.32.100",
       "storage_port": 22021,
       "pubkey_ed25519": "3eb334ec1bf896ffb1b51693a02e0fba3b4fbaab5aeb1f9ea4ec7521aaa409ce",
       "pubkey_x25519": "86b6c090d55331684c57ba969cc31e050d977056286eaff8eb9b154e2e821668",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "188.166.222.103",
       "storage_port": 22021,
       "pubkey_ed25519": "3ed6e27e6fec528dc680e8a113d05e3f924d0d494b3fe4cc17f0e5c6960445e9",
       "pubkey_x25519": "4a52d5aa9390cb341f59dfe5ddb3130ffa973238604c954b02359f7e71f35e17",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "216.108.230.73",
       "storage_port": 22021,
       "pubkey_ed25519": "3efdc569ff2e16a8760acd22f82f5838cb5ac96bc129ec8ffc997dd2a29606d4",
       "pubkey_x25519": "3f91f600501c31bfb905a103dedefbb39961b77ec3bf0f64b705c992b0c88c6b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "209.141.61.9",
       "storage_port": 22021,
       "pubkey_ed25519": "3f198b78efa2dbd12581a467b46fbad0390c6662bbe266424d6ae972d1566a4a",
       "pubkey_x25519": "4effc38774188381dca5346e3a4cc498d8e624bdce4ef1eab586ec42ca656b23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "64.44.157.112",
       "storage_port": 22100,
       "pubkey_ed25519": "3f38d38259ee8f2a4853e2944418064413f1238904923451fe912f8c3b7324a0",
       "pubkey_x25519": "c3fb8188c3bb93babd59dafda77b3b7d3c0e875c9092d9a1e8a3038e0b647126",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "164.68.98.58",
       "storage_port": 22021,
       "pubkey_ed25519": "3f4e1c8eb34b2da55f402a8ec612f1df109d2f6ebf37d898d564dcb21d553504",
       "pubkey_x25519": "7d1b54500494e30a2b410257734d6076e9afaf9f11cb13f50fd99ab16786f146",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22104,
       "pubkey_ed25519": "3f62700094f5548ecdd5eb8d9ab15af47812069e58a87d7655d03a7c25258001",
       "pubkey_x25519": "c49aa3a7d79f943b007d282b78fe5d881f5875a8d84ac58c664e237f6ddc5f00",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "65.108.80.66",
       "storage_port": 22021,
       "pubkey_ed25519": "3f6a486c15ce4e8b88138412db8b115a933902ccebbe49eb0155b209cdecc853",
       "pubkey_x25519": "6aace78b6087e94d0e042b3631228a567502e03976c5b2f290949121b3f07e07",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "159.223.233.23",
       "storage_port": 22021,
       "pubkey_ed25519": "3fb5f7e79ca60527108965bb6031c7a6155b30f626fbe40f6d35fd962fd71e54",
       "pubkey_x25519": "557d28b5965de500e5d0f0512c4ed43c4bdda614684b107d5350ec84f70e7c3d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "164.68.125.253",
       "storage_port": 22021,
       "pubkey_ed25519": "3fd8f2a71c8fd9f191f64d2efc6627773e9946bca548805dc178a468eed38c66",
       "pubkey_x25519": "aa6f343ce07aea4ce9c0b107eee8099ce60ee19c894c6df6d3e732b7e9e83905",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "20ffffffffffffff"
     },
     {
       "public_ip": "104.244.73.67",
       "storage_port": 22021,
       "pubkey_ed25519": "3ff9e8f5b9ca1aef803cad9cdfb707727a03d68078d7820e4adf3664a379598a",
       "pubkey_x25519": "93b90be788295a4231e3d3a9eb28a6e1eaaffd0ea8008bb3e6e1db414412bc7f",
-      "requested_unlock_height": 2063708
+      "requested_unlock_height": 2063708,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "23.94.63.201",
       "storage_port": 22021,
       "pubkey_ed25519": "3ffce1e4052e2d21ab90a90d7c9ae241d79c88579ef81f4489bc203d294e3204",
       "pubkey_x25519": "721d4bb98e09690045b8d992e9aa3682eb6733d442081867d095519652062737",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "164.68.104.61",
       "storage_port": 22021,
       "pubkey_ed25519": "40f414650f59cbcf87d507f4d03dade9c88de047ec256556893ac23e337cf877",
       "pubkey_x25519": "27f557158751212c3ca097237c3a29212260fe9371f35b29d397f50cf39fb603",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "135.148.138.18",
       "storage_port": 22021,
       "pubkey_ed25519": "416ac7baf7ea9a3e3f367f55340eb78a9044594104b7a80da8edd5dc4ffacc8f",
       "pubkey_x25519": "10b09875bfbb0793941a2f6c0f047f530131d00891a7ae34ba97143a44a74f44",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "487fffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
       "storage_port": 22130,
       "pubkey_ed25519": "419f10d19b5d551fdd450858bc9691787f4be19fac5c21373fc286e1669a8280",
       "pubkey_x25519": "90c536a2d149195d5c53d042fae948b9ccb9502126532481fe63ea112daa881c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20230,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "59ffffffffffffff"
     },
     {
       "public_ip": "185.243.217.39",
       "storage_port": 22021,
       "pubkey_ed25519": "41f195c73bac469d2fa7a8751a404eaa4e3628eae458cfcb9d29389f7b8346b7",
       "pubkey_x25519": "c792b3515f4a537f0ff017ac5256c809831f67ecd5b55628ce7595b1ad26840b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "164.68.125.238",
       "storage_port": 22021,
       "pubkey_ed25519": "422ac0256c5451b78ebe39178e8a0919547c4ff4cd1f79fd2cfda4013d4f27fc",
       "pubkey_x25519": "d52ec783fd12d9c7236b7f2a1ecaef6f88c9eea31390c97c1fa3c4a7cae41855",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "198.98.55.158",
       "storage_port": 22021,
       "pubkey_ed25519": "4274c018a2621b63220c4e5f8d3d14cedd18ce69b44099f57c0e59502aaf3977",
       "pubkey_x25519": "cb4c963be27590e19da448f01dd1a2a4e2ca8d07073f2ca35a005eb122e56000",
-      "requested_unlock_height": 2056296
+      "requested_unlock_height": 2056296,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.73",
       "storage_port": 22021,
       "pubkey_ed25519": "434e0dcf0d56ffa262b3aaa46b2e1e43e4c03a3d9c41e32d45a443b8909ff80d",
       "pubkey_x25519": "d30a54176fb046408c626d0d16809457479b430b513c8da7d4bcfc9799f17e5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "91.250.249.165",
       "storage_port": 22021,
       "pubkey_ed25519": "4367486dbd0aa0ec61837f9be5b73200fed400522fdc251a7b3f4e9c3013a005",
       "pubkey_x25519": "69666b1b210fcb2a7338ea4a1d4764fb98c213f1731a9185d14b051f30e53528",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "164.92.224.198",
       "storage_port": 22021,
       "pubkey_ed25519": "4396748bf514a9cf525e25aab0e3eb668c5337ddb594403bc7fab1ce9d50b40f",
       "pubkey_x25519": "355072c1fbbe918cf95a56b50c1aaa95fe6d931ab74bb585915a98898fc5f22f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "209.141.58.94",
       "storage_port": 22021,
       "pubkey_ed25519": "43a3defa9e420e1faa6f875c39ba7c3515200723a38a5574f7da088cfbdfa819",
       "pubkey_x25519": "4b3b75623fc7d494d94b2ff0a10261aa072ecd6fccf2d527de04da9f4d71db4a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22110,
       "pubkey_ed25519": "43b1a8de9928ff3e815c95f0c812caff4938ae2ba9769af487045b1117a864fb",
       "pubkey_x25519": "ac28fc277c6741d7ddabee44f7dbf1a87ae10e9c5a765cffc7bff64c691a4c4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "32ffffffffffffff"
     },
     {
-      "public_ip": "137.74.112.232",
+      "public_ip": "139.99.236.226",
       "storage_port": 22021,
       "pubkey_ed25519": "43f388b273f0f14cd72e977ece9bafe052129fab88670092ee46e8a6cef9e2bc",
       "pubkey_x25519": "a0cad4285b19b0859dc5f0df44425ac57c31496ccb31818c776be13aa44aeb24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.57",
       "storage_port": 22021,
       "pubkey_ed25519": "43fe958c80251ca0deb255a316a60669578775eb595f8c86d3c3e57c4248c828",
       "pubkey_x25519": "cd413e0468b9a7cc503f03d9d1705e3a00e9bc1af91829c01d4c154e94f5105a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "37.27.247.192",
       "storage_port": 22021,
       "pubkey_ed25519": "44315c76a244700b72eb76017278404b3b9e599dd00ad44cf969aff56170ea51",
       "pubkey_x25519": "7d1b302d4ba137f83b4a90e3d74f71c122bd352793ad8bfaec2b7881d907ac71",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "164.68.114.66",
       "storage_port": 22021,
       "pubkey_ed25519": "445f4c906bce8cb76f245d119311bffe1c22579ab280c62f5a55c5436f6b8499",
       "pubkey_x25519": "793f639ea1f25d1128bf28d2f2f66b7de8e5b0c56fba41443fd30b379cf04315",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "194.32.79.192",
       "storage_port": 22021,
       "pubkey_ed25519": "447a06897cb4f5af527e08bd4dc3d536001d096dfc9d6b6fb83c3e8b0e0ccc64",
       "pubkey_x25519": "bcb8e72b3b7f57bfbd5b2dc99af3240b33fcfea1868610bd7da0d18c19dea92f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22101,
       "pubkey_ed25519": "44cb70fd4ba06ce14e9f60754a8afb916720f9044f0f7c3e1c27b5b08838f821",
       "pubkey_x25519": "a2ef2dc2d38d499a876707433d9b29894635b780785971ebd357d31740533e36",
-      "requested_unlock_height": 2059465
+      "requested_unlock_height": 2059465,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22122,
       "pubkey_ed25519": "44e2ef67983dd3c1a1452cf82d352c5da3e949ec66eb5aaac1f672670eb59e1f",
       "pubkey_x25519": "20282c8e8dc149039c88de87381617b8d4865afe1b6631e2a3aef83877d29d67",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "89.117.59.169",
       "storage_port": 22021,
       "pubkey_ed25519": "4513f63d845543c7e80da3f4f1cddd865f8e38b341adf5bbb010d69720b15628",
       "pubkey_x25519": "e2fd99aad9c6e9dc4209e7e78951374fcdeafb5d5d29b69b8d21a50296059660",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "95.111.230.22",
       "storage_port": 22021,
       "pubkey_ed25519": "454891347edab12a0feb412eb9d32fcb2a3462cbaf18f8cef13772b5e92da1ad",
       "pubkey_x25519": "5cbc26bfda5983d1a0659e797a1db08ad9ecce97252f2f60eb06115765569340",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22101,
       "pubkey_ed25519": "455532866d1bfe93f5802fe936e602af5390b190109ebef951f414b55cf84098",
       "pubkey_x25519": "823480193aada933e69bada2f2ff2f9f221a8eebcaab5e979c9821b76ad0f46b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22113,
       "pubkey_ed25519": "45663386658c09ec042f80aefc0899693b4d736802447d4cafcdd23003e361c0",
       "pubkey_x25519": "59226eb64ea674bc45ab904a43590a279d933f127fd32adb1a3e885e5f776455",
-      "requested_unlock_height": 2059300
+      "requested_unlock_height": 2059300,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "51.79.173.216",
       "storage_port": 22021,
       "pubkey_ed25519": "4567a8d361d26a1d1a11f6b59f888c3536aa38286caf9a4cf65f7ac54ef99faf",
       "pubkey_x25519": "92b103a60af6bf8cfeb4f9ada2f6f07048b0448c957e1d0b6334a65167d1ca2f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22109,
       "pubkey_ed25519": "457b2ef68d153519ef94dd7cbfdd104d4b1955033c2c484c90e99c359b750fdd",
       "pubkey_x25519": "69e5f88f117a70094e0a87cb0886a9263d04ce7ffc32d79ec957d9d7bd6fb629",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22409,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "95.111.207.142",
       "storage_port": 22021,
       "pubkey_ed25519": "459c605b42b4dd3198cc9631c0b684b512d239ad893f8561c22d49456c231864",
       "pubkey_x25519": "cfd1700c9ee182292b135d3899d2e2ee8bf23e06fd2fe68d3702f40669eca656",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4effffffffffffff"
     },
     {
       "public_ip": "209.50.254.148",
       "storage_port": 22021,
       "pubkey_ed25519": "45cad2339d1333d30e43a6efa410df6a9b2b67d4ee1d22f31985c224811907e7",
       "pubkey_x25519": "45e351cbeefdf53f1f1f80baa7e60ff46d6df474b137b922c8d6ac5be969257f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2d7fffffffffffff"
     },
     {
       "public_ip": "107.189.2.119",
       "storage_port": 22021,
       "pubkey_ed25519": "45dd77b822a13810fa3b3ba72981375a0f62684b4607ca9e3749877b06a4a352",
       "pubkey_x25519": "7e0756b17b05de6e4d3d634ca542aa0877f974adcf24c1f8408799cfdcbb0d02",
-      "requested_unlock_height": 2064049
+      "requested_unlock_height": 2064049,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22101,
       "pubkey_ed25519": "45e6a33516862327ed2f0f60ea2fb9e4e7c313786cbeb07ad6c206a2ac59b3c1",
       "pubkey_x25519": "c9516d660000b18566d28851d6bc6768eb14ded83e83c91b484490ab6add5d5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "45.145.42.195",
       "storage_port": 22021,
       "pubkey_ed25519": "46142fbe922bf7ac85abde7a4f6005cc588e2b09314b94f68b830f08f5236b8b",
       "pubkey_x25519": "45562d6c9bf7b028d7e7e94818b6d82b544d7e066121a7ee5d6282feb69d5706",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "152.69.167.181",
       "storage_port": 22101,
       "pubkey_ed25519": "463fe08923802a1aa5db33bb053ee502e7aedba11c41c70f8901e0ec0bcd8517",
       "pubkey_x25519": "6ff756e6cd189ef6ec1b1b4d09095a8f0a3fb8ddf8cf11d1f33e6cf2cba3e470",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22104,
       "pubkey_ed25519": "4690761ab657da924df341d30549091b81382743fa12496d34cca50ef31d2f58",
       "pubkey_x25519": "66569cfbfaec6ccc65b27c20e127d70d9e49b69baf48de1e46cc617211d56337",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "46.102.157.201",
       "storage_port": 22021,
       "pubkey_ed25519": "46b1272e40faddbc3d21763222ac2736ef5b582a106b83aa5271bc803ba68f1a",
       "pubkey_x25519": "58cd5332b6dc45f638b245e750e39da65e4abf84158776c6c39f7de8c08da839",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22103,
       "pubkey_ed25519": "46cdad1dfc7c4f2c8483d6c54cb9894c09e0504883c38f3f68da53a8b8a471d7",
       "pubkey_x25519": "5754373a2c8fba7981ed224950499d2eae6d0912490b09aa399126268655753b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "159.65.106.23",
       "storage_port": 22021,
       "pubkey_ed25519": "4724f361ba26a353c933c98ea76c49a2aa68040199d484e6ac3141c61b00d287",
       "pubkey_x25519": "522852b777764796fb54f94d3068d45138668d238f34383dd546d347bef36765",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22110,
       "pubkey_ed25519": "474088d77f1e48d6b016e860416cd92e484d2bc66b419fdda6cffaf90ec38845",
       "pubkey_x25519": "29ceed71d743b035ac7566b2f2b530afc1a5586696f1e4ce8f01c5807355eb10",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2affffffffffffff"
     },
     {
       "public_ip": "194.99.23.252",
       "storage_port": 22021,
       "pubkey_ed25519": "476d425a03de162bc2b3f69ebbc9a39b317c7a34ffca126e2cf719f9323f4f7a",
       "pubkey_x25519": "cdd8dc89ce15150881eec2d8cd530578fdd6bbff457d6173f271ffa0397ff766",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "51.89.165.64",
       "storage_port": 22021,
       "pubkey_ed25519": "4790ae60806b4673a4d968fd11d5fe4e6a39772e4f2e7fb734909e0d24d4281d",
       "pubkey_x25519": "248334fa8e634197b34c3d72931947fde43c6c493da75c9cc8cf30938b85c32d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "193.22.147.65",
       "storage_port": 22021,
       "pubkey_ed25519": "47a6cb09dfd8d3ad123188f4e19d8299c4bf5ae35c19c10527db353c14319815",
       "pubkey_x25519": "c6c52af3153fadae833f7ad27af2708aaff58199d4d9061eea77d811c649e709",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22114,
       "pubkey_ed25519": "47c9bfdb6f388d15890ff37e8da50da8353e1734fb641cb30927f006e50a3543",
       "pubkey_x25519": "27da7270b02a383906fd1359ba9e6f04a10f20e76e671ce638a4dbf2c0559954",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "192.99.168.74",
       "storage_port": 22021,
       "pubkey_ed25519": "47d4bd71d3c8eee6e99d6e4be73f96b8fc827a0028ac7b274b779ea11bdf1662",
       "pubkey_x25519": "797ef4d87acc30fe1a96c96122b1160d9fd870efc40169ddd10790017c2a5961",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "209.222.103.98",
       "storage_port": 22105,
       "pubkey_ed25519": "4811909869172f62f9fbbc946f25f57e95e69e0936e4bb5eed68498d743cdd97",
       "pubkey_x25519": "14b37a4d2c862c2409838ea0c1b5772db20858eded4d9ba95292998f2589e468",
-      "requested_unlock_height": 2059300
+      "requested_unlock_height": 2059300,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "54.39.146.112",
       "storage_port": 22021,
       "pubkey_ed25519": "4819204984ccaa9f32c7e4af306623fb76099f511254d70e7c0a44fb49ca908c",
       "pubkey_x25519": "c9fc06d84eedbd1763b5839d47432c557a86bc37382e5a01790d8b539651e148",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "107.189.2.141",
       "storage_port": 22021,
       "pubkey_ed25519": "482a991af3c8799074b20ecfb3c378b08f6839132101e53cfec36d38737e3ff7",
       "pubkey_x25519": "928fab6d8b5dba9c31df78b65948737f54c015c6b0c58212f44daeb95b163b42",
-      "requested_unlock_height": 2063709
+      "requested_unlock_height": 2063709,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "142.248.31.145",
       "storage_port": 22021,
       "pubkey_ed25519": "4873dc082e8c11592fb8d3208770c1bd2b4e44312b9bd3c78f4be409fa15a56f",
       "pubkey_x25519": "882bae729b311dfbf5233296d327f760413395e20a8787be25509d1c611b056f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
-      "public_ip": "193.160.96.230",
+      "public_ip": "23.94.92.223",
       "storage_port": 22021,
       "pubkey_ed25519": "48e0f89725ec8259b8e725b857909eb5fabe7bea9b7f019b64f2e0167fb69f8c",
       "pubkey_x25519": "a46e8c73a367c59b01398aea196f2c4d191c1713b921614d4e2cb3145de9b745",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "91.98.68.87",
       "storage_port": 22021,
       "pubkey_ed25519": "495954e51f35907aa1085ee8b20e649f1261d681187f951dc90ac62979287348",
       "pubkey_x25519": "77e10ded61d8ab28cb7b9846bf6b027a3e397c13b99a1f28fa14a9c1910e727c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "152.53.246.220",
       "storage_port": 22021,
       "pubkey_ed25519": "49bc9346f9cfb46740aafd7397606d0f27d48a32dcf5eda180ebba1854df71fd",
       "pubkey_x25519": "c131084f148c64dd34524aa077b4e5375a35ed1115024dd4cdd1d7483af0aa61",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22106,
       "pubkey_ed25519": "49caaa7ce1fa02c35a1728c7cf7e43423cfc8588228c0d5518d8a4c2d08e747d",
       "pubkey_x25519": "f6d85b7cb6a48198155cc3319430efc8eba99323b3e0cdc1caaea9a4c04c9472",
-      "requested_unlock_height": 2059466
+      "requested_unlock_height": 2059466,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "91.99.120.185",
       "storage_port": 22101,
       "pubkey_ed25519": "49e0db8c12b1574fcfcf3120aca8d93a585c2edfa5645d86171cd49efce82063",
       "pubkey_x25519": "34841bb842588a684f42a9c159ab2ae58f5a1e99406d627358829271bc64c031",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "138.201.80.253",
       "storage_port": 22021,
       "pubkey_ed25519": "49e66639b227d4bd7c7b902e3da52851bebfb2d6f21eab6f8ca0bcba8e2a745f",
       "pubkey_x25519": "8f05be8a2e741b988b38948451df441ee119f455286a9e4e0bc103661ac74542",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22102,
       "pubkey_ed25519": "49e8caee083142e45f9c780166382105c28caef081ab08212365d847ea29944b",
       "pubkey_x25519": "57ca8094e4656397276e4829aa1aa8074046366f75fd5cc1eacd75234a65e72d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
       "storage_port": 22111,
       "pubkey_ed25519": "49f500c57a96797c5781c0fb8a453ead1463d9150e5933c9512a155092f5b407",
       "pubkey_x25519": "1528b54603410a52ed4716b96d10edddeb3aa66deb81efcdd8f3d042bed97a2d",
-      "requested_unlock_height": 2059022
+      "requested_unlock_height": 2059022,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "51.255.136.71",
       "storage_port": 22021,
       "pubkey_ed25519": "4a1972fb625cf60e0622b1ad26a6101b53ca5c47004b2ae04715815543c05ce8",
       "pubkey_x25519": "da2a2be50ca1759469c0b6419709261fd9ee0ab3181954ccb5332ab02d26f807",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "165.227.131.168",
       "storage_port": 22021,
       "pubkey_ed25519": "4a61efbeec269326fe46568061528d1db184c128bbae0c3bb008c2bc1aa45eba",
       "pubkey_x25519": "6ddae12dc8302129f1f4befc754d0d9cfeb40754679460a6886eda717395b417",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22107,
       "pubkey_ed25519": "4a6e471bd3a92f00c8532c179b11d50addc8236e9f941189ab800967eb295503",
       "pubkey_x25519": "e21274c98b33c2300a18e459b2f41f5cbea3c794c597afac8d4b1a22fb63b11d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "157.245.77.43",
       "storage_port": 22021,
       "pubkey_ed25519": "4aa65e35a458ef0e9e265338cf8d4e1daf1c9c4eb544144c25e854216552c5c4",
       "pubkey_x25519": "5813a6ab942991f224e58ebc8d93413fb9e29c58aa8b506017dede9d2d7f6814",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22106,
       "pubkey_ed25519": "4acbd494ef00e5eb4d5d01348fc3f6075b926fd661e4cec4c7863d53ff8da5b7",
       "pubkey_x25519": "89ce23ded9ea8060b36bc7c0007faf90635c64cea5384bc5ebd731307b8f6b24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "67ffffffffffffff"
     },
     {
       "public_ip": "161.97.103.88",
       "storage_port": 22021,
       "pubkey_ed25519": "4aed06904f522999e3cdcb036dc51fd741a189af241f6302a6f7ded13df5348a",
       "pubkey_x25519": "9ec7262b939023221badd14b97fae266f3b8faea194ba59ce88455f3d8199159",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2f7fffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22105,
       "pubkey_ed25519": "4aed58c64fa30913efda2aff953714e7f81dd10397f01323e4628738afe92ee9",
       "pubkey_x25519": "6486aebb5c476bbb2cf702a88a7db4092e8350b8186ec3cd63eba6cfb09ca22d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22108,
       "pubkey_ed25519": "4affc306c1e0b0798de1f890b95e8f3d25435c2af36a7f5942c00c8aaf806611",
       "pubkey_x25519": "10664f702883b05b604a474181817cab1d208741fe6648a94beedd8fe8c59e0d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22112,
       "pubkey_ed25519": "4b008cc794ab04c0fa30c6de3ed7b57680b8bbfe3446261cae03f54f056c812f",
       "pubkey_x25519": "570405bc27fd9b04a258b420983ac3ce6e917faa0ffb585c74b2b2f7887f736f",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "31.22.111.191",
       "storage_port": 22021,
       "pubkey_ed25519": "4b39adf79f6d6486ef8fadca8647b9331c7ae73de371849529e40760c814e351",
       "pubkey_x25519": "c6d27ab6f901ad09a54348cd4f7e9e1b5317a21dbc30e23d01bbf516b2df3422",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "46.225.128.110",
       "storage_port": 22021,
       "pubkey_ed25519": "4b6701c1d084af70e941741a311d95e211592dee04f9830b4ccd117545dd5094",
       "pubkey_x25519": "e138708486b8118ab3a4a07b89560c855518fcb27408163392b68c7290b30018",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "134.122.63.223",
       "storage_port": 22021,
       "pubkey_ed25519": "4be00d4d6100ba96e8696ffc9bad2625dfba8ede1e8e465a6a93e205e2cce031",
       "pubkey_x25519": "65d6c65e6932dd9f4ce53c7d1fcf7483a2e801624241f0e152c7b91833c2e04e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "164.68.101.57",
       "storage_port": 22021,
       "pubkey_ed25519": "4bec65bb9ff4f3873021d52ec78185efb7aa10973083adda469d67449626c7db",
       "pubkey_x25519": "c5c4296ce669c28b345b32166f6765e6d6ea6f0cfd3435972336b99849f5c95c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "51.79.65.165",
       "storage_port": 22021,
       "pubkey_ed25519": "4c006480165132e0bed3756f17bf1b7fb0c606c694fd2dd49dbd4514c0f03739",
       "pubkey_x25519": "64a9c42efa7388071ce55ce72f355b8b16317bcf9689500d0942a1f6b58dd210",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "95.111.207.226",
       "storage_port": 22021,
       "pubkey_ed25519": "4c04a0a31e0ef91a77be05741afc954d0713e9cbfe8bac549dcfea3142832c6e",
       "pubkey_x25519": "abf9fde23a146208843b24edb2ea4d5f7c14ff09fbd529cc014c0349b6744d6a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22108,
       "pubkey_ed25519": "4cf7430310e4ea8534f9bdc183f29fdd0077382bd0839167c7d2907737cfb688",
       "pubkey_x25519": "d06c3ae78721a83de0398c369032b6fecc9a34e1508e2b0d726efa2be6725276",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22130,
       "pubkey_ed25519": "4d1867319c182dd7e6bb6c156575c50ca657969af94ace5ca677dfc599323a56",
       "pubkey_x25519": "1d648f25a46559b39bd423f4b60f1e591307906a2841c40adf9d5312ed55ca78",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20230,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "103.199.19.138",
       "storage_port": 22101,
       "pubkey_ed25519": "4d78084b08c447143400b48c90b6f6b6827e1bff8fc08f93002657044e93fcca",
       "pubkey_x25519": "a71528ca1dee396f20c7e238dbd886855af69637cf969c7fbef04e3d8cb72842",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9affffffffffffff"
     },
     {
       "public_ip": "164.68.116.129",
       "storage_port": 22021,
       "pubkey_ed25519": "4daaede2511b28e2a7cd1595474088bd165eff7df9168f125dd7983071ed0a63",
       "pubkey_x25519": "3fcceda5280527094ec7cb8710608131e8b6b7ffc6c0a576eb937525c223ed04",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "128.140.87.239",
       "storage_port": 22021,
       "pubkey_ed25519": "4db57b0f2b20f59a2435df6fcb5a6eed855ad6415de598041491e9f4ddec989b",
       "pubkey_x25519": "404f040e0d2a3457062737c3d0379b36e83a5f6aa562339f9127b6e0e08bff52",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "164.68.125.87",
       "storage_port": 22021,
       "pubkey_ed25519": "4dc3abd888b6c71b255b95cbdcc0b8b7ac76c0b24d48869e5f1f9ffb7a3e7829",
       "pubkey_x25519": "c4b57bc952d11501d807f6c44ca0f956a924c2f9d395282de746f1774ad4c960",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22116,
       "pubkey_ed25519": "4e4055c383ee7f8f61e956ad2ab1a4904b07e254d4ee308175dc6341e4935189",
       "pubkey_x25519": "8e53a486b21bc127e6453964d584971eb9f1cf79517b75e616239e077207113d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "199.195.252.42",
       "storage_port": 22021,
       "pubkey_ed25519": "4e5431e983eda69032933481b7e3fe2434e5feb866784d54e1b7d8ba273db77e",
       "pubkey_x25519": "933f2dc21d71f5b749613ce37e6ab18ca23d6008fb1ba5091fcb9a1b658ece77",
-      "requested_unlock_height": 2056570
+      "requested_unlock_height": 2056570,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "17ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22110,
       "pubkey_ed25519": "4e91707683562c298ebdb25de8b91a860663f8a10f31c19a2bf96bc1afec5c4c",
       "pubkey_x25519": "d46a9c125e3d66a14147d1910814b6275e0a66158f404afdd0ab7387f9702119",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "66.94.125.216",
       "storage_port": 22021,
       "pubkey_ed25519": "4ec7f541f6713675fad2293862c65e4f57207f45b8840b2a8b4b854963aea697",
       "pubkey_x25519": "e065c1db87dbdddee29f9a992834fa6ce61f87feff276a4f5817dc35e7028974",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "164.68.98.143",
       "storage_port": 22021,
       "pubkey_ed25519": "4f0cffb44f43e99517a8beac742e57ab2df559e7591c33ec0291158c42ce66ea",
       "pubkey_x25519": "858c07f0c7c605f68ef7287638034b6be26fe71fbdc5608578d5786b5201e716",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "37.27.212.116",
       "storage_port": 22105,
       "pubkey_ed25519": "4f3bbda7874f29f04c5681ef9a642d93396aa287610b49271177fd217c582693",
       "pubkey_x25519": "9597fff7d60a6175ede46fd11080d4bfab741ed63822254663d3d1c590d19c2c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "167.86.100.55",
       "storage_port": 22021,
       "pubkey_ed25519": "4f414c165c8153dc59d2505851f1fc90a3399fcffb9df9a4f43ae84fa35100af",
       "pubkey_x25519": "cab20d42d3010dc04b1edff01113a34d82e2acabb538fd6504693a8f30f1c35e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22103,
       "pubkey_ed25519": "4fbb3ea16b3894d2cc152c073d4b1aae3d6988ec2e38d8f406afc047a8d3561e",
       "pubkey_x25519": "dea967f267119c1f1f789eda6e35a372655861e9254e9f07062b82e13fc8153c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22113,
       "pubkey_ed25519": "4fcdc303ca7c0fcc178da832db639b3a36870e872771f96e8683430f1e35ba6b",
       "pubkey_x25519": "783ae285be9914a955d39f4764876c9bd342f2c1ea7c8061c43d36ca01d0787b",
-      "requested_unlock_height": 2059467
+      "requested_unlock_height": 2059467,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22100,
       "pubkey_ed25519": "4fe324e4eb85d40d8d2899ddd7865237f8c3248d1415f6ea1a9192024507ac9c",
       "pubkey_x25519": "2eee9d8a84a787eb6e2f044619b682d927016d0e4c5ebb1c2fae87b8c4f24363",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "0"
     },
     {
       "public_ip": "102.222.20.141",
       "storage_port": 22021,
       "pubkey_ed25519": "4ff4dbed33408522f1e6a91325eb8d4ff402ba0258c172be9d97787922e676b0",
       "pubkey_x25519": "3d1c41074d01f91478012a9fa3cf90b4d8e7872514a6ef62ba90f3576d9bc169",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "194.99.23.208",
       "storage_port": 22021,
       "pubkey_ed25519": "4ff7a2af674f70ce980bfcded2d74e072047ab4432fd46c1e81b5788f8951e0f",
       "pubkey_x25519": "e13bfc7165eee9dadeacefdbf9664404c753a275206f3abdf61646b8d2007655",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "155.103.66.130",
       "storage_port": 22021,
       "pubkey_ed25519": "502dfca22ce0801a400b06a9e675a3977d947bb17b111f63c5f7dbecc2f2ffcf",
       "pubkey_x25519": "dd7a3a20673923232ce71ffaffaa1cebdc3e44dc3e7c87f11490f2fa367ec55f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22109,
       "pubkey_ed25519": "502fc33b9a19492d3daf34e5e19c795933bf58e39f02561345c4267c98110670",
       "pubkey_x25519": "39ea7dff560476641544aeaf7caf3c16bf322e11d3fd15f1cccbfaf118c92721",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2fffffffffffffff"
     },
     {
       "public_ip": "89.58.27.63",
       "storage_port": 22021,
       "pubkey_ed25519": "509114e49a8120d32492a054ff95c4923ba38d78e00a53266ab087e4c3ac224a",
       "pubkey_x25519": "f3d3249c1b2b547a4b63af500798dcc0f4fee4c2fcd3ac9d8d5d912a7df7c960",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22105,
       "pubkey_ed25519": "509526547e4f2fe0f7a9192773d774a254169fdb7b539558d5104fa024c0cdbd",
       "pubkey_x25519": "bfc186346fc90c38d25de58d084d1d4f7038b63f12ad9c1325675e6d7b49f06f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1f7fffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22105,
       "pubkey_ed25519": "50c6a0746f7bbb26307d1a2bba9ee769aaad399e5ebe7406aa294bc797edb0d2",
       "pubkey_x25519": "fd9d8e0fcec1b46ad51ed37b5a7ae8e16323a96ba8ab8f27c14269fac742e272",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c6ffffffffffffff"
     },
     {
       "public_ip": "65.109.4.149",
       "storage_port": 22021,
       "pubkey_ed25519": "514fa1a4817a2d492e434cda2d569707606ab797530d76ac9eb87551eeec34ae",
       "pubkey_x25519": "91fd558466da26b81e2d46cf4822871861377927e00dcdffd651df9918a19630",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "213.136.74.26",
       "storage_port": 22021,
       "pubkey_ed25519": "51a0ab02885fdf749cf05de9b2ec0962251ea21ea2c020fb6a1f7475f84ee6ce",
       "pubkey_x25519": "43d1ac3147ad69068bde99d357e2850a587566c3607b2b0caa7ccbedfd0d641f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "95.217.218.66",
       "storage_port": 22100,
       "pubkey_ed25519": "51ad97a6b6b710707058a16f550c9597910c84a73c49c3f67bf80d59077968bd",
       "pubkey_x25519": "ec2bb653bb62333b942f28acb6598fe41163f96dfbee4dd0a754e3296e6c4e72",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "49.12.220.221",
       "storage_port": 22021,
       "pubkey_ed25519": "51c68cad2fc39f477f5dba3f62c513430b1da9bf9bbd0e7275afe2a48d8f94a0",
       "pubkey_x25519": "3a0e84123639092a4c2a314bf9f9258625b29faad6d8076209fc064e32c12258",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "84.247.128.50",
       "storage_port": 22021,
       "pubkey_ed25519": "51c7aeb2ae9cd60dcaf9dc91c24ccbca274466d5b75ec04f91cc0de12cc3049a",
       "pubkey_x25519": "58f1790dcc220a26353d1cdcaed3bbe4dfbd97345e780b8818885c6ed591275a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "104.244.79.28",
       "storage_port": 22021,
       "pubkey_ed25519": "51d6dcf1d96dc1aa0e26facc9d6dfa781a696df1e220a76e812543558f13ee9e",
       "pubkey_x25519": "d25d1edcb9e67181e51c45eef6f3c6df13ebfc039debcab455b80c56997f7826",
-      "requested_unlock_height": 2064051
+      "requested_unlock_height": 2064051,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22105,
       "pubkey_ed25519": "51e746428652c9950a78dea8e5ff3521871749268ff51705ca8b8c102e4e7d6f",
       "pubkey_x25519": "9d92309bd19e09c121264d68e42342b459e8e49aacd2f4f7ace2bc5f381c387e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "164.68.98.25",
       "storage_port": 22021,
       "pubkey_ed25519": "523d1ff49ab1dbc42c8432a15eeca2a42c631de419ac5321a84f7ab7f76dc85c",
       "pubkey_x25519": "b93170bc5c217b4dd0a0b3e8db5e6be7551fc02d58628685f715753a7479fe79",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "198.98.52.166",
       "storage_port": 22021,
       "pubkey_ed25519": "528ffd5434596a237a39c93e1290d3377c51501b9e7bd95593b28dcacdeb2861",
       "pubkey_x25519": "418b3d51ca16175a21083d28ffe9167eb26942fab50f4e41580e26e7c95f146f",
-      "requested_unlock_height": 2056571
+      "requested_unlock_height": 2056571,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "407fffffffffffff"
     },
     {
       "public_ip": "51.79.84.33",
       "storage_port": 22021,
       "pubkey_ed25519": "52915d9192fa0db55cf269265cc96de289ef0008e4d40d4b3d510126e9dabdf8",
       "pubkey_x25519": "46d134c119a9d51baeefd20e3cc6e0274be9ca3e54b63ce52135bfd68e751317",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "51.81.210.242",
       "storage_port": 22021,
       "pubkey_ed25519": "52c2edce816aa7159e0b616c5e5dc787f71c8926196da6fd9088aa0cb6ae7898",
       "pubkey_x25519": "107fad21372f859f1eddca25a0277b3a99db8cd1ecc436f39db681c1b4d49550",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "84.247.172.3",
       "storage_port": 22021,
       "pubkey_ed25519": "52ed1b930d4281ec42352f3caa81d9a01596f15d21d3cc809516f4ac44986a0e",
       "pubkey_x25519": "e5a526d150e1bb3fb14a6afc8ffc99cbc01d95c2b264992983d6e314b8759d65",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
       "storage_port": 22103,
       "pubkey_ed25519": "532099282ac0603a4b5ae1ff6a7600cc60e405a0ae55780aee4f3f2164752c06",
       "pubkey_x25519": "923529aa87ce7aae9de7b27f61fcf97564e7f5b2eb72c2af76563812840e9e6c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "192.155.85.128",
       "storage_port": 22021,
       "pubkey_ed25519": "534d2139a087566d68a324c3e9db7fb2b187e297993e147b02546b1ac4d38d85",
       "pubkey_x25519": "03ae6625e1518bde63063e92ee4e3b83667c8b9f41c4b2fc8ca8e29f3b1f764b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "198.98.56.140",
       "storage_port": 22021,
       "pubkey_ed25519": "53917e69c0c0530b0710eb711389dcb6181ffdccd99e19dce481f3c0bc1549ea",
       "pubkey_x25519": "3ca470363e93e60a4d65d0f2c5544df8e953c23d0d9d0ee17c04fb2ba6d8da4d",
-      "requested_unlock_height": 2056570
+      "requested_unlock_height": 2056570,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "afffffffffffffff"
     },
     {
       "public_ip": "89.58.29.25",
       "storage_port": 22021,
       "pubkey_ed25519": "53a7c11080ae90b5c9a71867c14f9028efdcf12ac71d974049246cb5b8ef1bec",
       "pubkey_x25519": "6c7a03453e2a5dfb49a124201656cc95584148a1355ff866c63eeda20464db74",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "51.79.86.18",
       "storage_port": 22021,
       "pubkey_ed25519": "53b8d9c1971881842a41021e6d40efe869600de8f571ad287958c657c12cc71b",
       "pubkey_x25519": "914ef1e62304ff50b053fe04257d0b1387550858656eaf1f840c5b50db20ed2f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "164.68.113.164",
       "storage_port": 22021,
       "pubkey_ed25519": "543d539a12a5ed5932a169d44f1de64aa6d6e9dcaf200854bbda4c61bc55c9c1",
       "pubkey_x25519": "2c390f6dc48e3b4fa63f93867c94c4c70110097552aef5112d3f94368465a804",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "5.253.31.4",
       "storage_port": 22021,
       "pubkey_ed25519": "543da4217465cdbcee9b170735e9b15c78a3ab3d1a7d3e1af6748ca733d88b9b",
       "pubkey_x25519": "f827b8774a0cbfac268505cb0637bf5210af2212cc7a943963b684025ce5ba0e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "188.227.250.71",
       "storage_port": 22021,
       "pubkey_ed25519": "549a5a7ac7265ff01b1fedeb818c0aefc0e20d7b35f5b62c73ea2ac2cdf67598",
       "pubkey_x25519": "f222db461fa79bcf148d684fd3fcb08307bbff382b76095fe8254ad31c0c6e48",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "52ffffffffffffff"
     },
     {
       "public_ip": "77.68.127.126",
       "storage_port": 22021,
       "pubkey_ed25519": "54d2898bf0ac5334f15c685caebf446b511908bfd4f3aacb7339b958bae06292",
       "pubkey_x25519": "51910e9b41f66b0d188d7c49fe7d9cb408cbc6e31363f54956fec57ad9f44107",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "194.62.97.192",
       "storage_port": 22021,
       "pubkey_ed25519": "5534c3dfba4c7aa8c8125471c2ab2511780ffab311d7573a9b460f9b3ee199f8",
       "pubkey_x25519": "1d716a5159dc320d436340a997179ac097e0fd28c0cef3309a3677c414041b56",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c6ffffffffffffff"
     },
     {
       "public_ip": "45.56.90.64",
       "storage_port": 22021,
       "pubkey_ed25519": "55504bc4d0459ab475d825d4a75cb8bea6b0305915da394c2e1cf64083bc4917",
       "pubkey_x25519": "496a7143f17a01b3bafe5b677cf9ed259211e6dffea2c9f1414c7c412e712a27",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "5.78.94.109",
       "storage_port": 22021,
       "pubkey_ed25519": "5550756e9ff383c387c73499b54308f3f227da19444cfc5ecf781860ba64c465",
       "pubkey_x25519": "fc0794f266e28f2e25dd3a1393b9438b1fd01a1a6bb144289fec18e67a01e279",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "23.81.40.224",
       "storage_port": 22021,
       "pubkey_ed25519": "5566cd614f23ddb17fec8db75f0f6614c95332013c670bd3efe56c3bb0fa9a37",
       "pubkey_x25519": "327b15bf7e7196660233dedfd8c6d0d37ec44fb1b8a7128f314c3a63b9caa031",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "84.21.171.110",
       "storage_port": 22021,
       "pubkey_ed25519": "557dacb62f2f2169093f58228a5433cd6efb9f59ec09dc58a623850e65a9ae56",
       "pubkey_x25519": "447c1283cdbe766d94acac52698a5f5e6100e252e0357736c4357258e5f08e3e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22128,
       "pubkey_ed25519": "559f7debe1814f51412987c2d7302ea30ced1bae06f0c2070fbf42a5da5a8dfc",
       "pubkey_x25519": "ec1269421fec16e8bc3e964795244c4015f264177fefe150131b27ec5b3ecc48",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20228,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "20ffffffffffffff"
     },
     {
       "public_ip": "207.180.229.183",
       "storage_port": 22021,
       "pubkey_ed25519": "55b68e059454eb1036849a60816054bf5e31f163ba5605d8c8bee5d4818ba1a2",
       "pubkey_x25519": "45dcfed7bf3a0398ed5ba59add0feb5d525b9c927f798fefc01a2ae848cea534",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "161.97.68.140",
       "storage_port": 22021,
       "pubkey_ed25519": "55d6bc4446015e219c7f4fbb32780de91e009fe24ffaacf58ff2e03d9cfd6293",
       "pubkey_x25519": "eea2b981e5597806b483853d6930bad8bfffaa72c4cc694d972d93fb7b01102b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "159.69.52.66",
       "storage_port": 22021,
       "pubkey_ed25519": "55e842b077f8fbe643a08d1c687195ecca8ee06b9c10d0f5b8ad306eb875f70c",
       "pubkey_x25519": "c3946514e4f577c2ddd05b3f7fe90166ca3a8ddc4f8b040ad8b1a05ce535685f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22103,
       "pubkey_ed25519": "560984115efaee5eef63052a0292e0e4e74e83559186a3c738cc892e13c56c84",
       "pubkey_x25519": "c9d094b55035f233cc6fca1ef7c436a634e549d79dc745984726275ff25ea019",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22134,
       "pubkey_ed25519": "562a9f53323515b7ed22a88467e0b1fe68e166a42dc95f7371a403b0d2f54781",
       "pubkey_x25519": "682488349468e9eccd33f1442e72fd31ac9e72b0f70ba5f7cb211f7813f2c61c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20234,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22135,
       "pubkey_ed25519": "565a450700bf8fd2319fad851fa2f68fb932f77edf743abdea79a3665a75fed3",
       "pubkey_x25519": "fba711b7cb0f6b92f54887f1caad22304decfc7004cdc92585e0bce447f58040",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20235,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "0"
     },
     {
       "public_ip": "107.189.11.153",
       "storage_port": 22021,
       "pubkey_ed25519": "5665a57f1d00da35e0ce5258139fcaa75d8a2c5e395230643f521d604eea5b7e",
       "pubkey_x25519": "240575a999d1c1bd945751cb32b0372c87f203f0f91768011880122628404120",
-      "requested_unlock_height": 2063714
+      "requested_unlock_height": 2063714,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "57.129.67.254",
       "storage_port": 22021,
       "pubkey_ed25519": "5672a215df74fd7f42d4288da585853791bda286ba242ee7556a2b654275645f",
       "pubkey_x25519": "da6e6590f2f3b8de8f318bb90b182457903e156325ae4d756d82c0be40430c05",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "216.108.236.148",
       "storage_port": 22021,
       "pubkey_ed25519": "56c4bfcb9902ae5d6917f6e9f2d6d2282f27f0da9ae659c9efee8a9b4ac1c21f",
       "pubkey_x25519": "bc7fb9612c678ab52c43f176bfe7d12da5c26a26cfd3deb52f32199b32192953",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "50.116.1.7",
       "storage_port": 22021,
       "pubkey_ed25519": "56c9ce110a6c51806df3329c6b3f1eef294db149a026e8fab1fb06ad02145b78",
       "pubkey_x25519": "e91aaf49215ced8da7c682248e0f0497f95e6a917376f56666d20f550984be62",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22128,
       "pubkey_ed25519": "56c9d3c3564854ecaef86d74b42d5ce267d54af1a29ed5068698d1d9fc40f0b3",
       "pubkey_x25519": "0b026f394b2bf82bcd89a4e881e08e3c44e6d6a999b060951148ca85853d7b3a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20228,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a8ffffffffffffff"
     },
     {
       "public_ip": "139.99.171.45",
       "storage_port": 22021,
       "pubkey_ed25519": "56dbd878d0e82730967ac7aba31f56debb3e30179888a4b21cb647d4a4d46793",
       "pubkey_x25519": "ff47bba2920b057e73156175dcdf1034726b634c082b4bedc98c543314625353",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22133,
       "pubkey_ed25519": "570d0c913a5f63619b4aca4ee5b71f748bfd445fc724b7809cd5c5b0fdb5752c",
       "pubkey_x25519": "3e784e9a60e18abf1d940313a7e7d7a2113ad6f84a44c6d8d7e69070cf3f372f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20233,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "128.199.51.252",
       "storage_port": 22021,
       "pubkey_ed25519": "57288b6ca34c8e2288d5eed8445967cbcd9a5a1b14c8debc6720879f67e36188",
       "pubkey_x25519": "8ba06ed00d8adab821c697bfafe2db909da56afd1c7ed5117e8b05127c09ce41",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "185.70.196.22",
       "storage_port": 22021,
       "pubkey_ed25519": "57431cd829c0d1243d1aed93e70139fc0aa40456e2bb75b89f62b6854504e562",
       "pubkey_x25519": "1195808b50a3d5378e000817d6a0270952e2990429d50fe110e644e03ad7122b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "5.161.98.53",
       "storage_port": 22021,
       "pubkey_ed25519": "576e933dc3c50ab6d4dc04357ee613286c859e0f3164b978356130e35ee4c4bc",
       "pubkey_x25519": "f9979bd53d89b870558e47a6fb0d7424d46dc2e072d9d81fe431e45f03884511",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "192.155.85.177",
       "storage_port": 22021,
       "pubkey_ed25519": "57bab420837673688489b3d8e5761729218f8e5976443a7a0a41d36bff1616e3",
       "pubkey_x25519": "d40db9017b123c78173a8909cb2b2200670db4c0236a4981ed2a41359615e34d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "91.99.120.185",
       "storage_port": 22102,
       "pubkey_ed25519": "58074f4db735b3e81d972053bd54595dc788666c6caeb773fdc781fcc64cf5ee",
       "pubkey_x25519": "b95bb3518e1cb1105edeb212cdc3fa5544e0fabaa44dcf30b763cf9c2725ff7f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "89.125.187.65",
       "storage_port": 22021,
       "pubkey_ed25519": "5809717acc8ba54c40ea1337d4f57433d9b16fe5d540be18e877ca8c7bd5198e",
       "pubkey_x25519": "71e1fc29f8b97092ba1545d4de88c45b6145839971784e2ca9b85e7bef695a39",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "167.86.118.4",
       "storage_port": 22021,
       "pubkey_ed25519": "5814e7d7be5f920204f757003e63483525afbb10907f096587d064ad81956d57",
       "pubkey_x25519": "084d3127c9d14d755f81a3ef6fe1a11d12624fcff5cb9a2a240969cb9559d526",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22115,
       "pubkey_ed25519": "586f0fe35e764b6bb02e91d00f3ba9bb6aab0bfa3531bb8560fc3cd8588d0c8a",
       "pubkey_x25519": "af87d107a995a6a75a54033350d0bd6fe14be35e56994be9601e7e604db27d41",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "161.35.158.50",
       "storage_port": 22021,
       "pubkey_ed25519": "5875610a1754629bf849cc6bad6c16011bab9c16089c1910f52f4092928d93ea",
       "pubkey_x25519": "31def3df7b455c146e2d8484a5cb6439a6e6c842058f1c97ef3d72391da76b03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "31.220.94.51",
       "storage_port": 22021,
       "pubkey_ed25519": "587960be4cf01f5a9b747500831239c2bce099f41a7ec69e7525bfd10613aef3",
       "pubkey_x25519": "61b0223fb66b9741238ab87839fa6f0c732b2eda01ec3c7ee2400b96d6fc6873",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "37.60.241.162",
       "storage_port": 22021,
       "pubkey_ed25519": "589068eed7c7a941629cbd8d1b6ed836fa3cb50aed56985f818ca27d226d59af",
       "pubkey_x25519": "c550bb4c28223572d9b4b035c76ce00402618f1fe8401c6b5df7ebaae85bca38",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "96.9.214.20",
       "storage_port": 22021,
       "pubkey_ed25519": "589dcf185ee1d1859c308cb3b8de64091b6525589a76659c9febb809365a46de",
       "pubkey_x25519": "d78c5c5144d7ea99ad65a8850bc8c197417b1df419ca83a4068a1e21122ae86b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "107.175.194.177",
       "storage_port": 22021,
       "pubkey_ed25519": "59272e7433cd765fbd8fe0e54a8ea2fde59884ed78fb3eaec969e68252bf8f52",
       "pubkey_x25519": "e5f409ad49cbec7e45a688d225e3aaf180401cb2c2f64b0602dadb2ca5695953",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "51.79.173.224",
       "storage_port": 22021,
       "pubkey_ed25519": "597673f1b0f15529225c2af0cbdb6090c7a8057fe264e8856e376bf592075415",
       "pubkey_x25519": "667ef96ad7d7c846f24c6da8a16e03eabc9106eede8bdee597069ce3bd4e2b76",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "209.141.51.215",
       "storage_port": 22021,
       "pubkey_ed25519": "59a4d267bedd361388f9e5a41c1085849f2e7626c7ed55668fb95a25b709d525",
       "pubkey_x25519": "d2e2165c3ab1590ef8bd9682334c71665c51b360b165c20cbc7e0cbaa9b0581e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22108,
       "pubkey_ed25519": "59cb676c77fc8b923026547301aacb7e5c9684186f0cd631e7da7fb5a7501084",
       "pubkey_x25519": "76ef14cceccada0f5a2aea1057fe71637984509b3ad7dec4fb602e41ee76ed1a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22408,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "53ffffffffffffff"
     },
     {
       "public_ip": "164.68.113.100",
       "storage_port": 22021,
       "pubkey_ed25519": "59dc26e5ea8f91fba91725a85d7cd2537284f85a3e8f651b31d5330c15cb31cf",
       "pubkey_x25519": "882262ed1a73ab1097e95fe04d8fa8bce0e26c0e125690afc5846103aec35f14",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20608,
       "pubkey_ed25519": "59f3d7e6f9525a6970e712b72368f51dfe341c6dbd39810b95b64802260d3df0",
       "pubkey_x25519": "eaf86b9b88ab0be9c109b50899aa3e64b9875f1c5d911b2011688b2b6cad6446",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20908,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "164.68.104.81",
       "storage_port": 22021,
       "pubkey_ed25519": "5a22bcc8187e03d3c8b037f927d6be1d8cec391686ab3addfd5a33942e5f5b2e",
       "pubkey_x25519": "ac8da9648a8929458a76696e0338d1a6d07e0ec05ad242f6e5ada95157126160",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "217.15.163.107",
       "storage_port": 22021,
       "pubkey_ed25519": "5a4962c4d9a2319e20ff01dc32f84d96f3ff7f303fe54b30345ef74c0af5439b",
       "pubkey_x25519": "6a2f0e30f98d3a5b1f40631762c59dfdb9815ff41b297723a55fb315dd9c802f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "38.45.67.191",
       "storage_port": 22021,
       "pubkey_ed25519": "5a558ea86464ca91f94d6fe72dc1c4164d15c6d4de4bfb7c66531df159f84823",
       "pubkey_x25519": "77edc58aa74bc020c6c99ae49849c94fb7261b1136daa260d503e4d5e09b304e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "38ffffffffffffff"
     },
     {
       "public_ip": "188.245.112.98",
       "storage_port": 22021,
       "pubkey_ed25519": "5a7ca4360b82c934a407d85f9f22d33db73464232c86328271a34ec9173def8f",
       "pubkey_x25519": "c38de4de4f8697f352c9df1bbca48283f940075f17cd15f79cb61aad8610c20b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22104,
       "pubkey_ed25519": "5b5ce5b4fc2e71581956a402094e592cd1600a3b19d5312ab56f86b81c0d8b45",
       "pubkey_x25519": "f13a9a1c197b9c79c3c248df4256028c787fe84e77434064d88996a6079d1f52",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "139.59.29.239",
       "storage_port": 22021,
       "pubkey_ed25519": "5b6709b0b5b7fe02f508a39d047d73e336de9ddbf1526ee5562c3ade4aeaa6ca",
       "pubkey_x25519": "a62f05815f7b323373dc7241ab0e5494a43192935ab619fbbcc101f4b93f0560",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "144.91.77.35",
       "storage_port": 22021,
       "pubkey_ed25519": "5b753bf1f67575737848a791b315743f9081d4198a86543132d1b4a2068b8135",
       "pubkey_x25519": "76adb626b0ad64ca1040d51fa608ff1dd5859c4f51f7757f2806275e2ca21a47",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "38.43.93.173",
       "storage_port": 22021,
       "pubkey_ed25519": "5c9a8284615db3ae23e19c673c033c992d32f003770b93eb2616955afb5f7f5f",
       "pubkey_x25519": "1eff9b54c90caaf5aa12fe56a0bb98e12110eed4bb16df432d54aca39037e15e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "173.249.51.100",
       "storage_port": 22021,
       "pubkey_ed25519": "5ca3e8dca1ac7602304a200f72c8b5c4f1bd6e2a6ceb6b8fe0781d6c53c631cd",
       "pubkey_x25519": "1859090e3ac04ed117f393105323bd0e96565566756d981601ff1e03c84b0c7f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "2.59.133.103",
       "storage_port": 22021,
       "pubkey_ed25519": "5cb8068edbd8bc1ee6bd37cff6bce2e47ccff6cb6588c5fae94ef3c8961ab3a0",
       "pubkey_x25519": "002a8e79dc5dea1ca624903b14139f8f03e4529ea44abddc47e83838bc0f9f63",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "172.93.167.217",
       "storage_port": 22021,
       "pubkey_ed25519": "5d0418ef3fd605ca98b07dfab4d4d32fad9f6351eafc6188d54b69ec519539ba",
       "pubkey_x25519": "5016c7bf1f6eca0c5bba91bbcc382600c7c4fefd30bf0b9366a73b60fa4f2911",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "84.247.128.91",
       "storage_port": 22021,
       "pubkey_ed25519": "5d13bed998a7feb450c20fbd6d780b6be87c751b5083adf9774ec4610e78c5cc",
       "pubkey_x25519": "e8987cfab527bd02fa4aadc62fb76fbcf4851643bf6aac1d4e9e48f0429df579",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "45.13.38.196",
       "storage_port": 22021,
       "pubkey_ed25519": "5d1dff53e9263e18c5a287dee444c0c847987553047af373b319db21bbc8fec9",
       "pubkey_x25519": "4c2e929c42399914f7d985d891477a3bbc6967f501cfb4de03026f17ef6a4e27",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "5.78.76.181",
       "storage_port": 22021,
       "pubkey_ed25519": "5d2b276b2576a8c21dfa6f34a167b98f5d1c609993b85884e6aa1a512e2ed6d5",
       "pubkey_x25519": "c1a1ffc3bc4f4112be263e0a8fd9bec574bd1b85960420ec8ed3c30c33270f5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22119,
       "pubkey_ed25519": "5d45a825a407571c1b46a6dc1133d755c56d686fcba4de605bf664f9ee8026ec",
       "pubkey_x25519": "3f1359074066fc80e664856a4896e6d09fd6cca0f927e9747c0cb06f59dfa01d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
       "storage_port": 22105,
       "pubkey_ed25519": "5d5c99507dc1fc47dbca97295ec627823545cf82d3ca2f40a3d65174814e0355",
       "pubkey_x25519": "2065daddffffece82e453ccee769a6b41a31d14faa8a228bfa31bbfab4cfb526",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "57.129.121.198",
       "storage_port": 22021,
       "pubkey_ed25519": "5d6bb6eba00ac0146714823cab9a0baab55da8ea63a1245c251ed3c983281e04",
       "pubkey_x25519": "86e24f8273b3854fc2cc8d9f635588fb5686a51bd2a4b9c3711dce34f98e9b2f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "31.22.111.217",
       "storage_port": 22021,
       "pubkey_ed25519": "5d973fdd6e7333fe83b9df8ace0a63e23e3137ea67c370107e9b5cb1dd03de62",
       "pubkey_x25519": "4216a208b5b3b74c30b16a63f84cdc245a2861cf78ca8d775c87ec8ba249c61c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22105,
       "pubkey_ed25519": "5da3dd14812289c1b2497a5460e3966c9c1fc6a7e95d3d2f7307feafe5b92b7c",
       "pubkey_x25519": "2b649712aaa759d53fc94ec0b58adca3da065cd1f60b6b718fedba6c2e447a70",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "2.59.133.153",
       "storage_port": 22021,
       "pubkey_ed25519": "5dcdbf77141b93f32c5d268be5c5db09b8ac8d6fd881657690eb183b32421ebf",
       "pubkey_x25519": "dcc9e7175fed435929b4251f0b2bc35322c8fc1d9fe65c3dbd9b5d3daa076302",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "147fffffffffffff"
     },
     {
       "public_ip": "66.94.111.4",
       "storage_port": 22021,
       "pubkey_ed25519": "5e1bc2290698de3f538cce79d3804e3deadf0f19bd5a2b2d73096a79af229085",
       "pubkey_x25519": "556fc9cd86bd9a0d2d1a192e4b0389bbba2d4a0e7bbcd89d8a07502d51579838",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22119,
       "pubkey_ed25519": "5e1fe3e00d1b4834922c0ddc97b8fbffffa52bfd16286432c062b9b007528788",
       "pubkey_x25519": "121e39dd7b52bfac3d0bdbd51239553b908119632ae37aeb96ebd91a44c6cb01",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22106,
       "pubkey_ed25519": "5e3203890a5fed140ae1edd3ecff845a5410e070e6364985941f6a8386803475",
       "pubkey_x25519": "ebe75e963cc30ef949b8f1c889ac90e28c1ae7ee96cbb013149dbcf69e321c6c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "327fffffffffffff"
     },
     {
       "public_ip": "193.219.97.56",
       "storage_port": 22021,
       "pubkey_ed25519": "5e49c3a2c04658a1c5e53d45d9bf15811fcff454cf2aa930431648346d90b50d",
       "pubkey_x25519": "968101d84274d7cba6ed6d28bc429381b1585a134359fea3d89ad08d0be4697d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "198.98.58.67",
       "storage_port": 22021,
       "pubkey_ed25519": "5e5d91a0e2830b6c917811c1efb017c42d210b3e8cc26063f3af3837deb2af91",
       "pubkey_x25519": "2020e680a8f87361f4e3bf7fa22157874b86ff1b88a122d9331cd69532747e6c",
-      "requested_unlock_height": 2056297
+      "requested_unlock_height": 2056297,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "54.37.75.197",
       "storage_port": 22021,
       "pubkey_ed25519": "5e66c88f91e681c98b2c2ca5a45ffa43de26b8755db32ab2ede92067cdc3d6de",
       "pubkey_x25519": "3aaa684a690f5c94a39731da0e0a676add21ebfdc2154f9ffb4d504e59e42d78",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "51.178.47.243",
       "storage_port": 22021,
       "pubkey_ed25519": "5eb475d5722b48db6308eb7f3a7a415e500884ef4cdc614fe979ca1cd75916ae",
       "pubkey_x25519": "39c72130082c4fe026dedabd992dcf31efa1444d6e3a42e30f22399496e2fe35",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "188.40.83.187",
       "storage_port": 22021,
       "pubkey_ed25519": "5ef7c8a50f9dbd313735fcbca10c6744dbe23fde7b0c41f210dbe88fc729dc68",
       "pubkey_x25519": "093dc02a7a20661bf99d42bbfb020a703a9aa09552678362782d311c533e4765",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "159.223.212.143",
       "storage_port": 22021,
       "pubkey_ed25519": "5f200e2f93459808f8545d4d5570a6b2292b7d5e2c3c96a93400357a9a6b7560",
       "pubkey_x25519": "b5e75e60a6da0ce34068d423423d533ebad6daddf1b08c4fe0c364d9bcc15457",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22101,
       "pubkey_ed25519": "5f2f2e96a46db255a96ca5886156617dd295cea289b945fa3b95e0e49fdb893c",
       "pubkey_x25519": "2706f44f25b45d6afb943568903173c8d78f00d405c43c5e38738003ce61d622",
-      "requested_unlock_height": 2056797
+      "requested_unlock_height": 2056797,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "94.177.9.41",
       "storage_port": 22021,
       "pubkey_ed25519": "603fb587db235158727a642604465a3272a80a34712010fcd79af55aa40ebd18",
       "pubkey_x25519": "4de72af6e9380f9e0859d61b859db92d53a51ff35a88392212d1e48e70becc4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22108,
       "pubkey_ed25519": "6045b0642f9d6ba333d8a0833bb90181ae833b268cf46e53b3ff83f7ed564a65",
       "pubkey_x25519": "3d860e3f33d4e2d44f405faeb5500796b7c4946257871eab9047586d41469267",
-      "requested_unlock_height": 0
-    },
-    {
-      "public_ip": "82.223.55.22",
-      "storage_port": 22021,
-      "pubkey_ed25519": "60898d844e908962c689fb04a983d93cd1ff91803b24620e4d178f894ee7cec0",
-      "pubkey_x25519": "f35d637039db888f5c6c584b1bf648f029b97f29bf90709228822d73dced2c42",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "51.79.147.2",
       "storage_port": 22021,
       "pubkey_ed25519": "60c4e0914c06694ee91841df0ae8737e67bdc66a9ca74d11601717e387ba2287",
       "pubkey_x25519": "36ba57decdd6e88bf7a05c56f0d9f71b96142e8a4acfd62b5980782c487f0449",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "217.160.4.10",
       "storage_port": 22021,
       "pubkey_ed25519": "60d10db9233ab22dadc890607dd78ed994cebcec3ea27a6c6dfe9fdd98fccdd3",
       "pubkey_x25519": "6bd53902ec9d799b544b4ca84d5d5d4b59c7c950097263525921eb666a4dc323",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22103,
       "pubkey_ed25519": "60e50c0904bcdc68d7f607893924f9ac0d5acc553cbe0770aef236f7788c0f5a",
       "pubkey_x25519": "cacae59b879897e8ce81b27ba7636bf17988a0bf9422c9f52a77a0103a328a53",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "2.58.82.193",
       "storage_port": 22021,
       "pubkey_ed25519": "6123c1085850ce0a6e2c5986d07a6bd85a35c5f3af7c3a3742f45f9ca268cbb8",
       "pubkey_x25519": "aae871c00eb9da7a6a9cbd814e02eb0f18de392627c2590d39b1de16c4ed4231",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "23.82.99.100",
       "storage_port": 22021,
       "pubkey_ed25519": "613da38204f77fbd4a27976b6ea516b9d9c98ed292b6fd2bc9ff5f7a29a77e18",
       "pubkey_x25519": "7d2247577222b5cad240ce3d11ee803b00b646607bba812077a5cf2bd1b27f2d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "116.203.243.239",
       "storage_port": 22021,
       "pubkey_ed25519": "616e031e6b141bb0e2bedbef7915d36625f2175385f2651277ff399a308972cb",
       "pubkey_x25519": "4fcb520a8fafd9a96f46474b2a05c61c141d4c63b4b737f8f49e036547ceb96a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "31.220.94.39",
       "storage_port": 22021,
       "pubkey_ed25519": "61d1cb0bd87fc2039ebb267ea55548b42b313f0044e61284face5204f10d6aa8",
       "pubkey_x25519": "73cb58ddecb57c6fe1675f9e2e88944809ab0e6b7730f6861e6cbb477d3bd539",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "152.53.46.65",
       "storage_port": 22021,
       "pubkey_ed25519": "61e968067edebbb4f2747bf64fd29a9046bf5092d63884a5e9a0174b7e1c8b35",
       "pubkey_x25519": "66881337e7641215615265f4734dc3fe994024ef514f3b6fb5e0d3910ca6b62d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "17ffffffffffffff"
     },
     {
       "public_ip": "91.99.230.225",
       "storage_port": 22021,
       "pubkey_ed25519": "62348503949d28a0b083a481106c4e3084175664fd10fff84fb3e1393439e335",
       "pubkey_x25519": "f09831906e45138b26d9906e087ec1f53fd773f39245220f6a765365be6c7937",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "31.57.218.208",
       "storage_port": 22021,
       "pubkey_ed25519": "623f9f109f4865287374c70f12543af4ec309fe5d99efa2ffe0e524b730a497d",
       "pubkey_x25519": "109ed6cae0cea690e77f6ff0bc27431704957784fc0d76a20856bf0ad7255e6e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "194.62.98.40",
       "storage_port": 22021,
       "pubkey_ed25519": "62615f333dc215c1dd8bb3e0f0d3fd88c9cffbd7ee258d9687bb48792ee727a6",
       "pubkey_x25519": "1cb12f9545aac05ae4efbbf4345f1bd3803531acf63e6c120a2c4b1c438fd01e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "193.160.96.226",
       "storage_port": 22021,
       "pubkey_ed25519": "62eff494951d17473cd5652514af513fd58abba81f836dda307996ddace03b03",
       "pubkey_x25519": "923bb5ddd6c6c1256a5f828684194c3ccabfbc5985cf1da2e199e7c723009e5c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22133,
       "pubkey_ed25519": "632bbcac42d758e17d5ae5f9ce79c1938b13582155795628b95bca3ce427daf6",
       "pubkey_x25519": "6ee2fc255f5a2779c4f346991ede5292516a7d6d450dde80a4617c3516cb0678",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 2065849,
+      "storage_lmq_port": 20233,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22101,
       "pubkey_ed25519": "634a72a534d0f6458baa735a056463cd4ea087ddc8251dcbac042b9050fd958d",
       "pubkey_x25519": "aa124fc3ad4e8feea6ea9ab2f47d4f418a1ab15bec3d4be1952fd5d7e5baf80c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "38.54.75.62",
       "storage_port": 22021,
       "pubkey_ed25519": "634bd4b5b520e17a9a616e2edc2c6d09fc87a1668d646b045b6933429961ce3c",
       "pubkey_x25519": "8766bbc2282ffdd1f93a23955819a9c47350417ec6f07100ad7dbfc5c1e6860f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.210",
       "storage_port": 22021,
       "pubkey_ed25519": "63ee14b111463058c19d13ee4aaf8538f5d7efd42032606cc187bb4505f8e3aa",
       "pubkey_x25519": "e8338ba9c175826eabf83e32302fc5a881989c2d59c05be49feae529156ef27d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "161.97.123.136",
       "storage_port": 22021,
       "pubkey_ed25519": "640b1c376a1efd7de2776b0cf02584f7cbe10ba025049e16d951928cf28c6dc6",
       "pubkey_x25519": "0a3becee4752ce462e026a26a12f9648f9d1d1cf560d776cf47e47ddc3f6242e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.89",
       "storage_port": 22021,
       "pubkey_ed25519": "642ea0e9b5a97694297902945765b69ee31c9f19767ef80335ac917900094cf2",
       "pubkey_x25519": "cfd0a0b4322eb7105ae9d8bd57a4c9b9651c485982f409c1913350277bfb7a1b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "89.58.30.106",
       "storage_port": 22021,
       "pubkey_ed25519": "6442328af61e58b146d1dcabee685c80375da8efd0c4df01049b2c8b33ede5d1",
       "pubkey_x25519": "1355a14fc133c2492d822723c62241b44d87f470f26ec540c1e14d8a24512c02",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "38.242.236.119",
       "storage_port": 22021,
       "pubkey_ed25519": "64434888a0561b905de5f83850149f489831f67ee9afa8446abcd0ada91e29ae",
       "pubkey_x25519": "c8679f31218f85f727604b1d573dd1524ee0a410e9f2d1d431da17f82792166a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "178.18.249.214",
       "storage_port": 22021,
       "pubkey_ed25519": "64835edf9845fb5f992edc787cb8349253d295a0bb7c16132d71ed30fd18b4bb",
       "pubkey_x25519": "3823231c9ddcae6accfeaafcc41e11ac93561e7ea0f7b7815e737a6df457510c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "107.182.173.179",
       "storage_port": 22021,
       "pubkey_ed25519": "64ad6f437de8e9338d1e86e4c392c53844011e57e9647f770148ba76d1529ca2",
       "pubkey_x25519": "f256270c97a1ee97ba254dc92b950f884ebe1375c4e9f13f37869f76bd651558",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "194.32.78.254",
       "storage_port": 22021,
       "pubkey_ed25519": "64cc48cf08c257cfad12a2d9ba7126335233e2b755ec5391b6c84ea32499b909",
       "pubkey_x25519": "a164d12cc86b1154d6221a2636b7b058e6b931fa18dde11336a422bb3c4f9e0a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "176.96.138.97",
       "storage_port": 22021,
       "pubkey_ed25519": "655d94100583c5a9b4d9f2540cd2cb4a8fc295b2728d737c25bca3561b55e880",
       "pubkey_x25519": "3757762cddce21454bf2971c689a6cb75bd4ae6149f93449f249680b9cf45055",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "92.112.124.92",
       "storage_port": 22021,
       "pubkey_ed25519": "657d47a84d66867ac2fc28a65762fbd715e636e1996593c6caace8145f5dafb8",
       "pubkey_x25519": "c07fafb7277df7f12b9e0cf4403138b97d5231f3539d4955f9138d76772f6e4c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22105,
       "pubkey_ed25519": "660460492d9c8f519c521d7b0c20b3c8bd8c68ebf008731887610ed82138ab2d",
       "pubkey_x25519": "52ecdba4938b3b79909631353719058a93f96f829aa6c1ba2f581d09cf473f1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "146.59.3.52",
       "storage_port": 22021,
       "pubkey_ed25519": "669dc540d54b023a0c8ad9a5c07024b80a5bc3f4d94c634174dc31fa6dd3ec13",
       "pubkey_x25519": "342d2c7f468be0be5124fd117633d7851632bc263c28c9dc518bdc3fee9fb23f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "164.68.101.219",
       "storage_port": 22021,
       "pubkey_ed25519": "66bbbb5fb31fe5006a30bb61f2a780b2946c30f02f705c1374d1555a0e2b7c73",
       "pubkey_x25519": "31238a1c129250e451d0a303cc9cbb89954f033eac3a608fbea82548605bdd60",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "80.241.220.222",
       "storage_port": 22021,
       "pubkey_ed25519": "66c9effabe61a262abfe69bd96dd6c704d9836c60549562204a6868c9c41e7e2",
       "pubkey_x25519": "ea9ed78679b391017b7ade17380848ac3ac18001eab4eafb7580a387e15ff851",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22103,
       "pubkey_ed25519": "66dcf30f46cd5b7f26768dc4b2340c4dfb1b1d719869a1e28dbbb0b6d077977b",
       "pubkey_x25519": "0125592041cd0ce5df721caabc8c41945e31327609e4cce7c05578b5a0ff603e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "38.45.65.93",
       "storage_port": 22021,
       "pubkey_ed25519": "677f2da8f85ed612bada4c10e0876c2ad79a8e9accd7249656df23f5730b12e2",
       "pubkey_x25519": "2ed4b0796f99300f4e81ad6d9f6956d9f63ba39111f0b46a0be2061b5c542415",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "68.134.191.2",
       "storage_port": 22021,
       "pubkey_ed25519": "679c990f3112f3e9569e619e44ca9bdbdc175b53edf41351c5e5ca539ec6a8b8",
       "pubkey_x25519": "12f0126bc51a0da918a09600d09f31f76ff840910e93134d452fdab13b9eb479",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "209.141.37.73",
       "storage_port": 22021,
       "pubkey_ed25519": "67a748df5246210995b339065dc7c7a76b0efa39b5cf4773bb99c838139f3007",
       "pubkey_x25519": "5b1487c915f4774dcfe53256832b446136f0415c464c0089aa02064b44212351",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "167.86.86.191",
       "storage_port": 22021,
       "pubkey_ed25519": "67ab847d20e5168ee53d8b4cea33baf52453b46a3dcd5f8b0491664d965f74a0",
       "pubkey_x25519": "6a1ebdc2401e7aacd7ff63719c0aa10d751b4502e70643a42f1ac25745773f55",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "185.208.206.67",
       "storage_port": 22021,
       "pubkey_ed25519": "680fa25708f5db2357a422eac40bfdd0fc9481c69eb03d3599c569e8c920a60c",
       "pubkey_x25519": "9a18db6d260a237a532e2cae6c907ba484932866612c163867d7f6bd8a639a2b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22104,
       "pubkey_ed25519": "685801f71823a975ac5be3b440f0e0ee434e5fb5e2bdeaacf5f714c455e46861",
       "pubkey_x25519": "244a27f280b9dffae23d2047c715457d6dfd514c46d7968d2130c11936018725",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22104,
       "pubkey_ed25519": "689c6b5cd4a7578e8a851bf0c4cb0a143f0412a89880e170fc2ac59ec5c37721",
       "pubkey_x25519": "9393eb98d3008a0ba6dbbcd6a8d2a656b4ad12963b587c0d108ae7f19f344131",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 2065849,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22103,
       "pubkey_ed25519": "68bfd9c95e854e195d1ecf227514ef754ac4dcfc1a87150fb51e769789023f89",
       "pubkey_x25519": "bf0780ee83667357a15343f097588024d206590e0514d6b7e8ca07681c056337",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "164.68.101.175",
       "storage_port": 22021,
       "pubkey_ed25519": "68c495f37887f9888944033ca112a121d84fe9660040ad65ee69b7a45da77dde",
       "pubkey_x25519": "9b664bf5efefa502d8c892c8d37a721e4b8354896adc10fa95f47927f4e82122",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "164.68.99.13",
       "storage_port": 22021,
       "pubkey_ed25519": "68c993a16315d3ac4343ce021a99bcf2f12700874840b06ea8a6c1621e76dc9e",
       "pubkey_x25519": "6cb451e4341bcc5d426c0b91f4057f0a6c16cee4726c29794b13a9d44d6f8266",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "94.237.103.114",
       "storage_port": 22021,
       "pubkey_ed25519": "68d85e2723d03fdc288ad7cd4ef8466865b26e412d2de83f79caa38893785f4b",
       "pubkey_x25519": "96e19f915525da1959e63ba0a469074dcf602688f24fd2c9e3eba84100901d2a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1f7fffffffffffff"
     },
     {
       "public_ip": "164.68.104.4",
       "storage_port": 22021,
       "pubkey_ed25519": "6941c9cb4d8ed0ec8305765ce91acd5bf05ddf6f0ec99f67593ee1a24e04b1d8",
       "pubkey_x25519": "8bde5d1d341e4fe5ef418c5e8b8897c34ae2c763d10a10b7d3b1ea843c1fc111",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22104,
       "pubkey_ed25519": "695273a98049df7dd349549b33bfbd079bb8ea185ae9daacf922a512301a5319",
       "pubkey_x25519": "0794c947b5d78a09942d220c556f5dc5dbefaed94ffb9f8bbab605a5ebe89d74",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "38.54.97.133",
       "storage_port": 22021,
       "pubkey_ed25519": "69e9f483d816ce547b2c19f19853d6d2e8a630713ed593e2482b4e6609e574d6",
       "pubkey_x25519": "35716ebf58c1b8e7ec9a9a411af1a910a403d67a2f1d8a6625fe7aaeb6bebe0a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "164.68.113.171",
       "storage_port": 22021,
       "pubkey_ed25519": "6a0b07f109735abc2207cb0e956e02cf253563b3fffa46023f63909cd83cdc92",
       "pubkey_x25519": "139cd95f560cced928ad2c9235c6dba90f907c2674be06049f44d7cb91f2a474",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "82.115.220.30",
       "storage_port": 22021,
       "pubkey_ed25519": "6a23ec7eb16ac579cc4a355fa5c49bbb127fb50fa8895fb25288628216891617",
       "pubkey_x25519": "f65351a9ea5b7e08a79018bf8274362f87e97de1703c088ec8a30d6c281a5a3a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "193.219.97.167",
       "storage_port": 22021,
       "pubkey_ed25519": "6a2a1481de72f311f15ba3d81ee6ddca31561f729fbd1774b1764c2900633c63",
       "pubkey_x25519": "7287986914669c0bfa80c684ff2d3c344d597984a790fd43aa97feb1f428fd4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "95.217.218.66",
       "storage_port": 22102,
       "pubkey_ed25519": "6a70c5dbbe3b706a135977ca42645ce35d4a7e7d4c8b7188768e7b04f3bdf28e",
       "pubkey_x25519": "e7af12891a8567796598839b7c2d108b21e3db4cb03afc3093cac0a0c42dcd50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "164.68.101.139",
       "storage_port": 22021,
       "pubkey_ed25519": "6ac0a76a1bd6c396ea28e95a93a009ab3ec5fa708d7054572edec7b2e029208a",
       "pubkey_x25519": "79fab392dc41bfe24c767b6a80e30e9316da8e84a918264c8383e0c7b7cae143",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "5.223.77.132",
       "storage_port": 22021,
       "pubkey_ed25519": "6ad6cc66bb3a51a035fc539a9a42bc01924a55970ef5a4c469d76a9b08f0619a",
       "pubkey_x25519": "8b150f2075dcc15b6167905486376b0c321d3889190665045730301a3b76b953",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4effffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22109,
       "pubkey_ed25519": "6ae986969ca872ecdc57bb42d3b48faba612338fb4777434ca2d63923513577d",
       "pubkey_x25519": "b84a02fbd193b39d6885ff8fb805e40861726e8e9a74f280f4a48d314965f046",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9cffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22125,
       "pubkey_ed25519": "6afa99301bd73458f92ab68bfd21699bc5d17e674517f2a4e94a237e3b05f3f8",
       "pubkey_x25519": "8f4a414ce9b99f74acfe69925804a965054e5c6f4ff7bc732e1396557c9e756f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20225,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "164.68.112.220",
       "storage_port": 22021,
       "pubkey_ed25519": "6b7c8c01e55997409f236b4817d7b560f573e5d6f2e06f09e70c26dd44d74490",
       "pubkey_x25519": "e421ed51f58b900a47280258400ba9fd2d8deada28151e59f40c2deeb2809c11",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "66.175.216.182",
       "storage_port": 22021,
       "pubkey_ed25519": "6b90d0011a6a09b7e35cd5b21f700f1fc59fe93a0c533919437ae3479a9daacb",
       "pubkey_x25519": "acf85591635ece7c37efa0595f4979a2c76175f4ccb387d46d94ec51ae771b1d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9cffffffffffffff"
     },
     {
       "public_ip": "51.79.161.120",
       "storage_port": 22021,
       "pubkey_ed25519": "6bb64ab1d1c2c122b26f0acf90e2c804d87753b4a463221ffb7711676a94747c",
       "pubkey_x25519": "6ed5c088b905fd600f49b6fd2c173b1d2189aba4aa491ba9ded5f4930516f208",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "173.212.216.151",
       "storage_port": 22021,
       "pubkey_ed25519": "6bd98418bf893bff7fe5a2188ca17d37d74e9bf7b20d787c4370b4b9e84ee1ca",
       "pubkey_x25519": "a568a1d2929c8d14daca4e73cc291ce8d1e5fe8e15ac96bab090d56775979e31",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22122,
       "pubkey_ed25519": "6be9b9e61f291ddf5e67b040d6493a563494152682a1beba38326f36fba5677a",
       "pubkey_x25519": "b6ababe3c110bf8a1acc69ab3b96ed571b245863bfe14080f1da316b51744f39",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22107,
       "pubkey_ed25519": "6c0ce736fe225f159c0888096a0f0d5249e3c4db15917bf3b3157ded39ec84a4",
       "pubkey_x25519": "1f52a777b4bf7a4126733d459d64c55c9e9ad65eaae49c3aaf1f131575391926",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22104,
       "pubkey_ed25519": "6c95e36743812dbd50dd970fa0cedc6420c37186e998c9769a18ce1664f387ec",
       "pubkey_x25519": "07e1f476d8176d3d2b2e1f65beac5ff4b60ec7e260b240a43597a248c8beef32",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22141,
       "pubkey_ed25519": "6cd1b6456b7c6bb094705ec4b851c9f13edfb6ed4267bb40e0d22cfd6872bc71",
       "pubkey_x25519": "5c12c6563553c0020210cd1664d9c77d61b697997339d803036c84c071bb9563",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20241,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20601,
       "pubkey_ed25519": "6cdf800df24fb703d2eb61bf311c4253e403bf73824ab07d74b278ce200eaec4",
       "pubkey_x25519": "580491f8fb3dcf02a6c16511c55addd2dc1c338b670f800784009b0b324fb178",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20901,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "23.239.20.166",
       "storage_port": 22021,
       "pubkey_ed25519": "6cf2b0fee6a044cfd0612d77b9e2674b3fd077d61a95f3149d4d4649abe32dcf",
       "pubkey_x25519": "7afa948421a5be98a397c78cee6885bcf6e85a8adae3a47bd043952ec91ad51b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "5.255.114.11",
       "storage_port": 22021,
       "pubkey_ed25519": "6d87954b0a92c3ed3e227bca88f9fc943d30afeaaf0019b021af1c43e62c0a2e",
       "pubkey_x25519": "131cabc6daedb1616a67bc9ebd887c81fd1956f3e7dc307b1a98b62d31b1673e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "51.81.161.230",
       "storage_port": 22021,
       "pubkey_ed25519": "6d8990c88ecbe59a5836098e9bb63069ef718b3c87963542bd990b30452b343d",
       "pubkey_x25519": "e52052fc9d7bd543cbba479155d5ac6418fa592aded0bc3bcbee581a2274ea02",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "75.119.145.248",
       "storage_port": 22021,
       "pubkey_ed25519": "6dbfc3e985f816f4221f100450864d3f97e1451b6de1558331d1db515f8de37f",
       "pubkey_x25519": "adedb89e9871ab0bff66e46300092c1c9ac641ff88e642cef87891752d296920",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "172.93.108.154",
       "storage_port": 22106,
       "pubkey_ed25519": "6ded6e958d25cc49988bf7e8f23ef0d0cd98137db1f3dbe15810de96757053be",
       "pubkey_x25519": "087d34aed76778cf27ecfcc4df52ffa81c7311031be8c418346a1b48cbbd0013",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "193.219.97.206",
       "storage_port": 22021,
       "pubkey_ed25519": "6ecee30b54e452d330ef857ede73296264fff2d28fc0e210d1113d470fe60bb4",
       "pubkey_x25519": "66a1856f8a45a792fe78a71c0ffc301067bfa7c2b3a768ddfe6b2a143a96266e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22101,
       "pubkey_ed25519": "6ee88223192717d7a931674bd5e2bb1c735cf00cbbd0c3b4fff27cceccde5af4",
       "pubkey_x25519": "bc0a1b547e81cf5bf07cf975edb6ab4cbe7cf66a52495d681b0cf23605f3de57",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "205.185.113.143",
       "storage_port": 22021,
       "pubkey_ed25519": "6f0a5943eb188a2cf4a5a49259cb93f4db4830a0337d5149752208d5ca337403",
       "pubkey_x25519": "e3361549a38d54f26dafd3b881410873223c3c98361c9f3f6bd0bdc746aece4d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22113,
       "pubkey_ed25519": "6f43b305fa35d050966749e1828b7b4b194d5e0a6814f42fc73036c4af417415",
       "pubkey_x25519": "ebdbb7c0f9d37fe8f51f34de867660bb9c8f72cb47b0ddadc9b445e29582f007",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "94.237.95.195",
       "storage_port": 22021,
       "pubkey_ed25519": "6f75ad5718377b3a69ca3c65287a8b8038780adce28c254be5ba8c9297de4eaa",
       "pubkey_x25519": "e45dd3958ab0cb1d781889abb94311b6949f224a91299124b49e87288e99be2d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "66.94.118.153",
       "storage_port": 22021,
       "pubkey_ed25519": "6f8c3ec7a9c8ab14ab5c1943fb027fc926ffba378367a82523cfd7695e189532",
       "pubkey_x25519": "3789f96e185844263bc85cf602efe7377ff603bad0c489941900bf23fb10a963",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "158.220.109.210",
       "storage_port": 22021,
       "pubkey_ed25519": "6f9f99c21ebd8be5f7b1e6d06fe086d9e916ad62ec7e830d34108c7081560736",
       "pubkey_x25519": "f5b5dc19f0b32df3eebbe7bef2b9d03f1b3a835676c22b7e48c7f9e63c124830",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.230",
       "storage_port": 22021,
       "pubkey_ed25519": "6fb6a0bf218a86d8ef890bcac96b8d1007bf458c6d0bca144a75af468b7bdcde",
       "pubkey_x25519": "66cecbeddd1d81eabd4fce527a1fe7d70812f34edffde1f8b37ef7fad0f3ee13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22118,
       "pubkey_ed25519": "6fb898bfe143ce0de7b20b287c1f459d96b7a55329e83fe3be27892d1ebd638b",
       "pubkey_x25519": "33ce36b1dcadf6dfa28c7200088043215f7941485e6a742d7054625e3feefd6c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "95.217.209.146",
       "storage_port": 22021,
       "pubkey_ed25519": "6fc529a9cdb94eec11676077e799a5fb8289a7c6a4e097eb5a0dd33d2b97086f",
       "pubkey_x25519": "09381f2ad25bf9b2f754d9c8f6101558e51ae18caaddd160b3092c98bdd72f4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22118,
       "pubkey_ed25519": "6fcad395c41ab83ff8f937fe6d3446ba083d178f7bce1348956048b8de713869",
       "pubkey_x25519": "ade50e41d4b72147edda826131e9e1ceda067ba2106f34e00215527c67b3da5e",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "136.243.106.178",
       "storage_port": 22021,
       "pubkey_ed25519": "6fd89cbec6835b1c683de5110b9d0cf3d265822606448e809b4c4f358e5bd406",
       "pubkey_x25519": "ce3f6f3a9daad37db193b57822244b0c0b2e8b1f7fb8968df056d7d76b7cfa2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "64.235.37.175",
       "storage_port": 22021,
       "pubkey_ed25519": "6ff401e5e98c40bd6e0a094e27359683a1a14cc3becea50a00da9c03ffd7b3b0",
       "pubkey_x25519": "fc14880f21308719a52ff644c7e7ea36e2ccd9007d92995733aa09417afbf678",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "132.145.162.118",
       "storage_port": 22021,
       "pubkey_ed25519": "7028472aa40f1de3e001e57715796a6643c06b3432826e278472baba1edb9578",
       "pubkey_x25519": "f308ad40dd2494be964f65bade732f5bc77a810b0446a9e457112ce2cd87b463",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22106,
       "pubkey_ed25519": "7035741af5db98bd70b422168b94307c6c28416d726344fca6d6d5ede6e0522b",
       "pubkey_x25519": "60e67d75ec4c82772da7b5ee665f7aa1bb11e0f956a6f44818e524197662b74a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "5.199.166.227",
       "storage_port": 22021,
       "pubkey_ed25519": "7054f1c7a43c68b2681531ca8198faf48bb2532205a1db12c61640c7221b37dd",
       "pubkey_x25519": "6de6d447d12f25221f8c8ee67c38395f8dbb2b87ff044070bb8bf287b1fd9a3c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "5.78.83.111",
       "storage_port": 22021,
       "pubkey_ed25519": "7075a7e2d48c124c5210b400060595956b72a7e9cde29fd4211f1abc233da21f",
       "pubkey_x25519": "3a57516e177011c9ae65c5e258ccf70cdfbba0b0f4834008a304f9764088cb42",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "152.53.231.2",
       "storage_port": 22021,
       "pubkey_ed25519": "70b4d84ee4f20ffdad273b7c01df46d3174942ba4a7751587f9bdfe4fbbdca3f",
       "pubkey_x25519": "5afcb848d0293e13a44fd7fe85ca16aebce490fb4c52d8afb3a34bbdc63b5748",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "198.74.51.223",
       "storage_port": 22021,
       "pubkey_ed25519": "70c3b21bec91fe15981b75ca8f08e42958bca035371d5713119d01f2f4d638e6",
       "pubkey_x25519": "d770db20ae9cb7c56fb62bef6a7d92ad0f62f793f49579c471086df027948e71",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "178.62.194.126",
       "storage_port": 22021,
       "pubkey_ed25519": "70c3cc6a0c9004e049d9e52fdf838ca25f785187cbb089169244a50111553d33",
       "pubkey_x25519": "ff885ae42973884b7ad6d6d41784f6ecbc1fefffa2c0c244263f807659ee0065",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "102.208.228.250",
       "storage_port": 22100,
       "pubkey_ed25519": "72869d428bd97630f0e1a874eaa20c5a7f531239497eca1b7d8aa65c0053b152",
       "pubkey_x25519": "4bb906b70fa9c1ec241e3549c1701656a4ded6d6ace6133bebdf076fe6b2d24a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "164.68.98.39",
       "storage_port": 22021,
       "pubkey_ed25519": "728f925b17284c7dca6533cd9349e532b7490dc13afc3561efc19057d4016950",
       "pubkey_x25519": "b205b0ab86472cb685e0d9d1793fcecb95a6ff46b63af937adb8c82afb999e03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "102.219.85.93",
       "storage_port": 22101,
       "pubkey_ed25519": "7322f8e32d7e86f922728267dcd6d44553192effeab4035c1718f172baa5dea1",
       "pubkey_x25519": "2f8be1fb9e09e31e20b7969e9af749527d1381b423985ea1fccdec64110e791d",
-      "requested_unlock_height": 2059021
+      "requested_unlock_height": 2059021,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "145.239.90.154",
       "storage_port": 22021,
       "pubkey_ed25519": "736bcd68bdeba9f04c9874bf4a23991de3e0199ee5d776f74381b51f7031cf69",
       "pubkey_x25519": "c9f5808fdecb94e14daa3fe4546e1a39bced638e57859a86973da1fc96a0dd1b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "116.203.134.197",
       "storage_port": 22021,
       "pubkey_ed25519": "73758d3cd7ed225fb5affcf2f831d5e9d59386e642a0a14ab2e3209a5a5b98f1",
       "pubkey_x25519": "538b7570503313da2e4e0aea5d22bf3b6a1887bf03beef865563bf27bdde702c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22120,
       "pubkey_ed25519": "738cdd0a5459fc3db65dd8f682daace3f89eb7ea873ef940b1440cf0537db4c9",
       "pubkey_x25519": "5bf7132dc9e8c0aa4dc1168f03befd568efb05083f7b7d467919da5ff9a94238",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "172.93.108.154",
       "storage_port": 22109,
       "pubkey_ed25519": "73aff35de279bafaec09ac47d2a7c203062c84b88569cca8269d6b23e8084ded",
       "pubkey_x25519": "6fa3fe89cfe0610f5c9b734a88d545d74cff863e395bbca10b53bdf3adf4245d",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "144.91.77.17",
       "storage_port": 22021,
       "pubkey_ed25519": "73ec9ea886e34de7932593a1456514fc4d242f2b9f73b6bc54a32d051d2db2b0",
       "pubkey_x25519": "5dbb3647162eaedc0ac97b10b11d8494347ef2310ac0a22ca2b726827dce3f00",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "185.48.118.195",
       "storage_port": 22101,
       "pubkey_ed25519": "74c508c4fb908349792ddac8b9d107a33a3c8071a7f4504e5d891c2736dc62bd",
       "pubkey_x25519": "9fdbf9afea04da9419158c7fba17559a8699cda6f15e1c3dcb822b0380eb482d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22116,
       "pubkey_ed25519": "75077cf371cc6b0844e10b4e3442b19171a86866a7590cd338563b6868b5f578",
       "pubkey_x25519": "7f7a9991d6cf88416c1e535ff148d7a8b6b9cbcb7cdebaf0a62c3aceaf993705",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "31.22.111.49",
       "storage_port": 22021,
       "pubkey_ed25519": "753c147de637918df24e4fc7822835a23497d217e124e42cbf80cb81324694e2",
       "pubkey_x25519": "eb442d0f59c7254c34ec5553c1840d41c2f7c9c271db8e097245edbe09340161",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22117,
       "pubkey_ed25519": "754c3d80f407db59656f895fee6092c477589b65d07468e1c653886cdba5a542",
       "pubkey_x25519": "e099cf1d759bff0ae8a2d4d600d6e3ec6693c4d09d49654c85a0a7d4132c1219",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "69.164.194.93",
       "storage_port": 22021,
       "pubkey_ed25519": "7557100096533f939aec32d756b3d47b72db3bb766e31d4f20d3e855e3b7c4fc",
       "pubkey_x25519": "e4edd3d5a35a23d91777e49e0edd0b8d0583bfd112ca2f5ff9177334cb5bf607",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "45.145.41.130",
       "storage_port": 22021,
       "pubkey_ed25519": "755caac8df390d1e0248e93c3f899f00d66ce9d9cb8dc1d41fa5393a941bfd6a",
       "pubkey_x25519": "be26b4b60b61d3adbf3b0a179bc0b34636e00f3f855b854dfcfec2fc6e846679",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "407fffffffffffff"
     },
     {
       "public_ip": "54.39.148.196",
       "storage_port": 22021,
       "pubkey_ed25519": "759f64f06ba88361c4a560c857eec2d4fe6c03898031744b7a5c2a6c007990ee",
       "pubkey_x25519": "8e05c21e7befa2839cd9188684eb62fd007abf456fb206d791c21bd50a00a339",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "57.128.168.127",
       "storage_port": 22021,
       "pubkey_ed25519": "75a7b916e6ca6870a8f3bd7010d7b5e0ccae8d55866f1bd950f06efd15ab8fb7",
       "pubkey_x25519": "c6fa69dfe5a6aef55b32ca0749ffe6b58648f3a7c8564dcae0ade8d00067ad60",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "5.78.89.202",
       "storage_port": 22021,
       "pubkey_ed25519": "75d6c05b8148fc7b150c95ff6033fe2410afd36fa73ee734c08a11fdeeec5c4f",
       "pubkey_x25519": "8a97aaa0f62ca3cb8ecc75e3a8b087bef3dcdf2616bf7114a6bd6331f245b341",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22104,
       "pubkey_ed25519": "75ea6b7f108f6ae7a6293e900424d14cba45282a8dee84ac7a7cb3906337b31c",
       "pubkey_x25519": "abd36edf8c22c7acfe186c70667f9a5a0b6e4efe54223daaa84edfbf187a6d50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "45.153.187.210",
       "storage_port": 22021,
       "pubkey_ed25519": "76d9a6f91517687298300a5d1a17eca887947d15d5d7791feedfba3e7c4622ba",
       "pubkey_x25519": "f9d2a152b8098c12ec7feaa12dc7f64fef7d7cc62a08b08e264b1ccdd520d953",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "15.204.235.189",
       "storage_port": 22021,
       "pubkey_ed25519": "76e1f7995dd0b94ea7fef63eb973d3958b49e82849f91a7f56e9f93180deaf40",
       "pubkey_x25519": "95f44b55361d44b47a97d654776d4662e73b441d6491325ad73b8e205b08eb7a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22106,
       "pubkey_ed25519": "76e7478f918d048e91b73a0fd26cc4ca2c1a0a59e3bb3117ed91b0e42e68adf7",
       "pubkey_x25519": "aa5f1fd0141d7a355a22fb5a2029eb739ee831074b6bb2a2c8dac5ebf4c5ae61",
-      "requested_unlock_height": 2059344
+      "requested_unlock_height": 2059344,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "107.173.251.190",
       "storage_port": 22021,
       "pubkey_ed25519": "76f5127e43d8caaf6a12a516a0cd74d8fe6c9cc41c3528879890323378200272",
       "pubkey_x25519": "7ffd09c88b87e2fe272850c2e4b98255b609444c314e28ffd332fdfaa08a6152",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a8ffffffffffffff"
     },
     {
       "public_ip": "129.153.135.111",
       "storage_port": 22103,
       "pubkey_ed25519": "7713f3443ec4d8be755d408d2b3430e64b87072af4dc44d1c0cd3b406c347560",
       "pubkey_x25519": "d55ac0c5f998adb6dee7542c1b25924bb9d65595442c17ab9714bdca2a719947",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20609,
       "pubkey_ed25519": "77280059bb86ee248014d580d81377a40f8bf7eee0dbc932e763f7c5f8072b69",
       "pubkey_x25519": "46011ac7f9743a9ce02f8c169640b27b27e2725231437e897ca9d6b7424a2a77",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20909,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "102.208.228.248",
       "storage_port": 22100,
       "pubkey_ed25519": "772b436c009f56c3cb27b78541d27ba41d3c3ac839784dad2d0295689083a027",
       "pubkey_x25519": "dd3649b11681729d3607239d68c0181c046dcba3e4357fe968a3b0b5247cac27",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "206.189.101.37",
       "storage_port": 22021,
       "pubkey_ed25519": "786b02512f46f81e03ae359eee24bcc813230f3490467928ccebe3bff99b330a",
       "pubkey_x25519": "6ecbc59d153c7a906ad88fb9502bf47a5326e40d784b3786233a353fcc02805c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9affffffffffffff"
     },
     {
       "public_ip": "213.136.90.84",
       "storage_port": 22021,
       "pubkey_ed25519": "788ad46fdc540d745dd0bc9f2ce3c8cfac876761f998185f41c4d291b5d92ed9",
       "pubkey_x25519": "891924d5bd532d17b2bd40233da2e80047621f5a7f174959db3cc371ea113d77",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "164.68.114.8",
       "storage_port": 22021,
       "pubkey_ed25519": "7894c58e0f77408a8bfda9f07ef1eb4fa7114616ac848beaea214191ace22d48",
       "pubkey_x25519": "f39b6c41fc2e7d76faba49314edcb2daddd9c7968e7fa9d264e000996c5e303c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "91.99.239.106",
       "storage_port": 22021,
       "pubkey_ed25519": "792e99e97792df4c78fdfdeee0382173890f967c6ecc8d2ecdbf52758d0449ff",
       "pubkey_x25519": "4f1cbadacbaa629e9c742856eb7160d0460554beb744d279c21dbbde9452fa10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "130.94.44.4",
       "storage_port": 22021,
       "pubkey_ed25519": "7972d1a2f9d54a19de9f8a3a933040ef36ccf2535da5fc70566f7f6b261c0a4d",
       "pubkey_x25519": "9bee1db6250e849263fb3ed8cf2d011191819a452e616df75affd5424c783709",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "209.141.45.115",
       "storage_port": 22021,
       "pubkey_ed25519": "79730956d2fed1b9c6975e4476663951d31fd85042b441cd942e8fee51085f94",
       "pubkey_x25519": "1c3891a7b355c565acc44fd71763de116fda41c4ab1c1c655d722134bfa50663",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9affffffffffffff"
     },
     {
       "public_ip": "107.189.4.130",
       "storage_port": 22021,
       "pubkey_ed25519": "79ff06ab5d1b3154510c96e368ab4905abd4651e982d1f069b67f6f3b526b94d",
       "pubkey_x25519": "70109f924e2428d1d669facbc3c5d313af82ce2a1ad36b4b32827bba2f5b062e",
-      "requested_unlock_height": 2063712
+      "requested_unlock_height": 2063712,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "74.50.118.192",
       "storage_port": 22021,
       "pubkey_ed25519": "7a187a0dfadfb130d1f48d4d8ca10af4834484e046aea99a07b600ada2c89ec3",
       "pubkey_x25519": "3f01400349899c396867e5a4ac8dba3a86641a5f13209855a82659bc212d345b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "135.148.41.196",
       "storage_port": 22021,
       "pubkey_ed25519": "7a624cecce6322cc0ef6c2d76425dafbe9a5f0e11d6fd79237e450b48b3d7ceb",
       "pubkey_x25519": "ef2ed7eea3f68be120fc9747cba212e65a51fbcafc2f0dd415bdcad17b6cb156",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22107,
       "pubkey_ed25519": "7ab2bf116fb3767e63ecaf93accc9f3e886fca3f85a65adc9d3d903571458b2f",
       "pubkey_x25519": "8b7a71a348029063509500c96dbd48acd02a900f02e495e09e6e496183b6695f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "107.189.13.3",
       "storage_port": 22021,
       "pubkey_ed25519": "7ad7b9b4821f7bee2f8a92a1c7cda0399042ba8655aaaf5941539d7b6b03f36e",
       "pubkey_x25519": "101ddc2c35d9e89514bcee4eadd4b6611815ffbe19022a280315e31764687015",
-      "requested_unlock_height": 2064047
+      "requested_unlock_height": 2064047,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22100,
       "pubkey_ed25519": "7ae17951411191a705132cb91e4f92bbc8b68e75cced0b63d9374156ca0d02ea",
       "pubkey_x25519": "80cf70ca96db40e6bbd79f76d4ad2502fcb6b43324b65d473f13c305b57cbd06",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "0"
     },
     {
       "public_ip": "51.195.119.137",
       "storage_port": 22021,
       "pubkey_ed25519": "7afbdf2775dd58bc002bbf47a22e3f4c9f787c14001d7b2d63e0d55666dd628d",
       "pubkey_x25519": "ebf36af75ec50bc51792f53578f805356de3d3c43dbf297dce08f7e2f8763a4f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "167.86.83.21",
       "storage_port": 22021,
       "pubkey_ed25519": "7b499ed44e699b60f98770ec9b319fdad43c71b001ab513b6707095515642f73",
       "pubkey_x25519": "1b4f1508fc1382a06e4353cf483ce4f3bbc09211205f8bd9c9c8340a532c3d3a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "164.68.104.72",
       "storage_port": 22021,
       "pubkey_ed25519": "7bbf133aab2ecfbdd6f12b1eb63701aa63de91a34253d06ae8f8a2161b3a312c",
       "pubkey_x25519": "ab644ff9c87fdfa603d360b76de0eccc66382ea7497c7a191f6df316b6bc5959",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "172.93.108.154",
       "storage_port": 22101,
       "pubkey_ed25519": "7bfa011286a026dc4e762b16c719ad1369abed231f58c896ce0f434fe66a7ac4",
       "pubkey_x25519": "951101a93b1f479deb9d37e94af3f6c9d84fa9345fd643ba9db700a918181c16",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22112,
       "pubkey_ed25519": "7c2faaba7e81c269f00e24e18a8b1ded20fbd6143c26b36f3f10a8b94e85509e",
       "pubkey_x25519": "8520482a53c242a01624630bbedc3d23e29e69ff2a87b4c8a0a5903c0481ed09",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22131,
       "pubkey_ed25519": "7c798b31027f48ca09a1402befcc05ff5f7ce6f36eab726e7fb22d1fbf316157",
       "pubkey_x25519": "716e05ec5ec6325a3efe693ae87ae62e3e0e14d901d755285889d4e3fc26311d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20231,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22100,
       "pubkey_ed25519": "7c94d1cb7051706e8630ca0cfa02daa4dbe1387d1bf2cbc6af8cfa3877e8ffa5",
       "pubkey_x25519": "3ffe5cbed53e1cf3f16391df2d114f23757a239c0f76b669854671c62e054b09",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "51.38.130.45",
       "storage_port": 22021,
       "pubkey_ed25519": "7c963015e206c34c44acbc0c4f0f907f8bf7afa91d61044bace0fee30538fc90",
       "pubkey_x25519": "005a3172d10334d288a1138cfc5dd919ef3209168ce0bc5c26361adc1430d162",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "89.58.28.45",
       "storage_port": 22021,
       "pubkey_ed25519": "7ca44780a2ce74c0cbb5f19d2e3b9819de053f0b71b795d8839520beb71ba228",
       "pubkey_x25519": "148a024fbc1ee7e552a709863b12635b7a5cd6ce39c415497b6dc7b99694a527",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "209.222.103.98",
       "storage_port": 22102,
       "pubkey_ed25519": "7ca6605e5735176d383d9f9b40d7ee7c14a7bd3caf67a149e63d70d5854cd96f",
       "pubkey_x25519": "2e9f2de6c07e4252993aa1663556ced3cfa93929bcdc769b19c13026cb6bdc5a",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "107.189.3.227",
       "storage_port": 22021,
       "pubkey_ed25519": "7cfdac6978fb78be9b293a5db02cd0bdc02c012edefea9f682b2b4baf3ee4344",
       "pubkey_x25519": "15bf7c29f98ae33db4fb03727e10576dc8ad24e64d0890ceb35c0e283f6d4720",
-      "requested_unlock_height": 2063710
+      "requested_unlock_height": 2063710,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22112,
       "pubkey_ed25519": "7d0b4132ac85589d5a61f5f5fd4e19ddd592a7055cba0dcb0b6afbf3c1cc226f",
       "pubkey_x25519": "f39622b61baa77e2c27001447f94ea1c7db5b0d2f815388f4aa23c68a2a13b50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "100.42.179.195",
       "storage_port": 22021,
       "pubkey_ed25519": "7d6ffd56b5cb5c28193829b0980793d8b0a0a2fac8d68a48fbd17a8a71979c5f",
       "pubkey_x25519": "81f9e985b651df9b19d2a60e5d78c9290dc77b8f13e25b8fbdc44c7a5fd2b010",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "53ffffffffffffff"
     },
     {
       "public_ip": "169.197.82.161",
       "storage_port": 22021,
       "pubkey_ed25519": "7e0198af12c844712a1679e86841698d2b3a158451ff367635f7a1df830f92e7",
       "pubkey_x25519": "466928e6e457c1b00c092ee71d51cb1a28032d476ce9eb7b58597a550ac99b7c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "20ffffffffffffff"
     },
     {
       "public_ip": "164.90.194.228",
       "storage_port": 22021,
       "pubkey_ed25519": "7e416014f5f0b284e11ee8f44db13ac1b92f308325fa836d94b6afdb73a4ea2d",
       "pubkey_x25519": "745423298127e2300c62a07d4030f1763135ec29c050708675046e9150c05407",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "17ffffffffffffff"
     },
     {
       "public_ip": "91.231.182.38",
       "storage_port": 22021,
       "pubkey_ed25519": "7e4a23a85ca233eabf66eadc703655b739a4ea53901d7fcf14b0291acfa1cbaf",
       "pubkey_x25519": "4a0efc97126465f2fb68c57c48ed29a10e913b09642a2a097f1b22185df99153",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22127,
       "pubkey_ed25519": "7ea5090d54d527c2fea65576e041e41367944d10a17c0e97cd35392f11f57fbe",
       "pubkey_x25519": "dafb8b67193e698965597dd2fb9a8a5d5b10551d1d10723c411a1aecb3d53d20",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20227,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "84.46.250.250",
       "storage_port": 22021,
       "pubkey_ed25519": "7ea622ec09d5d97618228ef2e1720fd4db6c76339787dc3fa4e4eb4f60318e76",
       "pubkey_x25519": "611cad84eab2a8850621305a6cf944e8acf6644c09d1ef98923e2d193cf35939",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "45.79.95.176",
       "storage_port": 22021,
       "pubkey_ed25519": "7ed09f619798505ff3102c20ade7b80c4496cba0b0c3350084c69af59890e065",
       "pubkey_x25519": "815185e34c53b14d28e7cc144e44577c81dff8d1bc1b9579b7f2cdde3fd77f02",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "31.22.111.199",
       "storage_port": 22021,
       "pubkey_ed25519": "7f0a268df3634a8c216535381639148c9413e5422230f19fdeb81c1c60c7eb39",
       "pubkey_x25519": "73677d79b821f09138db5a6917ef5d77ea000e08363be275f6fa06685e816019",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20606,
       "pubkey_ed25519": "7f3a30b65b017bf2b3767560bef9ec187cc8d0b3f0b01a47c7f60f7b43485605",
       "pubkey_x25519": "29b0a43f1f71e679188ef07d94d474fa09685959ead34b1d14c5e1fa8430362b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20906,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "164.68.101.96",
       "storage_port": 22021,
       "pubkey_ed25519": "7f6f2ddbad8de39a2def4e2116da396d44ddc5467e3878008cfe225a08600f8f",
       "pubkey_x25519": "21ccb7467cf4358f2b8068209529c314c504a939325c24e8838e20214c004268",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "202.61.247.98",
       "storage_port": 22021,
       "pubkey_ed25519": "7fcddde8ffb12751d54df358051dc252a2cc43c4b1ff44e116f325972156e3fe",
       "pubkey_x25519": "f16637c109a3d117de7d93f10a94914eba2afc768f67d3fccaa1f515443bf751",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22110,
       "pubkey_ed25519": "7fea4387c12d9ff9960983bb2b35bd8cde7df7e32c785eeb2d7eea808c8e068a",
       "pubkey_x25519": "9b9300578024a944d155bbaaaa4069f2fe88a7f2b13da291c3834d2923823a10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "95.111.207.165",
       "storage_port": 22021,
       "pubkey_ed25519": "7ff7137500c95b93eccfde27f96580eed08dd2306a13b2f980f76343cba4a2e3",
       "pubkey_x25519": "d3449fe1080612dcfbc4b693fb3620fa685939679e451ee306e144dd443e0e6d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "89.117.23.203",
       "storage_port": 22021,
       "pubkey_ed25519": "800492614e5c7e791a87f9bca3c516189bd35c00d3e5cabf5700c833376a03b7",
       "pubkey_x25519": "a1505c5f55c76f7068fe601350edd1622d773c73f4fdd5b5fb09403ae495120d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "51.75.79.57",
       "storage_port": 22021,
       "pubkey_ed25519": "804fbd40d1b921ab20a30750741c09c409ecd52f3793b4a7e227bfcdb26430a9",
       "pubkey_x25519": "6135c32802b200b80f26ac6fc74af3abcb7f19041d4e1d9abd2bfc9327043b26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "164.68.101.172",
       "storage_port": 22021,
       "pubkey_ed25519": "8079ba6747154a3a5e746e7de10c5d27051ac8280563a460bdc34f9d3d8c91a8",
       "pubkey_x25519": "580b5e0589b89542d2d89e88b53f6b67875f7aa29bcb661db5897d879a767e03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "198.98.52.4",
       "storage_port": 22021,
       "pubkey_ed25519": "807f6154a52ad15bb0b2a6e1fdde2f0bc65e92effdf9ea0a5e60aeb5647a6395",
       "pubkey_x25519": "2086d55b44c5edb1a3ff36cf840d55b15a8a92e3baa37108b693fc142f19ad70",
-      "requested_unlock_height": 2056572
+      "requested_unlock_height": 2056572,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22102,
       "pubkey_ed25519": "813c13fe5a66c1bd79f65b5b96542a30599f60752817ca7088908d23dd7be6f7",
       "pubkey_x25519": "bbd4c670eab649bff9f6964a3bd4accecda15089f11b1a48f79746bdc4634911",
-      "requested_unlock_height": 2059465
+      "requested_unlock_height": 2059465,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "46.102.157.194",
       "storage_port": 22021,
       "pubkey_ed25519": "814ce9c8e2186be0fd1356bc215113e974aa5a22624300788727fa39d5004234",
       "pubkey_x25519": "2b798e4d5e8f5a7cf5a0a3a4c19e1a70596a770a48c0e695130d616bd043e714",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "164.68.98.89",
       "storage_port": 22021,
       "pubkey_ed25519": "815007c26559625e7c230394d6fdaeed0bc64f75caca228bda15446f7d7b4ccf",
       "pubkey_x25519": "14d3b9339cffb9abb6372b1266c4307694b03f18312c31aaf33aa02942e5b95e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "38.45.65.103",
       "storage_port": 22021,
       "pubkey_ed25519": "81ac347100b677657b1475ed96898df4be8651114d42db9a7d238dc47ee993fb",
       "pubkey_x25519": "00c8299f292d9a16c2a63f1c7e3067f488d0efcc697787161b2fef27a495254c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2affffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22111,
       "pubkey_ed25519": "81c1b3edd43d94f10d445850908226b8f6a048ae4788d76ea6cabf1a469b9e1a",
       "pubkey_x25519": "76177edaa0f9a3fdbb5b4b63331f60f83dd364d029db0ca69b5f2a84c637d56d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "144.24.165.22",
       "storage_port": 22103,
       "pubkey_ed25519": "8207c6b0730f9067c550597c8a70841fcfc386fc4399f385a76a5eca6bdddbfa",
       "pubkey_x25519": "aea4944c18a738c9f54033b6316bde8275c8fbeca86e2b0ad8b5425a57b96d09",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "198.98.61.187",
       "storage_port": 22021,
       "pubkey_ed25519": "821616f17ae116be01bc4fc594c2201128ccdcceed0837585cc4c1cb6e065025",
       "pubkey_x25519": "45b301c3cdba2d6632c886757e578b9d5bac7b8d2da612ee6c467a88fb0e0168",
-      "requested_unlock_height": 2056299
+      "requested_unlock_height": 2056299,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22103,
       "pubkey_ed25519": "8238c53ada51602edcc1a97f3b3fdb144e5df22e61787a40062a641ec949902d",
       "pubkey_x25519": "910e9d1ee2a4159a86112a7d0d7fdc0bb6626d5e776aa633365898f4766ea838",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "46.62.196.12",
       "storage_port": 22021,
       "pubkey_ed25519": "828cb764ec2b1ff07f620bb8f3a674db83f0e9b5a6361b6192fb35080c34951a",
       "pubkey_x25519": "5b2b3926d5b601bde5602a8461aaada7ae143b4de17fcc3b484970a97a135d06",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "77.74.199.87",
       "storage_port": 22021,
       "pubkey_ed25519": "82b3daa063bd295799fcbf0c2961347194ba5c0311e5076aead98ef3711b6a16",
       "pubkey_x25519": "601b69f4ebcf8cb0df65ed87d8fb4e0d362592899b97814709e99feb0feeb909",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "107.189.28.95",
       "storage_port": 22021,
       "pubkey_ed25519": "82b416ce66b35cccd47259bb2ab0c0235fa83b57be578c3ef8301ccec631703a",
       "pubkey_x25519": "bdf6cab3037e96c076a5dd8a8a6dc9aee956ba94fbf085acd0e3c148b0681a60",
-      "requested_unlock_height": 2064047
+      "requested_unlock_height": 2064047,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "94.16.107.50",
       "storage_port": 22021,
       "pubkey_ed25519": "82e03ab09568a9035f7f5bf6c7b6c6765c4218b161d945427c9c6ed6ed9e1f8b",
       "pubkey_x25519": "e11fed0bed1d897c222719113c8a8594acf02f97b37d6145cb142bf70a39cd33",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "164.68.113.98",
       "storage_port": 22021,
       "pubkey_ed25519": "83199327cbb14cd9029a3c688c127a86ad24e1463def82f5ecf186b297e90774",
       "pubkey_x25519": "4ce279ccb8e443be32f959889ba7b5eb4872a6d001dd8161fe3585a64d6d222d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22104,
       "pubkey_ed25519": "83fc1ba78dc954dd7431eaa37e9c592ea977b020e220c9c8eb65d880dcb07f81",
       "pubkey_x25519": "aceba8e4109dbf01b64f971e9fbaf064b72d7c575aa3317f2098a4c7753e3705",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "205.185.113.96",
       "storage_port": 22021,
       "pubkey_ed25519": "844b9ed2086461c1d12093b37336d122c165bf154b649117d83dd8aaecbab56b",
       "pubkey_x25519": "31a0bd229dbd2337e80d436c78542bd5a985f6e4d3121bc50f557389d13a0408",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "185.13.148.8",
       "storage_port": 22021,
       "pubkey_ed25519": "846c4f739d7450c4cee8817b0888bc452e52297a24a1f6fb9564aa96830b1654",
       "pubkey_x25519": "b09e31e5b13b40d05c655018457ae6667edf0d0b2ba1c85902d9f29c87e39960",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "45.79.95.210",
       "storage_port": 22021,
       "pubkey_ed25519": "84d510b81c5c6568417a6febf3b3c824ddcf5317e42d47c654b0942c3b1bbebe",
       "pubkey_x25519": "7163eaacc2431c00ec269333f1c62051932acabbbf00fd0e4f18d84704d74b10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
       "storage_port": 22101,
       "pubkey_ed25519": "84daeb764b9c23047cc595a44da14d8dd1c1596f318bc7714025b64d5c660980",
       "pubkey_x25519": "33e98e7291e4686efce62df1ac9d624379b0a26921d20042a85894bb71618b14",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "209.53.217.150",
       "storage_port": 22021,
       "pubkey_ed25519": "8516dbf1a049ca3a2da9771b333b4cc022305ac43a5f92e964d8f0365db88ec3",
       "pubkey_x25519": "17d95f7dbe3c8535762454c54154c70bd7df6a729ef96c4065df3f094554e122",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "144.91.76.204",
       "storage_port": 22021,
       "pubkey_ed25519": "852bdfe8849679de83c876fecfc4de83a3bdca8e1054505ec0c893e15017af45",
       "pubkey_x25519": "bc150853ef3eff27e1ea4fc33a0d6b1ca4fc71b7d36d530cd28219ed2b0df23e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "85.9.214.176",
       "storage_port": 22021,
       "pubkey_ed25519": "85956aea65dfb12c05aee39b043d58672d01d7cbb9ab5f614b4e423cbeb62968",
       "pubkey_x25519": "60f33d25a275f12e7736d515c83c4d25ca7ae142151812ec8298dbc2fedfe925",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "135.125.112.182",
       "storage_port": 22021,
       "pubkey_ed25519": "85c9cc92777fbd46f44dee65939e75d50eb2fdf2ff236e701327dc9ac8328c35",
       "pubkey_x25519": "e91357ffefa1b684d051b86b14a3b83db776179ef47c2783c6e93930e136d477",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "104.237.154.110",
       "storage_port": 22021,
       "pubkey_ed25519": "86acc99bae8079916923df5b8cc5aebad6a08797fda92a9e79c49ef63a938182",
       "pubkey_x25519": "ede08e50eb5026a3b277e9720843a96c49857515fe30b380d6f977b758def75d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "51.81.210.200",
       "storage_port": 22021,
       "pubkey_ed25519": "86f6e6519dbb75107d5b4600c8115466e754cd324fe49a3de296f39506fb2018",
       "pubkey_x25519": "c86be7985cdf193dcd1f8610aa9e99b75b03c90b3eab9039e8e092e922d90907",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22106,
       "pubkey_ed25519": "87294222b04e1fc889af7ec041ea9977bad83d90168c8264139bc18905551ce4",
       "pubkey_x25519": "2edbd263c803a199ef3b72329d5f4423a0624ddd98304b2238b15df6a9b92c41",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "89.58.25.106",
       "storage_port": 22021,
       "pubkey_ed25519": "8769b18bbd1f9e426ebba333fb3e460f09e4f8af7d1bd9a60c53ddac2c3996cd",
       "pubkey_x25519": "d27c1519bd091bc4afe2dd2a4781f8ae341ed7e8fefda582d54d7dcb7e9aac6f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.22",
       "storage_port": 22021,
       "pubkey_ed25519": "877eb2c2313b0b964386cbf26a9370612350c0d5eb9db58e05d4e21cce24e0ff",
       "pubkey_x25519": "887f53006d088118ad3cac971d19295a0ecfbd31207f021ed6af541587a29f56",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22101,
       "pubkey_ed25519": "87cd28e535ccdb096b5e807788c741dde96f9884c117b1cc2ddb1e54b59eea4b",
       "pubkey_x25519": "a162525f611b9e269173cd42fab6477efaa6459361225b3be9ee281766a5c665",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22112,
       "pubkey_ed25519": "87d62cff1e5ac4004c10fbd0d166773e77ccd5cb2690f5090ddb4a058911591f",
       "pubkey_x25519": "015a5b87664bccb6674cc7b5fb3d434de4f2ca89a89743921528dab2f45b8942",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22102,
       "pubkey_ed25519": "87f802d463a9ecbc18667563941f9d8d3e6681c070bce3c8bff522e0c243b3d8",
       "pubkey_x25519": "95627eae5ac1f4b841570120da647c9975d01acdbbfbcc4fce18d59a93c40830",
-      "requested_unlock_height": 2062111
+      "requested_unlock_height": 2062111,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "59ffffffffffffff"
     },
     {
       "public_ip": "157.254.18.36",
       "storage_port": 22021,
       "pubkey_ed25519": "8805f60035554e7095a7b1ebc32ab9fb5c710416047f0860f4c9156582dea6e0",
       "pubkey_x25519": "edb1478769362833cbc80c44335c5eaa76f9e007c06aeef64e34c214d9e40721",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "147.93.40.1",
       "storage_port": 22021,
       "pubkey_ed25519": "883721878c9c6989cbe10fd37b85cf7878b0ac474aa7d7072314cbdd1d672160",
       "pubkey_x25519": "5b3e06f04d85c3f9f34b401d2c4141c4da373f8e0e583e16e50affea624f9a69",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "2.59.133.234",
       "storage_port": 22021,
       "pubkey_ed25519": "887e42dd8254412253ad32a24264a23f8e4049d94c0cc320e394c9c3588a73dd",
       "pubkey_x25519": "19b780ae06937ace7abaefabbdaec4e5debfe295f9a119ea3362b350a6ed6c11",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "30ffffffffffffff"
     },
     {
       "public_ip": "209.141.41.159",
       "storage_port": 22021,
       "pubkey_ed25519": "88f28262dafa51d36ce24540fe127aca3890d1fffe3bfd17e245bb89f2a4b6fc",
       "pubkey_x25519": "6449b0d6522610c7193ca0fc14e628661c783c38abac48893c823baeab957b61",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "66.94.111.202",
       "storage_port": 22021,
       "pubkey_ed25519": "88f41f5e71cb0cc4f8fcac9b7c53c1141df1381616c24b8a9a840ad744b2c073",
       "pubkey_x25519": "34e881c254b368ad620fd1e2c8ead2348e116b68db992dfba8ccdcc6f284612f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "51.81.83.232",
       "storage_port": 22021,
       "pubkey_ed25519": "88f9e05894c1480c1a4d5a295e9cd3e971736172e6adec99ff7361fca22510b1",
       "pubkey_x25519": "a70d3801e8e51df6a59085f78794affc9a78771f6c7faf083316bd279968a647",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "107.175.49.159",
       "storage_port": 22021,
       "pubkey_ed25519": "892c05f37dd8eb29be1cb658cb7cf9819441e2a91929adae23cf620dc4538310",
       "pubkey_x25519": "581309c8b807846f1f71e9d428bf2e7d9f3d0ea02e766546596f75fae118f361",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "64.235.61.16",
       "storage_port": 22021,
       "pubkey_ed25519": "895360bde86788dd31453217e7bf338cfb7b4d4200d33d276600da38c8a6ab30",
       "pubkey_x25519": "f296b3f9bf58c028744df86371c0daacf02a0a75480adf678ba2a9f10818000d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "51.79.161.47",
       "storage_port": 22021,
       "pubkey_ed25519": "89a86ea666c66321f8df2155eaa8806d31073479829b173bc48756f879c90ac3",
       "pubkey_x25519": "8401cd11eb2b2ac02ce8b2073ed36c3f614cb48e1e8d59fa1a0a63f6a1eac046",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22138,
       "pubkey_ed25519": "89e12490290fc846e0f94d8394cfea6f0d0a39e6bfec2b8fec271e0fd0461ccd",
       "pubkey_x25519": "098203db37ab1c046a6a2c851c46f654dd81cf48bb53471e0944865951cd485f",
-      "requested_unlock_height": 0
-    },
-    {
-      "public_ip": "87.106.236.99",
-      "storage_port": 22021,
-      "pubkey_ed25519": "89e86ee4de0bfcea80109745951e5f1d7bae5b59073c02c49ace4adf619f367f",
-      "pubkey_x25519": "2b8d67a629c2a8864442cb09d769ee3461f61bd339daad92d3bb2d49b26e956a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20238,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "205.185.122.57",
       "storage_port": 22021,
       "pubkey_ed25519": "89ee6a41e97caab579fa4cce0229aef64febed9bbd3575885381c0097e8ff169",
       "pubkey_x25519": "264ee92375d89fccdaa5a9fe12420ef4324897ddcbbf3dce18909e5a1daa625e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "37.27.212.116",
       "storage_port": 22104,
       "pubkey_ed25519": "8a15a2f64315c6d92f3971c8950e594f7fb14f5ded248cfaeeca3801caf79ed9",
       "pubkey_x25519": "137d040e043f2df125d938d7c9fb727df9ea7570cb7663b256a9c17facc3a525",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22102,
       "pubkey_ed25519": "8a87b17dc53b23ea61b736dac98f8b69f7ce4bba110b1a494f0cb50d71d897ef",
       "pubkey_x25519": "09a0810d62a519b7a21d2bbe909621044d3c4760ee2fd8374ef5e1bb69466b30",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "146.59.16.179",
       "storage_port": 22021,
       "pubkey_ed25519": "8aa0d7409713e853334bb02929dc0bcb73f7a184638f99b2341d2f6b2efe77b1",
       "pubkey_x25519": "65612fc5316aacd1dc4491cd546797151e82e59543f32810c011c33fcb9bcc50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "94.72.102.238",
       "storage_port": 22021,
       "pubkey_ed25519": "8abebf54a1a3ad76c57c42c612c0861b7aaef73437e3490df9545d86d6fa009b",
       "pubkey_x25519": "eac540a4779d218acb5aa91552e603ac65c6d500ad90d638c572231977f1b178",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
       "storage_port": 22102,
       "pubkey_ed25519": "8ac8bdcf83026d1929708b120404a1e21331be9a992b8eea9e2b4ce9fafad4f7",
       "pubkey_x25519": "ed540b22bd5c6df9175dae29427f32d833cf03f993d1433d93e86971bf318111",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "64.227.69.108",
       "storage_port": 22021,
       "pubkey_ed25519": "8ae307d9d796f59b6c37bda86101d65a3d062a083cd134d7c1918404325534b3",
       "pubkey_x25519": "21da188c49abd3ba9d63025922ef49474e6d46b009b79e4115ac67ef1cb0d10b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22118,
       "pubkey_ed25519": "8af0d990c8fac42829db9e2b7fa434c417a095c064d8098a7a21a7a991231fc3",
       "pubkey_x25519": "ea11eac805e1e1dd87239a5075278b0bdd6668fd2194704c7eb5d4c3921eaa2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22107,
       "pubkey_ed25519": "8b08a0745f7649bd5ce44efcff6f12c8317a98e686fa41929233a9413246af86",
       "pubkey_x25519": "16dbe78775aae7116b61c3af5a1d8166400f74d1e8ce434d6608e92af85ea839",
-      "requested_unlock_height": 2059344
+      "requested_unlock_height": 2059344,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "107.189.28.108",
       "storage_port": 22021,
       "pubkey_ed25519": "8b0d3b6b6d07fe6127bbe426eb5c5f139906c7b56bb4cf4af35b4806c6aad2cf",
       "pubkey_x25519": "4d8ad64d21e9a422a95fe859ac5b70964ee458266877056db6529d2ebf057478",
-      "requested_unlock_height": 2063710
+      "requested_unlock_height": 2063710,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e5ffffffffffffff"
     },
     {
       "public_ip": "45.84.59.88",
       "storage_port": 22021,
       "pubkey_ed25519": "8c1fdeef2ba20c5d94ccf6e482640672812be0792c08800f0514e49e97e9cc97",
       "pubkey_x25519": "cccf66b7e0d34feb8d8690c96897ec7decad4165f249dcad0ab181c4ac9e561f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "129.213.162.17",
       "storage_port": 22021,
       "pubkey_ed25519": "8c1ffae994bee3613ad03438fb8248406f87ae70949b3593969c1be3ae1fa0fe",
       "pubkey_x25519": "f0925d63c8f0be0323b635cabd65831b705ed0473606c9f3ece2ce8f76af7f35",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "30ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
       "storage_port": 22104,
       "pubkey_ed25519": "8c34fbd9d47876f9d9d57ebba8329e8d9a66ee482019f3ea19fce5ed920832b0",
       "pubkey_x25519": "a08b32ecb09898f9513557591ccd38a690e0933daf2b84934e620731a2192840",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22106,
       "pubkey_ed25519": "8c58a4acd16066dc5fc2d390cd35d99aa69a86f531132a92d832df47d0301077",
       "pubkey_x25519": "ab17239582b0f6756f5eed927f53b8058c0fb245c16ca07e5d6cd2a477a03339",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22103,
       "pubkey_ed25519": "8c673b74801ba27a2c23596d681ddfe77fbe17ff852a922f93de410b23721eaa",
       "pubkey_x25519": "52958f5feacc4243466a9074815d1780fecbfff363f7463367982727921ed464",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "88.99.195.142",
       "storage_port": 22021,
       "pubkey_ed25519": "8ce3bd6adf8bf5d5fe68f19ac26de2befe5e1b75358cd965860d13c25f28aea3",
       "pubkey_x25519": "9cda29c9ce7582fdc73d1f95ce8bdc9ebc873f75b632f8f9b3b641f666ea642b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "89.58.10.191",
       "storage_port": 22021,
       "pubkey_ed25519": "8d6bb688c12bd77bf06f6ef3b3aa7547eeac45e3f9b3b48d4c5cb9eee4c45244",
       "pubkey_x25519": "c4287c64e654b001dda048c5f7820a511a494c5e8d9074897942d2b6ed5e1171",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22105,
       "pubkey_ed25519": "8dce517ab5e22a9df9792f909cdc4969d41106577c8d0c28a533dbeb36dc3652",
       "pubkey_x25519": "928d3e54ae161f098e3c1fd6bab8d5c1a2b98addaa6af4f6b07b499e4f208671",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "147.182.176.227",
       "storage_port": 22021,
       "pubkey_ed25519": "8df8d50108a84d417708c084688471cc4f81c0ea397f67fdf424d99199b74422",
       "pubkey_x25519": "b470250ca09a551f08699108a5b249817816757b7c6e494a143c6c2a60cdf322",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "104.233.210.15",
       "storage_port": 22021,
       "pubkey_ed25519": "8e07acd1a2708c865b6c86907b6327f42c153b8ad8affd87c08f03203a8f9444",
       "pubkey_x25519": "cc2710acd79fc1ae1cd0cbb124977109f6d74d1d3ca554efb7e044e03825e27c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "51.222.106.156",
       "storage_port": 22021,
       "pubkey_ed25519": "8e33dc86d1746a274e3c9451597f948ef44b492a6aff7c7b9474e569d8bc85d5",
       "pubkey_x25519": "afadde4249288a23455c5f27f80ee020bb500fd7ad334fd43ef11a0bd2b2b16c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2affffffffffffff"
     },
     {
       "public_ip": "5.255.102.187",
       "storage_port": 22021,
       "pubkey_ed25519": "8e4248d15cb8f5ab3885e8621a8f3c6958af0e110bbcfa2ea2da33aa4bcab982",
       "pubkey_x25519": "8f005491a6259dc2dbc71bd9eb037ed4307f2bcd2a5c438a6e61c287191a531e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "135.125.129.15",
       "storage_port": 22021,
       "pubkey_ed25519": "8e595b54efb07a390d91527a2de05bb1207ac62a0875ad8b23e2581c1ec4738c",
       "pubkey_x25519": "6a606715d334b4ba6a89f41fef4400128b910ded31fecd5562291ba0d5c95933",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "51.68.138.95",
       "storage_port": 22021,
       "pubkey_ed25519": "8e64043bcd5db8a8daa894d8bf6a8735d1efbce1a74e591cdfbbb82a615fc4ec",
       "pubkey_x25519": "b97829fb7ada629bb75e240a25b04a561b20f44bca99639f1a921a69af77454b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "198.98.48.151",
       "storage_port": 22021,
       "pubkey_ed25519": "8edc160b25a2e5f5df1be04e9ee516112cc56b2e4b94c192d5cf5e6d9977fc13",
       "pubkey_x25519": "a0c2d98f4a180e772e0f76b0e9afff3cb80f75839ac320ed6938d7d019c42c21",
-      "requested_unlock_height": 2056574
+      "requested_unlock_height": 2056574,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "217.216.35.231",
       "storage_port": 22021,
       "pubkey_ed25519": "8ef6849155b1a12ecddbe488802b722b835d9521b90d637a5451c84b3a560d30",
       "pubkey_x25519": "8aa3bd4f3e1ccd061a3a874bb45adaa8ab687802ad4c084ef6b988817e95772c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22109,
       "pubkey_ed25519": "8f471af3c6c110430c3fe118ab1c132dae8586eb5986514eb6dd1efd5a9ae57a",
       "pubkey_x25519": "3d1c8a02b66bb57a39474942127242038697bd8ac29b7cd948d90ad0fe6f2f79",
-      "requested_unlock_height": 2059466
+      "requested_unlock_height": 2059466,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2fffffffffffffff"
     },
     {
       "public_ip": "209.126.85.21",
       "storage_port": 22021,
       "pubkey_ed25519": "8f7de0bf397565eeffcacb1e04cf53007ba2ce7ca4ae4c9bb77542d95fecb7af",
       "pubkey_x25519": "6482660ce17aed4867c7252eaa55eeee3ce42d60d34e252208b4e641c36c2935",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "15.204.236.128",
       "storage_port": 22021,
       "pubkey_ed25519": "8fc3edc358d03320c45bbadef61a867d599beb58e42ad7cd2a5742aed91de229",
       "pubkey_x25519": "3e4ac6eea7dc0f7e46eb2679ea3bf50e663d296e76f026e625598def9f4f595d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.33",
       "storage_port": 22021,
       "pubkey_ed25519": "8fd07437dffb94b56e713f70fa1ed6cca7119bb9b1a80c52047bd38257ff0403",
       "pubkey_x25519": "43d158111794ba1cd64b553638f7ee5818f4d9bb690c2c1f52bd57e509327f3e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "45.33.56.54",
       "storage_port": 22021,
       "pubkey_ed25519": "906296b8713a62ecc14eafca0ce217d7a668fd1ed1abd2c229461f100ddae139",
       "pubkey_x25519": "632402191c68eae1bd560a76bc74c10a9032804930d5d4ae520c83b096ed6f76",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "38.45.64.146",
       "storage_port": 22021,
       "pubkey_ed25519": "909b82b2a7212c1810027fadc912054d7fc6ed2ec2575ab0773383d280c3f207",
       "pubkey_x25519": "641d90b6d9bbb5a2d596390158d6e01cf75c767f34bd1910273ea297ee483624",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22101,
       "pubkey_ed25519": "90a74727ec61674fc013228927276187fb9fc42c8e7bc4012192dfd7bf00dee7",
       "pubkey_x25519": "5a4ccbeaae8ba04273c67d1a3be82ce275356d7f21853f0b5e6f283ca286ed41",
-      "requested_unlock_height": 2056796
+      "requested_unlock_height": 2056796,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2f7fffffffffffff"
     },
     {
       "public_ip": "198.98.55.4",
       "storage_port": 22021,
       "pubkey_ed25519": "90bf51a1d948e2fb84a36347f97ebb975a3b9c6f669e7e60800f034a1653bee3",
       "pubkey_x25519": "1e3d404a44a61f40d0a2e33f83a931e0cf5af2b6d3754bc65c434ebaa4218717",
-      "requested_unlock_height": 2056573
+      "requested_unlock_height": 2056573,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "107.189.1.61",
       "storage_port": 22021,
       "pubkey_ed25519": "90ec88ed886a58d0ce3300b42bccf5f10a07646276c54ded13ad0bc70c1a84af",
       "pubkey_x25519": "a3d1c6106ade775b9af782df286341a97139d5308b456a01432444da163d945e",
-      "requested_unlock_height": 2063712
+      "requested_unlock_height": 2063712,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "64.235.61.138",
       "storage_port": 22021,
       "pubkey_ed25519": "90fef69704f7b3378a2bf0e98ed49d8439897db4b08196726374027e9cc20381",
       "pubkey_x25519": "ca2b33e7cbcfc1ceea0351d6218c2e6914b208763848c27ea23aaf6173e15846",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22112,
       "pubkey_ed25519": "9147c04478c28527f5b4a54479c6f139d803646767cf0190b3bd2cb62aff2fd6",
       "pubkey_x25519": "68eca17af350821424b42f14d9247728ee2cdbeaec988f9352fdc620ddf8bd3e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22115,
       "pubkey_ed25519": "915f066e9424e92663cb2fdcc9086bb028b0367bd6c8807a569ade237bd91da5",
       "pubkey_x25519": "9f304f227c28d1d5bd623b9dca00a9d50da630133ce25147f09bfceb772a5078",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "2.59.133.53",
       "storage_port": 22021,
       "pubkey_ed25519": "91da3f26c61eb398058e62822802fefcf7ba88f49ca18cbd48a7193c0fe24f80",
       "pubkey_x25519": "3d756f10cf2525db325a4f628064480df1022f40145445e18c6d40dd7c74b613",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.123",
       "storage_port": 22021,
       "pubkey_ed25519": "91f3bc97d4b0e7ed309d977060f5b0d1f55fb7e559010eb0ca2f737360e86c5a",
       "pubkey_x25519": "990ed567bcc45d327588fbfda92c967ccca93cd93177d16616d152526138cd0b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.111",
       "storage_port": 22021,
       "pubkey_ed25519": "9203221c65c3ee14cade3beb8e57a393e127102ea06e3e07591d082c71926633",
       "pubkey_x25519": "5101cc24afc83090182da317a193fb79e6aae58479ca40e60e5d9749d0eb8e6a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "164.92.211.163",
       "storage_port": 22021,
       "pubkey_ed25519": "925b7c0e7a5ed7109dce7a116398fb3b7ec81ac218674bf760523ea521aca80f",
       "pubkey_x25519": "fd2894aa965ffa5bc237d45d05f04d23e1ee1fea39db58faf2903c381fb0036d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22106,
       "pubkey_ed25519": "92c4e00b8a69a749c575075be0353e7f9f53eeab0748ee8050467ae688917efb",
       "pubkey_x25519": "da7562d40b916ede47ca7874387e061dafd9323e6c597293756c35d3aae40f24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "38.45.67.208",
       "storage_port": 22021,
       "pubkey_ed25519": "92f6d3fc8b83eaab3ada73e1119fcf647eeb8fe419e1103eb2fcae290ef348a0",
       "pubkey_x25519": "af4ecc945c802cd8ec5b243b0f00073c2cb6e0db1ec6240954bad05ad594e010",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "30ffffffffffffff"
     },
     {
       "public_ip": "50.114.206.217",
       "storage_port": 22021,
       "pubkey_ed25519": "931fed63fef8fc81f768c25b317bd57afa361724ea7fc8a90ae5cf01b6029ee1",
       "pubkey_x25519": "d0817807d701124875ee85ee65cb6e610653f6c08beebed7a030a9a9b259a464",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "89ffffffffffffff"
     },
     {
       "public_ip": "130.162.50.158",
       "storage_port": 22103,
       "pubkey_ed25519": "933a81bbdc8ec6ddbf512654027dcebe3d4bcde2b072b0d8a292cd0865be1622",
       "pubkey_x25519": "8506076bd6ae88401866cb631556c3b883fcf166bbe656218e4244001e50644b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4effffffffffffff"
     },
     {
       "public_ip": "154.53.40.109",
       "storage_port": 22021,
       "pubkey_ed25519": "934032562001b2f7b8c1df3eaa85a12da15c50f37060004fb36fad1851bd345f",
       "pubkey_x25519": "9b51be97f59b426e33f89f1edfe76edba2157d59f23b9636e8bd17ce5b954745",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "164.68.98.105",
       "storage_port": 22021,
       "pubkey_ed25519": "9353d7d130edcf285b08845e1edd45dcfb9e70c80d1ecc2f1ac575cec7f5f535",
       "pubkey_x25519": "92f4ac9d8482af346c0bb27d63b3f5e218f816bcbae3937948cac8386060174f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22102,
       "pubkey_ed25519": "9379c2df4b5e3e3a2750b6fc152546ccff8e1b69f919b015ee47b5a3edc027c8",
       "pubkey_x25519": "f7342283a4e16cedb3d1d528d073a77953b2a55950c386bbb4d072e82c2aed43",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "45.136.28.239",
       "storage_port": 22021,
       "pubkey_ed25519": "937af3c2767bf9608919dc1954d6e18a60efded35d0e032138ae8fac8a3d0b2c",
       "pubkey_x25519": "330905716b2fba937070fa68915eae60e21f522359d128e5ba30ae2549b4d40f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "5.189.152.176",
       "storage_port": 22021,
       "pubkey_ed25519": "9381e658bab25a7b52371b0966dc9ab8e493bee98780fdb2e6fdd2074661064b",
       "pubkey_x25519": "0b5e8c9df69c9c7191b86fdebcf54c4bfa1984ae91c0b85a7d3199ce080ec972",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "107.189.7.179",
       "storage_port": 22021,
       "pubkey_ed25519": "93a002bb3815db4be19296e6937d4cc23b94e6afa45b1d1dca608ecc8fe9ad9d",
       "pubkey_x25519": "3e5f81fbb2fee9cf5584b80d0d83068b23469888d635ebddd94397339fc55728",
-      "requested_unlock_height": 2063708
+      "requested_unlock_height": 2063708,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "107.175.74.23",
       "storage_port": 22021,
       "pubkey_ed25519": "93b7fa8ebea4cb213ba0179e32af6b985a036e669deba5cb5166bfd6b414de25",
       "pubkey_x25519": "cc04e4eb32b95df80dcb28d7bc8146208dcdb8b9607f53bdd7ac2f149d26303f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22109,
       "pubkey_ed25519": "93bd41c0e972696d86bb66e6962263bffb8a81c67d0983ef2425a1e78a7eb2bb",
       "pubkey_x25519": "5d48ea8b4c4ac1ca369f82b6fab5bbd9b01f676a2e78719b322a173feb44104a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22122,
       "pubkey_ed25519": "93c05f2c75a454bddc1865c77b0fa1c1b4bd45546c2478b7723d781bb6d00ec8",
       "pubkey_x25519": "ef4a6ed78969be1201e9bc2d3417cb75a7b8d64ec80273aba5a09243b02fd671",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20222,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "178.157.91.16",
       "storage_port": 22021,
       "pubkey_ed25519": "940bf0393cc2cf181719ef4e9b423bcd62d093a8579a8d44851ee30e490da693",
       "pubkey_x25519": "c0e1f0ea711edb797cb3160fe289c9aa629465bd6aac995e3eeb875f37e2d428",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "164.68.101.160",
       "storage_port": 22021,
       "pubkey_ed25519": "94543f863a76ba6160524bc02ba2c788cbaf230f4deab2e5f6599211f6f3a7f8",
       "pubkey_x25519": "86c8a9de9ae483898c4a5513447827d11fd8fdd22f1fd1b8862a3be8b9bede49",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "5.196.114.122",
       "storage_port": 22021,
       "pubkey_ed25519": "94c446fc486dccd33d7dafafc0c084f2937e77096fb855790e44649ff1c5f5b0",
       "pubkey_x25519": "a8f70439dec8edae7f45cbf5a9b09b05969d78f9fce2417b02c6ab123217dd28",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "161.97.172.143",
       "storage_port": 22021,
       "pubkey_ed25519": "952091b3bc7e59df90bb61169b6e0b684a35286eae9c05c5cf709ae2ff59b344",
       "pubkey_x25519": "dd7274b21deb4d344a0dd514a36f2b3cc9f9bb500db48a96e87673c89c77c754",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4cffffffffffffff"
     },
     {
       "public_ip": "209.141.33.235",
       "storage_port": 22021,
       "pubkey_ed25519": "9605c916463a0db24c527512d7b5a6e3d82b23eef24e3450d225b72e24bb253a",
       "pubkey_x25519": "1978a77662cc18050f7784fb7ca7a6b1ebe2b7d993ec8e44155ae071ed9f7a16",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "198.71.58.236",
       "storage_port": 22021,
       "pubkey_ed25519": "96ab7cc8bfbb4a481f1304a3a502700960568670ee1272892720dc2d6cf4f499",
       "pubkey_x25519": "2d97d6a852e825304c7420658fd00a5fb6651550789b83e09b2e493c3ff01f12",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "5.255.118.220",
       "storage_port": 22021,
       "pubkey_ed25519": "96ad275ae0a89cf0f665cd8426ed5ca6c1ecf983c6a879bdd070d7db91973cab",
       "pubkey_x25519": "f72ce7632973cece16cf4a8b97bea55c505f24d4f1f378330884796b4b810243",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "107.173.244.40",
       "storage_port": 22021,
       "pubkey_ed25519": "96c051516c0dac60022fd5f9163e131025dcfaa519a1d8fe9728545c43618d0f",
       "pubkey_x25519": "44f8347f0741923d505be9eea51f3b320d6b8783b723e7a6b41acf8cc67a6f37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "46.62.169.159",
       "storage_port": 22021,
       "pubkey_ed25519": "96e1b538f4b7e43fe2318296253b2bdcaac29b8dd766ccdbbd5793926809f775",
       "pubkey_x25519": "1ca9b217909a6088c9972fe60168922e1e8c4c7180500488f929334b0d382962",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22105,
       "pubkey_ed25519": "97dc5c8f449ce764f01b2de82fb32c308d20892049c5d9ca24f554782618ae77",
       "pubkey_x25519": "d88e3e68b8b791edaf3b8c05087a9d3146b7f1595d4ff1d98ae0376fce65a365",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "159.65.196.229",
       "storage_port": 22021,
       "pubkey_ed25519": "9801c7dbabfeea5675b2b6f8bcbccbaeb653fbd07177d575adb73ec7aa260f3b",
       "pubkey_x25519": "26153c6eb0af127dee7bbaec4a40ec5b9aa1b702fdb256d71ff82ff79f357e58",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "96ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22120,
       "pubkey_ed25519": "982f54b09c8a817489c0b9a68a023182415a4d0a14a4beeabae54be8b10c8d80",
       "pubkey_x25519": "3faeac009e0cb1f85b1633b7fff298fa608958e07dea6029eb6947ffe999fe2d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "159.69.19.204",
       "storage_port": 22021,
       "pubkey_ed25519": "986dd5bdcd432dd5b0779bc83878d44e704f9ae0bed215a1a7a4324509207d2d",
       "pubkey_x25519": "6436f0e29e70f06f9327bfc59e8666d7f863f788f52d9891f64ade2285e3df4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "38.45.65.60",
       "storage_port": 22021,
       "pubkey_ed25519": "98b1932491c42797481dcd9068d3dbf53de2b3cf61ae85a33d29c3b0c9843485",
       "pubkey_x25519": "ab802c2f10f2ffb3d016505ef2577eb512203c06c836c15da9d5886521bbc16d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "217.217.250.41",
       "storage_port": 22021,
       "pubkey_ed25519": "98c838df51a2e5599f675f38448bba83e627d8b471db857ef7755bca2700b9d5",
       "pubkey_x25519": "c37e030f79e901712ce18d89b7eaad094ddbaa26d343c7c90b42a84186301f02",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e5ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22113,
       "pubkey_ed25519": "98ce73b325859a16b906d7d1a0d568b4fed2b1def950ffa07d07f037455ebd79",
       "pubkey_x25519": "1399501c0e94bd1f8dc7f7a1e13bb031437b646fdf9271a42d3502fe74ce593d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "45.85.147.254",
       "storage_port": 22021,
       "pubkey_ed25519": "99347815b79a109f91a369568dc7276c7fd551769ca4fb39bd90bf3cd9ad44e5",
       "pubkey_x25519": "67bfc5797476e96a17556631eb1088bd0114dc07a0ccff7231a1ae4b9caa406d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "91.231.182.121",
       "storage_port": 22021,
       "pubkey_ed25519": "998db74e3db1dd3c3f57403191c31177973d68ee70700c82dbc70baf908b03e8",
       "pubkey_x25519": "16bafd5d3f86638f9e7ee50b18f691c7e2a03d74279e0574d0d56520cd8afb06",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "64.235.39.22",
       "storage_port": 22021,
       "pubkey_ed25519": "99ae8886e286c1ff38e6d367acb71127e9336e9a8864c9a19e2ec659545bc58b",
       "pubkey_x25519": "96a2e9460a337245a06b019c38f778ec2ed55f939dd0a29ff2985ba26d29966c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "157.173.192.73",
       "storage_port": 22021,
       "pubkey_ed25519": "99ce8d112edfe8059f44be61d5cab23f4962fd65d38fee3bb90b8e7d2d7972a0",
       "pubkey_x25519": "2f143aae388ed5fbd5d67736f5679fcf5769204d3741579a5768d780ae4fbb08",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22114,
       "pubkey_ed25519": "9a189679a00f60dc0ec9a862aec30d6d7d723f24fcb762dc9a1a5af8b4a74543",
       "pubkey_x25519": "b2d49fc76602944fb374aca34e5498b649331a1ad5513da1b1360af826411e31",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "198.98.55.38",
       "storage_port": 22021,
       "pubkey_ed25519": "9a19a3c86f8b1c6a78e14b49f4bdcd1a35a5aaafaaaafce74801375ba7addc61",
       "pubkey_x25519": "49165f938ffbaaaf9db10a677ca474a364ed38a6714e150871fa6c3330145e6b",
-      "requested_unlock_height": 2056294
+      "requested_unlock_height": 2056294,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22106,
       "pubkey_ed25519": "9a2cedc085daf9fd7657d697296c3f9f16c69546b33c572d9d3bdb123e599bf4",
       "pubkey_x25519": "956006352fb70f90a56055002b5ec98817390dca32556ddc462424ff83d8dd4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "152.89.29.36",
       "storage_port": 22021,
       "pubkey_ed25519": "9a36451dc3e053971ed11a26453411ce69eb462bbbdb1f09efb0ec1474146fda",
       "pubkey_x25519": "9e7e15bf8577af7ca6951042a4d3cdb5f6768b46ce3739a0e27b4e068fbebc29",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "89.168.69.126",
       "storage_port": 22102,
       "pubkey_ed25519": "9ac8055c3f1196c3fab2364b0a4b0c287ab24aadd69dd446b7950cfe3c9dc5f8",
       "pubkey_x25519": "3d8a3bd2000bad419028b94cec12505395ce931c6907c43571960586b1e4c028",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.68",
       "storage_port": 22113,
       "pubkey_ed25519": "9ae0be5d75076b694e8b5463ee586b3321fbc176bf67b9bb6efb0215eeb37e18",
       "pubkey_x25519": "ae7429e21e57f5a57a9509e11892b02737cfa0a604ccda3ff57ac8190294bd2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "23.88.103.210",
       "storage_port": 22021,
       "pubkey_ed25519": "9aeab67aa26c531e6ee877273dc043f4a53fc7c9346b4b2d3f2531f44668e07f",
       "pubkey_x25519": "7c4bafb237f6f86fb6cf0cd792cc16547670419dea2e935afcec05478be1e865",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "157.90.226.160",
       "storage_port": 22101,
       "pubkey_ed25519": "9aff986e48c4ff07f6ed909d03039366bb3dec4e8279925a70be9fb1811b979c",
       "pubkey_x25519": "20f5b0d0c0bcd6e2b6c006358631e556f5a05bd8b1da9779929a67ca607f1643",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22104,
       "pubkey_ed25519": "9b088fc6da3fd916830f885f20500fc9e40cee5b625ea2765fa4bed590e7151e",
       "pubkey_x25519": "6e0f96b8087f8d03605314f7c37cdec13b86b314921754b147d0d23f9ced2d17",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "51.68.71.134",
       "storage_port": 22021,
       "pubkey_ed25519": "9b0e855f46cd9a5f2ec5588a1c5ae80751b696e05a9c3a379a87eb74399e4119",
       "pubkey_x25519": "a80563f280a823931818a208126608c90faf0b5fe94d5dce29b65358db8fb441",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "192.99.169.55",
       "storage_port": 22021,
       "pubkey_ed25519": "9b95e6d4d6bfd26abe0b0c26a62bbf32783092baeb13b053bd58d42525ca34ce",
       "pubkey_x25519": "b7472f9a18dcdb403d385c3cd2a50a22038d5d0b49b5cf296d45d2d7498e4c0e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "192.155.81.197",
       "storage_port": 22021,
       "pubkey_ed25519": "9ba3b9de1081c17e01afeb52d58c661ba1d5221e66984e54b1fc16879b91d865",
       "pubkey_x25519": "abd2b2bf5746e3276a02c503626ad1521c6be52fa215a8f6e03497f810a1b549",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "46.250.252.180",
       "storage_port": 22021,
       "pubkey_ed25519": "9bbf350a687311f15f20f2e7bf4e79f62b9542b565ed865a8c3166211cbeab1c",
       "pubkey_x25519": "d7439f534d2fc9d509caf072db7c5347507f9a64784bfb8615cb10419095984d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "135.181.90.158",
       "storage_port": 22021,
       "pubkey_ed25519": "9bd0d0249150dd2b3d9982e75359b5dde4777692cd0d3136b3f5207a4c484fff",
       "pubkey_x25519": "436bb0c8aadeeac4e64dd4623bd3257c7c9c26575a37bec3178848d604a75e6a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "51.81.202.49",
       "storage_port": 22021,
       "pubkey_ed25519": "9bfb491a08db3e778f0bc10f16bfb3cbb9a69fd70cbd45c9442bc96f62f55e6e",
       "pubkey_x25519": "1841629d11dccf5d2bcd2a0e2b9f8701b611e86e36115850afc965f0281e0756",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "108.171.193.114",
       "storage_port": 22021,
       "pubkey_ed25519": "9c2355c4257ae616e2cdfd48edd454e8479347bfbc439dba5fe560372ab02c93",
       "pubkey_x25519": "5b77a33db624a083ba5186c94e02af3867d9402d836cb41d86e0d947951e5e0c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22110,
       "pubkey_ed25519": "9c29514b20632df0afbabcdef88b1bf0befd8946d99e51bb13e8b8754b48dd58",
       "pubkey_x25519": "baa4685cdce3f5812deba90fb384d2bd7c2ae1710fdbe38dc15131fbe6bbb655",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "107.173.166.139",
       "storage_port": 22021,
       "pubkey_ed25519": "9c8593fbd6eab37cacd56c74532e71f1c265b48059fa11d6c927953d2a94f692",
       "pubkey_x25519": "5a366f953fcccf34c4e2ba8b3c727af668ddfd5362ca6651c9adb8bc6332f31c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "407fffffffffffff"
     },
     {
       "public_ip": "217.182.206.34",
       "storage_port": 22021,
       "pubkey_ed25519": "9df272ebc0dcde5bb245ebbdd17655d5c359f222b66c76f6a6d917407d1f273c",
       "pubkey_x25519": "d4e24eb85de24627aec7793a4053f4af41e523d60db3547d17ace406e1733942",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "62.171.174.143",
       "storage_port": 22021,
       "pubkey_ed25519": "9e4bbc06a736b6b8389f06abf2a32165d61a5fa4db65edd696fe40adc983cadc",
       "pubkey_x25519": "36f9a0bc430bb96c65c6ddc2fb993801292c73ed8a4dc74d7fc105b55c24d02a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "193.22.147.70",
       "storage_port": 22021,
       "pubkey_ed25519": "9e932ffcc0018054ece1f65f8de756cd30c540d9ba06aec8d9ca41bc59022dbe",
       "pubkey_x25519": "b781a29667fe8054691e8b585471a61bb18a96e4ced9d7cc494227eaa4d99b7d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "139.162.25.130",
       "storage_port": 22021,
       "pubkey_ed25519": "9ed94ce28b048d4eb50a0d6dd46baeb7c8b7bd7ed87dd75f93ec22b30adcd69b",
       "pubkey_x25519": "18f16cf8c3a5bed67d2aa2fb901e778873e5c11b99c016eb9fbd2e34be6fd850",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "138.197.173.72",
       "storage_port": 22021,
       "pubkey_ed25519": "9f6c18fcbbe27995134e5298a8fca34c51c1e5fb00563681823523f1796caa72",
       "pubkey_x25519": "9c7fac8319a71bf76d93071cf948aef982e7ef4de517251ffa100a21bc412969",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "185.234.52.249",
       "storage_port": 22021,
       "pubkey_ed25519": "9f6cc182b192f4eacc10d1ac52858daa0e4beecc0928239165344b61e0bb4cc5",
       "pubkey_x25519": "2ce63b89f905b72380bfada438900b9fb154b80ff5a7b94e516475537b98e500",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22109,
       "pubkey_ed25519": "9f91c9a45936503fa00ec0ac21f8bc023e0b51c9b4612a3ab7611da0afd12e1c",
       "pubkey_x25519": "fd44f7a89163134ff5bfcaa61889e5bc21314a0e68519b7be09db3c6c004d055",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22409,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "192.53.126.238",
       "storage_port": 22021,
       "pubkey_ed25519": "a005ac057d7764d6ab0347b2d9779f03b4645eaf33f804f89f4855a2af89c5d8",
       "pubkey_x25519": "ad78425dd90a771d199fe2570d6655f42130793f1ebf7ec8ad1f7d171f3cdf73",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "94.237.81.75",
       "storage_port": 22021,
       "pubkey_ed25519": "a03ab4097997be3a3a99c5b47561c1fae5a9c6c475c4af70ab143058a72eea03",
       "pubkey_x25519": "973f95080b142eafccc4eee21de5f2210578a2ea937803c196a2fdb14229216b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "140.238.126.154",
       "storage_port": 22102,
       "pubkey_ed25519": "a058fd0fb97a297fbfc80c42836537df8f09a59a0232673adef1e5047762e9ac",
       "pubkey_x25519": "50fdc5bd50c430981c49c50fcbe6a1e0862d539b45a3de955120348868b38f37",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "107.182.173.89",
       "storage_port": 22021,
       "pubkey_ed25519": "a0696c69aecba4f43bf1723a5f5e2412c9ee2f2baa82ee749af8b418df4c6b6c",
       "pubkey_x25519": "2cf859417fd7065fa47031e672bd19c00d0d365f6e5a24a293348d623f87b14e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "193.42.11.100",
       "storage_port": 22021,
       "pubkey_ed25519": "a077d8536c9260ac47a624d61acffedab62aa61e1d0fc7a311631c3f1eb80bef",
       "pubkey_x25519": "750e06cc7a89a635da35405f1afffc123cf3fcdc4f81af7d020f1c575246d77f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "173.249.18.34",
       "storage_port": 22021,
       "pubkey_ed25519": "a0cbe49dbbda77d81e6f3972a0714bf62cbf09035d1c1113529a1d7904004b89",
       "pubkey_x25519": "8beaf910738a79aa16233489ee44591dbb4aebc6bcd55d3ad70c810438cb8657",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22102,
       "pubkey_ed25519": "a0de8baa2406d7f52e133e0fce76ef7f802955d313145431c72cb6a30e729eec",
       "pubkey_x25519": "8389159f413d38fde834764250daae62380ac2fb415abbe6acf9c05309067d33",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "5.75.229.75",
       "storage_port": 22021,
       "pubkey_ed25519": "a0f68c694212083049b4a8cf7ed60b9af20f2571483835065697a64732d6f2ef",
       "pubkey_x25519": "9f91ed5fbab4cea49e6a72da48c5f5cd8ab41d8c3bca911e7b8ade065ae7365c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "96.9.215.215",
       "storage_port": 22101,
       "pubkey_ed25519": "a113fb884ec0cd7f7cb44d4a09749e823b1bc7042fb9d487c4de113d57563f2e",
       "pubkey_x25519": "9d1f58fe0839d2da5ed4e3662e275d1837582093c8e5ca32b4f2fd70927e4c73",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "193.70.87.174",
       "storage_port": 22021,
       "pubkey_ed25519": "a117e74e36eabf2753425bcdf614125cef972a346759ee2c2c03f1e3852c1b3f",
       "pubkey_x25519": "7ac195cd854a1ceccc08dfb91e61218168f9dbccfa6654fdd7911bee6c820777",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "146.71.85.210",
       "storage_port": 22021,
       "pubkey_ed25519": "a135bc2e3926a5106f0d53c88440fa7e7e02ce9857538eaf1e8ba5d921867a5a",
       "pubkey_x25519": "395671df134817717e75423cac4eeda971b3666b80c04ec0b6a5a52ce53dc933",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "176.96.136.161",
       "storage_port": 22021,
       "pubkey_ed25519": "a13c6e8cbecdb0a00c735313d824268a58ae3ccc1dd6f7efd8ddbda32db3e366",
       "pubkey_x25519": "a11f5da986844c885e054be85135a1277e2c444762da7977989032b651688a7f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "74.207.241.190",
       "storage_port": 22021,
       "pubkey_ed25519": "a14e0cd9f1a0c99b90e561228719b2e56d42aa446262a42e93ef3fc20c6eb0d3",
       "pubkey_x25519": "7aa254e10034aef1fd9518bcfac4e247d59a558ba1109bbf85e42d6cb1042e72",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20604,
       "pubkey_ed25519": "a15da479e8d2b131a46ad61a067c7d6804c6e338e863614ed35d720768c265a0",
       "pubkey_x25519": "e00e23a21c3ed28df2841f39af7309a805ba42ad8747db11c32d2373f3591874",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20904,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22142,
       "pubkey_ed25519": "a1662109e074e4b4d4526386856bb4ee1e01f7680a3ae652c84479c5f4ec5273",
       "pubkey_x25519": "5c207a04021f1703bf491c5ef53378aba0e2272a1f8b7c4ca726b099130a4a4f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20242,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67ffffffffffffff"
     },
     {
       "public_ip": "164.90.166.150",
       "storage_port": 22021,
       "pubkey_ed25519": "a16f614c5c9f40b00342848f5e95478a8163c24698bc936157f8aa139327b65c",
       "pubkey_x25519": "caa885028be2f23d49b02055ff1bc940f94c7b6c7d2dc2a88cb0fb7115343320",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "104.234.124.143",
       "storage_port": 22021,
       "pubkey_ed25519": "a1ba2f493993eeb93ceec6676fa6c530f24ca468c6c2ee8387a4667a5ceea511",
       "pubkey_x25519": "05579b15cb9582bee032be9d2a5c419c1d3b173603772dab994d18056c117503",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "5.189.160.68",
       "storage_port": 22021,
       "pubkey_ed25519": "a1f0fffd63e19d5b0b21d2a8176f0911aa2a7c4c5ff85cb1d3fd6e063710c002",
       "pubkey_x25519": "9b544525bf1d540f0f7e2e4147d5b3c12c10aff80f7fa4f5e0521c5192af3b57",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "104.244.77.81",
       "storage_port": 22021,
       "pubkey_ed25519": "a2457503723b2648d1be78db748e4db159879c870d2f9e26ff1003b994f188c9",
       "pubkey_x25519": "565d0b094797f5899a75ad14cc40134bd69a1ba39dc48070ec5a6d38e1e1021e",
-      "requested_unlock_height": 2064052
+      "requested_unlock_height": 2064052,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "204.44.125.247",
       "storage_port": 22021,
       "pubkey_ed25519": "a255cea4e443b55c195ffa2455cc8a888f9a655f2b462436c6bf7835f9ae6f3d",
       "pubkey_x25519": "daa5d31a3c0e878d555b14fbbb5e0d4ba65e1f7cfc74a1aee6814aed213c7b59",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d8ffffffffffffff"
     },
     {
       "public_ip": "158.220.112.165",
       "storage_port": 22021,
       "pubkey_ed25519": "a256674e78d92c71f65c0cbae976798b7e37228bed8a9781a8fc8b62e194b436",
       "pubkey_x25519": "6a839f80ca0b738afce7df2d08e0760f0d44a888bd963ba0135fe59109501c62",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "89.168.35.61",
       "storage_port": 22021,
       "pubkey_ed25519": "a26fbddd391c0d1a66ad89739086ca7a8de345b4bb3e8c8a57224ea9528d9bec",
       "pubkey_x25519": "c1b671d61bf4492201906403c206c6ed0f7418f6c8dd87f552fb916c7f5d7f78",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "141.105.130.149",
       "storage_port": 22021,
       "pubkey_ed25519": "a2d22f886dc60fdccc562d0137a02f4e874790cecb39a08dc59a7182a8024bc4",
       "pubkey_x25519": "6d99fe604195b663b42522a7db2d21d7503310db672382f8b2f292b94e2fea2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22105,
       "pubkey_ed25519": "a306100cda33b27fe3788b2bc8f069d2d127d9ff377b1fb6ddfe9460d608a39e",
       "pubkey_x25519": "d41bb113a7936f2ee26f4abffcd6aca357aed42831c695429535f7fa7ed39052",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "68.251.149.41",
       "storage_port": 22031,
       "pubkey_ed25519": "a32e427aa5ef6b0e9926cc8a89a76a943dcda25989c542d3fbd63ec508914198",
       "pubkey_x25519": "fc217995fcbade89d5818dc91bac137f4f179815e4e93d5d79f93fb08c914203",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22030,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22104,
       "pubkey_ed25519": "a33f171b143136d14913a0366247de6169e2bf1abc30d783a001aa895eee72db",
       "pubkey_x25519": "d3db49b5941f0596f5e88d04417b70f7cfa39bd54f987fa478bd7d3bb087a162",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "31.22.111.219",
       "storage_port": 22021,
       "pubkey_ed25519": "a35131b118b211189601e75b0bfcdf5ab58dcbfb35110ae56dafce0d98762dd4",
       "pubkey_x25519": "827d45024600e6b0d45617660bfbff1661ff07095f6ab5b11374f9352cb70c3b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "188.166.116.176",
       "storage_port": 22021,
       "pubkey_ed25519": "a36cb6548c15611a4a1dfd925907e9049dc520a9603f212dd4b205600694b186",
       "pubkey_x25519": "99c620fe729751b7dab2ca3505cbec0c36f31e1f458e3bbf63d3ea6733696f69",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c6ffffffffffffff"
     },
     {
       "public_ip": "198.98.62.178",
       "storage_port": 22021,
       "pubkey_ed25519": "a37dc5f51d4e56655da13f4a1e558d80840d2f252f77a398498d62a72b4271eb",
       "pubkey_x25519": "4404a84e71a9b99c960c086badf9a0545874da1e80943259a65e37b62bd01b46",
-      "requested_unlock_height": 2056297
+      "requested_unlock_height": 2056297,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22108,
       "pubkey_ed25519": "a3905fad001787b8449640a1db859cad4399eeae8df17c10208cc72707957633",
       "pubkey_x25519": "76d780c7474eeb870e997a1d659afdb29c3d9ccfadf5a119ceb3108258588b67",
-      "requested_unlock_height": 2059466
+      "requested_unlock_height": 2059466,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "64.44.157.112",
       "storage_port": 22021,
       "pubkey_ed25519": "a3c15e3b893a334eec8e9d8a9326c31387aeffc5562991353ed0d67f8a3afe31",
       "pubkey_x25519": "bf7581c9d6f2717fad5b275b787aa6d35502d18fcc9f2369398056b2ec18320f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22119,
       "pubkey_ed25519": "a3e416ccc22bf0a5ded68095db8e7b7abaf71c05cc3d1557ccb5d165200e32bb",
       "pubkey_x25519": "547ba473d0e78e64ffba98b9c3f207357285ff1444b9783452217d9d352ad669",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9affffffffffffff"
     },
     {
       "public_ip": "104.233.210.18",
       "storage_port": 22021,
       "pubkey_ed25519": "a43531db111ccb300d5608bfba41a182b13c6400008997b29343d326a64d9bae",
       "pubkey_x25519": "f9502184266881042c0c2d67d071c0ff53cd4fd4e90e67e28ba563762b442c18",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
       "storage_port": 22106,
       "pubkey_ed25519": "a43b862024e54318ef41f1b45f344eeb4def79a3f4f6d4e5644f8102287833e4",
       "pubkey_x25519": "d91fa7e7b174b97b16bdb8ce50358d94e7033fb1abb6b9d82887e34960e3d617",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "185.48.118.195",
       "storage_port": 22021,
       "pubkey_ed25519": "a45176e5ead1a19720049c89d8b471b5f9cabc9827322243760732854f65cf2c",
       "pubkey_x25519": "1b8b5e302d62048761eb31da02e53d23bdb4c87fe87c563d6a8cc6f2164db779",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "205.185.123.189",
       "storage_port": 22021,
       "pubkey_ed25519": "a4ec728afc0cbc0baba7b221a0b52cc6e8695120d0d9a4e37f3ed5383e5b274c",
       "pubkey_x25519": "667b6e65df91e906878a82961a748fe5deae7a26e3a469f98c3e9ff658ab8513",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "161.97.98.151",
       "storage_port": 22021,
       "pubkey_ed25519": "a51de4246702a95fc5a6aa6b8667c4c9b6f5d6a6d26345421165ce11090ae544",
       "pubkey_x25519": "b44709aff8222f160f0a7f32495b82b089f8e7682c63e64dd80a45da25082955",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22103,
       "pubkey_ed25519": "a5566441e6e275cc9ef4c85e34c4005119129eef295cec784772ab37ce37c6a9",
       "pubkey_x25519": "9b237b8352e40147323d39f324506da027c141c26c62299f83ff52035316d836",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "176.96.138.191",
       "storage_port": 22021,
       "pubkey_ed25519": "a56b5252002cc6a9569765d7d84127e0e77efef4078d50628b3eea4ecbd5b1af",
       "pubkey_x25519": "44cbd07cfabdb4a8b03b29c76f3d648c27fd59e19940f544a683bf93bdb01220",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
       "storage_port": 22103,
       "pubkey_ed25519": "a575e22370839a04311fc836ecd4ed5edb48f1690778fd24b422e61d0b8b4361",
       "pubkey_x25519": "c26abe9dfdf271e34d9b3d85006f10c720caa2b2cc2cd4bc347645e1edf53436",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22103,
       "pubkey_ed25519": "a61873441990c5af043232bd02fc9e773738db6e7b4d2293c46b7f935aa1bb30",
       "pubkey_x25519": "deed0b573eeecfda250e6a7e42680da87978108f965bfbb2d77df91803120416",
-      "requested_unlock_height": 2059466
+      "requested_unlock_height": 2059466,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9affffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22111,
       "pubkey_ed25519": "a64f4e45218281c8a0e3c910b0d503ea2af1ca5277e0ec34915be060d4bb3f64",
       "pubkey_x25519": "c0d3b72355ec40ea2768de422fcc92c49ecc8bea96588fe9e465706c0ddbae11",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.166",
       "storage_port": 22021,
       "pubkey_ed25519": "a67bce0a3e3a2fc109f5390b03269280c6b53fb08a514e70497dcfd67efae738",
       "pubkey_x25519": "0d34ba88c4e9353e270dead2a4d9d78cd43bc31972efcae672046109ffebe05b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22107,
       "pubkey_ed25519": "a69d45ad18afe193115a54a451f71a16195605f8b758b2ea720a7273793062b1",
       "pubkey_x25519": "f82e12e337ef0c1d4bb3677a8e31768357732ec9e2a2c2955f93b71994fb966b",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "45.33.41.68",
       "storage_port": 22021,
       "pubkey_ed25519": "a6db98017e44356a6f32a1ee0a030635cccbfbd897622ec4be1f944dae499650",
       "pubkey_x25519": "19dc83bf4f49903dbe3defd3d4ab762585713cb7ae22c969e473dc3d06c30306",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "216.230.232.35",
       "storage_port": 22021,
       "pubkey_ed25519": "a714443c233bb87090215ab3efa7d72a9f29eaba6b5796e4422cf05fcb4e070d",
       "pubkey_x25519": "543c4afe5b063e423cc674f0e6563130d7a140251a06296442545e03b6420225",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "57.129.102.67",
       "storage_port": 22102,
       "pubkey_ed25519": "a73f40f7babd2cdef0f6dc027dae92fdbd70f54780260ab85005d15ea1270d88",
       "pubkey_x25519": "5c0d8ab9c1cc0c23a7e6d4717d2f7b8ad36ee7ca72ec7a123c3e0bc990da523a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "216.108.230.145",
       "storage_port": 22021,
       "pubkey_ed25519": "a74e0c7ec31d8ad0f1d5a55282180e4e9a63196d8ea1ab0ddec6e32e1c0cfc96",
       "pubkey_x25519": "e5a883e76e9f76eaad819755cb724e39c03efb5fadf4b2a87c2bbe92ba3e6668",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "45.79.76.51",
       "storage_port": 22021,
       "pubkey_ed25519": "a76247911cc18530bba99f4bbbf02f3edbb6c1eb384025b5dfeda220125fa8c3",
       "pubkey_x25519": "8653d392d26dccb6e346d09c686f123cd03fcccd9b40219d086aae0777f24c77",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22107,
       "pubkey_ed25519": "a8191ea6fc1f7c9969624a7e57de22f415463850c16d9c6fd27a91dbfe7bb74d",
       "pubkey_x25519": "a18df014d2d1ae9e04989471a47c8728f6162eb464f6f40f5375063b942b843e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22407,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "173.249.195.109",
       "storage_port": 22101,
       "pubkey_ed25519": "a8473cd0789ebb7cfdca48a6c3ba5bddb6fd42a02da910a64d6b9393bb19f327",
       "pubkey_x25519": "b2bafab8939686446c1fd96b3835ea54d1a7d0fbfffd38b64ad1bb0f48f8743b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "95.216.199.207",
       "storage_port": 22021,
       "pubkey_ed25519": "a88e0b75c1f885641b12316d51708fa27e50f46f79682a6f86501781bf0b916c",
       "pubkey_x25519": "15c02fe7777d27186feaf859f338073e5babbd6ba52803d96b5b9f42f3d63530",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "107.172.5.239",
       "storage_port": 22021,
       "pubkey_ed25519": "a89ac255756e4ff1080c40e2e3f63e2ed498471303e174212c171f8e9ba6f630",
       "pubkey_x25519": "bae6dd9e9ba7f8ddde11e794ba9e052702276f1fbc736bd627343183b6c27a4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22113,
       "pubkey_ed25519": "a8a8704d891837210b675e863181baa10190068007758aedce9e49547a5eb500",
       "pubkey_x25519": "743f24f6274144de5fe9d5024846ceaa857090d59a01de8769159d5def3c9660",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "164.68.104.218",
       "storage_port": 22021,
       "pubkey_ed25519": "a8af759b0b6ce0beed24823dad981dc7811b7d19744d83c19c57459187cb5fd0",
       "pubkey_x25519": "7c52b44f4d7dec431efe982ba6b71222e3a3091bee94a714804844cd0879ec1c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "39ffffffffffffff"
     },
     {
       "public_ip": "46.102.157.155",
       "storage_port": 22021,
       "pubkey_ed25519": "a90d2f6041457941c6a34605562207938a9db89f875e4588fa2f23429d3096bb",
       "pubkey_x25519": "0945149c5be833dc158d882a7df2e769fec407f9c5ac0e0172dd1a4796ac8c7a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22105,
       "pubkey_ed25519": "a918c110d103849df01ae4f494724288038c94e2086bf391036a62afa39b6e5b",
       "pubkey_x25519": "4744faf8861aac057e19a7776c61401b779f1e4c889c7033574003533e259847",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "144.91.77.72",
       "storage_port": 22021,
       "pubkey_ed25519": "a93d5bcb6f337c3dca6545ebfc3894d2f16b4ce93081f5c3b6d70ddfe905ceeb",
       "pubkey_x25519": "d888b92823ae8d13f75389a30473375ec7d6b7314e484e30dd1d23a8d2734a15",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22115,
       "pubkey_ed25519": "a93ff5442dca7296fb33da7f7e40555ba32c91960803c88eacfbb8dc3298eb90",
       "pubkey_x25519": "393feaa22682e3104d726b47f7a900dbd556a3e6f80f15ab5fa3832a09b7c64c",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "107.189.2.69",
       "storage_port": 22021,
       "pubkey_ed25519": "a9559a4dae30e4d7afdf65b2457f59bdddafa41ba8a86adfbc6d224ad87440df",
       "pubkey_x25519": "30fa0f9294cce4ac8aa31176b6e5fb69ff6bce311725bd0a07a9f81a51bcec28",
-      "requested_unlock_height": 2063713
+      "requested_unlock_height": 2063713,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "162.55.32.78",
       "storage_port": 22021,
       "pubkey_ed25519": "a968b729769760b5ba70039b3fe77d1598862563521b32fcd5d2a5e59ae283d6",
       "pubkey_x25519": "356c106fd7e0ae02ad4a317838c3994780b295a6d527460464ffb73edb250a6b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "100.42.181.126",
       "storage_port": 22021,
       "pubkey_ed25519": "a972f3e8b4068120ce7225cb3bf0715c182444872f00f878160e35c01d404480",
       "pubkey_x25519": "c16fba1c7311a6ae102caebf41c5ad3184bf23a72a63dbd88994aec542474f45",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2f7fffffffffffff"
     },
     {
       "public_ip": "164.68.98.19",
       "storage_port": 22021,
       "pubkey_ed25519": "a983cd3c0b2699e4729516a3b5c63be01f1b134c22fdf0eb1011a43e5cb75198",
       "pubkey_x25519": "17aed0ecb10ebfdc0752150990e189d66be4bf9253bed7a0deba48f44b0a4345",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "89.117.60.23",
       "storage_port": 22021,
       "pubkey_ed25519": "aa2bd6bb1e3daba2eb16b7fea86565277bdbb55513f8c42551d89df71df8ea07",
       "pubkey_x25519": "3f8939b1a6f672e660f3eaa95e0c2c741402fbccb69ecd5d358f0b00acab6063",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "72.11.152.205",
       "storage_port": 22021,
       "pubkey_ed25519": "aa3b15ccc00509eabbfa2d9838fdce248db6c250dc81a159bacf46425159b9aa",
       "pubkey_x25519": "45cda0582c2bc5c7aa7a98bad5f77a3bbe4e2ef38f666dbf87ca0e6b3378a470",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "141.105.130.183",
       "storage_port": 22021,
       "pubkey_ed25519": "aaafcc3306e862b2f4ab6b49d21ce057d9672544da4c2410c8189d16c9980764",
       "pubkey_x25519": "081296e42315ee5ef3018f2394df201031ea228d8db7c8af9798cd066e2d9d0d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "64.235.41.74",
       "storage_port": 22021,
       "pubkey_ed25519": "ab154c8cdaf5afcc0e590a860319ef2868426743d1b82a2c9f3db2b9c53fe3a6",
       "pubkey_x25519": "ee5d921f06dd14107a9698ab910d2513a5263e5d2fd2ba7ee6512525ee72e44d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "62.171.160.88",
       "storage_port": 22021,
       "pubkey_ed25519": "ab26bb821f414022db5f27ea72ec788be3a35b3174d1285c912e645d8095e7ab",
       "pubkey_x25519": "be456e264933156d15fba90d62191224af0d0eca4a3ff5a4997b3c2d298c3a66",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "107.189.12.37",
       "storage_port": 22021,
       "pubkey_ed25519": "abc8293a81f31a6985b5e5ebdaee13e82fa8889bba929a91c19b2e823531ee47",
       "pubkey_x25519": "04cccdc8509e14d45411f530ea4553db0b79879d819224d869f2d54d21797011",
-      "requested_unlock_height": 2064048
+      "requested_unlock_height": 2064048,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "144.91.102.255",
       "storage_port": 22021,
       "pubkey_ed25519": "abe0ff69a0321a1ed7bb793d049663a9ff98356f1f99632ce46e0c2bbfc80082",
       "pubkey_x25519": "21b99082fc09ef53fb5549dd650652fa7a15528367292de11a46c4db126b083a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "45.92.156.210",
       "storage_port": 22021,
       "pubkey_ed25519": "abe75df72d88c5e43b3312c0aefaf1202bb98c23a1efba72248edff6cf5cce09",
       "pubkey_x25519": "fc5c1b3e4f2469637c5dcad88f77a5aba0849ec58496bf3ca3d66c2ecc7bc242",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "64.227.78.106",
       "storage_port": 22021,
       "pubkey_ed25519": "ac339bdd44da77dd39086d04b7c1235b81b4323943f38cfffa4a4940aaca4998",
       "pubkey_x25519": "7e22ad688876979b5be5a8310a4420a769fc3c6ee5bfaeca41a8cc9512eb930b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "209.141.43.224",
       "storage_port": 22021,
       "pubkey_ed25519": "ac3f41e83bd28de52ff671d61aafb7cac8385739b56e6cf948f0de45af78d384",
       "pubkey_x25519": "c475084205dde9c569f878bb8c2c90e9e21ea2ed59a37b2cbb032cb991af8274",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "164.68.112.212",
       "storage_port": 22021,
       "pubkey_ed25519": "ac6d0d3cb63303c13ecfcbfafa64ccbbec25242d45a5b97973f167dd52c3dda9",
       "pubkey_x25519": "33ac95be69b8220e78c86417ea0fd14079b5263f900e5883cf329b9f09b0b932",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "95.216.159.12",
       "storage_port": 22021,
       "pubkey_ed25519": "acddd42f3f153237f8dbfc75cb35b9bba792be3b27970e20867595027f9683ff",
       "pubkey_x25519": "54a40e5772820f4fe742e3e95084d55e25429a39549a155a0ca4e08fd2ed2b0e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "57.129.14.232",
       "storage_port": 22021,
       "pubkey_ed25519": "ace2cbd30d8eacfefc651387b86069784c0068c3a9a7151e183aac93fa59f0b0",
       "pubkey_x25519": "2df4d8a16151e9a63329a77b59d23e8478e0d7260d03630dad9ac5ad9758c418",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "188.215.229.67",
       "storage_port": 22021,
       "pubkey_ed25519": "acfbd8b9cc9027ab521cb84290e00b48ba0759772f211c44b1fe574e77da2278",
       "pubkey_x25519": "e520533a348d6b2546a5ef07c3c31d3192d31083fbb6ce31b825d8756690e359",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2d7fffffffffffff"
     },
     {
       "public_ip": "5.189.140.6",
       "storage_port": 22021,
       "pubkey_ed25519": "ad1c11000c8dab6bcc99b3ef71b42787a9748c7d33a56b29d32657631c2f8bb6",
       "pubkey_x25519": "2cf93d24495edb3b7a6602b4c3092bc329ce5e69b0e1c5451ee3e127ad187557",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "194.13.82.76",
       "storage_port": 22021,
       "pubkey_ed25519": "ad4913564aa31495c6cc416c6e246b8d10e7ac6329669965436fd76e972db632",
       "pubkey_x25519": "494de8a3e097911a28bb2de07fb69838b9d8df9988ab24fe1fe81b8ad8570978",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "107.189.4.249",
       "storage_port": 22021,
       "pubkey_ed25519": "ad9d03afd710372e747f5725c20296b1cd175ee7400afed9a7ecc532b543b6aa",
       "pubkey_x25519": "7b91ef85cf70d89490aff0ae4b2f7001572b6744d3ac8447bf45818fe0edad59",
-      "requested_unlock_height": 2063710
+      "requested_unlock_height": 2063710,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "198.98.57.68",
       "storage_port": 22021,
       "pubkey_ed25519": "ad9f0efbde5a9b61178d6e4cf7014df5ef1d5a91a4941243dce03b58f4e53e40",
       "pubkey_x25519": "e80c770723efd337edfaacbb2c9b9eba90282b48ef24ffa09228c88601cb741b",
-      "requested_unlock_height": 2056575
+      "requested_unlock_height": 2056575,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "207.148.87.230",
       "storage_port": 22021,
       "pubkey_ed25519": "ada94dfc54c3870c057aba62dd68f990a6fc439e16e853f3e34cbafd7a1d758b",
       "pubkey_x25519": "8a6b11bb0c84bb7b324b979567aa3a8f43e535a03ccf4efa79c56a329571d15c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "152.89.29.65",
       "storage_port": 22021,
       "pubkey_ed25519": "add842f0d02a555a8787be3a940c6ee3aa19bc2550ffc6cb1e1dc1ec4701d9e9",
       "pubkey_x25519": "71c348f6e0084b8f72b047a9a6833ecbf54daf6a0200d52f67c05d17efa25c63",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "89.58.29.149",
       "storage_port": 22021,
       "pubkey_ed25519": "ade6e10994dfaeb4c5c0a0a4d4db9f2f2f796f022020ab928dc493ceeac81fe7",
       "pubkey_x25519": "b656830fc6604def5a996e8c2ade423032a50df54a39a455b05a80e5f93ad824",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "84.247.184.139",
       "storage_port": 22021,
       "pubkey_ed25519": "adef212987e79e59a774af057655c5e79feb5440077e697d8593dc46c0d71750",
       "pubkey_x25519": "15dec3c2bf199431e27d01cc57ca06981dabe8939f089f41dbd0bf447197cb3b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "107.189.5.113",
       "storage_port": 22021,
       "pubkey_ed25519": "adf161e4420d7efafab4bce8b8aa27a5ab065eb241cb0ecad764dc7a78638b73",
       "pubkey_x25519": "c3dbde5b5771f01f82ca6e411ea18ae2e9d098286c749571b7f9fb40c7dcc444",
-      "requested_unlock_height": 2064050
+      "requested_unlock_height": 2064050,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "135.181.32.244",
       "storage_port": 22100,
       "pubkey_ed25519": "ae12111d89f309f3482b0c23ac0c96e8a1dbecbffa11184aaeb2c8bf856c1cf0",
       "pubkey_x25519": "816849189c7de6ec7f63b45efd40a3727ecea2108838a670f7ef8667394ccb1a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
       "storage_port": 22101,
       "pubkey_ed25519": "ae121126cf2e18e693e3191a5ca19bc36e172ccd0cb908270f45820c6c2f7013",
       "pubkey_x25519": "84773fc8c4cb1620a2ecf352009af2cd9d935e87403a7fc97dea0a07b6b1c43d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "157.180.112.36",
       "storage_port": 22101,
       "pubkey_ed25519": "ae121155a7461f1f522a82d30856f45da876a9090e2ec0e8c914311cac1ddd01",
       "pubkey_x25519": "e2a789a65866e895c5e9afc818d44a0ede075c3914b9f9eb090c3f9e1b35a543",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "135.181.32.244",
       "storage_port": 22102,
       "pubkey_ed25519": "ae12115e780666a6f77f3082bcdeb0be8f412f67278bdecbc5601b18f23bcdf2",
       "pubkey_x25519": "a3532dbddb68d803198e5c9cfc057b346ceeedfa057523a8d13248b2fbda3c1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "157.180.112.36",
       "storage_port": 22102,
       "pubkey_ed25519": "ae1211baa79c310efca25265cef34a19ca59da382d98e17f041535c36b283702",
       "pubkey_x25519": "0591e4c305981ff6a06f754380277c54d79f1660a8da5d247bda125e52ab8410",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "157.180.112.36",
       "storage_port": 22100,
       "pubkey_ed25519": "ae1211bcfe9c09bc717a5b7e1fcacd23795a39e53569cf77a1883e6a0a609d00",
       "pubkey_x25519": "6372e0b3d519dc6cdd38be9d6c92bdd1c5876f72932d1ba892f5cc1615d0f35d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
       "storage_port": 22100,
       "pubkey_ed25519": "ae1211f9c6cedb72907c643681e050705b2f662aec4af30d44c0ac81885b3410",
       "pubkey_x25519": "0b70d88b2911d2749de385e43e1ea796659a493a16490d93892ec642c14c991d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1f7fffffffffffff"
     },
     {
       "public_ip": "135.181.32.244",
       "storage_port": 22101,
       "pubkey_ed25519": "ae1211ff0d67937b6ce1df9276150a564e324bca7940fbb8b3f9f1a34a6cdbf1",
       "pubkey_x25519": "4adba1fc5a9ede742bd60b91a79d283bdd17f219b8279d3c985c27d21028654d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "afffffffffffffff"
     },
     {
       "public_ip": "209.141.42.34",
       "storage_port": 22021,
       "pubkey_ed25519": "ae1745b0b9dcf7c2bf6fe6a3c60fe196a3922800ad3038103629ea1d5d9e6058",
       "pubkey_x25519": "148bbdc7677fcb58d111fb4cb0a33cc240e95d643c3a0f997c2e01db21bc520a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "77.74.199.107",
       "storage_port": 22021,
       "pubkey_ed25519": "ae3cec0036d407af9a78a2e001183ef5a9adc0fc03d4a84141886300802be0f0",
       "pubkey_x25519": "b1b160b9c0eb62c0f85bfa9e476e92f63455f53fd832f661ba429fef66f8ec50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "38ffffffffffffff"
     },
     {
       "public_ip": "77.74.199.112",
       "storage_port": 22021,
       "pubkey_ed25519": "ae8274ddd194c42c13ff541fd0d4b7956810a2103915f86db980ccd4492e815d",
       "pubkey_x25519": "a0e4eaf20f8268d1dddc8c6e799f4bd2ec9b764b9e8958b83d567ae46cc87224",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "144.91.77.57",
       "storage_port": 22021,
       "pubkey_ed25519": "af58e0466038d918d95b387e372474fcb4849e1fd23f3aa216b88fbbdb8ab632",
       "pubkey_x25519": "d828cda380e6b5f5b1b9a6c9eaa5110403ef0d2a2ace9e651ea9ae17b6ba1617",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22114,
       "pubkey_ed25519": "af9f27ff07b890a3496a93fd8dd9b5452f3c704c8697b0b5bb5e62cdb178ef8e",
       "pubkey_x25519": "8f16164b8674bacd3ddb6e79dcda0dc9fc9fbf0e1cf0119f3c5b469bd62f710b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "168.138.102.244",
       "storage_port": 22103,
       "pubkey_ed25519": "afa24d063597209e080efee51ca370ba4333cb93fbf63c0761c398c86f669683",
       "pubkey_x25519": "c7d82b813c273770212a8cd34988c4f8bce0785ddd181cdc4af9f90b059a5e59",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "89.58.29.122",
       "storage_port": 22021,
       "pubkey_ed25519": "afc4cf4f445f5cf0268e4ba38b6fe3dc1c33e80002d074664656bfee357e717c",
       "pubkey_x25519": "2a8421c231b7222948ae494459cd05cc9b090966baa17beb6a1e07bce4445d1a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "154.38.172.138",
       "storage_port": 22021,
       "pubkey_ed25519": "afdf1f440a7e9c3bfc168edbcada218e1d4543c149a0be7cc5a286c479ff0576",
       "pubkey_x25519": "6989559dc320960e5361a3b89aac6c526e1c254f48816665ad9c160c905ef640",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22108,
       "pubkey_ed25519": "affdaddc66cadab689f50a8df44b20806459ac7cb05dadeefb516b3ddeda539f",
       "pubkey_x25519": "2db0a69f8b8389257910ba3521c64e0d6f0021e14c809c1f0912cbf9f95b0044",
-      "requested_unlock_height": 2059300
+      "requested_unlock_height": 2059300,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "45.149.204.19",
       "storage_port": 22021,
       "pubkey_ed25519": "b008756229b91e1fa71a555a16eac4b9f863938113cc63cd9afebc26b94b2eae",
       "pubkey_x25519": "a2297b850624131529052c0bbc7381b13d4fb2d47d0d51cef86ec7d6d937395f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "205.185.114.108",
       "storage_port": 22021,
       "pubkey_ed25519": "b01fcc83aea88583647066c1e6529386375269e86f011299abfc5732092ac0fa",
       "pubkey_x25519": "7d21ed606bf0ab034fdc0ba4a00d40073cb6ad782c475a45d51cea04af9ea702",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22109,
       "pubkey_ed25519": "b02d1bbd6cc7b043a4ff52d012b298c30e27cdf34cc31b1ef1f0795c7658137b",
       "pubkey_x25519": "4bed7948fa5048e2efff740f8da2ea6c2c9c2da90942a1edf47abeac84c0d840",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "59ffffffffffffff"
     },
     {
       "public_ip": "135.125.147.171",
       "storage_port": 22021,
       "pubkey_ed25519": "b053c674eec20ff891d4862bce32420418468386601172bb4bc62b068ac5f66e",
       "pubkey_x25519": "f8a5ca2a42832ff9d57c46e6553326780947e8aa444cf4efd91dbce007f38f74",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d8ffffffffffffff"
     },
     {
       "public_ip": "165.22.51.13",
       "storage_port": 22021,
       "pubkey_ed25519": "b05bc2150f1a0ca1d039cf6ab276371b99efbba4c143c2d133deb01df1f498bd",
       "pubkey_x25519": "9f3d57657fbec5d52160e9f9bf15a4ce6409a37363ff7f06503b63e70de3ea6b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "31.22.111.15",
       "storage_port": 22021,
       "pubkey_ed25519": "b08c9549e3b546531f31849ccd9fd24833b83fd43a9995e6fe80e1e691a10df1",
       "pubkey_x25519": "92b79c4bfa5fde2a039a41ad2b89d98f876608734c2f6b0df2a7f838178eed19",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22103,
       "pubkey_ed25519": "b0aec092f18af234aa9d0de7eaf9c2551ba35bf0d8e86b0b1f8fcea434d30bc4",
       "pubkey_x25519": "94fe6cc0caccda7b17b7e2eb7844b46d1f5b0c810db89013007a7ac4710f916e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22114,
       "pubkey_ed25519": "b11b08da9c19229a4eec4177699bbf062b2c6f8af325e89b87856986359d0014",
       "pubkey_x25519": "28881a81f099db5d219df519c1aa3264271a11c519a0d9e094364d53b1f94923",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22106,
       "pubkey_ed25519": "b11b15aebca70403fa51b416d4539f26ee9a33d60d8c66f10ba3a73414ac0006",
       "pubkey_x25519": "33611b2d39826b3d6a02efad3496a0ca5c2bbad37ef9843c30e63b952d10f16c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22116,
       "pubkey_ed25519": "b11b1a48c53b5dd1a130a09feea1923d92d910a4825ad1e5455c23d261dc0016",
       "pubkey_x25519": "d1e307f3735c40dbf09f85c3664b466bc78063f6606dac620c73505c26551d68",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22102,
       "pubkey_ed25519": "b11b210f7694dcbc56669df27945068a4d2a1e297999431ee2f0d89287fe0002",
       "pubkey_x25519": "7257208d78abee46391d214b04bc433de05d5eb99191c1e1c63567e73803b67b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22112,
       "pubkey_ed25519": "b11b21931557fddabc6d2b746f0f22f07ab98f5dcd0e5199fefda15853be0012",
       "pubkey_x25519": "9d17bf4f14e77b034c0d8a9b380c959914e843398fb532e5a30a10422bbe4e07",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22101,
       "pubkey_ed25519": "b11b355878a571a475dc78cc9d2542150c450246e4ea076f872e1b0e8edd0001",
       "pubkey_x25519": "c06a970b3c91cec260188125d0036370272dc6729673218dab3dd58be9e93b19",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22110,
       "pubkey_ed25519": "b11b368516807554550c91fd3b7aab8bb4920d82bafb993162535787d3250010",
       "pubkey_x25519": "1995bca8d0a306104a5b16f61da54881bdfe6a93415d7886b7d396a5abbb1e59",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22105,
       "pubkey_ed25519": "b11b5b7bf77513174260a6354294499d7487fee85461fd7dce8263e4ae230005",
       "pubkey_x25519": "73c3c6655ab75f5ea1ebdc15b7b7778c6c667aa738cfbeb57b06e6e3a4fc9150",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22107,
       "pubkey_ed25519": "b11b5c947975ce6d3f9c4619a007fe227ed8e550fd8af8666c39da4c0de10007",
       "pubkey_x25519": "af7c2b68c744ff2c55e87cf58926d43a783f69b50a9582a35f769e19e51ee92f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22108,
       "pubkey_ed25519": "b11b6cf0b5fa4b29bc5f2b3772822f8475e6e6ff79a567d05225fcc321430008",
       "pubkey_x25519": "3ff498c94367f9b94865bb4e3fc7d384dd388ed2dee2ec155d9e91c791f32e53",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22100,
       "pubkey_ed25519": "b11b82579c052a1fdd21856436cde7c9a142af39109f1a2aa9fec4e24e240000",
       "pubkey_x25519": "baa4bf47f4ab1725c24cd5d7743572465cfde4a128d0d63b59f418ba28d52c3f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22103,
       "pubkey_ed25519": "b11b8a8e9147a060332056a190269aa6319dbc124e4b7959df89f39b8dac0003",
       "pubkey_x25519": "2f53a8e6007e5bbf9387bb12b4198ee21c892c1989fdc05867f0d4582ffd9611",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22113,
       "pubkey_ed25519": "b11b94f862a426650ec25c960efe62cfdf066185c622c3feda0c3273052e0013",
       "pubkey_x25519": "02cef3aea2883fe0fde31b28c7d87d77c55f20ece33fd30b4f72aa84c5f0ee0e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22104,
       "pubkey_ed25519": "b11bba2711ed61b54d5876bd67f820bc28a9915d2aabe011cd4912adb3ec0004",
       "pubkey_x25519": "f4797f51430d8cd701d8af8d66ff74f5e440d2aab41d5144b084eabf19b4865a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22109,
       "pubkey_ed25519": "b11be7d5e3396fddd75515987c1b26a5662a28a737039205ff6bc43115eb0009",
       "pubkey_x25519": "4999664ca686a3deda8f31647a6826c69dcdc27a5ff4f76ca7bc47a56ff31463",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22115,
       "pubkey_ed25519": "b11be9cba22b03c36de27cf9b646b81b5033e760a142ec9466cb7cf023cf0015",
       "pubkey_x25519": "ef9c3eb06fb82ed70cec752f238b6d3f45104625aacc21232b2aa5eaf95dc229",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
       "storage_port": 22111,
       "pubkey_ed25519": "b11bf22a728de56c72507175e5d7511e0883f0c93dcd5faf1fbd0dbefe810011",
       "pubkey_x25519": "d86883bbe6ab810cf6bca182f6fa8bbddcd88d34e922a3c107acf9418370e55c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "209.38.98.242",
       "storage_port": 22021,
       "pubkey_ed25519": "b126373b3c664b0fbc658caed258c5267ef0b205a8400212e31e6982bf000ced",
       "pubkey_x25519": "8d342bbd66ac9ce623cf568185dc0ee90058515e3d3e8ba1d7b7fb80d75d1710",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22107,
       "pubkey_ed25519": "b171c788f264c7cc2997171d4c2e6a23d7767e995311c564d70aa6fd9d646edd",
       "pubkey_x25519": "2b283f912898dc87e89c93b003d4b5c3a0eb74adf3aad8ca2649971e8aa1d36c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "172.93.108.154",
       "storage_port": 22112,
       "pubkey_ed25519": "b1a57ba9b9dcde06d1084e9eda5ff31d361204e0206c9432aaf9b8f0952eb35f",
       "pubkey_x25519": "ae195a20f186e7e26e88a49a5d4069b150f3b8dccdd155c0d0374cfc3187493a",
-      "requested_unlock_height": 2056795
+      "requested_unlock_height": 2056795,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "198.98.49.76",
       "storage_port": 22021,
       "pubkey_ed25519": "b1cd57aaaf6aa5b23e9159bc1848f1735960e907985cfd89bc49e7ed32ca9b9a",
       "pubkey_x25519": "bc393b816ea160d6ec2344ddaa840ff0c0d8f0a5313e1ec0fd86bd6f4d447c34",
-      "requested_unlock_height": 2056572
+      "requested_unlock_height": 2056572,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "130.255.76.53",
       "storage_port": 22021,
       "pubkey_ed25519": "b1d0dc87a9e8ed9bd17ad6f87a98780a50e8e41badbdb3f0b609ebd4378a51e4",
       "pubkey_x25519": "9887aa615c073f6d43926596f37f102062779157987f8404208b3a6cc305832f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f7ffffffffffffff"
     },
     {
       "public_ip": "209.222.103.98",
       "storage_port": 22103,
       "pubkey_ed25519": "b1f1a81fab91b54d92aff30678b88769e695b0c2c3090ad86ab8c5af91e07b6c",
       "pubkey_x25519": "a9e8274fc877d33d6ee601c188fce0bf6f55b2340e7fd7b103f6d6819e1de323",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "38.45.66.164",
       "storage_port": 22021,
       "pubkey_ed25519": "b23fc8273e12ce738b98ed42b255b5481c004cdd7ee6a14ba88575b8d2a68710",
       "pubkey_x25519": "5a96432103b5597866aee604c1a2acf828e920fd06201010d431a5fff53c4874",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "164.68.113.60",
       "storage_port": 22021,
       "pubkey_ed25519": "b289716dd31f39d23838993fda6ed9dadc3d70d02a85029cac36343206a7cd36",
       "pubkey_x25519": "5ff3953b26f0c23b594447ea598e457435211294da84cb8cbb15cccbca0e6364",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22118,
       "pubkey_ed25519": "b2d0b5665d0cee2685a640cafea6e69c9ccf15817a491c524bf4777cd7c9760e",
       "pubkey_x25519": "91e36f89b8e8695edee590c2d548a4fbeea3654830b7f030c371a96ae56b1813",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "185.207.250.197",
       "storage_port": 22021,
       "pubkey_ed25519": "b2eea529cce144a69876ba55b8f11deefda71c6b72cf021bcb2f16b2f9668de0",
       "pubkey_x25519": "c0a1e7e2720ff2a7e480b5acc8e51f84b90fec83b32dafe1726b0bad0817002c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "46.250.251.176",
       "storage_port": 22021,
       "pubkey_ed25519": "b3fdffae324dfe229a2a718a405234a1ee0fca9efa38d6bce6e8f9adbaed412a",
       "pubkey_x25519": "79457873e63e5589aa35c29763579de214b5806f80e37db5f5b5fb2b18a2e96b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "46.62.139.87",
       "storage_port": 22021,
       "pubkey_ed25519": "b4037e7c04677f810ec97ac9854ef49ba8de56a2c663ca21d7487aa091b5532f",
       "pubkey_x25519": "b7a34b1e6a4b096806e9a01a899fa999ef6bb01b68f3ac8aefe212ef28be6c31",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "77.74.199.116",
       "storage_port": 22021,
       "pubkey_ed25519": "b41a90d471ddf71b07c8d02e05ec4b32a841ef6269c2277ba6a2567be0ec7421",
       "pubkey_x25519": "3846de12d20294e051f83ffec53b3aa6c219893f9607998f402974a8b872ed27",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "144.91.77.95",
       "storage_port": 22021,
       "pubkey_ed25519": "b451a384d75d106917e610b532605d96e7812a0324d6664be3e7024167c397f0",
       "pubkey_x25519": "ac17bce8453412a9e6575902460137dc8a0db61c54c3caf053d14a0dc65e9726",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "51.81.174.80",
       "storage_port": 22021,
       "pubkey_ed25519": "b4b8b0ac2ee8b9ef6c7cb5d7a286ae7fab4d641e371e6ba44265a154dae03cea",
       "pubkey_x25519": "9e2637fa33013be2544f81fcad4f80abd24351efae9ad7f95d80220ba0414001",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2f7fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22101,
       "pubkey_ed25519": "b51bfb50397d7317240eb925dfa4f2912b89519645a436cad5437014c7d08847",
       "pubkey_x25519": "cbfaaf98693d97d86b922d19bedaf2f8bd4d115560d9e17c6bd1004611e18d14",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "172.93.167.59",
       "storage_port": 22021,
       "pubkey_ed25519": "b52ee4fe875702d5a83c280aeaf32fdbcfff4922a6c2e8cf1243d4921043005a",
       "pubkey_x25519": "78702bf131bba499786fa2d149ff3654864301d3b1bf068ddc1c513af5a8b35c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22106,
       "pubkey_ed25519": "b5715524948bb0bc31baa2fa5f7aa98ee5f0b26142ce0b4cb6ffa5dc4056ef43",
       "pubkey_x25519": "1c8f28766ee72df57f12e5204882a57e139db16910d33af52c0fe6d49e2b7674",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "89ffffffffffffff"
     },
     {
       "public_ip": "65.108.159.68",
       "storage_port": 22021,
       "pubkey_ed25519": "b5b3bb394826976ee1a95fe7601adf5d07f8ced78263643619b6542bed491945",
       "pubkey_x25519": "6f09accaf672cae6c0fa602d55b7b04b3e9181ff8e49381b1ca27ef30cb5597b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2fffffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
       "storage_port": 22103,
       "pubkey_ed25519": "b5db53f3dc2cb63ba7d5e4a533198d0e98ca5b7c2a693dd41a7c9092f7b827d5",
       "pubkey_x25519": "fee7864b5a524a51f086e4b797091cc638db5ecff707cddcf4f30b44f19a3c19",
-      "requested_unlock_height": 2062111
+      "requested_unlock_height": 2062111,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "164.68.127.19",
       "storage_port": 22021,
       "pubkey_ed25519": "b5ea3b383ae4218d1a7bb796a73ee2265a03224154db0c133a8dfb9a4f30a28e",
       "pubkey_x25519": "d99b8fdb95b0923b2a47548ea813cf392673f33a28d0551157f61daac6255b6f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "53ffffffffffffff"
     },
     {
       "public_ip": "135.125.112.188",
       "storage_port": 22021,
       "pubkey_ed25519": "b5ed0932695034ccbe24d1460dca11ef657057a66a3a847439ddf28994345393",
       "pubkey_x25519": "4993cc41c18a2a79d176d66922fd3b13d7e1276d8f1e8f1896b7c1cad1927566",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "77.74.199.80",
       "storage_port": 22021,
       "pubkey_ed25519": "b5f299e59f51b84f9c2e443ea5a73d5b51f127b0c9070a384345f2f330ebff77",
       "pubkey_x25519": "918be7aa7af2811edabebdff1ffffbe8588a030ee3974115f99931442abb767b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "45.79.94.226",
       "storage_port": 22021,
       "pubkey_ed25519": "b5f35c99b058f6a53c2d91b0dca7196fcb3641528d882b4bb0cae203b1e10103",
       "pubkey_x25519": "f253fa1ee0f94646388fea04f8f7366dec247559b0cf8448d8230766c3dcb640",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "164.68.113.85",
       "storage_port": 22021,
       "pubkey_ed25519": "b5fc4d8a5c25f9947aae0aabecc953f368c90c1d413ad6f35e434d38da9ee8a5",
       "pubkey_x25519": "072f91ef34b730e5b488036bc8371458f8081f48598f708db48801a7d7512441",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f7ffffffffffffff"
     },
     {
       "public_ip": "5.22.223.133",
       "storage_port": 22021,
       "pubkey_ed25519": "b60801bb2c63d0eed13ee5f1c3773b9c613fc95312e0606d882b89a3cc241f10",
       "pubkey_x25519": "5e93107fd8bb6997e1a4572b248625488c9e911699626c6795cf40a1e7999242",
-      "requested_unlock_height": 2057264
+      "requested_unlock_height": 2057264,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22102,
       "pubkey_ed25519": "b637ce1e8040557c827de06bfa9c3a86e5e95a30cb0749517cae7ad3332ef91b",
       "pubkey_x25519": "61681207a95a4ce61ef4f6815b0a63e31af5e1effc6831303fffe41952607767",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22109,
       "pubkey_ed25519": "b68ec51f664c35ae81280d5c7fd3d3bbc419bee63db0921a7c504fec7c10c39a",
       "pubkey_x25519": "275473d18bcaf4fae6aecfb9e7c2c70aaae83c13f2f454aa35de542bd2e9043f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "164.68.114.77",
       "storage_port": 22021,
       "pubkey_ed25519": "b6cb4b5c8e9be7a3dda05a18f004612350eba3debddc1940f143bb6174a1df61",
       "pubkey_x25519": "52d2142f98d8fd53efbca863c5f8e1fac59408e4cc4d64af3faf84a013853a04",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.112",
       "storage_port": 22112,
       "pubkey_ed25519": "b6d2823c3aeedfecd5d5aa65b4ba99e22b9b4e82643a827bd72bfa78804a36c2",
       "pubkey_x25519": "b813ac661f063db2f876b6a211deea325e6f7fb360fb48d1ff5c06c8ac310c0a",
-      "requested_unlock_height": 2059467
+      "requested_unlock_height": 2059467,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "164.68.125.214",
       "storage_port": 22021,
       "pubkey_ed25519": "b6ed86d800f829b314fb49fe81a920c7459e6b02426e78159f0ab354e7e10370",
       "pubkey_x25519": "2465c4603f54976a92e458d727a7cd693f448f61a9acdd88c14656d39d711e54",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22102,
       "pubkey_ed25519": "b72142bf9a847fb9de1f97845bfa69f146d9aea2bcdc433137d8d089a31b00e7",
       "pubkey_x25519": "f7965297353736dd8a892683408445930a64ac379ae4077fb4d51a2060243225",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "62.3.32.12",
       "storage_port": 22021,
       "pubkey_ed25519": "b7b22526e08e94fccba81169cd3f61004c4fa739d22f011bdb5fce22e1ef89d0",
       "pubkey_x25519": "b7d6cacf22c061acf229bd782427efcb0838d6f4bba2d7cca60f4bc8a7750e2d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22106,
       "pubkey_ed25519": "b7f4be6123dd9f9ff4e76083fe6ee2f953333312490a244c4c8a676faa956b52",
       "pubkey_x25519": "8126eeed9fa57473ebdc4f8e5266ce162ec37cad0f4d24273e899aebc944800e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "77.74.199.77",
       "storage_port": 22021,
       "pubkey_ed25519": "b80a6ebbb842fc7822d49dc40f0a5ece5d5fdd0faa1469686e7a3e90490638fa",
       "pubkey_x25519": "99853e92f48298532200b26235b2808dcac7d794430b8bc93a12d54e625c6e1a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "51.81.87.72",
       "storage_port": 22021,
       "pubkey_ed25519": "b8538d3b3cc95259ac9064fa2069e2798d278c3ff026793962d7587c5fc28a64",
       "pubkey_x25519": "69ca4d74cdbb6643175ef44dd5efc4c8d626f416f4aa6f8a4447ea6d95c1f85b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "199.195.248.42",
       "storage_port": 22021,
       "pubkey_ed25519": "b875d9fe826f268430ccc6386a6ac8a3a112ada3717498da2a10368b82d79b56",
       "pubkey_x25519": "935d07cca5e1e7ee488b2b79d50e34049a6806f47176161d6f36f00a3fee3d67",
-      "requested_unlock_height": 2056296
+      "requested_unlock_height": 2056296,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "91.99.186.162",
       "storage_port": 22021,
       "pubkey_ed25519": "b87c61ddd31ec506e8310cbafcd607a720bc8bc3cd9704484d88415b53a3c895",
       "pubkey_x25519": "fbb1c70c3a9ed1f4e25387b0eb089c90300a0beb7c00abc5b8e0c15c9ddd5f31",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "178.157.82.104",
       "storage_port": 22021,
       "pubkey_ed25519": "b8dc58e5a7b14c68a97132bcc81d97eb045c250a549f8405f6bb0ff4f6445b54",
       "pubkey_x25519": "e3c8af37384458c609e9b25d744ea916b8634ba0c0ab4f02d56ef1092590ec4d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "176.126.86.31",
       "storage_port": 22021,
       "pubkey_ed25519": "b8fc7b2fa596392a6b17bca28d00c034ceba696510cbacd4d3923bcceb4288c5",
       "pubkey_x25519": "51551a38a1941e39f59e0dc3e2d957441907629d0ebd0bc4394061a7bfcfbf03",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "152.89.29.20",
       "storage_port": 22021,
       "pubkey_ed25519": "b95d6e3360f19aafb2a016cb3623f8afe28600dfe4a8cba2944fce7023e40f29",
       "pubkey_x25519": "1340148ca02b45cec6a55ccc09d3b06f73dd2fdf4e66963164de03c69bdac56e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22114,
       "pubkey_ed25519": "b9c8b5c2f4fd418a82300673352e911e7e4bc035441cb2ea932d69211b3cd536",
       "pubkey_x25519": "a401d0837838f6ab54d0be6420cb67129b9bb05d2bf86c6fe40dac76e8e18e5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "104.243.34.25",
       "storage_port": 22106,
       "pubkey_ed25519": "b9ce05d9a464a0b276c480d6ebac2439dde75c308897b4e7b70179edd39b7c1a",
       "pubkey_x25519": "bcac23e1c2edefb4855d0a9efede77ce6815cd918d7d51d0c151b0f8d44bae0c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "178.156.181.213",
       "storage_port": 22021,
       "pubkey_ed25519": "b9dc96f4476adc1d346b80a8ebc93b4667af4c6aad8024ce1590b94223bf1491",
       "pubkey_x25519": "d3d2f4a7671931bf9e35f42cb8920fef132a10b2cf8268fefd8ab0f85dcd2b77",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "89.58.28.248",
       "storage_port": 22021,
       "pubkey_ed25519": "b9e5b60aa2e45fc0509129a6e4e42eb370bb0ea67294f11f9a810881e78fe29b",
       "pubkey_x25519": "b3efe1f6f42c2b14a8da3e7e6e06a29eb7125661f25596a1df7986bbfff82d1b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.71",
       "storage_port": 22021,
       "pubkey_ed25519": "b9f9a8336ee4e6a91d6fcfe264e2535fd38e7f7d2d7abb3a36aaefed92903cc8",
       "pubkey_x25519": "89682badaa2b505633ee9a1fba40078ee76248a590527ccf986b3a314ca0d435",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "157.90.226.160",
       "storage_port": 22102,
       "pubkey_ed25519": "ba00491b1c1cfe112a46178c996e0af0d9606a3e2156087189bea2c51c414708",
       "pubkey_x25519": "21d8689086e67ca9c1f9ced4af3ba223855466e5a85cedd65d7e78fb0413ec3a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c8ffffffffffffff"
     },
     {
       "public_ip": "150.136.106.40",
       "storage_port": 22021,
       "pubkey_ed25519": "ba48da83f74406dc617cfcfba58bad515c5566d63d39ad8a3d86f6f336a9a088",
       "pubkey_x25519": "903e42089c9973a7d5c0cb4f5c55cee68b9f88bfeea8897ae6fc8da1d4208c5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.20",
       "storage_port": 22021,
       "pubkey_ed25519": "ba92db85f0f3e8a9ce9436cd866ad1b6af82f84ec34d84bb0859f02bb2dd4c4b",
       "pubkey_x25519": "0eec7163c5f6c68ee10dbbd494a376c50643ec1eef15ceeb3feadc7ac60b6749",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "82.180.147.179",
       "storage_port": 22021,
       "pubkey_ed25519": "baaae4945a020e35dbe8f63af9fd3c8b84b1b557a595e721f97c7abb77a716f6",
       "pubkey_x25519": "93ccb45037755204b63a8fb64b55eef74eff194d1f82cbe8429a5bd5f0ab3b22",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.66",
       "storage_port": 22021,
       "pubkey_ed25519": "bad52b8338107d4f4181cf0d9f353b83df41f91d3eaeb29b56ff4b6fc66c45ed",
       "pubkey_x25519": "680bc30efa3c5cc076bfa123c72df96390c13723c02ea6c16e06c7ef6ed59211",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "157.90.226.160",
       "storage_port": 22100,
       "pubkey_ed25519": "bb4f3d7a01548b99f7b64ddb521e84c583e4a2c8b9865b328a934576bac6a94f",
       "pubkey_x25519": "c691493f2686c73526972b6e993e742ead89a9595a674c0571351b85d5e7464b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22113,
       "pubkey_ed25519": "bb581b7ee8b6a2a1869fcc6c877e45d5d0952fee2a1a76d99e939743e21e9376",
       "pubkey_x25519": "368faa6fc52f32e774bd724d7a1aced1eaa1d32683355bda0a9f73f0c542f61a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "23ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22114,
       "pubkey_ed25519": "bb5c2c2509213f30e1c155ece0b58bc0c704b7a2f11a63e00b71859647608817",
       "pubkey_x25519": "864a9868885391a15695172b9e1d88767c6671c35e2d7e993ab56872cda3c243",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22108,
       "pubkey_ed25519": "bb689ddd5bcd12f19905ef292a7d5d8ec60b7d08a4e520431a098e0a05dadea8",
       "pubkey_x25519": "bfef260a94d85c3a5ca761637bb47836023d297cb3930447e4134526e56f0d50",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "23.239.23.208",
       "storage_port": 22021,
       "pubkey_ed25519": "bbabe410766e752469d16c4eaeb6f5d235ff5b37880ac3e733c722fa88777365",
       "pubkey_x25519": "f4f99932d81aaa097a44b3835b8eba33c2aa7d44520eaabcc33b9e1d27609270",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "affffffffffffff"
     },
     {
       "public_ip": "144.91.74.95",
       "storage_port": 22021,
       "pubkey_ed25519": "bbe12b70327f94e9b408ff1c10a43aa9424ac888369aff07a16c394c9d8139cc",
       "pubkey_x25519": "7a436ac1f6120677eedb26d95c610894dec9ab9368d214458a6aed715d245e16",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "20ffffffffffffff"
     },
     {
       "public_ip": "185.135.137.82",
       "storage_port": 22021,
       "pubkey_ed25519": "bbfa5147c71d6d7772de164779da198c577381c779407d8c49a58509917edde6",
       "pubkey_x25519": "ebba671c35ca46223adf70e81ab811112b66657128c32a3aa5a543cc00daf71e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "162.19.227.254",
       "storage_port": 22021,
       "pubkey_ed25519": "bbfeb4d2b41703b94ff3d3557dec733075d443f6142b1b2f337d6c35ff710707",
       "pubkey_x25519": "f763def04ec40fa2d559a86518b675f74bb8d10d5a2d09a20ef974338910df28",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "46.225.90.28",
       "storage_port": 22021,
       "pubkey_ed25519": "bc67c993dbf95c416bf65cf7ad8e1ef28e6c93e9a09b58132b0333b8ef1a26d1",
       "pubkey_x25519": "a3393a557fd9bdfe96a92eb42a19390053278bfe8329440b44c1a4166c340845",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "67ffffffffffffff"
     },
     {
       "public_ip": "193.219.97.159",
       "storage_port": 22021,
       "pubkey_ed25519": "bcc88c24c4860843dd84500da78c339895748e62983a79793ef07c37fb61fbdb",
       "pubkey_x25519": "feab77098134c200f08941192a58ba9555574bcf692879e435ea9428aa89c045",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "91.109.118.103",
       "storage_port": 22021,
       "pubkey_ed25519": "bd12f1392286162f297d9592807b51a51de1fcad32ed7d8f63e3f7e3c625d74c",
       "pubkey_x25519": "f03cf89f2abf19e0233c7bde1b4ece76123a20f2571912c5fd6516b8cec25b65",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22107,
       "pubkey_ed25519": "bd154539fe54a0cd98c1d78dd920a3d8be080bf2dcf4eec13557fcee8e20d1f9",
       "pubkey_x25519": "749514e63ce37e05230f97f121cf384cf11610beb900c055dbcaed4adfb45127",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22407,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "104.244.79.249",
       "storage_port": 22021,
       "pubkey_ed25519": "bd46068a2af982e13c77733c6faf1e8a72699fe5eacf5dc0bdd1c894144ec29e",
       "pubkey_x25519": "83172a34510c7b2f10cd65c77bc2c16adad77f98870ad6546ebfd0e40cd21448",
-      "requested_unlock_height": 2064052
+      "requested_unlock_height": 2064052,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22101,
       "pubkey_ed25519": "bd5025557aa3f96670a4f460e2d75d8d24e013ab0e4eb612d9403aaef8fa08c1",
       "pubkey_x25519": "542be3c0f51ae7e3b9680bd424106b987d8fd83f62a58e6252c60105a3cf147e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "51.81.202.55",
       "storage_port": 22021,
       "pubkey_ed25519": "bd82fc5d7c8d1bef807ffcb7a4c1ce19854216a27f646f1c420a5330228b9547",
       "pubkey_x25519": "e337643ec09e5268b3a215a298ae7c8dbd6a3a9cffea828b44e8dd4e11866e25",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "107.189.8.34",
       "storage_port": 22021,
       "pubkey_ed25519": "bd9bc8c86a0501c5767f8070161cb4397b63969c146278ed302c68f7c1e969eb",
       "pubkey_x25519": "ae50c896f8995fa87145ff99dacc9af0340f05b6affb800bd2149218ac34467e",
-      "requested_unlock_height": 2064051
+      "requested_unlock_height": 2064051,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "92.112.124.192",
       "storage_port": 22021,
       "pubkey_ed25519": "bdb88830a27b0fa7dcce657d2a60319e36e01d79f2c5c4d56bdfccd347c334be",
       "pubkey_x25519": "dcc2553c77f225f78a1d59a73cb192c2d2ee12c8d717311cabc9c046ce810336",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22106,
       "pubkey_ed25519": "bdba90f4e827c8879c67f3a8e3c0d8d4777eae4820454acccdd6dfa014513eed",
       "pubkey_x25519": "d288715f92382308b288d8c366af17c80dccabbc25011f14574309e6dc20c014",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "65.108.251.24",
       "storage_port": 22021,
       "pubkey_ed25519": "be5bf471ebc7eb3f22427b5ab4b7154e59533f0dcc02f47ad887ede551e75734",
       "pubkey_x25519": "6e73f3612f018a74b85918244169063a71af33465530dd06a39ef8df58701a23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "89.167.53.13",
       "storage_port": 22021,
       "pubkey_ed25519": "be7ca0d6c1f18c5be6e998055a7b05d5870fb3a13b4521226b422340eb69f95b",
       "pubkey_x25519": "6d835cc87db7ce2dea2b6224bebeb9ac7969c1c67ba767e2f2b81258cb239f1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "209.141.49.92",
       "storage_port": 22021,
       "pubkey_ed25519": "be9906d26b71e8687efff5697268ebde9863290e39c27c81d111fcb79710dae8",
       "pubkey_x25519": "e4e6e918e7174c719be2e3b22cb4632f437bf0fd5d7ee7eca467c27a34f9a657",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "164.68.116.136",
       "storage_port": 22021,
       "pubkey_ed25519": "becac7961948a24d271554ffb0b4b5f736498d3da05caf769aa49f55ae41f03b",
       "pubkey_x25519": "3d49b1cdf0cb13e28bbacac7c9bd46532c82fa6ab8610791ff8281050b35ea1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "107.189.4.161",
       "storage_port": 22021,
       "pubkey_ed25519": "bed03bc105b8be71ec450b93a3211b04c2f9a6289318729cad3e7890b23dd629",
       "pubkey_x25519": "45c6908cd47f67f6bbdd04700881fc90cd4295b3481bae3e158658dca5cc430f",
-      "requested_unlock_height": 2063708
+      "requested_unlock_height": 2063708,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "23ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22105,
       "pubkey_ed25519": "beda0d207020c02aa9f4dc1c1920231e9ea6115f122acd15ceb462dc19b1a567",
       "pubkey_x25519": "fb4590a8a993b4cf2ccc41c3721186700f1adac213e6e850c3ac2564c6efc57d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
       "storage_port": 20607,
       "pubkey_ed25519": "bf0e0fc9f600413138736a62f025ead4aca667590936f89fff295db1b0b67c70",
       "pubkey_x25519": "0faf2eb3eccf5f9988765dcb07bf807db65161f612fc4879c85815be00bd4e6d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20907,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "5.189.177.246",
       "storage_port": 22021,
       "pubkey_ed25519": "bf24341da879a379589a663444a59a2e82df8cfbe306c719fe27ed5ea46575da",
       "pubkey_x25519": "a57dafaecc1d55542b889274a836a4287bc499aa526cec04dfa593146d3f4671",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "23.82.99.99",
       "storage_port": 22021,
       "pubkey_ed25519": "bf3adf701b6b364ae630ffdb363fe244693620ded66c2b1757a6624d428233d0",
       "pubkey_x25519": "693681b56323be3b75e3d264809d3decf3e9ad97bec1337efb759ba950370c23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "51.81.1.170",
       "storage_port": 22021,
       "pubkey_ed25519": "bf99f87c6e0a72df72baaeb8e10f942c99e4d4ddd76117116e3f572e97e1fbb3",
       "pubkey_x25519": "c6cf8c16bba6b740db9d2d09542685690f96586ea919a129dc89418cac734c13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "46.225.102.55",
       "storage_port": 22100,
       "pubkey_ed25519": "bfbb58bf0f34e2dada5916aaf412fa3bb1d131b0328cb9f3824da8c3c7f16659",
       "pubkey_x25519": "55b61203d0625de9e5c2c19a84fd721b80c2aa08059f4e6a8184429c8784ed2f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "37.27.212.116",
       "storage_port": 22102,
       "pubkey_ed25519": "c0897a743277d0c97c2b75132763edb32d9adaf771caa2f914a40e0900a101df",
       "pubkey_x25519": "04cd54888af266293e23908be1034ef7042adffbdf75c8c022d0c17c473ec965",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22110,
       "pubkey_ed25519": "c0a227844f048bde8e56d83056e77abde60c11ac32b9df76a706cb6c5cf17869",
       "pubkey_x25519": "4bfc3d6913b19e940de21c487a94ba63109e947456e3158e6856e8756cae3f2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "23ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22101,
       "pubkey_ed25519": "c0c85c117c52d5e97830d7f2cf424d8916190dba2d311a742b9c7b2f34f4b7ec",
       "pubkey_x25519": "9a4cb558f9202d974bf13716641d09f5780d3f4a335de5a3d9d06eae5d62965c",
-      "requested_unlock_height": 2059290
+      "requested_unlock_height": 2059290,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "158.220.105.1",
       "storage_port": 22021,
       "pubkey_ed25519": "c0e653d08a6243af56d3b8a331dc47a295f0c1d255480ca8a4ce434ec9347930",
       "pubkey_x25519": "f61bb82a53640acde3e518679813658353e5552f61af740fc58efb5cae98a651",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "172.236.51.205",
       "storage_port": 22021,
       "pubkey_ed25519": "c0ffee00bdcdae5c3ed64442b39c44ce04bde30bd71f7a38309f02aa9c9511ee",
       "pubkey_x25519": "f905932ce5c1f1482b47c3dd82112b512e55747b475ce2d944d59876f7c23a75",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a8ffffffffffffff"
     },
     {
       "public_ip": "172.236.52.223",
       "storage_port": 22021,
       "pubkey_ed25519": "c0ffee01dc9a38fc5bf24a82500122fdaaffc9fa9cefaac4acfc80d2537b6837",
       "pubkey_x25519": "6bd1beeaea15435de97d450f2af338b846c4e1f48f5d69eea5fcdcd38089ea05",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "52ffffffffffffff"
     },
     {
       "public_ip": "139.162.158.65",
       "storage_port": 22021,
       "pubkey_ed25519": "c0ffee02fbe6be89047f605843d9f4b701186d8f9b9494791f22947da421ff31",
       "pubkey_x25519": "25d03ba669a00697462755004132f348ff27fb4d0de361347c3bfc216e9d7f7c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "167.160.188.203",
       "storage_port": 22103,
       "pubkey_ed25519": "c0ffee036c8206b23059d8c9aeb18d0dd865f9a12f8a8052df02b29babbaacbb",
       "pubkey_x25519": "7fc3868f6a4601e5035b1492946d5784bc51840aac48ee05f00e2f48fb65315e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "4ffffffffffffff"
     },
     {
       "public_ip": "167.160.188.203",
       "storage_port": 22104,
       "pubkey_ed25519": "c0ffee041005179f95b7e87396116872de49e079f62fae6512d530be392eb0bc",
       "pubkey_x25519": "6ee8e8e82cdf8081a6ea0d26b5f856c0a6a48b03fdae6e3425177ff69b19955d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "167.160.188.203",
       "storage_port": 22105,
       "pubkey_ed25519": "c0ffee05e92af93e22f795d3333dcb17ede382bc1e5f413aa1cd1947933efda8",
       "pubkey_x25519": "eb632df744df72bcea8f5713f0b1c130ba277652ab1cac736ab8628367ed541d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "167.160.188.203",
       "storage_port": 22106,
       "pubkey_ed25519": "c0ffee063c8c728e5c806b0708bb8c608c70a1ffe14108a61e9fa019ddc421a1",
       "pubkey_x25519": "0a7069593175ee88ede99dc41becfee5771a993c48bf3d3eba6d381ebf355323",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "205.185.125.111",
       "storage_port": 22021,
       "pubkey_ed25519": "c138b6c174c79205f9b0020ef47fd3ad8a42927f3772ce1a8d08549f2a68f8ff",
       "pubkey_x25519": "6776dd3e1a97e85922f5a65372d128f8912f5f61cfa46c046b228758ea95f95a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "155.103.66.146",
       "storage_port": 22021,
       "pubkey_ed25519": "c13caaf9fa14db02f1b7eba0240ae148953d2a421bc16cd502da8e375042b30e",
       "pubkey_x25519": "55b8386a8576bf09e502e055e7813273691b35214cb129a9ab7dbeb885ae5216",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "487fffffffffffff"
     },
     {
       "public_ip": "57.129.61.213",
       "storage_port": 22021,
       "pubkey_ed25519": "c164bc7f5b80b7cbd0e1601553b5b7b0303fad69de94d2fd3208cc1c5f2fa137",
       "pubkey_x25519": "a7b7035a318113d177c7c1cd783b0bf4b6d60b67ad0d668a15a4a212cfb58963",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "116.203.182.145",
       "storage_port": 22021,
       "pubkey_ed25519": "c1b8ade25f7fecea9a76025a174ebebd84d2b5162567f7aa44798186d9820334",
       "pubkey_x25519": "6975a58c51c649e23f88e4044450bfc38b919bb2ed13c4b972d6cc7d85d60f4f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "164.68.125.78",
       "storage_port": 22021,
       "pubkey_ed25519": "c23b705f48a639efcb3a9b3c3688e0c8936f8a29236272ba42a384b3820aac5a",
       "pubkey_x25519": "89540e88d985a1316beb575390a9afefe4c0222674e5649218359bc9e784856a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "205.185.122.236",
       "storage_port": 22021,
       "pubkey_ed25519": "c241e9e119766ad1796061b609c2ec36390d0e6f3d2b06577dcd73ea849375f2",
       "pubkey_x25519": "1fbad9cede01e14db5de72abfcd0b965f5a04eb9bd4283e5666a5b125f1aa222",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "209.145.63.121",
       "storage_port": 22021,
       "pubkey_ed25519": "c273254c2a9bfb3cb2adc9d616400fd792b366810a468e3fa4c3adba766c0acf",
       "pubkey_x25519": "c6fafbd98f03790eb8b9d8b4c2c852ab5d015c2dae1fe2714033c10586dfcd18",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2affffffffffffff"
     },
     {
       "public_ip": "164.68.125.96",
       "storage_port": 22021,
       "pubkey_ed25519": "c27f243185b5a2bf8eea91efcdcad478d94fb5bec74ee585584bdf0fd4696f7a",
       "pubkey_x25519": "f1f70270cbae3193af90699d6ca275821182eca9f261f135a08be18e4f5c9f07",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "94.130.15.33",
       "storage_port": 22021,
       "pubkey_ed25519": "c2ff515c025b9999f15c1b948a745a3c99777d71d44434dffe420fba25ee9277",
       "pubkey_x25519": "a9a4683adab57a290f0a326661e5e29d3bba938cf4f5e1b2dbe11b472f3a4f5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "209.141.42.27",
       "storage_port": 22021,
       "pubkey_ed25519": "c3300e4da6a0ed1a9cc426b6b4172bd946356e066f0f19c8f66fba85cbbccc19",
       "pubkey_x25519": "73e64e380aedc16b860eae75e472da7da252359b38866bddfc412d7b9e0db514",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "158.69.223.104",
       "storage_port": 22021,
       "pubkey_ed25519": "c3b5dea081b32941aee1c71dcc2948af2ed5efda6bc571d45258d6a44ffa1a7b",
       "pubkey_x25519": "ed7041b52bc2f875a54ef45c8b9469e3e32a0d6601f0ca8309d4065830c9604b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "5.83.150.60",
       "storage_port": 22021,
       "pubkey_ed25519": "c3ba2afd5aa46e920839c008098fd3e3a2ffbdce809b8db51033a40ba0e614e2",
       "pubkey_x25519": "3876cc5850c582f8e9025f285a0004d240cca9bf75fa9ea622a2d46d98ab4607",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
       "storage_port": 22114,
       "pubkey_ed25519": "c3fdb97e49f08d94cdb2fa20bd94402ec91ec4374c3d01372601fcaa2e3b7585",
       "pubkey_x25519": "11c98f1d96326ef2d6141edc013a368225d913b5884cf3ca326569f43ce0a36b",
-      "requested_unlock_height": 2060659
+      "requested_unlock_height": 2060659,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22101,
       "pubkey_ed25519": "c451e5ac41e4f6d5324b1bfb5c72888ffee66fd3efca833986b6a394b81603cf",
       "pubkey_x25519": "04a78d98779e69a12809543f86ef7763b22835c994cc3aedd333ef29022ab179",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "164.68.104.40",
       "storage_port": 22021,
       "pubkey_ed25519": "c46e4bddf47dc6616c88633bf57ae5afb126f25e36541fce95b504f6eb4abea3",
       "pubkey_x25519": "e3c0a8628bd82aa0318630978e3421ff51525eb8f8f12293c613d7c30245402a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "188.245.98.109",
       "storage_port": 22021,
       "pubkey_ed25519": "c47f23a50ad09bc879c80c7bc0784b8b6a027703ae84b11888047523bd274d3c",
       "pubkey_x25519": "ab72040a93a93f8df9fa38d95984ef915be20d84fdd40d370f395a3233302858",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "30ffffffffffffff"
     },
     {
       "public_ip": "100.42.181.71",
       "storage_port": 22021,
       "pubkey_ed25519": "c4c18120d65af9cea5e6efc9a8c89eb4fbdec5213611a61793314276346aa941",
       "pubkey_x25519": "825826273811f3218c5598f0878fe53ece881acd2efb6e4d6c44610963f31f1c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
       "storage_port": 22102,
       "pubkey_ed25519": "c5380e4d85bbcfbb391540ba45da87e807d392fa9fb4c432067638bff0553e25",
       "pubkey_x25519": "04a38f07aa64de059fb3c1234bbc5eed58768d1647f09b544bab6205e421753b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22111,
       "pubkey_ed25519": "c5475090d21281693c55f19ea4eec1d537f79918226f42b38217c753977b3a38",
       "pubkey_x25519": "3dea491458c6cee76dd86aac02110e1836991fe7020601afb3898ed9949d630c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "407fffffffffffff"
     },
     {
       "public_ip": "51.79.86.65",
       "storage_port": 22021,
       "pubkey_ed25519": "c54e5de21f93ef90caf551b08f364951c84b8e95c4faba03bdfde53db4b1d8f7",
       "pubkey_x25519": "21080555d35cac9240454e97a92fc406b07176e42cc07800cbe896f009289639",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "49.12.101.226",
       "storage_port": 22021,
       "pubkey_ed25519": "c55d772ba96dd1a81f64910eb74c597167c0342c227c012b8b5a83c4585093fc",
       "pubkey_x25519": "e58371d2c0efb7c38abcbc831fa1845d4535b3960907db78b4c58af3981ab35a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "5.22.218.53",
       "storage_port": 22021,
       "pubkey_ed25519": "c562de8157d991ac36e77d6319dd5a5a3ef7723ef2a88eea4085dd919f293594",
       "pubkey_x25519": "39d547f129bd50afc8d4afeb09e97947d0bb73082f32907f8c25d66f6c3c036b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "198.98.61.172",
       "storage_port": 22021,
       "pubkey_ed25519": "c5694ae105999d24a31ac6137c0c065c2a9a1390966ebf5caaa282d4ee0649e5",
       "pubkey_x25519": "092c8439fe806cba041fb5ec25f9eeeea6136391e2b8901686e1c73180863621",
-      "requested_unlock_height": 2056568
+      "requested_unlock_height": 2056568,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "199.195.252.173",
       "storage_port": 22021,
       "pubkey_ed25519": "c5a8a2016b94c05da063d8d45b7dc70612685aef1bcc2805e4dd4c80de334b98",
       "pubkey_x25519": "2eccc05e9f3aa2e9c7dc228f20bff467b15f28fdb8a1c4c1db087e70b9b07e72",
-      "requested_unlock_height": 2056574
+      "requested_unlock_height": 2056574,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22106,
       "pubkey_ed25519": "c5b02edd5b6260de927a1d6d63555b1bb24e97fcfbaf7fd412f63389c6ad7a19",
       "pubkey_x25519": "b336319f0d106a0f1b0aa4aece61faeeae364d9e2d33217a69d34e149796fc3d",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "45.130.104.239",
       "storage_port": 22021,
       "pubkey_ed25519": "c5c3365df3e71f72fe37cd02e0fff7a07b475deab4e87ab15ce51ea816adeec0",
       "pubkey_x25519": "47c82fec270dcf6ac2c26345036eb1482235121248af2d4efe702920b0027f10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "91.231.182.106",
       "storage_port": 22021,
       "pubkey_ed25519": "c5c42bbbca36ed6e1e41b6de05629cb2c834b900d869839d338d466e6d308a57",
       "pubkey_x25519": "1e3a978d529ed455df54fca51633284d48afac20a0e2bc93ff31013adcd38013",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "185.2.101.84",
       "storage_port": 22021,
       "pubkey_ed25519": "c5dd423914ffb0a7cd782539990c4aeec68680f5edb2736cfba928db21461933",
       "pubkey_x25519": "0ecfaacb3d500d5cdf7dc2e4d66259ceb5226563a99ef50efd9ed4ca6d9da524",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "89.58.31.158",
       "storage_port": 22021,
       "pubkey_ed25519": "c612233c46830efcbcaf474676a5710e78a0602c13de06708599da0ef2663666",
       "pubkey_x25519": "fb36d265277079cb3d62f8e78ba04eaeb5703534d12dfdd2c45b90369f5c2141",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "172.245.228.217",
       "storage_port": 22021,
       "pubkey_ed25519": "c66d8b775b69a7b71676aa7b0236e101daecb134de1ccb4d80f677ad2c1c2b86",
       "pubkey_x25519": "2226448c868c289a2bcb724db2cb15a26af135388f477f5afb02327d1ccb7616",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22103,
       "pubkey_ed25519": "c6714dfc45fe1ebeb3bb0f0568b6f6a9578caa6d4acd14275aaf1e4204ebac16",
       "pubkey_x25519": "87e29c19828f6699ed8e7cd4afe1974fd9bbe21d9406397e620cf1b939354e00",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "141.144.243.51",
       "storage_port": 22101,
       "pubkey_ed25519": "c69e6833737dc588671dd78cb05d5c65ca23ee6d457cb4afbc4637803bf6a8b8",
       "pubkey_x25519": "eb9c3861a7589a25bdb34c15a61cb6f338e692fafc7b72075de740b585dfb024",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "178.157.91.231",
       "storage_port": 22021,
       "pubkey_ed25519": "c69f9d0740e3e261ebeb22244f2e1d96dbc21a3a2977983984b1b5c0f613d96a",
       "pubkey_x25519": "814786b22ec3ae51f5f80c8b1c08c8350d4282f6025d5a02b12ed44ce3192657",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22110,
       "pubkey_ed25519": "c6af2f6233514f68c3845e61356855abf09228ea6fc5ca48fe0d63c228cc695e",
       "pubkey_x25519": "90fe5e772c672d2c4e1089a53f86399b29de0f3178ba126b837977740698111a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "164.68.113.32",
       "storage_port": 22021,
       "pubkey_ed25519": "c6c6c819fb205253864a971feb163e95ae8ab19b847316f4ac0e9ef58d0d083b",
       "pubkey_x25519": "d34478dfd8bfe6a47692f8973a46324837b0f6f5f955eb39497e256fafe16142",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "193.160.96.235",
       "storage_port": 22021,
       "pubkey_ed25519": "c73c3090e37f8f39b16ddbb25b18ad7fea25909ef915f82c24c62a03ac971e55",
       "pubkey_x25519": "16e15ae0f31a6009c7f9fb4e28fffcceb2da8b70e90794697e350cd129f0c60c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22104,
       "pubkey_ed25519": "c84eb4923d55b1290e007bb3a5752e3b71b8486a3fa3a6e7f019d2253848a415",
       "pubkey_x25519": "ccae94fda6071a730173740758450506c0cbfc920801697f9cfc8b99f746ae7b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "164.68.107.76",
       "storage_port": 22021,
       "pubkey_ed25519": "c925b6122b87d5cc854292beedf6b8dcc9822cf3897d45abf640096097e5e6ba",
       "pubkey_x25519": "ea37f01e3db55a8a08be2ffcb1faea4b71ee96226d96a89660df5c5844129846",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "164.68.125.174",
       "storage_port": 22021,
       "pubkey_ed25519": "c9375215b4e119fc5ffc86744e605262f7910e2d2256a8e502cdb8ff51b39eb3",
       "pubkey_x25519": "a4157863fba1578b2fad5842c0768566941f6a79e67610ef6ee4dccf8b486874",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22111,
       "pubkey_ed25519": "c9673a2677ab5423ff575b8943fbad20bc7ac56e5a7f079a2f1c137fd092e8e9",
       "pubkey_x25519": "d673a1fbe533546ae0cb2cd32f892bb233c66276cbe9d601c8ed901851589433",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "192.99.237.162",
       "storage_port": 22021,
       "pubkey_ed25519": "c989930b59fb14d7bde39227c1b5c61f37d94f8d985bf049c725eb8f937aecc9",
       "pubkey_x25519": "43119fbb9854faed81c5e1e690c590716cdea7ee264e9c87a444533c9de67f20",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "141.105.130.162",
       "storage_port": 22021,
       "pubkey_ed25519": "c9b8ef3151b1438f90c13fdfe3230e7b9fa70f7df21a8eac665c8dd3bfd5cd69",
       "pubkey_x25519": "44f78904eee98c5d677338796fb239d0d62a6141e65f979f474779dbc4e94a3f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "38.45.71.55",
       "storage_port": 22021,
       "pubkey_ed25519": "c9cfb8a5d5064fd35c8c7faccdb0280705a70b19e3249be7ea1d852317de5d19",
       "pubkey_x25519": "2d99b6e337aecb3ef970923eaa48d98220f96be146dbcb9427a37ffa65983e5f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "65.109.132.81",
       "storage_port": 22021,
       "pubkey_ed25519": "c9f426ee9cb8b983727e9c14e44aeafb48ab930c97e0a9160c5b58cc87dbe162",
       "pubkey_x25519": "13c29e3f7880c421457e6f7c5687f863e54afd2fbd0f20e179c62465c51c4d08",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22109,
       "pubkey_ed25519": "ca7082a1d3c2e503d1c0fcfc5ab6e0c0e12bcce606f9328f73e183ae654c6021",
       "pubkey_x25519": "0ad0e071dd88261bf7affb1f3e41f4e9a33ae2a14ab6f10e3a07388865fb6b2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "193.160.96.225",
       "storage_port": 22021,
       "pubkey_ed25519": "ca77d19915bd905b06d769892bddfa930c6be9cfb93941c80924495963af867b",
       "pubkey_x25519": "f323421f8c690ec4c8cb2206d5bf0b5b4523b728faca4c2e3671c1ff0ec33434",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9cffffffffffffff"
     },
     {
       "public_ip": "164.68.104.235",
       "storage_port": 22021,
       "pubkey_ed25519": "ca92601b37b881bd3c653bf45d9b222143fa10de9cc84a44c1afec38dc65ad00",
       "pubkey_x25519": "14f96f9d7665c39105ae12b237f0742e5f03cfc23d743839017351d644a00b48",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "45.154.197.41",
       "storage_port": 22021,
       "pubkey_ed25519": "caab86dd10e727964594fb93838c5a31fd0e0eb9e7ddc201d69330f4e62a6fe4",
       "pubkey_x25519": "f68116b735cf343ab2ba4ed5ece91471a7a60853127354e714d55fff93769c3c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "5.189.129.195",
       "storage_port": 22021,
       "pubkey_ed25519": "cad96ee5be19b3ebb403d46ff58cb917024332f97f56ffdcb1541f45dd5c4e7f",
       "pubkey_x25519": "f32aff7c86de3bc37417e4cd7a7355123868678aa0541ad7ad5a4046ff4f222e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22100,
       "pubkey_ed25519": "cafe00c136be239dfd1f7894c8f3d5448125ceb57df3f04195f41eca74ca11a8",
       "pubkey_x25519": "29090886172a41a8eecdf3d84a56fd6af02be28321c16756485db8d6914f0b20",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22101,
       "pubkey_ed25519": "cafe01fb4861027adca248de91c767e8ac54b32d12e3bc7364db2e845f88c038",
       "pubkey_x25519": "02a40a35974f97f1ef3ad5db3c5a2d75c80849324a09897e3151afc5dfa5ca60",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22102,
       "pubkey_ed25519": "cafe02aa206a99c3699a028a3805fe9d65776f2a3588dc094d54da82f36fbb02",
       "pubkey_x25519": "bd34f2ad597830a78f9e05565b9d89ccdc9611f0e81b9aa1a580a70f1e237414",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22103,
       "pubkey_ed25519": "cafe03aae890902c2db5a2f4b3afad8add7153fec38050bfd01dffcc6b1a09c2",
       "pubkey_x25519": "8e2d205bb46f53005aca2b7854a0bc506dae85a0a046b9234ab311ce74e3c65e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22104,
       "pubkey_ed25519": "cafe04f2db57043f8b9d26a9aa305e5707fd7b196b74b3f11daa35cc2a8928fc",
       "pubkey_x25519": "0a20d9b1719d80d56b86e27ace872def740deb9dd9daec67c3d214e599983420",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22105,
       "pubkey_ed25519": "cafe05f4c33852dbfa298bf798aeae23f531c2b9df2a86d017ebc4eb947eac87",
       "pubkey_x25519": "2b41d734a1026df81693b74e9fba61d27568015b6be25287a341a0e122acb943",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22106,
       "pubkey_ed25519": "cafe06e4acc10c4032ee83b9e603f350fb5c6ca09ba155efecaedb591d44ee6b",
       "pubkey_x25519": "712e7e8bead0c325076ceecedf214e5ce0a4303aee6030aedd3d1162a2cce45f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22107,
       "pubkey_ed25519": "cafe07ef66126fa40e7c02bfe9a570877aeb61e95b2912fbb5d03bb1666583af",
       "pubkey_x25519": "4dcb404991b5db97e4fc28dc06f7dc3c8b627d8bd3d329ec3d4bafa6b9b9d46a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22108,
       "pubkey_ed25519": "cafe08f8d3580f2665366a22d74f5cf9d1584ea7ebb0551305f6ee4c1b9bc116",
       "pubkey_x25519": "0d4dcbc7b40d73a9ed3eeb51cce5a2ee81222c0ea53e15a5ff81a094aec93d29",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
       "storage_port": 22109,
       "pubkey_ed25519": "cafe09f69a99f5bb67e0ae0b8105a88e48879b8d3f802c04202c48fcaf388a8a",
       "pubkey_x25519": "d2616056bc06ef33d0ac0f16156e9519bdbcbd9619647bff9a4965c0d179ab68",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22110,
       "pubkey_ed25519": "cafe10fd2c4f729c44c1582f1f1471c5d01f5847578353e63ba7f6b8bfecb5af",
       "pubkey_x25519": "25a102d41f221641de074cda4f7db78945a386a4fa1ff7ad913913edc586e42d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22111,
       "pubkey_ed25519": "cafe11fc493af7440600c09d7c8ddd7b5f0bdbcf72168a472dbb925cc613c1a9",
       "pubkey_x25519": "1030a6423b9bd95317139595bb027c317d5baee8682b1e74470a38fffcaa9200",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22112,
       "pubkey_ed25519": "cafe12dc248fc081d8669c7b4f41302711aaaff1b87579eb2eefb36a695414ca",
       "pubkey_x25519": "f8b1e1af6b5ae1c8b4a9968b824bb9bcf6260358d176cac3c5fd2b4c3162d000",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "407fffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22113,
       "pubkey_ed25519": "cafe13f5b415bb0014350638156bcc4e6df13ee2426b8f7ff4f2c8cddb352410",
       "pubkey_x25519": "d669628d8f90d133a29851923873c2fc4d33cea047882ff36895f7765e7b1668",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22114,
       "pubkey_ed25519": "cafe14fd7c7661e98475715de0ec9a999f163e5a2cce6c40f4d2658c630ab742",
       "pubkey_x25519": "9dc87251a690fb6bd5183e698054c92b2963de0a3261ff6944e4966a86407029",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22115,
       "pubkey_ed25519": "cafe15fc149fc6e014e5739eafecdd85fb998d3243bc9e4eaed85c55651b6aab",
       "pubkey_x25519": "ecbec168fe55408f415641f87ce73fb56bca72622be606cf269a9edebafc9742",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22116,
       "pubkey_ed25519": "cafe169ca19899c6adb9b4378c0fc2d83564eb33aeb628f49a52a3bfaf6ce9ae",
       "pubkey_x25519": "26c1c463a439cc334aba00efaf9e851a5d4f90cdf6b9db00fa35558d68521d1d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20216,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e5ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22117,
       "pubkey_ed25519": "cafe17d1dd66a01f49b69b54c7b892b31a26844fda66108fbf3a5cb8e6ed3251",
       "pubkey_x25519": "39d89734a3c948ce6a42215c98da9e05a55fb526764ad9ab7a42997650070c23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
       "storage_port": 22118,
       "pubkey_ed25519": "cafe18f385636bfcd303c0036105ddacdb6772b5ee2dd9e2bc0804622beea863",
       "pubkey_x25519": "bbac0f714f5ad19322474fc6ae8533bd7d8e843e381162badbd62052cce5977d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22120,
       "pubkey_ed25519": "cafe20fd1bc860c815300b994d42db9d16dda7e04ac2a5a7d1d7c3d8240c08fe",
       "pubkey_x25519": "924be2dfd842db71bad703d151e058c71d554ae5fe2d4924c0ed278889b64409",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22121,
       "pubkey_ed25519": "cafe21cb5e2871b18d2b90c1de3489e6af55dc78565882c415d25bec4fa682a6",
       "pubkey_x25519": "bfb5a06335df0c60b87d8b3119b1287cd3aaffca2eaeb0096ee133c933a99c38",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22123,
       "pubkey_ed25519": "cafe23fc42e617f10cb7ee7774bf40bbc827010f8ba6932eb3d155fa5fe4da07",
       "pubkey_x25519": "aad34898f6e315149a54b289287b96563426daeb4f2fb263564a200560c6df62",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20223,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22125,
       "pubkey_ed25519": "cafe25abef21cc6eebfa18e96524466350800eea03e8a0bb7066c79ce57a66ce",
       "pubkey_x25519": "c28d5df8e429b4c3c170cfd91bedff535b280785e32d1ee4a50d30f8f3d77379",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20225,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22126,
       "pubkey_ed25519": "cafe26f1cc7e7f6680a5669356d0e0b32d507434a1cc27e64fd1a700d34d7e6e",
       "pubkey_x25519": "e62e52b7314dcb7f35bf7e458871fc14d482be08ca9453a5a971758d2e7c6d57",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20226,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f7ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22127,
       "pubkey_ed25519": "cafe278941c671389b92b86e50b85a5a95de1824782d80a1bd51d40abec10fdd",
       "pubkey_x25519": "3e857372958af5766bef6671e78b35bf6e56f7d003a72aa277f07eac4fbee154",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20227,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22130,
       "pubkey_ed25519": "cafe30e590138993ec8f0c371624fa585d6c0f5f7199f34194c0e36b428814f0",
       "pubkey_x25519": "9a80b9d349280c93f706cb87692cda342f1dee3e68a47bf94c9a9415d111bc52",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20230,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "467fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22131,
       "pubkey_ed25519": "cafe31ffc5028b95d96675a0f0f14bd58d16047962767c7f12bd3a3d5f82f295",
       "pubkey_x25519": "20dd64784c7f2dc9285c0dc0a2eda57b22416f5e62a932b7782a77b1f6924d58",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20231,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22132,
       "pubkey_ed25519": "cafe32f03d75f3a5d9dc7bd2ea50c92db98ed719676b6dc388cdc1bfac56b71a",
       "pubkey_x25519": "682ed63aef33c655c03168e9cbe53e9e609ac5dda8c4476741c194dfac655577",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20232,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "387fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22133,
       "pubkey_ed25519": "cafe33f77845d5e4af49744dab73e1272c19d8ca88425b75e56369c88224e08a",
       "pubkey_x25519": "b51a752f533e3f0e4e349a55b3bafb0891e0bb3f98afd7d1b5719725b3fc1906",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20233,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22134,
       "pubkey_ed25519": "cafe34fc02a28fb86e23394dc73d992526efbd04667784bd36985abeb5142688",
       "pubkey_x25519": "5987acef97f448e9fc7e27620994d7bb9eacd41dc0d2aa908876eef4410f334f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20234,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22136,
       "pubkey_ed25519": "cafe36e23db9e7586c8005de75b8d66fe10cd190f4ec9e26f4d2980506c90c3a",
       "pubkey_x25519": "6a48d9e14b104e3506134139dedff2f6a0581e84e0108471c70f41b155db6473",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20236,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "327fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22138,
       "pubkey_ed25519": "cafe38ff5358d034cf2f7bd490bc27220b9b362aad92e6303e81837aaf56e01b",
       "pubkey_x25519": "63d340856ede9be4e666cecc036094adee64057304068594ce8b8bfa4389fb4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20238,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
       "storage_port": 22139,
       "pubkey_ed25519": "cafe39ef26ba0b8580d5db076409f72aa6fed3d5f379365f993124d9060845bd",
       "pubkey_x25519": "dd98a97f8cbd6cf71a5baa228c3ccacebb29a88f21ae68ba2d383eb7873dc250",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20239,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "467fffffffffffff"
     },
     {
       "public_ip": "135.181.149.114",
       "storage_port": 22021,
       "pubkey_ed25519": "cb8387c41ef37d550947836202a1da21d92509681b5d58b3d822f858da4ba2e9",
       "pubkey_x25519": "33985f5e3b04a3eee6801a1a10bfb24f083fd6a27e1f1f883c62f75cb38bc304",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "128.199.238.28",
       "storage_port": 22021,
       "pubkey_ed25519": "cb8995c36bd430f4483eddf8f98d873b5c9b178c9a9c8b48e4997a0e2192edfc",
       "pubkey_x25519": "0b83351875a7f70aa477495b6815f8168e2af6837ef099ae50121751d0c1b50a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "161.97.137.219",
       "storage_port": 22021,
       "pubkey_ed25519": "cbeaa9f1115254c2ce225018908c2166d4f4b3f3f624ff5750c65387f4ce98b6",
       "pubkey_x25519": "6636e95eb46e39c7d44bcfcf39c95dbf6e3cffc1c387bc13d88d68b8cc6ecd4c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "91.229.245.243",
       "storage_port": 22021,
       "pubkey_ed25519": "cc1d12b3fcdff3a00d098abda9ed3ebbed062a902788142a826c018706f4eb68",
       "pubkey_x25519": "a840063146f7bf32a2615858e1a113bf62ce6f0ca708405edfc090bcdd683123",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "185.209.228.134",
       "storage_port": 22021,
       "pubkey_ed25519": "cc41aae3388d4629753033f55c27ad130080f700bb3239cd1766ea0ccfa17ed9",
       "pubkey_x25519": "f64065118076421c5eae84d9a560eefd8fd792c20043f69755d95fc429194653",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22125,
       "pubkey_ed25519": "cc70f6135c51a9bfa365580cf2ce94076174c728a0ada570627a2c62abae4b62",
       "pubkey_x25519": "da17610e7de606e87c27313b894228e28913b623a7e751bae2d1dd3ba398f579",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20225,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "94.72.125.80",
       "storage_port": 22021,
       "pubkey_ed25519": "ccba88dc9c24db706f961de688265791f7ed4650acc1c180983a32bc8726574e",
       "pubkey_x25519": "0cb4874794725a8d75259fa41850e68d1de3369673dd3476e7a275f7145d6e16",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "31.22.111.5",
       "storage_port": 22021,
       "pubkey_ed25519": "ccbef169a13b207bbe4ba6b26ef137fbed788f670a7d1913d19beb60a43d5e35",
       "pubkey_x25519": "945aa11c17cff249da87efeccd2c0e8d8fb4405fd3ec8cdfb2348d6610bda46f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22114,
       "pubkey_ed25519": "ccd42d82f315d4134a1e5bca44fe12af00a974df6e0e0bd6e2937bc8ba3a7ebc",
       "pubkey_x25519": "4092f1669a4a4637aee9e1ae29ce6817ae4032329893d7e9a40c926f979c302c",
-      "requested_unlock_height": 2062111
+      "requested_unlock_height": 2062111,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f7ffffffffffffff"
     },
     {
       "public_ip": "5.189.189.215",
       "storage_port": 22021,
       "pubkey_ed25519": "cd37c634b475723556e1d6881e99052f11db55dff7987889340610d894326ced",
       "pubkey_x25519": "a5e4eb7baf85f881590d6594495bc43795427e9c755c4af88eb09b5237fee57d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d8ffffffffffffff"
     },
     {
       "public_ip": "135.125.140.64",
       "storage_port": 22021,
       "pubkey_ed25519": "cd4598d8a6fb87d53e17dfc770dd88433175eacdf95f16d0501fa6dfd7b9c504",
       "pubkey_x25519": "210ee6f2d82fb0df329e4986dd6129dcf5b37ecdf5102dddda1cbdfb7def8e13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "95.216.137.153",
       "storage_port": 22021,
       "pubkey_ed25519": "cd6d8a7336f01a062ab14bd27218b1843fd45e5f99e4d48a1922806ff1e3faa3",
       "pubkey_x25519": "2b5f67544af22bb681b65262e85d127215499fbc96155e460718f8adb1cd4779",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "93.90.206.17",
       "storage_port": 22021,
       "pubkey_ed25519": "cd88844a5e609600c44f081cb0e4428408fa9046b952ae4bd82ef16e5251b406",
       "pubkey_x25519": "6d1374b7680ea8adc4cad43b0da38a2eff0f7fdefa383c6bcb35dc6a68d6ad59",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "185.198.27.134",
       "storage_port": 22021,
       "pubkey_ed25519": "cdb274d473fa5bf03edb1f24b9c12b6d0ef768d9644571b5c567f0de6ae4a467",
       "pubkey_x25519": "1b1d36fec1f04b67222a623605c56484a7c4082f001f0567a5c58a6c57a03133",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "207.58.175.90",
       "storage_port": 22021,
       "pubkey_ed25519": "cdfbcdae2de00da6058312a88e05249840168e8725847a0a12e4b3818d6ae037",
       "pubkey_x25519": "97f72b77d9cab72ed659244c1a1968e30555955ad898534322c48b44a1139940",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "144.24.179.149",
       "storage_port": 22102,
       "pubkey_ed25519": "ce0e9dff3877faa6011cb3aa89bd2a58a568a667fc33295f012d45fc246dbf40",
       "pubkey_x25519": "5339b037e574cf03a16faa737251cd65e251388dc0c444392960c426d1999f41",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "138.199.168.156",
       "storage_port": 22021,
       "pubkey_ed25519": "cefcf7871300fd94ee2397738a3b42518ac0f8a46df4c50beacc0f69bad46d4f",
       "pubkey_x25519": "89b205f6bd852be5d25571b80a2289950b39e877b42107573c7618d87deba617",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "102.219.85.93",
       "storage_port": 22100,
       "pubkey_ed25519": "cf446948060ecd12fe12b5fbc28e67d1251d0ec33d522a8c9ac31121724a8588",
       "pubkey_x25519": "e9add909986d043a326469f3b5941160e75a7886aca724f8409b6f0d34312e42",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
       "storage_port": 22106,
       "pubkey_ed25519": "cfd9faf789b7bf7c3a1c24895756ddc1dbbbab0a69cc9bae4c79d7428d05dae4",
       "pubkey_x25519": "75d99f39b3365ba8ecc0240473450ddf2990550ab6e1821a29834e8c1481706c",
-      "requested_unlock_height": 2059344
+      "requested_unlock_height": 2059344,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "23.88.58.63",
       "storage_port": 22021,
       "pubkey_ed25519": "cfef91bcf3083601cbd4f770fd14bd4cded59a2029b37abc34023c96e813d770",
       "pubkey_x25519": "c15b2f4e3683aa87e308b8209d1f66e8d797e062c30722a99b090b61c8089a13",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22100,
       "pubkey_ed25519": "d027993ee0ef66b99930216cbda95a4242ff41e11d62b0efbeb1e711acae7589",
       "pubkey_x25519": "c0ff855fbd1db2e11491df93be65d1da87ce58927b928815f2f3974965381975",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "164.68.125.136",
       "storage_port": 22021,
       "pubkey_ed25519": "d0358a902f237f44f6c75948783e69c98b8092f76c6d5e20f16e5ba4c17b4cb7",
       "pubkey_x25519": "960dd6bc935c3a6a4c086afb0e06f10a5660009ecd35baa9e8b1fa4efd6c6970",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2d7fffffffffffff"
     },
     {
       "public_ip": "208.87.129.102",
       "storage_port": 22021,
       "pubkey_ed25519": "d03738f8a4d3e49a45e104d14775e8fab9e3e81927a81178e550dbda41e31b9a",
       "pubkey_x25519": "e90c345863dc50cff06cdaf6d68c9c3cfa2e3933491609b9cb7de480c47d3a7e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "185.150.191.68",
       "storage_port": 22112,
       "pubkey_ed25519": "d0989e60ec38e6447d97410b87eaaf8843367419a978e7d5b222d561ffe159d0",
       "pubkey_x25519": "f9b33a6c72e6b26a2f3b4774323fe33e24cd3e86a56b42075896061988d50b36",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "109.234.36.164",
       "storage_port": 22021,
       "pubkey_ed25519": "d0aa3ac5b984174a4ef640da93adaae57ad8e4eecc97d2a338e58e511db757cd",
       "pubkey_x25519": "96f5d5ddfad37e48e757e3d92f23a89748c1a57f6b2b65f45717c1005fab095c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22102,
       "pubkey_ed25519": "d0b22df940dd22bbb16759b24f11799125a442aa7187f2d1ae47eddec98ad572",
       "pubkey_x25519": "47c28eb0a738de028dda603d85f8262be6a3468b66b2918c492d7c0f8d0b6613",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22121,
       "pubkey_ed25519": "d10097cdd26e57bc6162d75b231f449d6cb31dc798261ba9d592acddd42e78c8",
       "pubkey_x25519": "b568d529dae3ca9f820334d409806a214ce252d99746f744ddcf49c5be612b24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20221,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "164.68.104.98",
       "storage_port": 22021,
       "pubkey_ed25519": "d103b5ccd3aef4283e0ef4780d7db44090694f13feb7fec830d5b2d8b1865590",
       "pubkey_x25519": "5d603a1fae0a6304e11131bb0554b4f3c132891e7d03be49cce5ec335bf5c006",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "104.248.163.43",
       "storage_port": 22021,
       "pubkey_ed25519": "d136d3c62f61a35e33de5ee9c793285298163918ce10659f9763ef56541ff773",
       "pubkey_x25519": "eae5f5d99d21ec373c9dde6bc87ad7f781ed17c8d7829d9df49d6a6d9c6f845c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "144.91.76.191",
       "storage_port": 22021,
       "pubkey_ed25519": "d19783f75bc0e87cad4b8a9d63696ffb0122edf495da6d5c3a627512e485bc85",
       "pubkey_x25519": "777aa868c8315a23ff15ed6053f9d4172c0ca4f4ae77468b8d835c266f44e74a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22107,
       "pubkey_ed25519": "d19c29eb7c806f30d8f2fe77a3ef5cb526c3ff6c1a6f70d7b2e3d8a84ab204ae",
       "pubkey_x25519": "a78bccb4d6cd2e5948c6352fb53eb423b06753644f76324a8a8bc93f7169ac7b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22407,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "142.248.28.45",
       "storage_port": 22021,
       "pubkey_ed25519": "d1b03c9c36c123a870aa5fbc1d02286ff78681ee862bb3e24b465446216e2a32",
       "pubkey_x25519": "85b0f6f684a423d3a0d9b9e8f4620f2b54e40bbc43dcdebccb5bf918e001766b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "199.195.251.55",
       "storage_port": 22021,
       "pubkey_ed25519": "d1c97946a5ba1c0c875a39b583bf69ac61179f2c91b6fc9048a5bd02f78fd133",
       "pubkey_x25519": "4e09878687e965089dc1f2c93c2c5494568d1b379b0ef841c7f70c9066de9267",
-      "requested_unlock_height": 2056575
+      "requested_unlock_height": 2056575,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "64.235.33.156",
       "storage_port": 22021,
       "pubkey_ed25519": "d1d935f6fe71384ee7f5765fd3e909d1df294d15db0183be2de0b59552e2335d",
       "pubkey_x25519": "e7149af982603279f13ac0dd9fb2091523587f7a81c31495fc701a726f1d0a64",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "188.227.250.41",
       "storage_port": 22021,
       "pubkey_ed25519": "d273bd93e04d8fbcbf1cb5adee0cab008ed241828ca726fd44cefc2db6aae5de",
       "pubkey_x25519": "bb60d6aafd2992131eb2c87b48b25ed1e307255c15b87c3967569739761ce302",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "192.3.63.197",
       "storage_port": 22021,
       "pubkey_ed25519": "d29251a5ee2c8f7022b47488e3defc6b6184117c9e455ed800ac60f9c1388fb3",
       "pubkey_x25519": "6c68ff631e64f09c48170b9e5d576531b4a5fa8ea4580d583eccda989eb1e973",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "85.239.247.57",
       "storage_port": 22021,
       "pubkey_ed25519": "d299056394d9e52a9c3c8633cd801a42f5ab0ba72d9d44d296388f0ccb216ed2",
       "pubkey_x25519": "38c990454cb3d31c1ac1ea06dac989601e9e26a37b9f182c27575a2dad2b8066",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "188.34.177.95",
       "storage_port": 22021,
       "pubkey_ed25519": "d29f87c9b1f629ad0371506cd10e39da0da43a3d214f729d5d2383b24a4dbc59",
       "pubkey_x25519": "25e9d7f7e469be9147319be2124f3aae39da4ffb68603385620f555ad4c8fc58",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22108,
       "pubkey_ed25519": "d2b4ef8868104b97331a0973be04abf6b692a58c2613989e264041e806691c70",
       "pubkey_x25519": "dfed9b6142d83cf90449834070fffd189bf5e768702eaa32a522409de0fc1729",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "185.153.55.236",
       "storage_port": 22021,
       "pubkey_ed25519": "d2c3f58a65d611228b49343bddfc03800020b4a244438fdec627b17b0b892701",
       "pubkey_x25519": "f271fecfb21b5478596242325e4d9ef12e4ee4f831ebada48fcaabf24000e20c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22109,
       "pubkey_ed25519": "d2db0142725c139d494207619ac348c72eaaedf6383bd0a10df5ec1a52bb3bb2",
       "pubkey_x25519": "5f0e4398604c06f02869dd96abc9a2b98b3def2ee65796cf33ae1bedd2ec8b42",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
       "storage_port": 22103,
       "pubkey_ed25519": "d338915e083ec873ee9c5f24d983f3320e5182df02425c33da494fafab9c70c3",
       "pubkey_x25519": "d11a4b0c8289256883b383b80eb176f2d41c4fc001c1a8be8f696f15a0644c71",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "178.62.226.233",
       "storage_port": 22021,
       "pubkey_ed25519": "d36bef9b92c9edee797998d96a41a64a2d919c9ac5dbaeedb32ad6955c8cbc9e",
       "pubkey_x25519": "cc320f6f822d30fdcd08a6b1cd913a42a2bb41e9bba5781f60ef5ddb5ffda737",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "141.94.206.162",
       "storage_port": 22021,
       "pubkey_ed25519": "d39fa7220e421ea8a6906dcad803be9cecf8e1be93f88c749b1a5bc59ae5c2f3",
       "pubkey_x25519": "8c71f2d7ec5af97e239d4b98ef42fd3df890af28acfd86d3965eeeadc2632717",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22119,
       "pubkey_ed25519": "d3a1b5cb29572409d479e21f0fd3c3ecab56f0910488f73e17c6703485a38d49",
       "pubkey_x25519": "502de7e4551d6b8ac3315638d201a933be27a0d3fae901aa3f32e6581e169f04",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20219,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "185.219.84.241",
       "storage_port": 22021,
       "pubkey_ed25519": "d458bccd428b87db4da22a20b41da2a5672d6d0e3976a24e9f3e594ac593abfd",
       "pubkey_x25519": "5c27d9a28c3fe2c4ccc58359c661f34dcbbbfc96faa31d5e0de8450f054c8061",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "164.68.123.162",
       "storage_port": 22021,
       "pubkey_ed25519": "d4b1e879d9ad4c8e5278cbfc8711d4e739b499cb2ced29c0065439d7f45b4757",
       "pubkey_x25519": "69f922608ac561e2991be8f3162e3ad20919563e73e63d4b5d7ea5586710e815",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "198.98.53.254",
       "storage_port": 22021,
       "pubkey_ed25519": "d4ea40416f828834058c1032c20803b00af9091e1b82f8df08e1e3fd4f0e4725",
       "pubkey_x25519": "9b844000305b167fb872859123f02da48adf21f808de1f8e9eb4d92ddc93ab2f",
-      "requested_unlock_height": 2056567
+      "requested_unlock_height": 2056567,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "135.181.103.95",
       "storage_port": 22021,
       "pubkey_ed25519": "d4f9f6d8d96be5c3d26155cff379c52854a42c7da8b3bf95bdb500b9644819ae",
       "pubkey_x25519": "93789301abef326fe77aef4da9463ac19c22707db6ae2001fb843e412c256979",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "147.135.115.55",
       "storage_port": 22021,
       "pubkey_ed25519": "d5043ec54680f279686a2fd56deb3899519eb2fbc19e7c1d48b8e563787f74e3",
       "pubkey_x25519": "2ffb22b7c9a4b1919739a9aebb1356fa0b21bfbe90897f916edc93309b728c14",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "31.22.111.227",
       "storage_port": 22021,
       "pubkey_ed25519": "d53130ee19018c7f2223675cd5d7c9f7a6a7b3694cc0cc37a2b34ae03f7e2a9b",
       "pubkey_x25519": "d85b379bcba84278504410a2c70884b86e52d84b7e7179c50e0a7bf25337000a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "139.99.135.156",
       "storage_port": 22021,
       "pubkey_ed25519": "d624df8573ffd69e45949223657df772df29dcac2e9c675804be1cf099a071e4",
       "pubkey_x25519": "68f799a448aad6429b22461755e7f5ba55128a73f2479d0612332ac20e7a791d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22113,
       "pubkey_ed25519": "d627de06cc2d4820cbf4df5b7ade2392b684dcf470e9ca9cd7a198032e1f8ee3",
       "pubkey_x25519": "7d426e94ac42f00ffb47c5f1d0c324b253bb8d2867cc2202e011d2dad718df2b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "247fffffffffffff"
     },
     {
       "public_ip": "164.68.126.68",
       "storage_port": 22021,
       "pubkey_ed25519": "d65a221b38bb7f1285bcdb64d4b03490c36487e54a1331b430256a7643914247",
       "pubkey_x25519": "a066b671eb6cffee0709632d9326727fb1434a12d1e7d46232b6a998b8cd554b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22112,
       "pubkey_ed25519": "d69d45b83cd34ebd394e761561d4feb0ad7a47daa8f198d0997cbea3a7622858",
       "pubkey_x25519": "41548b2d0c9774e8682412d3207f3379807a128a200f74e9c87572885aecae08",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e5ffffffffffffff"
     },
     {
       "public_ip": "142.248.30.247",
       "storage_port": 22021,
       "pubkey_ed25519": "d6eeb243a84c55190514188084a69da2393213921aa169c11e8e5424256a5915",
       "pubkey_x25519": "d8a04a6821ab35f790a23dfbc95b93c709bc2a13964023930a9ad114c472a013",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.220",
       "storage_port": 22021,
       "pubkey_ed25519": "d72ea1a6d387d9242a47b21839ae81c99e3569dae96196661ae2ee2c2f654c43",
       "pubkey_x25519": "b73a9771fee04c99b91f09d853833eccf072cff4a220452ccc58a2c2e1c7ef52",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "15.204.87.227",
       "storage_port": 22021,
       "pubkey_ed25519": "d7419f3b498f546e20017d031114d642d354409dfcff167e341228a20d7017b6",
       "pubkey_x25519": "f0375a78c17d9a0486c55ca3974d3bd6f6342da917f0b01bbe7b33a587d1b51b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "51.79.71.92",
       "storage_port": 22021,
       "pubkey_ed25519": "d748f2093da3f426c961e5eefc8a47ef62dc2ae32fe303e3b61c06c447437368",
       "pubkey_x25519": "bc4605058756271e0dcfd2f965e8e4ddb2eea886d48da31b532c850567bd6051",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
       "storage_port": 22103,
       "pubkey_ed25519": "d77069c7366db2ed67a88e802a973b9f3daa78deaf4785854e726447e68dba70",
       "pubkey_x25519": "2d673cfe96e44012c2049a7852d45e573c91b5bfd3321c5426f62a0f914d846c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "45.159.220.22",
       "storage_port": 22021,
       "pubkey_ed25519": "d778e23c36a5568dfaa042c9b25542bdddee7931678ae5defa960ce3a001355a",
       "pubkey_x25519": "546a3cf81f54d5ebaffd9d1bf4c0e2a175095700b9882e2c30ed5fa21602da06",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "38.60.229.76",
       "storage_port": 22021,
       "pubkey_ed25519": "d7c7e35b8aef7734df6069762d417e46fef6e05b197f2ebe67cc5cbe0f4487ab",
       "pubkey_x25519": "ed331774e6e26b631f989bf7d02e263da52aa9847ea870dbda75687775f9c65f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "169.197.86.232",
       "storage_port": 22021,
       "pubkey_ed25519": "d8081e0f5c1ee1687b0dbb7de7b12d38f778046e35cb75142122a7309e200220",
       "pubkey_x25519": "cdaa0515139b54ebfc3313a30206d5e04eef5a12777446af179daad05354e869",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "193.123.76.22",
       "storage_port": 22103,
       "pubkey_ed25519": "d86c877d04b1e2beef1ea3b78f05253e95fb843b6edd687ce4c12c34d6228696",
       "pubkey_x25519": "f0ccaa585e9774b8e4107894c511f93a39a5050119d13544426446c7bc48104d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "89.58.0.228",
       "storage_port": 22021,
       "pubkey_ed25519": "d8de7fd4c975908226718fd82ff50959c3cb64079cdd408cad5bebb580e2984f",
       "pubkey_x25519": "92032dd805e14fb992c20f545a6d1857e26ecf1fd7d93a69e7ee7c1af9406130",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "104.234.231.219",
       "storage_port": 22021,
       "pubkey_ed25519": "d90ef997bc4bbe7c0fc4b267e2340cc8f6e9b7232235c3810284c497a2adef92",
       "pubkey_x25519": "988505d81e232d3a04410b842ee5dfc13de0da7fd4398b5be71deda1ea9e1c6b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "185.173.235.101",
       "storage_port": 22021,
       "pubkey_ed25519": "d924abd23be89ce1d062a6d583b4658be110343bffbf831dda3fbff2a451718e",
       "pubkey_x25519": "8b4fc95f83297dd6b46666ac6b9f4c624ba9fb511a1732494416f00072a0270d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6cffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22111,
       "pubkey_ed25519": "d9277d7d800e09abb0fc79fbeb36db8f5e4201c7e86180019e9dd6f4df9dd7e4",
       "pubkey_x25519": "1f60bb4e6710d7dedfbc5635da645e3808071c723b012e74d00dd51de44fc013",
-      "requested_unlock_height": 2062113
+      "requested_unlock_height": 2062113,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.68",
       "storage_port": 22115,
       "pubkey_ed25519": "d99a17fc9eaf71457bd23f77d8fa1ab77be0788af7a0d988c8b23dcda6845ed3",
       "pubkey_x25519": "fd49ec101dd3c253c96f5d567d2af059103ec6772917a4511fd106e29daa0059",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "107.182.173.71",
       "storage_port": 22021,
       "pubkey_ed25519": "d9b65d97d5c4b474b13883e6a1ce5f7b6b140fd99f736eae508d3fcb8c92a30a",
       "pubkey_x25519": "67199ec9d1bcaab8808c096b3370aea4e2c9a2d91341cba68730bb1949891b7f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "158.220.126.109",
       "storage_port": 22021,
       "pubkey_ed25519": "d9ef91ebd50315ebe2cee7ed3add941b44aa83629f932e0d0768d7e526628e18",
       "pubkey_x25519": "5dc8bbc77d5a57d3b11e8bac2161d5b4bb203247e3455df76a3ba79e4dd5be1d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.16",
       "storage_port": 22021,
       "pubkey_ed25519": "da280f677391f00244d5e7b13859a56e5347cee5f2fc0d9bb5e7e78d6ca8270a",
       "pubkey_x25519": "c11ece75669e5284f2f977d3258e247acfe42e20c11afccd756ba06567caae73",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "155.103.66.138",
       "storage_port": 22021,
       "pubkey_ed25519": "da5c2b2cfc541987093c589abc0c736531dcfe1cae5b276cd95f3ba4770e3f59",
       "pubkey_x25519": "40160a04eb710525a283a9359d4b39a4bdcb5d7c81779d850430d7b69d75f039",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "135.148.27.21",
       "storage_port": 22021,
       "pubkey_ed25519": "da7871a6e9eb5a7a849f6a45812e6ab2506ff2eb37562c8543f9bf8831fac54c",
       "pubkey_x25519": "3578dd8b04cf4823c349d33b807fa5b293376eb56bc82f0461cc4cc2e4a8ee38",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22103,
       "pubkey_ed25519": "da8b10f4acc44d75dd5524c34987b61a698cac0429e6668e80e8cdcfb2b797fb",
       "pubkey_x25519": "b97809d26bbf40d17b7594568043bf9dd73dcf8462d772b744d608c615df9d26",
-      "requested_unlock_height": 2060658
+      "requested_unlock_height": 2060658,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1f7fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22118,
       "pubkey_ed25519": "dabfc5ec574579f004f5e7c481ad12807aceb8b2c114cfdaea0b578cb36eed71",
       "pubkey_x25519": "c19dc5a78d32c3bf0dcc7298d23b05906cd2d5a5a9b606ae27b96f94a0ce7868",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20218,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "173.249.28.221",
       "storage_port": 22021,
       "pubkey_ed25519": "dae4a22a18d769b49928d7d17e6e8aa2d40691089638994331db76eff40168e7",
       "pubkey_x25519": "084a23fc10ef7abf65baaba181e6600f6ea9926b2a306b66ae47ea0e87f78330",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22108,
       "pubkey_ed25519": "db4e72005254ef0ace19567d8734802458d9af895953fbadc7e904225394f29f",
       "pubkey_x25519": "e953c575ddee59a6653a79fac31a732a7d00fb89589a79ef1dbfedec52cb6849",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "65.21.244.24",
       "storage_port": 22021,
       "pubkey_ed25519": "db9ad0f417a0b79e2dd2923be8cc5289a3d552bdc5f7bad51574d98d7e584e5a",
       "pubkey_x25519": "6b594d054be1bac3bee0286039eee6716319afc0a533592790a0e2585ea42f40",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "144.24.183.0",
       "storage_port": 22102,
       "pubkey_ed25519": "dbd97e7d6abcd38917ebb60f9d9ba697185ac67617c357276c2c403fa64fc4da",
       "pubkey_x25519": "75b509dbd4832f3a911d24016bb2964ded2a444179cb76121e42653f12ddc22c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "164.68.126.233",
       "storage_port": 22021,
       "pubkey_ed25519": "dbea94b570ea06818323067a618b1a88ac24b18a16cd9aeacd97b132e3cf2f00",
       "pubkey_x25519": "eb05d0fe7260907db89e1bc3398f5d2628e113b0de1379e2586c65bd9aa44822",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "67ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22105,
       "pubkey_ed25519": "dc548201343c40baf0d5017891359606c3cc936be64143bb1b1bc59046230514",
       "pubkey_x25519": "40e0ee30d7ceab7fe93598c4bf95a6332d3f5ab704bf50a0ed8dce09163f3f23",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "9cffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22108,
       "pubkey_ed25519": "dc621c55dcb90d7f2134c82d6c8923a500bba480d3fb394fb08a2294721ebf3a",
       "pubkey_x25519": "8dce4d2bfaa6f8d79f6df7114d56b5fa3a43bac546910132769a7069f0ef924f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22408,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22100,
       "pubkey_ed25519": "dce98cc2602f0673c365dc41e3df099bb44c9d3fa8ca393d1c25a6aa1c7a59c3",
       "pubkey_x25519": "245312f764acb5c7f8573a7b0ae4b864a1c075f3b839345b3284f55828785256",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "146.59.32.165",
       "storage_port": 22021,
       "pubkey_ed25519": "dd3657fcd820f51e6a0d4328256a6cea6bf14f18602a425549575acaf708e4bf",
       "pubkey_x25519": "af092c260a078ca11bc4e1d79f3acc3523957c2aa80fbd8e128b9b2c6f1b0c0e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "193.160.96.183",
       "storage_port": 22021,
       "pubkey_ed25519": "dd7a27c830745d8f304f8e2f505cc1d9bf6255ca48bb70c7867bd8992035d7bb",
       "pubkey_x25519": "a015243bb21c72e1b1c18903da5002d1dc0de1846cb4fa9c6fc78d07c5021952",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "37.27.38.161",
       "storage_port": 22021,
       "pubkey_ed25519": "ddb6e0665652287203c1d4108ca13c5a31ba8411a911244b734afb8a4ed4d5e0",
       "pubkey_x25519": "4fb63510efdd0a6f4e34dac6bb5f6de9b917664c65b7bbf65bf10daae19abf2d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "85.9.211.140",
       "storage_port": 22021,
       "pubkey_ed25519": "dec60e8c3af5e7383f5cc8749988e2a0d105fd9c6ca54811ae1a790bbfe06267",
       "pubkey_x25519": "2186678eb2df1aae2b148ba40eebf27a13c28f5728118d8fcf5f9eaf0e5b797f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c8ffffffffffffff"
     },
     {
       "public_ip": "152.53.230.229",
       "storage_port": 22021,
       "pubkey_ed25519": "df060d570f99a32bfd74af6814483134fc049d9ea76aa8a08c4ad6f4dad469fa",
       "pubkey_x25519": "6a63b3afa1ca0ad492f3eb88c13dcacf8f0a50666a348b1475fe9b69f9ec9b28",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "164.68.104.155",
       "storage_port": 22021,
       "pubkey_ed25519": "df3b644169a37f816519a87d8858efa636da5483a25b2a62abd02f9ff24adb59",
       "pubkey_x25519": "b80f35bba920e7715ab924928bf0a23a01eec1e7fe32480acae629a04e585832",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22106,
       "pubkey_ed25519": "df5f041f59b9b01f12d3e325cde945fb64e3366e80fb99212478a9f943798aba",
       "pubkey_x25519": "a6fcd21acc61d1a1b025d3920ba1e2799bf039a81953bb31a18083714b6a2676",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "52ffffffffffffff"
     },
     {
       "public_ip": "167.17.40.236",
       "storage_port": 22021,
       "pubkey_ed25519": "df65f3baee7170efbc3ff263cc034b1f18c71cc52be0bcbfedd2acac266c6a0d",
       "pubkey_x25519": "86afa90c299b209f358b30764de2f2ad9a0d9d8c9b958c2765d8ae431795260e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22115,
       "pubkey_ed25519": "df7907cf6d967bcef4374424b9326308086acb5044899e01e39f41eb2590c592",
       "pubkey_x25519": "18e920b93119f1e658a859619d6a62af56068db1ded7e6ee82484ce3bab9116d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "158.220.127.207",
       "storage_port": 22021,
       "pubkey_ed25519": "dfb4d131046af3b03ed213ea360e5f7fdab240d0de692cbb735220cd85ae3f3f",
       "pubkey_x25519": "f9f8f9c209f9ac93559b0697859745bc459abbff685f2c2b043820a951087e21",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "194.5.248.48",
       "storage_port": 22021,
       "pubkey_ed25519": "e01a3e9479ba1fb35f31d107981fc74ae1e8674160d950f89ad5e87fcfeca050",
       "pubkey_x25519": "ff55e7893e8252100affd8a192dcc7a24289ab122a5f870b94fc2de0d940c353",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "209.126.7.133",
       "storage_port": 22021,
       "pubkey_ed25519": "e0be1a63c30f6dcff9c3c2fec4c643dd19dce30da5d97b1ba9de6a16850aef74",
       "pubkey_x25519": "c16707c8ef5f28121e91d15ef59bb5d66fd287b4ee4dbf1316930b8e5443e158",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "77.74.199.82",
       "storage_port": 22021,
       "pubkey_ed25519": "e0f259d5620e7c6d16bcbe470d53f8e900c06eb5c00ab021c6f0e8d3028ef7d6",
       "pubkey_x25519": "570718d983f4fb66303c690abe2e57481e90f7ca7d800a68f9d5b0bd0f6e9574",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "85.209.48.151",
       "storage_port": 22021,
       "pubkey_ed25519": "e0f6eaba6ba08e32befea4b0bc6a74216630a97fed944eb38c52946a6545d494",
       "pubkey_x25519": "174cfc72aa9405732305ce53f61102565deda3d004d5e19d49f668b264730633",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "91.99.144.21",
       "storage_port": 22021,
       "pubkey_ed25519": "e162cca9dd71a73add7491c44c833387526d61ba0e6a2da9bb81cfb3e50273b7",
       "pubkey_x25519": "fb88bc9230672d4e952e198bf34804e6ee285c43edcd38f81a5ed9fb0e1c1270",
-      "requested_unlock_height": 0
-    },
-    {
-      "public_ip": "185.132.37.100",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e164bcf830b1289a2203151d7f0a1d5475954c2aa20679df0ff154982294f515",
-      "pubkey_x25519": "7bdb0c13dfde1ed535fc6a37a99a8375514dfc17257ddfb1f8f92f28fef2770b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6cffffffffffffff"
     },
     {
       "public_ip": "209.141.57.149",
       "storage_port": 22021,
       "pubkey_ed25519": "e19268d3df0fe8cb2ab63cc0513d2254b515aad866e74dd3ce20771771e0e6bc",
       "pubkey_x25519": "6abfbb944ab92d8e1edfcbcd614b2c0d2cd855ca0323178157a9f2f69efb4852",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "193.26.157.116",
       "storage_port": 22021,
       "pubkey_ed25519": "e1af541c255ccfa56f63185e9aab06e8afd7b3c385bea4f21dd2b3f6bdd3a8ff",
       "pubkey_x25519": "af04e07bf6237645122961dd91170fa595446db9e55d195c53f3eb27f63c723f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "158.69.201.96",
       "storage_port": 22021,
       "pubkey_ed25519": "e1ba2c7879efb3c4f23ac2c090545f07010a67a1aadfa43fed89a97a4d317729",
       "pubkey_x25519": "0a0e209b071f721901bcda21e5c01224568d2b9596485e0cd7a97e438cbfc352",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "45.145.42.82",
       "storage_port": 22021,
       "pubkey_ed25519": "e1ce2988f417424799668c20c55891ee97423b0a5da5062df93b7a062d99b8f9",
       "pubkey_x25519": "1ab159d2a811b99a735e9eca8b8b9ef4f4dc13357d753076f272522ced7e9b5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
       "storage_port": 22101,
       "pubkey_ed25519": "e27b2a2ec8dd434187111ec4bc81cfc03329a074c5fefa7901c5cf4080d0a14c",
       "pubkey_x25519": "b521c0e29309d870ad23f9810a6adb7f8d5a29eb5bf031072d065f175dc19f13",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "144.76.74.2",
       "storage_port": 22021,
       "pubkey_ed25519": "e285ca3ae5a3755293d326f59cc4c35763446bdba5351f1c034ee377eeeaa727",
       "pubkey_x25519": "92e72a5b71722ffd1a2dd10e7343e2b18b1167fc11506f8b317d6b7e93812f32",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22106,
       "pubkey_ed25519": "e29106d27e4c43de76e66a38d743761afc89ec2af04756e6db637cf080d6c505",
       "pubkey_x25519": "8510e9e535d020b1ea06e9b4d55a0a10c1f5be98e8efabf80dae207dd25a045d",
-      "requested_unlock_height": 2057095
+      "requested_unlock_height": 2057095,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "45.153.186.74",
       "storage_port": 22021,
       "pubkey_ed25519": "e2d8577866e2e0cae5d882b4c3431104bde5a09a13c772a6fea70f3085003a7f",
       "pubkey_x25519": "cc1868981fcdded4e3161dc722d4ca8378c3db5dea6a6aad4b1c2d990e84222f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "89ffffffffffffff"
     },
     {
       "public_ip": "46.62.134.250",
       "storage_port": 22021,
       "pubkey_ed25519": "e2dc0b7dbef83bb23a1c7b24930b957ddc9f94f7fae6eb6ff9a4fe8fe845cdb3",
       "pubkey_x25519": "79b7310f6a2bea1399c92843979f0cd4db540d6f54239bc8fba1f9261adbc526",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "193.160.96.182",
       "storage_port": 22021,
       "pubkey_ed25519": "e34245544f2dd7b0ad4c9e2b3fe31a2d614b4342f7af02218644bd193bbfbfe2",
       "pubkey_x25519": "4afed8fee0a65934ce5be75ba7cd32af78158d901adbe04be4870e9f0c032f6e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "64.235.33.93",
       "storage_port": 22021,
       "pubkey_ed25519": "e344dbd26de8a532e8f7607b86c3be9eb073e42c8a886e220e63ba7c05201fb1",
       "pubkey_x25519": "01e776cf253d8beb3a7aa9c30b3bda0fede816187fa570ac1d41bf3db3f23116",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "51.79.251.59",
       "storage_port": 22021,
       "pubkey_ed25519": "e38db1098786dbb68f23647e72e5f20b2d6565f9ac9147ab71e3a3620dc13cda",
       "pubkey_x25519": "087e50310762757cf3b547ed059b2eca598ab5ef2adecb9ab3c4357b9a8aa532",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "158.220.89.153",
       "storage_port": 22021,
       "pubkey_ed25519": "e38db659c2df17d64fd8a6a35fd6d2d8e769de82b1bc0adde227ff3da0023557",
       "pubkey_x25519": "9e85e80573f31e5f80fb2729fb9faa53231fa5b7699dce8b3de27d83bb0ea85f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "39ffffffffffffff"
     },
     {
       "public_ip": "154.53.37.42",
       "storage_port": 22021,
       "pubkey_ed25519": "e422704615c072e6ce5e59bd21013e6b74952e218be04e6eae9e196dd9695692",
       "pubkey_x25519": "f57ab48ed683078396be57100f7ec3723159cdfb655d80b059050194c6823447",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "173.212.204.166",
       "storage_port": 22021,
       "pubkey_ed25519": "e42e1d5ddac8f002be1584f902ca59251fe08e05f1280bd62427cc419fafa23c",
       "pubkey_x25519": "c999d3b15d67a548ad1692e707e77cffc9ce346aa41f627576303f733da2e856",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "72.60.178.74",
       "storage_port": 22021,
       "pubkey_ed25519": "e45e3cf39aedcacc4413a9032d4806f9291985783f5f946b768ebd93ef8f7910",
       "pubkey_x25519": "da692e6e6ffc316d64f9fff727b0807a5a8d092f960a41ebc4929bc57873803d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "17ffffffffffffff"
     },
     {
       "public_ip": "164.68.101.213",
       "storage_port": 22021,
       "pubkey_ed25519": "e468e032835ff7b08b100efca8b1231fe3340d266e7f968a62504c7e1177edee",
       "pubkey_x25519": "d1eb2475fbf3446cc3ffe367a7c9646025cba86cf392986ca3e333b245974132",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22103,
       "pubkey_ed25519": "e4def653a34f05b982de4250f3b93d1cc221ab39aa42703205e25723c1903d34",
       "pubkey_x25519": "f18fe8527804117442a9802aea873c6125625184741ee0749cd9a4f4ae09926b",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "407fffffffffffff"
     },
     {
       "public_ip": "45.33.105.193",
       "storage_port": 22021,
       "pubkey_ed25519": "e4f20b84eacfb22380f4960ecefaf34d362decf8df555d60fbd34b614298c95b",
       "pubkey_x25519": "810d3edb9759c2a43c737b58607141e64581ff02fc4f0b0ee170537a3cde212f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "84.235.243.197",
       "storage_port": 22101,
       "pubkey_ed25519": "e528636ef0ee43b5f42e2d3708c21f51c3748b455f041b3b9dd138a8178bc26f",
       "pubkey_x25519": "9fffe195e0fd81a5e67fb77bb2a04b5182c6d902f494e4be8271e5dc4ad0182e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22112,
       "pubkey_ed25519": "e53edbe54fa6a3f6b701d356c444d6772475dec15ee0a353c1c7351187d11f5c",
       "pubkey_x25519": "15d69ae50e61b90e6b79c3b645e109841b2cc052b952851d2c4afd09d4225024",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "74.208.35.76",
       "storage_port": 22021,
       "pubkey_ed25519": "e54371b1ea3e7bb59be9be1f637394c679d22b5cd1a9062da2d1781f3a5edf61",
       "pubkey_x25519": "1eefa8233005c05b1a6e01e7bb31886536dbc83e3f98bc4943b5e3e1a80e524f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22108,
       "pubkey_ed25519": "e5438d2014508260d28263689164aae09f4147c01d3626785786dff52d3d8cb6",
       "pubkey_x25519": "4effa632f00be55a7efafd77785297396c587fa7c207755334e7582e1ebca157",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22107,
       "pubkey_ed25519": "e5484d32f6411cfb79a2fa4d7c0a8e371ac1781c5fccfe1cc867deaff7d99484",
       "pubkey_x25519": "860d5df8a017ffcffe9caf7c7ac540b93ece2c0200e1b29f90af5f71919d8417",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c8ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22102,
       "pubkey_ed25519": "e5673ec0d1525de2ef13399bbb77fd7bbbdea09e83441c9b8f14da7c16192544",
       "pubkey_x25519": "c8403d9f58c3cf400999fa8e233499b05ec842b13ea2ba54636b5c9be8a7b56e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "170.64.144.131",
       "storage_port": 22021,
       "pubkey_ed25519": "e5839359bc47edb1404c075562c15a893ddebeb90603f18bf9b2c65ef52840db",
       "pubkey_x25519": "f694b85d7e7478d08759b62f06177f479847639699d88ec767c93a5220e9bd68",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "51.81.210.5",
       "storage_port": 22021,
       "pubkey_ed25519": "e5b8a3014e2ffc44aecfcbe7f6aefb4bc818c2112510d23b9276bb64931d21a9",
       "pubkey_x25519": "9fe0999bd430a5b229444ce6b2dd7e2a86870dba240bddec0e8e3722503e9a33",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22105,
       "pubkey_ed25519": "e6562fb8845232c190130c5b2698ea0c868c7b8b28972dfd3bba900b82db5198",
       "pubkey_x25519": "2e58a08d45b5f060b3b24ea33e351eeac432736ce6ae720745697e7c45cb9b29",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22405,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "9cffffffffffffff"
     },
     {
       "public_ip": "158.220.127.144",
       "storage_port": 22021,
       "pubkey_ed25519": "e6655f0d8f58c8d8994132dad121d04a1d309566b775914c1dd4bc99625e1219",
       "pubkey_x25519": "d19c93fc49858a8c018866cc21ae3f51c9d9fa19cf35006638720a52732b4a62",
-      "requested_unlock_height": 0
-    },
-    {
-      "public_ip": "209.141.52.233",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e7081453f1345e79b39a58d154ccec30c55484c25a3dd4222e890f995dcbcbaa",
-      "pubkey_x25519": "625088eb07a20067e880af38f2540a9346fef459eed9342aaae831854af35818",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "54.38.52.251",
       "storage_port": 22021,
       "pubkey_ed25519": "e714c94f45032159fe2872999483dbdb89509a3e027f06ecffbcdd41230e46e8",
       "pubkey_x25519": "b46b6d8a1f42128bf69f6d0176c128a075084e6c0ccf65f9d67a05502e5de75b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "185.216.178.30",
       "storage_port": 22021,
       "pubkey_ed25519": "e749ccef94f39284252bf96a7465cadeb5551355b37a82ec10ba5eba70192376",
       "pubkey_x25519": "6a665654c68479c34f49e005d12e03788c885fd9040d03750b316038e7a3100e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22104,
       "pubkey_ed25519": "e756ea4ab22d7905d9c7ae8972c8adb9a2a776b347a0f8fdf072ad313f8e4e14",
       "pubkey_x25519": "95dbe2225f633c45a730d706b167a29229e963ddbb8b029073099f0fd1f6cf5d",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22117,
       "pubkey_ed25519": "e78edb02540e1130c57ead0a1e8603549c9e23c507740131b61b153e7c722970",
       "pubkey_x25519": "5f7f70229b98af0e2a66b4044d0be5dce4df255b927304c589ebecaa15683c7f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20217,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.229",
       "storage_port": 22021,
       "pubkey_ed25519": "e7bbb6f54a2b7f61589ab4eb1832d2ba8461eba9b537256bbe5b55c027a25cc9",
       "pubkey_x25519": "1bb216470bbccada8145d63f50563f2098c57b01e43b28ecd79c994d71c0fa40",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "173.249.207.148",
       "storage_port": 22021,
       "pubkey_ed25519": "e7f416ea16c3a297b3e8e4543a2fba9edde40f4a2f7b14c37c2ad12094ade61a",
       "pubkey_x25519": "d9bd339b01a822cfdfcd0b46691b59a892d0df42cdbfc5a32d9810310ecaf749",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "129.213.211.207",
       "storage_port": 22101,
       "pubkey_ed25519": "e80770cb550fc45a5a52ff5b077ad418803d9fd4d04c7a5a30d00f5fff90d664",
       "pubkey_x25519": "00f5f955181f335eba14b70e66b1ab3ea4c64c681671aecffa76683163a9bf00",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6cffffffffffffff"
     },
     {
       "public_ip": "209.141.51.234",
       "storage_port": 22021,
       "pubkey_ed25519": "e83fe359c680845911985908edd84e6f946dae0386cc48e062dbd616e517625a",
       "pubkey_x25519": "72fc54adc5ead77241446ad803492cce5442d6a7cc1f7224303d23c1b8ac4b25",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "387fffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
       "storage_port": 22150,
       "pubkey_ed25519": "e873fd9b8259dc297f962124cb16e367d82394b974fb1f6e90d9c6473d1c5494",
       "pubkey_x25519": "26ec3afa773d7d46aaddd99e919732d957f7e19d901f1c9b0a663d04f82eb236",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20250,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "164.68.113.145",
       "storage_port": 22021,
       "pubkey_ed25519": "e89ecaceb83c158ce2f962024c6eaeeb26ea5f97c6a09f65eb33828c19e13b45",
       "pubkey_x25519": "6cea696149fc8d54f5068bf8c3bcb9d2f6064b19015e846d7657e44e994f0277",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "172.93.167.217",
       "storage_port": 22100,
       "pubkey_ed25519": "e89f36f4da67024366d7a0d1ff7122cbb1d08af442e8a6122dae91c6289ebdd2",
       "pubkey_x25519": "c053849af98f4e1c5ea3659112b62ee4ed4a2ade39cafa6a63766f08b0863e43",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "167.99.32.79",
       "storage_port": 22021,
       "pubkey_ed25519": "e95cc8aa5016e192f7a54bce275aa137ca91986ee93b2228a8c842d13a09d104",
       "pubkey_x25519": "d20f81506c82f9cd8c40d01e48777fa6ebc80c680a2b2548352a72ed8a234f0e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "104.234.124.142",
       "storage_port": 22021,
       "pubkey_ed25519": "e95eada37853f449a448fde3d190422c8401108c51477000a692b91821df5c0c",
       "pubkey_x25519": "a136e8e9d3580863f4eb4fd3468e7d89059cb51ea396f3444abbf6dcc273a528",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "199.195.250.36",
       "storage_port": 22021,
       "pubkey_ed25519": "e9635600825bb63f44a7b1ffc07e208cf0a11b625eb2ad96243914666655fdf7",
       "pubkey_x25519": "edbe641d06a28ad17d3a96cae5c19797577b9efdfe6006bd8446665fd7ebcb64",
-      "requested_unlock_height": 2056299
+      "requested_unlock_height": 2056299,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.170",
       "storage_port": 22021,
       "pubkey_ed25519": "e9a65df172ef366752bd6ba29dcfbcbc35bed13feb1ebe070917f68c0f3604ef",
       "pubkey_x25519": "3eb04ee15b3001025951efddc25211a2f7817827624e3c587505e8f44f73f434",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "198.98.51.211",
       "storage_port": 22021,
       "pubkey_ed25519": "e9ac133db0f49632cb905f5e428e81d3ca3fdea6481d0ddfd7484327a81e37b2",
       "pubkey_x25519": "ddc5b223c46df7bc40e79fcaa5d2d22044592d353e10e0d4882c363ae2612752",
-      "requested_unlock_height": 2056569
+      "requested_unlock_height": 2056569,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "30ffffffffffffff"
     },
     {
       "public_ip": "67.217.247.11",
       "storage_port": 22021,
       "pubkey_ed25519": "e9bbe9fecb2366287b68b10df9f447b9cfbae48fa8182e45ed7116d59a6c7113",
       "pubkey_x25519": "21d5b1b0280726e1c27db2d2eeb10a7e91cc0a7a7fc9b0ad2b3236236af97474",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "51.81.209.45",
       "storage_port": 22021,
       "pubkey_ed25519": "e9c02cea9422fa40b0ec16ee6c048a586e25ca7f7b6add76ad158d803083fa14",
       "pubkey_x25519": "dd6e0038692931a1f963c94284cc6909451e0e48575d24ec3a298f6fdc19d24e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "107.174.102.110",
       "storage_port": 22021,
       "pubkey_ed25519": "e9ea4c8afcbe0157ebf2a46fae481788f2f990b35737971fca8ddae6bec2bae8",
       "pubkey_x25519": "a29630c1ae8b26c24f90785bc968145ae583825d677e0e01bcd1586a055b3e51",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "45.33.57.47",
       "storage_port": 22021,
       "pubkey_ed25519": "ead26f7a6e1add12bea5349c28f9265b947498b0b0f99e4bc67dd3176f04f75d",
       "pubkey_x25519": "d24e285871ff6cd43aad99d4cbaf1cc8722fffa3b813bc1c4556471e15586a2b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "194.62.99.75",
       "storage_port": 22021,
       "pubkey_ed25519": "eae5c527247f2f20ae1d65bf37002dade15f5c3d4ff31d8f77384ffc8c81066d",
       "pubkey_x25519": "2528aed2d123e6a2a34be5461f600eac8d0753cc56da334f2adc9579f35fe123",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "107.189.28.98",
       "storage_port": 22021,
       "pubkey_ed25519": "eb5e4afc1a12f553982dee3f419d8c55fb53ef2784f6f3895ed9fa9853b46a18",
       "pubkey_x25519": "88e7961a951efbd1e4dd1d090c37559c515f79f8452d4aff53f05bb73eb9672c",
-      "requested_unlock_height": 2063710
+      "requested_unlock_height": 2063710,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "51.79.173.146",
       "storage_port": 22021,
       "pubkey_ed25519": "eb61d3d80ac9a6cb32c0bbaa032301f566b101058913731cf1002da7f076add1",
       "pubkey_x25519": "83d0dc0e0afe2d5f65e46e318619c4447495bee5074d069e196693596412e326",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "198.98.55.67",
       "storage_port": 22021,
       "pubkey_ed25519": "ebbe177fc5b875e6c08904f7b47d42a5d530095ad929dff56a169afbf670d05d",
       "pubkey_x25519": "25d14849349e45e52fe0739324a7c0d9b917335aac984d08c7ac35ca4032f412",
-      "requested_unlock_height": 2056295
+      "requested_unlock_height": 2056295,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "141.94.55.63",
       "storage_port": 22021,
       "pubkey_ed25519": "ebe7d350e9bd0879cade067f7cb1cd42d70cd5320c8993b47cfc57850045879f",
       "pubkey_x25519": "a6152cb7d6de7d072312a38eca5411bb8de1b6a37921d9df3e76268bf141715c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "89.58.27.224",
       "storage_port": 22021,
       "pubkey_ed25519": "ec0778d51e1fd2a678ce73bf90e960ba80877ed5cefe6d216159b8d908ad88e1",
       "pubkey_x25519": "6c54f91a49074834b0cd6acc7d52bc084671331e22726b47967012c6b8ff2d22",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "209.97.175.53",
       "storage_port": 22021,
       "pubkey_ed25519": "ec0c3f2c406f7db21cb577f420abe54cb6148e5ebda96ed54b8889378e3ad0e2",
       "pubkey_x25519": "907fe48eebdf1d43586abb83351b5047ebe035cbf836f42cc7a9ba8ef911d40a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "209.141.52.82",
       "storage_port": 22021,
       "pubkey_ed25519": "ec239f5d9a10854949c527def83cd904dc5dadceadaf1dc727b2eb3c95dc9372",
       "pubkey_x25519": "f2867276955fc4d41f91c6891807cd191028990a64523955c5c5105b5ccd124d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22104,
       "pubkey_ed25519": "ec2ff31de1aca6abc8ad06cd97c575e539057601759b6890fb775e5f80f61857",
       "pubkey_x25519": "8d85ae50a6859edf24ee0c8b11f3854193968e248768a0bb9ef135ee79bcc151",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "154.26.159.141",
       "storage_port": 22021,
       "pubkey_ed25519": "ec47ee2e60a73fe0b13db04c507f0e28799f2c9ace808790444cded77514c79e",
       "pubkey_x25519": "91e253463d918fac8c93be935863525bd936a36e4031a066d30e1afe5641a066",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "172.93.167.229",
       "storage_port": 22021,
       "pubkey_ed25519": "ec4bc2b32baa8693d61448befaef53f400db538d814ff17084243b0bc9ec144f",
       "pubkey_x25519": "8fb943de53caa07f0f129708bc55703f6ab003ef12aadde34f67aad8ee9f201f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "154.38.188.206",
       "storage_port": 22021,
       "pubkey_ed25519": "ec6a4b84ba3fb62e35a5dd2df8383f77b03e0cc862afba6031b2fa97c72c6e3c",
       "pubkey_x25519": "be80932a4df14e16a38b7375786ef520a1cb54cf5a6b879761f8f49476398b26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "4effffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22112,
       "pubkey_ed25519": "ec6a53ed44223f2aa5fbb7fd9752585930958584fea5bf14a7beb803591894a4",
       "pubkey_x25519": "710e02b0cc7390089ccec94fa4c14c4cda0abeb3cb7f3ef1acb274ca4d23b72b",
-      "requested_unlock_height": 2062111
+      "requested_unlock_height": 2062111,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22100,
       "pubkey_ed25519": "ec6e2c3e74ce5d95d2697923641adfb71faae5bfce79416021a4d43c6091c426",
       "pubkey_x25519": "88792b56a861aa71e0cb2b2b159224603454d9f7a4407006f3a60451f9e42b24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22139,
       "pubkey_ed25519": "ec73fffa7f13a4c613eef05560589b8a79899fe3da434f4054884b15726f20b4",
       "pubkey_x25519": "24b4db9ae3231f2fc5bc4d7604e66b9bdd73f76773b1947c3396f0de221e003b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20239,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "194.61.28.228",
       "storage_port": 22021,
       "pubkey_ed25519": "ec89e10c5888fbc3e09711f2b04db9a4f76c14f98a48406c3c794d86879b95a9",
       "pubkey_x25519": "de256b8ebf75f92756ef6a37bb8f0e8283098fe255c9eb9cfeb4c426fbb0115a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22101,
       "pubkey_ed25519": "ed8a93c9516ecfcc1986616adf91eacb33e36239dcbe779b2ed2de75575aca8d",
       "pubkey_x25519": "34e1fbde971a442bb4e7d117c236ba9c29b3cfe3b51ddc790677367c8803450a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "104.248.87.76",
       "storage_port": 22021,
       "pubkey_ed25519": "edf3cecaef192da0e0c4360b81fe1a16b55be3ca7e9ac37112950b9d26753e5d",
       "pubkey_x25519": "ff0381d5510485bac05d560d739665f84b63dbb64e6f0200eeee7ccefb577275",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "28ffffffffffffff"
     },
     {
       "public_ip": "164.68.98.135",
       "storage_port": 22021,
       "pubkey_ed25519": "ee2b833abf4edae2112a124087e7b269f7e8f741d6e3920a2f1bb969f45dcf7f",
       "pubkey_x25519": "010c45545333eef36cf74320f84bcafa87bbb04f8d6f7037d91e845155f72b4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "107.189.1.148",
       "storage_port": 22021,
       "pubkey_ed25519": "ee3b2fa96a8c39e9e39c7dbd4a4518f3adcf2ec2ac99fa13c5b8e114e2a01f26",
       "pubkey_x25519": "31b6575bb53bc0d7807c2602c4545a19ba1697bfbf7d9b584217cffc40a73b7e",
-      "requested_unlock_height": 2063711
+      "requested_unlock_height": 2063711,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "205.185.120.200",
       "storage_port": 22021,
       "pubkey_ed25519": "eeb40a6fdbccb8311a19a05ffeef6b7ac6220eeb1227328870b792ca2fefbb97",
       "pubkey_x25519": "4cd475b23575721a55396632407f06071bb9b871f721c1d3d75493fcbb2aac24",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "23.19.230.174",
       "storage_port": 22021,
       "pubkey_ed25519": "eebf79d43b94a520fdb58de202ab41ccc76b48eac7a9b3347d4a4f47d0287177",
       "pubkey_x25519": "c5a3ff2e53f18e1fb33713488b44b85f9f2e3d597dafb8ca64ec365f0bec4236",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "209.141.50.48",
       "storage_port": 22021,
       "pubkey_ed25519": "eed0e997edf38cd4ac88650b57747e4f4fdb6278785f15b1ec13f10bf747938c",
       "pubkey_x25519": "94646d834fd576f18f914581c32eb5e8a3f27341a2262a68f9c4014a65144609",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "209.141.54.13",
       "storage_port": 22021,
       "pubkey_ed25519": "ef1dddae6f1e99ebaf3b33909767d23aab212667d5c9b6b8176ae5e1cbd93c01",
       "pubkey_x25519": "6fe5ccc16f7df0d65e9e6a255a74235a8c816d933c773d286122f4ef0a3d5d62",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "129.159.125.192",
       "storage_port": 22102,
       "pubkey_ed25519": "ef46e7e0a0dfee041feebc00cc84f650ae5cd57c8a1230b5f122134f0d68513c",
       "pubkey_x25519": "1248f654dd17d5f4dd10db8005a273f727042c3564a608d7799cc793875d7d19",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "109.123.240.83",
       "storage_port": 22021,
       "pubkey_ed25519": "ef51d4a475670a4e71e125fa4d7315c51925356395eca529f3193119d6c7d4cd",
       "pubkey_x25519": "a231db47a762dc958f7f48d23f0af109d0a610185b442d8eaa18c008e826063e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "193.160.96.238",
       "storage_port": 22021,
       "pubkey_ed25519": "ef79ee74a68130282865be957158ab54b602508045ce9120af43262d168bff62",
       "pubkey_x25519": "964e2d9a901319f47398cdf2dcf8f0b127f0ba2ba09aa29ad4495d649e90a851",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "57.129.102.67",
       "storage_port": 22101,
       "pubkey_ed25519": "efaff98ef284b782d27e0935c6a3a85fc67dabf39ae6eb91167dc03ce8380dd3",
       "pubkey_x25519": "1c339287d930706dc14e874d7d5ea323f9f1c4181a98b3978d2942aaaf75b616",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "144.91.77.9",
       "storage_port": 22021,
       "pubkey_ed25519": "efc8d1c0cc2ef97bafc210dc2bdc6bed4cbe0435cbf365ce8f3083c4b0b87dd7",
       "pubkey_x25519": "6036c72b6ab909b83bad43c80cbb6cbab9a43edaaf29256340a5fd07573b1a4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "144.91.76.126",
       "storage_port": 22021,
       "pubkey_ed25519": "efd13cd61671588c11841414563cd2d467888543047b6e2d893211ec96ad96ea",
       "pubkey_x25519": "ae300831d1cc08700797be71ffc65eab92ce13f9a9ef29386a78895599980d4e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "57.128.221.36",
       "storage_port": 22021,
       "pubkey_ed25519": "f0859a565d11d6c7ea52a0078b6d645ca13b4e117e69feae170e5c354cc56181",
       "pubkey_x25519": "259c8a6210babb43ff1bb860cdd1bcb1341408db09d43f2da5a45a906f6a1520",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "178.157.82.138",
       "storage_port": 22021,
       "pubkey_ed25519": "f0b8e9da22f68d496348541933c728f2e7afe78454184104facf4cc9d0847ee5",
       "pubkey_x25519": "9c56cb272f0643dd3772de73385259c20a0e274036058527dbefc4aae1e0441c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "164.68.101.217",
       "storage_port": 22021,
       "pubkey_ed25519": "f112e19a5b0d77cbd3b33a682fea3aac5c446a209423ec0c6d794e61bc616cd6",
       "pubkey_x25519": "ce818b001c840e0c3bd06506dc945bca4db701a2d5d3368f774c93568b3a2028",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "205.185.113.44",
       "storage_port": 22021,
       "pubkey_ed25519": "f166bdeccc370e7a988a0eaa6bb22c25c8e5e611ea0ab655c3d0effae97a3c40",
       "pubkey_x25519": "b0fbaf78a68c2bac8ce12f385a2f349d11a6b11ddbca2dd27483cccba3cd4e63",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22114,
       "pubkey_ed25519": "f18373cba32a1e33b569623f94161d7f9a9c666ad6723fa59aab8a72d5b5d0e8",
       "pubkey_x25519": "27b9c26f37094b3f8ef4ed81afd72143bb77b4d8ebf0bd3d86bfffe15f81396e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "39ffffffffffffff"
     },
     {
       "public_ip": "91.99.120.185",
       "storage_port": 22104,
       "pubkey_ed25519": "f193cc571289e182cb5c6dfabd638ac6831fa61a82f1bed21047152b5eaa3869",
       "pubkey_x25519": "d8da8966b2650f73ec94b3518e3d45541d07feb302ebfad7e3a49ef5693ce053",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "152.53.139.17",
       "storage_port": 22021,
       "pubkey_ed25519": "f1f9bee0ade678cdbe8f969e8a44c0d9f6677d172f0e4aaf1d73718c25d88136",
       "pubkey_x25519": "cf094e210af7afb114ecff72c89aeefd95d271d7ca97c512057bb4d4e51ebb54",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "202.61.195.129",
       "storage_port": 22021,
       "pubkey_ed25519": "f21281a5ad0d34dbed6cffacfa189ab0b9f35593a2d6cfd1736c65ed3f6b5630",
       "pubkey_x25519": "ad617436722732672c79b3a98be7006a1aeede1f1ca55ecf35094276d674f638",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "46.101.15.115",
       "storage_port": 22021,
       "pubkey_ed25519": "f24c36650f5d182e81353898611cfb78fb3ae5e4d52b095dce3a07205ddc7134",
       "pubkey_x25519": "e1630d4bf173be5a6da803cc66ad94eb0b5704e5692e45f65649b8fae8902762",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22100,
       "pubkey_ed25519": "f257d3bda39efe0b4ecf31fd4c6554e790548bd47ab7b334d57b6a69e22a0134",
       "pubkey_x25519": "e87762782e1e3b2ac5a5984555e1b235ec82aa21167db3ce820b9913c7f5e77a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
       "storage_port": 22180,
       "pubkey_ed25519": "f2f0c7ad98ad892ce804b9ad60605a207d412f18871a1729e76a3c208c0ce02e",
       "pubkey_x25519": "0e1cd648c9481ba0d88e381841fef6eb18c589a63878fd2df2bf9b2d75b9de6b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20280,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
       "storage_port": 22102,
       "pubkey_ed25519": "f32f12cc9f9e19d4faab517bf54cbdb2b30c1d55dc906309fd32f41619151b88",
       "pubkey_x25519": "1c14cd1d7c617dbd4b7d4d92e714670c084c03cfdba612ad1310cc048e9a9934",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22106,
       "pubkey_ed25519": "f330c6b6d6789535a02befe42b08a6f490e4a7162c05f6007100ac024f837d35",
       "pubkey_x25519": "ad06688183bfc9a74164d52b9ada771b6653e516e7eb73cd69c709935d2ceb28",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d1ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22132,
       "pubkey_ed25519": "f3809b208bdeb5eb0addb556451ede8b79aabbd675875341033e3d3378dd2f59",
       "pubkey_x25519": "c31fa66744aae36a5a1c3d43df26bbb94efc1936a49f5f1b268faef87b8e5514",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20232,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "209.141.40.229",
       "storage_port": 22021,
       "pubkey_ed25519": "f38a42c353bbf9c5f029533e2861bf25ac4e55e21f38cd0a585858a131137dc9",
       "pubkey_x25519": "063e1d38371d49e1ad19ec25881cf8c6cc1d93a2633ef2e10115900ca5049632",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6cffffffffffffff"
     },
     {
       "public_ip": "164.68.126.243",
       "storage_port": 22021,
       "pubkey_ed25519": "f43964325ae9452b6ca6f01a6be6d344adc5cf82deb2ac1045e28d00b6366fba",
       "pubkey_x25519": "ad052ed8c0f890f8b6dfa58091cdb251d2650dda5492b2b872e5cfaa63483e5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "173.249.205.185",
       "storage_port": 22021,
       "pubkey_ed25519": "f4468e7b89d772cca2648f0fe3dd7b38aa9cd08850911f2b4ae053533bebbf58",
       "pubkey_x25519": "a794b64cf4b1f31cdaf5536e63173ecd1f454e896b93ffa4b1b3880a95120a2e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "209.141.42.160",
       "storage_port": 22021,
       "pubkey_ed25519": "f47ce57394d4e54d5fa2abd80a6ba152e623ed2a46fb90f0b1715e29d805eff8",
       "pubkey_x25519": "4502f94c726f751d53938ec827a35f4b62acb83efeae8d40dac4c617f1c5fb37",
-      "requested_unlock_height": 0
-    },
-    {
-      "public_ip": "217.160.101.163",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f48fcbfbb08dedb80de867ee78225293350364ece2166e0b66d4a7d4dbf13495",
-      "pubkey_x25519": "cf67fc5cc5b980eac4d827beb8d6cdf34099f63cee60dce4b007e71315aba14c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "157.173.201.190",
       "storage_port": 22021,
       "pubkey_ed25519": "f542d10f3f21a3d22b371574e1c430bd939bbd35d198cb76adb1ca838bd1ac07",
       "pubkey_x25519": "f334f5d620be66ec447c29d98a811689a94f13fd338aa022f92b675eace2a127",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2d7fffffffffffff"
     },
     {
       "public_ip": "5.189.146.159",
       "storage_port": 22021,
       "pubkey_ed25519": "f5de277a6aa7f52dd7d87edcb99b0b4e38c7c7b03a441e84c067f38d89bdba9b",
       "pubkey_x25519": "2d92ff9f478ba4db6643c9425d4b69d52ee87865a55ee993faeb113253ed8565",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "152.53.225.64",
       "storage_port": 22021,
       "pubkey_ed25519": "f5f8f41e6aa83007a206ca979cff39d77d9d59d2d68ecd8a8680ed434faa4521",
       "pubkey_x25519": "e1fe51c41af352bdc893979af89d4f42e4bbe7dfcab79f2452f5394d61f60f1f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "142.91.98.18",
       "storage_port": 22021,
       "pubkey_ed25519": "f61234c884969e10160b627eb6cf477e14dce483130dc9878c61e30f6210e233",
       "pubkey_x25519": "65077015e7fc3eccc83e86a3b12a29d650352dc2feace0c1549a5404707db527",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22102,
       "pubkey_ed25519": "f61fe86cd412ce3f94b3545c6d1f29804fded6b8b1a0846ae190fe8e2d3e5e34",
       "pubkey_x25519": "f1a06ddd3ed1f4317b70710870819f34830a230d565d3e11a0451eee2ff9fc77",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "89.58.39.31",
       "storage_port": 22021,
       "pubkey_ed25519": "f65d1fc5a859c086c7ec89685f715de99433f90fe19ba8c417c4827d93a0fdfa",
       "pubkey_x25519": "c2c8c3c2050647a1a77749f0827478aeb04619681185e0bbbb9308337180d87c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "164.68.113.43",
       "storage_port": 22021,
       "pubkey_ed25519": "f6e2f1ec801b0d39cfc61acd43dc3314024ae1837c00fad2c899ea64be5c0363",
       "pubkey_x25519": "f25f5732437af35f363a6b08faa9fa45b96f999c8566505158176723cc998777",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "104.244.76.155",
       "storage_port": 22021,
       "pubkey_ed25519": "f6ebfc815af4ac2d444781f2ccd43bf5f2b192f9434185076a2bbd425f56f738",
       "pubkey_x25519": "4aca2383fd3ed8ccf24bd54e3bfd3da8c5d999bde48579ede2e2ab2784ea751a",
-      "requested_unlock_height": 2063713
+      "requested_unlock_height": 2063713,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "107.189.28.170",
       "storage_port": 22021,
       "pubkey_ed25519": "f70467449a1f0aeb7cf246f6a233ca2369ffd9ccec903d57865a66b596768312",
       "pubkey_x25519": "5c637343f4ed4084e56ce7cac368d267355577490fd4a8b1ca3eda2b95c0cf79",
-      "requested_unlock_height": 2064047
+      "requested_unlock_height": 2064047,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "38.45.65.234",
       "storage_port": 22021,
       "pubkey_ed25519": "f706c02d9056a70c32eaccb4824ad5fd11f123a5d9c45c0abbce1785c63647a8",
       "pubkey_x25519": "c09a987022db5f0346f4b9c800a16305ea50ea36274a14971be6137301ccdd53",
-      "requested_unlock_height": 2065121
+      "requested_unlock_height": 2065121,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22106,
       "pubkey_ed25519": "f70b16935cce36a78a3db75ba6656666e9ba48adc5fa39d1c01e7e0943f5ae31",
       "pubkey_x25519": "186bc491a4d3847ea1c863d3940c60e44968d5a13be21c6a925a38272f820515",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "91.98.69.235",
       "storage_port": 22021,
       "pubkey_ed25519": "f73130e9a826bec46bc1bb529830a00a4a113dc46f9a1568a4b73c9df3162a6e",
       "pubkey_x25519": "08b9283efbcb3247efa931704e2fec31fc7d5dba416fce546df090d219381e10",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "216.230.232.198",
       "storage_port": 22021,
       "pubkey_ed25519": "f75ed545eb5ce8df858a1b70f42fc02270624ef06cf63fd3b1adc8003b5a5019",
       "pubkey_x25519": "0f7a945814ba29d144307d28415b22e17f5ce10abab2c80d773087d490e39b33",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
       "storage_port": 22108,
       "pubkey_ed25519": "f7a2c41bc399f82202bd37b18345e579a9c2c5757329b6d97db4ccf58e7ae005",
       "pubkey_x25519": "adde02e31973bd81d4539886f40a92a99a3af74157159728e4c51221d4729860",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22408,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22107,
       "pubkey_ed25519": "f7b08bcdb32bd77e004e63786c208fbf5c10676d372b3b41e02a5395fdb2dca5",
       "pubkey_x25519": "fda7556dc5fe0ac59bfa9ba737557fc8aae717061878bcddec55f4b5c1fc271b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20207,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "45.154.197.25",
       "storage_port": 22021,
       "pubkey_ed25519": "f7f3d4e9d0fdbb1fdc5838ff30f6f766ad7724f33d67596bf34e69315d0e6224",
       "pubkey_x25519": "70b23853ac21d9ee2688b33251fed493b092cb737a7ee25a5130cc3c65bb2057",
-      "requested_unlock_height": 2065128
+      "requested_unlock_height": 2065128,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d8ffffffffffffff"
     },
     {
       "public_ip": "107.189.12.72",
       "storage_port": 22021,
       "pubkey_ed25519": "f7fc94601fe47ed537d8ff6046b40a2ee0eefd03c2d39f874d56b0cc29da36dc",
       "pubkey_x25519": "53963150a5e27fa98103ce2d18896713a23e22ee74279f908533bccea2c30a12",
-      "requested_unlock_height": 2063714
+      "requested_unlock_height": 2063714,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "173.249.207.149",
       "storage_port": 22021,
       "pubkey_ed25519": "f808666db6349935dba8202ac78ba6625af13bbd4b87d0334597a4431ab6f953",
       "pubkey_x25519": "625625ffb000be935ee95137d7184072cbe64b4afe36cb68c1f1753379d6b96f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "51.81.241.138",
       "storage_port": 22021,
       "pubkey_ed25519": "f81098486acf33cb433ac2f0d8c76b0fb9a307495a564ee7da1d898b53cafb5b",
       "pubkey_x25519": "5c4032532d3cc9eceff6f4548745956a92dcb08836387723068139c65b35ff2c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "157.180.33.180",
       "storage_port": 22021,
       "pubkey_ed25519": "f867ca7ca5d6c53eaf1d47fb235e049c69a43511766d6abb5a2cfd55b9c56833",
       "pubkey_x25519": "fb6868dfdaf2a5875d674c63f1b859b731b5cc2f4803b050cc3bb86e4a22824e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "45.79.84.176",
       "storage_port": 22021,
       "pubkey_ed25519": "f8689dc51df0a8cfdda1f9d3cbbdccb128b8a0f719269c9a01cbabcf0e3f9027",
       "pubkey_x25519": "53d43d19f8e167c08a31b102957cd880c13c7d3846e06ef7ad5c7e5871916f57",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "83.136.209.69",
       "storage_port": 22021,
       "pubkey_ed25519": "f888c18175eabfbd13d82d996e1bf0609ad3b92ff9f59dac2de78b185ff37999",
       "pubkey_x25519": "0b87f1bc196bf21ea304ee63e5153e0cbbb8573f6cd68e4639be1ee3c135694f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "193.22.147.69",
       "storage_port": 22021,
       "pubkey_ed25519": "f8f02a167d3b291fbcf8ec72b9a98dca06973009be0f0fc1caa5ea8f07b7560e",
       "pubkey_x25519": "bc54576d3b968a0812f4555423b16b71abd4ab37e849206ba03dc885d821b11a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "107.189.3.58",
       "storage_port": 22021,
       "pubkey_ed25519": "f92c938fd525c1950dc89e6949327b96fcbcfc5eca265d38a9881d850d4fb98f",
       "pubkey_x25519": "f907aaecd9a6d595e15f7aa82b0399caf6e3b33dabfc4831579a6dc1f327956e",
-      "requested_unlock_height": 2064046
+      "requested_unlock_height": 2064046,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "45.153.187.108",
       "storage_port": 22021,
       "pubkey_ed25519": "f9eebe1f987f5c084cae3627ef9ad7145f59cc06621b0448e1c63b7cb84356e9",
       "pubkey_x25519": "081870c5b3c189108354c09a830db48c7bcb9c4bfaf2bdb498c3cf042ce3c678",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c8ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.68",
       "storage_port": 22111,
       "pubkey_ed25519": "fa3e6151f161e88f711e695df4f5929572767459961a6c5f83fa0d0cc6110435",
       "pubkey_x25519": "e1740fa7781dfa75894d7267b909b95aa753493ac1497f8bc3728235f2b06e26",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
       "storage_port": 22104,
       "pubkey_ed25519": "faa9248e8b65af1ef4067f7422aa67eeb54253c9a2e0361ebfb39adb60010340",
       "pubkey_x25519": "d7d591fd654fd6da8e18c479f6da37510077781809a10b7cba695c44922b5946",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
       "storage_port": 22112,
       "pubkey_ed25519": "fadc6e7980e4ead82b489cc043ae424c8fd33760372b9459b165668c0f1e2120",
       "pubkey_x25519": "03a1676c459b3dde65d28d204ec3eee4f94661f2cfa4cf49b3c3af58f7306e4f",
-      "requested_unlock_height": 2062112
+      "requested_unlock_height": 2062112,
+      "storage_lmq_port": 20212,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "152.53.162.123",
       "storage_port": 22021,
       "pubkey_ed25519": "faf7e163435709ced1aeb57066c8d8a178a18ebdf55ca5d76a78e846befa2365",
       "pubkey_x25519": "d63a0dc1b55678d611a634b4482a3868bf70a393400b12733dd0bb1de4ea942f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
       "storage_port": 22110,
       "pubkey_ed25519": "fb27c6fc9188b02fa99e0dd46e98905e91933e2b04b394fae75c8cb83a851477",
       "pubkey_x25519": "4bca85fbacc7424223a0cb5a62d247a2c5ca0aea6f9f1c6e12bb7927726a1904",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20210,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "64.44.157.64",
       "storage_port": 22021,
       "pubkey_ed25519": "fc1890b2602949d9d2587688a05aa435ff8f65ebb118f903be95fb326c67659d",
       "pubkey_x25519": "17b5dc154af3584019128ad27f9db00161efa411f01cd827f82a31567fd6c145",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d8ffffffffffffff"
     },
     {
       "public_ip": "46.101.13.85",
       "storage_port": 22021,
       "pubkey_ed25519": "fc194f8e71ee8ed038c5eda26517d870a8fb3c890614ad311cdb2fdc997a99d6",
       "pubkey_x25519": "0db862807851754fc25d91161a8f7c78834a44f1ee8807417994ccb6f65c492c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "142.91.105.130",
       "storage_port": 22021,
       "pubkey_ed25519": "fc7b2be66b00ad1053d75aec3378494adfe9c1305bd8069e832287c1328fa099",
       "pubkey_x25519": "3e13b0466fc31888748e8bb6062397d66372087a8829fe9809e3dd974c3f056a",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "107.189.14.147",
       "storage_port": 22021,
       "pubkey_ed25519": "fc86918eaaa9bed6a7f0accda488009d073a9ff9aef52e28df0ad27c6de0fa28",
       "pubkey_x25519": "5596e8d776d8c66f72a620629b70263d5e33c1136136533632e221e4852e1028",
-      "requested_unlock_height": 2064048
+      "requested_unlock_height": 2064048,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "23ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.47",
       "storage_port": 22115,
       "pubkey_ed25519": "fc9f51ffa5c70885049c278805339c44dc164bfda5301e5de33c9cb7215d94ff",
       "pubkey_x25519": "139d3c3424086919ae809f567acd5fd8aa9fb9c14150054e94d4269605a96119",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20215,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "107.173.15.127",
       "storage_port": 22021,
       "pubkey_ed25519": "fcbcd7644525b776d34ea295ca48927431ac3e07edb4c3e969af4f1bf1a0dc18",
       "pubkey_x25519": "703727ccf46b1025793bbd9a93415dc406c0778270572c1bdb51a39113f8ef5e",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "45.33.32.101",
       "storage_port": 22021,
       "pubkey_ed25519": "fd3754c38a7b291de9d1210bc74480149548deec8109e4860cc60a98b53c60a5",
       "pubkey_x25519": "05e4da21d0a423fa8d300351e7e87714aff5ee648d248043498aeb37046d900f",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "387fffffffffffff"
     },
     {
       "public_ip": "152.53.240.177",
       "storage_port": 22021,
       "pubkey_ed25519": "fd7db9ef5e05a22bd4509c0e304442a849f27f417d728db1d2f5f5e6d95473dc",
       "pubkey_x25519": "cfc3301d4e10403f2c8943066e3c65e477e7d6762da3c514f2be2635ba938b4b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "102.208.228.249",
       "storage_port": 22100,
       "pubkey_ed25519": "fe5abebdb75955b38348b62b444e6782f6e47a8352c17eb02c736e6029703479",
       "pubkey_x25519": "6fe061c926d995b251b86a4f9df7e7f5c677b49915f57c1c5f81d0d907ff810d",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20200,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "104.233.210.13",
       "storage_port": 22021,
       "pubkey_ed25519": "fe67e78ae24cb6cccbaa1e5b1282ca95d2a7447bf61a3e97cb4ad974d60c6631",
       "pubkey_x25519": "c2fbade0f4d54c6a216a2b0a9bbb167471e61a150dbfebe281ed451260010a0c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "57.129.77.227",
       "storage_port": 22021,
       "pubkey_ed25519": "fef9ff4ba7b61d26749c8421442edd0d7c44bc16985449af3206c177d0001b83",
       "pubkey_x25519": "c13f4da96bb375bebf2c5a253def6996ae98305144bdaf6504ebd5614f082d3c",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "141.105.130.210",
       "storage_port": 22021,
       "pubkey_ed25519": "ff045d0792d79b924416312f3b9718002c2639dc741339e275662224cfb9b125",
       "pubkey_x25519": "29e7b53f947296d7300e08c272c058a6b468b958287ef7d73646de592fc4e643",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "45.145.43.202",
       "storage_port": 22021,
       "pubkey_ed25519": "ff678b797ef57b3df6e8702814a3c0743710583c096d86420600ba86fe8eaa6b",
       "pubkey_x25519": "0aced62417309e6ab74905ee6b128c823730154b32370e7ec7ed7797f0dae079",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "154.12.246.164",
       "storage_port": 22021,
       "pubkey_ed25519": "ff7a9782e66b20bc29ee97c6c7591da1a72333df6e3e76ee85b4708cc6788c0b",
       "pubkey_x25519": "3d723113a98838d576438176230613ea1dd478cfcb890383ba09272796813431",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "38.45.67.124",
       "storage_port": 22021,
       "pubkey_ed25519": "ff818ae58e8ea240aa6bd3b0b79381f8ed516fb4d322605051ccc1d589d39cb8",
       "pubkey_x25519": "9654880ff5a5d1e7967858a6553b6e0f351d3dc7a4e509997e8d99c8d80e3229",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "185.187.170.128",
       "storage_port": 22021,
       "pubkey_ed25519": "ffa2f50dc5f741f9a53cf4677faee365a02110152f01dec20a3747c188a69bc6",
       "pubkey_x25519": "8900619c8fad516966341d949b93ef687e4b7205c82f7302572b17f4216efd77",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "31.22.111.20",
       "storage_port": 22021,
       "pubkey_ed25519": "ffafecd0441a56f7e0f2b6c0771bb10c8c0aa2fbe4b03c9850b19bed2b0b262f",
       "pubkey_x25519": "c14d53836199af7f96257f005881e4ee4f9b4f0e3af78a976007317ada88be5b",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "159.223.228.183",
       "storage_port": 22021,
       "pubkey_ed25519": "ffb0cda81436b75ae414f1e18d1ce9f0c324d347f851f7b4b8e1210abf555c71",
       "pubkey_x25519": "720b249e64e27e425b82a6fbdc3c29a829a282d05b54556922f503aee2e03601",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "176.46.126.68",
       "storage_port": 22021,
       "pubkey_ed25519": "fff33926224aebdebadfa986865b8d7be2eaee55dedd69d75e67eaafbaf35787",
       "pubkey_x25519": "577a636178a1f07e4b0e75413b83424f8d618a3b6dba2bac8543fe18ed3adc66",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
       "storage_port": 22109,
       "pubkey_ed25519": "fff8ef3abae6f1aa6e4c1639e3cbdad29d636255f77043ea23505e19fe8ff703",
       "pubkey_x25519": "7f992ea00c1575970b9d43f148886f84891c381655af5c54bbdc4117a2a02d08",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20209,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
       "storage_port": 22103,
       "pubkey_ed25519": "ffffff35508bc999ae402872804528ec4754314717851723207ab99dfa0f9003",
       "pubkey_x25519": "584341c05e52efa57b6273277262197df09d4acdcf0bebf993389ab0de494169",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "327fffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
       "storage_port": 22105,
       "pubkey_ed25519": "ffffffb52245fb47b3a286db09db28d3e75bdf2d18e3418b9fbaa8c71ea73005",
       "pubkey_x25519": "67b03f1dcd5d0515532d08eeec0c11eb54a262c41f3db4439ce2b45f9eba0013",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20205,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
       "storage_port": 22104,
       "pubkey_ed25519": "fffffff2e7dc9e1560794ae34f2b93f5f258be196338ad63b008542107ea6604",
       "pubkey_x25519": "8836d27806e54a8b45b3f2710d9ae2638e1c99408ee65ebd35aa433d636e4279",
-      "requested_unlock_height": 0
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "a7fffffffffffff"
     }
   ],
-  "height": 2054708
+  "height": 2055136
 }


### PR DESCRIPTION
[Automated]
This PR updates the static service node list which is used as a fallback when a new client is unable to contact the seed nodes