### PR TITLE
[Automated] Update fallback static snode list

### DIFF
--- a/Session/Meta/service-nodes-cache.json
+++ b/Session/Meta/service-nodes-cache.json
@@ -57,20 +57,6 @@
       "swarm": "53ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22136,
-      "pubkey_ed25519": "00d2971121a55b9c023b2e8b03ea5c1af4d256ecf7528f311524fc5d0eea621d",
-      "pubkey_x25519": "0dc73bb26715f373d232c54462606895fa75c30ef7af4ed90bb88632b1315719",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20236,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "41ffffffffffffff"
-    },
-    {
       "public_ip": "199.195.254.208",
       "storage_port": 22021,
       "pubkey_ed25519": "015a6fbcc24ef876cbd5c417791e4b6f37a16885cd074764e30aae388a81110f",
@@ -99,34 +85,6 @@
       "swarm": "427fffffffffffff"
     },
     {
-      "public_ip": "102.208.228.250",
-      "storage_port": 22101,
-      "pubkey_ed25519": "019b5782c2fd8327187aa8722dc9258b38da8b871cfdf6e906b9c6e136db9551",
-      "pubkey_x25519": "abe40c04c6731b03f8e934b4c189e728d47f19ca15904244782acd4168e55c2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e0ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.151",
-      "storage_port": 22021,
-      "pubkey_ed25519": "01b2d3a58ed4a10eaed8b7450de21bb0b63abd37b9862caaa188a36093099b66",
-      "pubkey_x25519": "bbd68b82f24404d4c22cb5eb2939f1cdb2d638dd683d13d1036975e5e6ba980f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f8ffffffffffffff"
-    },
-    {
       "public_ip": "184.107.141.171",
       "storage_port": 22021,
       "pubkey_ed25519": "0216a30633cc87446b3beebaf30280e031c17cd7831a46781a3274cf1b143ebe",
@@ -152,21 +110,7 @@
         11,
         2
       ],
-      "swarm": "6fffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22115,
-      "pubkey_ed25519": "02713c311c82faae85a92480bd1db6dc1b230cb05be47388dae1cb2cd60b5626",
-      "pubkey_x25519": "37360c1e11478f6ad961d5e1e5fbc84c0d81cec34ff2ed3d76f679ed3c83e35f",
-      "requested_unlock_height": 2086601,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "66.175.222.15",
@@ -183,20 +127,6 @@
       "swarm": "27ffffffffffffff"
     },
     {
-      "public_ip": "102.208.228.249",
-      "storage_port": 22101,
-      "pubkey_ed25519": "02aba91de5b54501895677632509a405ae6ccd0f0607a932efe3053844931618",
-      "pubkey_x25519": "479725c6bfc0c102fa3f25c6249611ea40190111fe845e26cfebc4ba13adab79",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "afffffffffffffff"
-    },
-    {
       "public_ip": "95.216.32.189",
       "storage_port": 22108,
       "pubkey_ed25519": "02c29484abbf83f2efec44c59ea22992a7f22cd068ede29914dd81a239d8addc",
@@ -208,7 +138,7 @@
         11,
         3
       ],
-      "swarm": "b1ffffffffffffff"
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "165.22.195.5",
@@ -222,7 +152,7 @@
         11,
         0
       ],
-      "swarm": "f3ffffffffffffff"
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -264,7 +194,7 @@
         11,
         2
       ],
-      "swarm": "affffffffffffff"
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "5.189.184.134",
@@ -334,7 +264,7 @@
         11,
         3
       ],
-      "swarm": "197fffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
@@ -379,34 +309,6 @@
       "swarm": "edffffffffffffff"
     },
     {
-      "public_ip": "107.174.102.142",
-      "storage_port": 22021,
-      "pubkey_ed25519": "04732ca016ab612f00c98bf5716b59ddfe4c683ab7eb7158090b573274f1660a",
-      "pubkey_x25519": "ce597e20cba3193dc897d0fbc2e200faa90a53a614ba93eb962e9d101e85161d",
-      "requested_unlock_height": 2090292,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "aeffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.39",
-      "storage_port": 22021,
-      "pubkey_ed25519": "04cd78d5cf6b615aa33505797d163ed55a739d6b6989e5737cdf5c7c13d52bde",
-      "pubkey_x25519": "c359717548ef06f57609f11d8033feab4ba9e45b70fb0465adaa83f6eee4c75b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3d7fffffffffffff"
-    },
-    {
       "public_ip": "150.230.150.46",
       "storage_port": 22101,
       "pubkey_ed25519": "04ea9eb5eeb7114329118dfbd5f7cb3b1f8681272edc327bc137e86017e59024",
@@ -432,21 +334,7 @@
         11,
         0
       ],
-      "swarm": "fffffffffffffff"
-    },
-    {
-      "public_ip": "31.22.111.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "05272906543a9cb53a6fab6585dafe5f6f29dda44b847bd90000138b5f4df378",
-      "pubkey_x25519": "97405551f5af15a0b01afed91ffe8cb4718a5c088eeaf64e998edc45c07aa532",
-      "requested_unlock_height": 2090314,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "89ffffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -488,7 +376,7 @@
         11,
         0
       ],
-      "swarm": "89ffffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "157.180.78.109",
@@ -530,14 +418,14 @@
         11,
         2
       ],
-      "swarm": "247fffffffffffff"
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "116.203.91.99",
       "storage_port": 22021,
       "pubkey_ed25519": "059078ddf563e94964a7165f3571d3cf4244c0abe433ab538fc34cfe0f166951",
       "pubkey_x25519": "bf1f00960bb0e0fc460bf12f30e246a039726260c8532903aab580575c090e3c",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2104258,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -561,6 +449,20 @@
       "swarm": "f1ffffffffffffff"
     },
     {
+      "public_ip": "95.217.21.148",
+      "storage_port": 22100,
+      "pubkey_ed25519": "05e684c9c9148cc06b09a1abef50945aa260ed6324b391a039de139fdb25f78b",
+      "pubkey_x25519": "fe46faaba80a8a55b0682189fcb5107888b9ec142a69876cce8eb6199d16c629",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "407fffffffffffff"
+    },
+    {
       "public_ip": "164.90.199.112",
       "storage_port": 22021,
       "pubkey_ed25519": "0607deb29b2f20248ca87a6f5058b9d3dca0e799703288472b4df639631b6ef4",
@@ -572,21 +474,7 @@
         11,
         0
       ],
-      "swarm": "5dffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.53",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0625c01f284086f659e9a2ba4b94d2b6eec4ddcd971fedffa858d2c2d833fa1e",
-      "pubkey_x25519": "00ff7385815ff0753bdae126a5028d90f6bc2cc94b942a7635fb25c2dd3a986e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f8ffffffffffffff"
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "173.255.248.132",
@@ -614,7 +502,7 @@
         11,
         2
       ],
-      "swarm": "8bffffffffffffff"
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "104.244.78.225",
@@ -642,7 +530,7 @@
         11,
         2
       ],
-      "swarm": "1f7fffffffffffff"
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
@@ -677,7 +565,7 @@
       "storage_port": 22115,
       "pubkey_ed25519": "07675c83ec30537c296f622cf38b8df50f2a4bbb11daa8a65ce562930a680e97",
       "pubkey_x25519": "a927c2abcfe231926b5bd0fd5294b716bc577a3bdf1be5fd3a93743c95d9ae6f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099925,
       "storage_lmq_port": 20215,
       "storage_server_version": [
         2,
@@ -698,7 +586,7 @@
         11,
         2
       ],
-      "swarm": "38ffffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "207.180.201.59",
@@ -715,20 +603,6 @@
       "swarm": "3dffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.8",
-      "storage_port": 22021,
-      "pubkey_ed25519": "07c6170434e3a96512288d8a2fb3246afe2e58292b413421930de463352dd3c0",
-      "pubkey_x25519": "692d7b2c95c6354c5e6021e5e214829355b2ae0960f25514908fe8dd8f1c1344",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f8ffffffffffffff"
-    },
-    {
       "public_ip": "188.166.57.188",
       "storage_port": 22021,
       "pubkey_ed25519": "07c6636d3e42955cea5d49ff0e1501275873b1d193f1fc210ab29e6a4fba136d",
@@ -741,20 +615,6 @@
         0
       ],
       "swarm": "dcffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22101,
-      "pubkey_ed25519": "07cc2d5c96f177c20d62d80d11fab8b1c4e738d5c8d30b05b63099e7ed47c19c",
-      "pubkey_x25519": "12c7ed1f305c95b68f009d1a7d067cd40a24ad317aba3be4f0c72be15a19a162",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "54.38.65.27",
@@ -799,20 +659,6 @@
       "swarm": "90ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.9",
-      "storage_port": 22021,
-      "pubkey_ed25519": "084a2d45603ac18b1f1f10c547d85c6a140271366500f34be361577d54bc6411",
-      "pubkey_x25519": "823f5eb1d57769c452cf7f3135185df70065bd69e85c987892d66a0f5557990b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "87ffffffffffffff"
-    },
-    {
       "public_ip": "95.216.89.43",
       "storage_port": 22021,
       "pubkey_ed25519": "087649b9c46a92fdeccbaadb81c96c542912e10176c7ae195f1f8db407afeac0",
@@ -824,7 +670,7 @@
         11,
         3
       ],
-      "swarm": "1cffffffffffffff"
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "62.72.45.244",
@@ -845,7 +691,7 @@
       "storage_port": 22108,
       "pubkey_ed25519": "08c5f20aa9be8a0470926225a73c565d8d140b306826f2cd36483f0abab49752",
       "pubkey_x25519": "7a076e4ff4e31f4be973f9e5de363346bcc2d6c51034ebc0b703ce09c1e25e6d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099923,
       "storage_lmq_port": 20208,
       "storage_server_version": [
         2,
@@ -859,7 +705,7 @@
       "storage_port": 22101,
       "pubkey_ed25519": "08ff8a8bf860aee0aeba6c5ebf5f7ca0e0480228f5ff50b70f2e04916c176739",
       "pubkey_x25519": "be0ecef4b2996cc4027de95945cc2b299da465c0473b7e40673f80343444b72e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099927,
       "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
@@ -908,7 +754,7 @@
         11,
         0
       ],
-      "swarm": "b8ffffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
@@ -922,7 +768,7 @@
         11,
         0
       ],
-      "swarm": "f9ffffffffffffff"
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "62.72.42.149",
@@ -950,7 +796,7 @@
         11,
         2
       ],
-      "swarm": "457fffffffffffff"
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "154.38.180.45",
@@ -995,48 +841,6 @@
       "swarm": "187fffffffffffff"
     },
     {
-      "public_ip": "164.68.126.130",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0ad04d2e4d73382336cedda832e86cffa1235342a534d775e6191e292b4c31d6",
-      "pubkey_x25519": "ce707b65f6440c1af8666844b910596a2f35003ae4718afc1ee57e761457e703",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "71ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.76.172",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0ad6d50b6cc25ec48e1322b2806978c517c4b012dc6fb8cfeea2801f7efec0ed",
-      "pubkey_x25519": "33b29cd764290467a946d3b1829b8ebd6ae56efc68ab956a18f2f9de5eebea6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "42ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22111,
-      "pubkey_ed25519": "0b5e1b69725af866240d1ba59a39220a8bb176f04715d73ace35b6894b50ca30",
-      "pubkey_x25519": "743902fb0212e41d78fe66ab29e22864e3505f4cbe5940ff3c8bb586e170fb69",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "6effffffffffffff"
-    },
-    {
       "public_ip": "89.58.30.52",
       "storage_port": 22021,
       "pubkey_ed25519": "0bc0ff22113bb03d521eb0a60aed7f1dc5b2866a9a04590f66dea9592825139c",
@@ -1077,6 +881,20 @@
         2
       ],
       "swarm": "97ffffffffffffff"
+    },
+    {
+      "public_ip": "199.127.62.234",
+      "storage_port": 22120,
+      "pubkey_ed25519": "0c41db4142c8a8102b4c50b240f33220144c951b8422917ac7b178ebb1ab43cb",
+      "pubkey_x25519": "2e643c1856a1992aae4165bf36c143f396a4849575daed312a1c2095f79dce76",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20220,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "45.79.66.109",
@@ -1121,20 +939,6 @@
       "swarm": "69ffffffffffffff"
     },
     {
-      "public_ip": "104.218.100.6",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0cf0d9581388fca85566ccd6f40de93f14521f01bb41b841337b662ee633a3f3",
-      "pubkey_x25519": "fc0052ebb9a44f03f3c21e249b7aebd3412b0530dfd40d37e2c8a6150b3c7a58",
-      "requested_unlock_height": 2090336,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "37fffffffffffff"
-    },
-    {
       "public_ip": "135.181.109.199",
       "storage_port": 22101,
       "pubkey_ed25519": "0d04257018b89e991b5a27848bd2a6e9574981e5c244c317f8661733f300f099",
@@ -1146,7 +950,7 @@
         11,
         0
       ],
-      "swarm": "20ffffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "154.53.62.195",
@@ -1160,21 +964,7 @@
         11,
         2
       ],
-      "swarm": "67ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.97.254",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0d56fb3e3a0239a54c48b40f42e64a2d7b7d6043cbc7a7ecc768fc15a3fcbfd3",
-      "pubkey_x25519": "eb191d7eeb84300dc5c7f2cf621490f8bcd66614ca62205b068e92e974c7d20d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b8ffffffffffffff"
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "139.99.133.148",
@@ -1202,7 +992,7 @@
         11,
         3
       ],
-      "swarm": "147fffffffffffff"
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "51.81.34.178",
@@ -1233,48 +1023,6 @@
       "swarm": "39ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22117,
-      "pubkey_ed25519": "0e3b2c5bc03e0a42c16f2930f7a4b1e5a2885d5ba7025648d7e0aec08a0b7930",
-      "pubkey_x25519": "e2c22fe6cc5556432a49c55dac93e15dbc0cf7cc1a88ae9b7be06b5d1963592d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20217,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "7fffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.109",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0e48a182ee2670f3f078911288286e6d9141e02c6d845668181d28c0456c0111",
-      "pubkey_x25519": "0e0171ce4b0a5ebe5063a6221510c2493085ce7d105e6c60e592bf6c5490c321",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "96ffffffffffffff"
-    },
-    {
-      "public_ip": "100.42.178.63",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0e89abd7ee561131be4e52539da9134d4b3d3faa5798e2b1975db002bfc0b2c7",
-      "pubkey_x25519": "dfff5e78a86586074316bd05a873650aa87b639c1a80358b3dcd21ad4f59427d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b2ffffffffffffff"
-    },
-    {
       "public_ip": "57.128.22.91",
       "storage_port": 22102,
       "pubkey_ed25519": "0eb20b4ccda995691578eb2294804dfa23b4ea83ccad1345da2b32d9beca8a17",
@@ -1286,7 +1034,7 @@
         11,
         1
       ],
-      "swarm": "20ffffffffffffff"
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "198.98.48.221",
@@ -1300,7 +1048,7 @@
         11,
         3
       ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "104.248.196.63",
@@ -1314,7 +1062,7 @@
         11,
         0
       ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "59ffffffffffffff"
     },
     {
       "public_ip": "142.91.105.124",
@@ -1331,34 +1079,6 @@
       "swarm": "4cffffffffffffff"
     },
     {
-      "public_ip": "46.254.214.27",
-      "storage_port": 22120,
-      "pubkey_ed25519": "0edf48cfbce29f71da6ba60b213c89dc1d44703fa69949c66e31b664e37942a2",
-      "pubkey_x25519": "b057a4fd95d172583776fa362de9ea51e2349fe78d59fd673f398257a8b0824e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.26",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0f19d169658d7b3ab8e417332a48abe5edfc0e34352d002c04dec8a4be49c8cd",
-      "pubkey_x25519": "57348059d7706b4d81aaeb3cb19cd0c86239ee4dec327621b9fb207f2ea34f2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "1effffffffffffff"
-    },
-    {
       "public_ip": "154.12.235.135",
       "storage_port": 22021,
       "pubkey_ed25519": "0f366f78ee4fe0f0a9a0b029f5730eea53dc84989604f1e327212e36495d192f",
@@ -1373,20 +1093,6 @@
       "swarm": "257fffffffffffff"
     },
     {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22112,
-      "pubkey_ed25519": "0fbd9df5e56f5e9224d4bbb0645d465caca803fd2c8907dec40b210aba82f55a",
-      "pubkey_x25519": "eb9187b75e48e9d8285517acb60774ea5c5121c72b48dd472671a671c3d04b09",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "faffffffffffffff"
-    },
-    {
       "public_ip": "91.99.186.114",
       "storage_port": 22021,
       "pubkey_ed25519": "0fd6b23d93f4c7b95e5a1333deb5f5994a22797e77ac5f38701c2a0aa113a2e3",
@@ -1398,7 +1104,7 @@
         11,
         2
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -1415,20 +1121,6 @@
       "swarm": "c8ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22135,
-      "pubkey_ed25519": "104b26541826a2fdb4ee22d5feffe7b69e9b4e6e0bcd03b7651b0538aa686cea",
-      "pubkey_x25519": "ad792ccf84ad0ca2d48c3cd4d97ab27293d9552fa9d4f141a459982638101a68",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20235,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "49ffffffffffffff"
-    },
-    {
       "public_ip": "193.160.96.224",
       "storage_port": 22021,
       "pubkey_ed25519": "1058661e1a5595c2eecf3a8f83dc58b83d1f3139f5b6bc10e2840dc8662d74db",
@@ -1440,7 +1132,7 @@
         11,
         0
       ],
-      "swarm": "c8ffffffffffffff"
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "86.48.5.122",
@@ -1468,7 +1160,7 @@
         11,
         2
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -1482,7 +1174,7 @@
         11,
         0
       ],
-      "swarm": "23ffffffffffffff"
+      "swarm": "39ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
@@ -1497,20 +1189,6 @@
         3
       ],
       "swarm": "4ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22111,
-      "pubkey_ed25519": "10d4fa524947c94844b1c9b5f851d0713a68b4fee09a2355599f2ce36be3248c",
-      "pubkey_x25519": "d7f98675ced5c3f0103513de3e9bb1f471b3395824cd54a15c98ee7d30065743",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "89.117.59.152",
@@ -1545,7 +1223,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "11444fd6b1aa725a9d975571eb26804626e6ab8640e7e3fb2a8516cb327b0414",
       "pubkey_x25519": "422021db6824aa39f0d9f0fada5a54bd13d6f8ba692237707204d9f55cfae639",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2101101,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -1566,7 +1244,7 @@
         11,
         0
       ],
-      "swarm": "8dffffffffffffff"
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "138.197.206.211",
@@ -1581,6 +1259,20 @@
         2
       ],
       "swarm": "97fffffffffffff"
+    },
+    {
+      "public_ip": "185.217.125.45",
+      "storage_port": 22021,
+      "pubkey_ed25519": "116d7be19b97674e108cecbfaa23657b17c02ea72bd8d751ee66c922137620f8",
+      "pubkey_x25519": "d149f0a504f5f4a72c6c8c5acc5395923922b7555de189ffe8ade5593ba91f0c",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        1
+      ],
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "91.98.16.40",
@@ -1608,7 +1300,7 @@
         11,
         3
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "3.215.58.127",
@@ -1622,21 +1314,7 @@
         11,
         2
       ],
-      "swarm": "147fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.218",
-      "storage_port": 22021,
-      "pubkey_ed25519": "11ad1ed83f3904d8594bb41b7cf8de6aaa6b1ccf8eb5719d2addcbb0efc2ae5c",
-      "pubkey_x25519": "7cca5e137e0bf98ee0841e365561977c93605d359c3dee84e656ae53aef7d12f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "237fffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "91.231.182.75",
@@ -1651,20 +1329,6 @@
         3
       ],
       "swarm": "3a7fffffffffffff"
-    },
-    {
-      "public_ip": "139.185.46.77",
-      "storage_port": 22102,
-      "pubkey_ed25519": "11d6e04e3bfe5591d98966962aae348bd020989f361b22223bfa2db0e1f05939",
-      "pubkey_x25519": "877d41b484bcb205950f5548174f07a36ec77f1fc487b0088c49a1aa2dfb6816",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
@@ -1762,21 +1426,21 @@
         11,
         3
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.167",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1439c118e7726865a3efc2141b443d5e05a2b2e03f37a74403c1144752001acd",
-      "pubkey_x25519": "13487305ef955acd111483f22ebe16c2eb50cfa65a102e3fa8203cfdbd39a920",
+      "public_ip": "95.217.218.66",
+      "storage_port": 22103,
+      "pubkey_ed25519": "14ee48fb4bc6fbd58f34e1064d496dfb0b0b1fa7fe2e1af082b943796b1c1456",
+      "pubkey_x25519": "3c3420967184be279f24bd9d8ca8488685dd60624d626f875b5018fc31a5401f",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 22403,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "91.99.10.205",
@@ -1793,34 +1457,6 @@
       "swarm": "b4ffffffffffffff"
     },
     {
-      "public_ip": "164.68.114.12",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1554eb566edb0c1d4423d35ee20a5ab173f43a2d2d8a5334b61ea9f5723cdea2",
-      "pubkey_x25519": "d956e6aea43065a3384dfff86efc82e75bfa6ac8625842babe574e8b1b50e179",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d0ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22114,
-      "pubkey_ed25519": "15950224de750eadf0b013f9cdd86f97e62306ac51670ff26406dedd3ed685ea",
-      "pubkey_x25519": "a5111e2b116b250270d00201406b276a28aecfdbff9044971e3581911245e72e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "207fffffffffffff"
-    },
-    {
       "public_ip": "95.217.21.148",
       "storage_port": 22104,
       "pubkey_ed25519": "15ad47847fe129ae40d0676fc74ba9ea6bffcac0c6dbcaf27154be682b132b8d",
@@ -1832,7 +1468,7 @@
         11,
         0
       ],
-      "swarm": "247fffffffffffff"
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "51.79.173.182",
@@ -1847,6 +1483,20 @@
         0
       ],
       "swarm": "36ffffffffffffff"
+    },
+    {
+      "public_ip": "95.217.218.66",
+      "storage_port": 22101,
+      "pubkey_ed25519": "15d5aff81157128e0a5d9c3dc278c0b8c23f5ad734b3627a15d708e9bd50eb21",
+      "pubkey_x25519": "d4620c192bb23eea61d64451b59ecf10a8f17fd32240dca030a76d2a6acdf56f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "198.98.54.28",
@@ -1877,20 +1527,6 @@
       "swarm": "d1ffffffffffffff"
     },
     {
-      "public_ip": "164.68.101.46",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1636d40eea2639088b11affaed8ddcf8650377019d4385559cd6f205e645ea33",
-      "pubkey_x25519": "8d3c61bcc0d7f23c21ccf35efe9551612e30b0d54bca3aa26207b55c84b82a08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b5ffffffffffffff"
-    },
-    {
       "public_ip": "38.60.156.237",
       "storage_port": 22021,
       "pubkey_ed25519": "16481769aa4e9aeaf9b016402d7c12518558b28c79bc28b9973db971618a4b50",
@@ -1902,21 +1538,7 @@
         11,
         3
       ],
-      "swarm": "147fffffffffffff"
-    },
-    {
-      "public_ip": "185.45.113.185",
-      "storage_port": 22021,
-      "pubkey_ed25519": "165b15e05cbe2cf946c45222f8ab65006043b3586faf6d0f648651a2b3ff059c",
-      "pubkey_x25519": "e78c268b5ec7a37792acc8884ba92cbfb558e9062306290733b7de3e7a1d703a",
-      "requested_unlock_height": 2085210,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "198.98.59.173",
@@ -1947,34 +1569,6 @@
       "swarm": "afffffffffffffff"
     },
     {
-      "public_ip": "164.68.114.10",
-      "storage_port": 22021,
-      "pubkey_ed25519": "178a0447573738dea4e83a1897292b2d711072aad6d44bc39565ce791efcefa3",
-      "pubkey_x25519": "c90c18bc6f778fdf8128cc781afdcaf5585cc86dd0816f942485fe91b4c86163",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "179042eb07305f608bbd3a371067593aecd77d1fb3da9fd551ecfc58f6066421",
-      "pubkey_x25519": "1c220712693c434832d03f5f8c516a2215db7abd33818d60b3416cd2fba1c735",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "397fffffffffffff"
-    },
-    {
       "public_ip": "173.249.30.151",
       "storage_port": 22021,
       "pubkey_ed25519": "18074a5068e15e1289e6279d13fa0d0aa6d1e055b5956c829671eb887c2aef34",
@@ -1987,20 +1581,6 @@
         2
       ],
       "swarm": "bffffffffffffff"
-    },
-    {
-      "public_ip": "45.88.188.183",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1812103cfa87f63f5cee3d1f731ed12e8c2d2810c0bfd927990e4c474bc80909",
-      "pubkey_x25519": "f8b934ef918bd080de946d5335a8f23507da86caaf597a9f08dc5c2809b0fe6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "51.195.117.60",
@@ -2063,7 +1643,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "18e50a127bc94a3b3bd89c61258cb5469473d6e9b327e95ce09781198e720f91",
       "pubkey_x25519": "147cb685c85e4d9eaca49fa789a0a25836c52ab4ce4eecefd8360f55fe9a3861",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2107057,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -2077,7 +1657,7 @@
       "storage_port": 22101,
       "pubkey_ed25519": "191c854219fba4405c244c7c750fff910f6ce669b0e72c444b8912a29cac1806",
       "pubkey_x25519": "67c85b06822a12526bf484b77b0ddfc54415bf74e314f7d0549fb9f97516496a",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099924,
       "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
@@ -2112,7 +1692,7 @@
         11,
         0
       ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "64.44.168.82",
@@ -2133,7 +1713,7 @@
       "storage_port": 22116,
       "pubkey_ed25519": "19c03fffa95753fda1b41bfb226ac47f4ad3788fa5472157e798015edc042042",
       "pubkey_x25519": "23a9bb5a1233dd1e0529f9ba3a697e8f402c1d5f1c2cb880c07e0ac3c0b88061",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099913,
       "storage_lmq_port": 20216,
       "storage_server_version": [
         2,
@@ -2147,14 +1727,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "19e50188acb58de0ba43e1ff2f2eb8381f964718e327d8b591eb8fde413ea296",
       "pubkey_x25519": "85b430a9f8f0c174e8b0579fe860b96b08db580c96e9be9112b6c0510695ca0d",
-      "requested_unlock_height": 2086519,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "487fffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "104.244.79.204",
@@ -2168,7 +1748,7 @@
         11,
         2
       ],
-      "swarm": "77fffffffffffff"
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -2259,7 +1839,7 @@
       "storage_port": 22120,
       "pubkey_ed25519": "1ba159a878cfcc649f7118783ab45b819da125037490934f744dc7d2da8e8fe3",
       "pubkey_x25519": "b4b1b0b93e38d33097cafe0b1896fdea350b0325c4d491e423f43d81f08bcc26",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099917,
       "storage_lmq_port": 20220,
       "storage_server_version": [
         2,
@@ -2281,20 +1861,6 @@
         0
       ],
       "swarm": "66ffffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.37",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1bc939df19403acbb796ccbf18c0f96a97b931074e2d3fc81494a318c04df794",
-      "pubkey_x25519": "3a67ac7f8073a93f79dc9a0505d4d8b0bbf4241e9c70b392aabc8a03ad017850",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "205.185.123.63",
@@ -2350,7 +1916,7 @@
         11,
         2
       ],
-      "swarm": "a7ffffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "93.115.20.135",
@@ -2378,7 +1944,7 @@
         11,
         3
       ],
-      "swarm": "ddffffffffffffff"
+      "swarm": "317fffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -2455,7 +2021,7 @@
       "storage_port": 22102,
       "pubkey_ed25519": "1d8ae98bdb603edc55f1b39af84e8a2f0fc776fdec4e501783513ad4f12c77cb",
       "pubkey_x25519": "1f000e20c69bafd68b34460de78d58055477a326a6cd6cd8e128f13ee4bf7639",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099924,
       "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
@@ -2465,25 +2031,11 @@
       "swarm": "52ffffffffffffff"
     },
     {
-      "public_ip": "164.68.104.12",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1de39c84ec9dbbb00ed47034b24d93a76f171c7ea0339b769d62e0d21e0b2691",
-      "pubkey_x25519": "0a7ab47efc9653f7659c813fddfd137a5094ab0e44ba249decfaa98d47205b54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "297fffffffffffff"
-    },
-    {
       "public_ip": "195.246.230.27",
       "storage_port": 22100,
       "pubkey_ed25519": "1e01d3e756fccd9aec0f2cad477547cb09bd58d2707c251aab15587bffedce46",
       "pubkey_x25519": "0087048a1929e7989ada5cba3e3cba5dc65a8b822d919f5cb2a69af0c70dd649",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099929,
       "storage_lmq_port": 20200,
       "storage_server_version": [
         2,
@@ -2502,9 +2054,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "457fffffffffffff"
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "152.89.29.28",
@@ -2563,20 +2115,6 @@
       "swarm": "c5ffffffffffffff"
     },
     {
-      "public_ip": "5.189.153.18",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1ee6bf85168b76cbd20a563ebdb142c73e92a2ec4123a8dc8a3837b4b928b7ef",
-      "pubkey_x25519": "51cecb0465fba1ac8362c97a57a4d6d134f07df497512ffc9f313dbfcf1c6905",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e7fffffffffffff"
-    },
-    {
       "public_ip": "95.216.33.113",
       "storage_port": 22100,
       "pubkey_ed25519": "1f000f09a7b07828dcb72af7cd16857050c10c02bd58afb0e38111fb6cda1fef",
@@ -2602,7 +2140,7 @@
         11,
         3
       ],
-      "swarm": "2fffffffffffffff"
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2616,7 +2154,7 @@
         11,
         3
       ],
-      "swarm": "1cffffffffffffff"
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2714,7 +2252,7 @@
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2728,7 +2266,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2742,7 +2280,7 @@
         11,
         3
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2784,7 +2322,7 @@
         11,
         3
       ],
-      "swarm": "e3ffffffffffffff"
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2798,7 +2336,7 @@
         11,
         3
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2840,7 +2378,7 @@
         11,
         3
       ],
-      "swarm": "afffffffffffffff"
+      "swarm": "3fffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2882,7 +2420,7 @@
         11,
         3
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "0"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2896,7 +2434,7 @@
         11,
         3
       ],
-      "swarm": "67ffffffffffffff"
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2924,7 +2462,7 @@
         11,
         3
       ],
-      "swarm": "54ffffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -3008,7 +2546,7 @@
         11,
         2
       ],
-      "swarm": "65ffffffffffffff"
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3148,7 +2686,7 @@
         11,
         2
       ],
-      "swarm": "39ffffffffffffff"
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3204,7 +2742,7 @@
         11,
         2
       ],
-      "swarm": "b3ffffffffffffff"
+      "swarm": "2effffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3400,7 +2938,7 @@
         11,
         2
       ],
-      "swarm": "467fffffffffffff"
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3414,7 +2952,7 @@
         11,
         2
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3484,7 +3022,7 @@
         11,
         2
       ],
-      "swarm": "287fffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3568,7 +3106,7 @@
         11,
         2
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "c6ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3708,7 +3246,7 @@
         11,
         2
       ],
-      "swarm": "dcffffffffffffff"
+      "swarm": "d2ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3750,7 +3288,7 @@
         11,
         2
       ],
-      "swarm": "2ffffffffffffff"
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3764,7 +3302,7 @@
         11,
         2
       ],
-      "swarm": "deffffffffffffff"
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -4005,230 +3543,6 @@
       "swarm": "c4ffffffffffffff"
     },
     {
-      "public_ip": "91.99.120.185",
-      "storage_port": 22103,
-      "pubkey_ed25519": "1f3c49b0b3a3cf092bc37131aab2d49eee526aa9c05b7e9de82c43134bdf1517",
-      "pubkey_x25519": "9bf08c20691ce35a5bb519be7a3d36a694d461c828fec9830caf41dbfdb71a4a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3e7fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22100,
-      "pubkey_ed25519": "1f400f199a4d0242a05a26e952264042646bbbe0333ddbb4aac1628512f44558",
-      "pubkey_x25519": "77eb13516e0efbfb7baf60d27e5cfb6b7c5b8f03ffdb64881fcf93493f759b58",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5effffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22101,
-      "pubkey_ed25519": "1f401f2773e8bdf07cf14b4f57adf58a63e63a98b14033ebebd4e0b635035f67",
-      "pubkey_x25519": "1e2ad5a2d031815ae56bb684f049d284834e4a6bf9e3df0cb11c75ac912a5218",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f3ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22102,
-      "pubkey_ed25519": "1f402f0373679c687e9a1ef4f38e113e8a16392677629da2d8bf6fd4874fb897",
-      "pubkey_x25519": "af024db1ae94ef750bd0f250c86f76ba0b75c49ffa57015e9c4429d9da573873",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "467fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22103,
-      "pubkey_ed25519": "1f403f10a864e3e08b14412b5cef75b2f682b38bf9894a9f26fd4210785d4f7c",
-      "pubkey_x25519": "216740f91b74d7357f9acbdb850cf12f664aabdd965b6aa99f0fd661d00aed08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "19ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22104,
-      "pubkey_ed25519": "1f404f113d471d0b89369fc27a9edf1831c6f83d9ed7ad7bf9c7f66c88b77d4b",
-      "pubkey_x25519": "c264bdd1102a0bcbc3f0339f35292c19cd6a1da9df7f432cc55956929c38ab49",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "487fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22105,
-      "pubkey_ed25519": "1f405f0060d775717a1343db333847de070d0779b85e1e0a4115e41ffae59ef9",
-      "pubkey_x25519": "eab1c2dc9d52babadacc80c30a30e9c072b9eb5a06b5f86f596fba5e10e75f53",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "59ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22106,
-      "pubkey_ed25519": "1f406f26f2e3382043eda8a2ba163182a38812f4f7d04dc31599701367860dde",
-      "pubkey_x25519": "4af54f327a65c35882be6b6ba5ef6f279c54a576c0055a25d692a5015369bc37",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "0"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22107,
-      "pubkey_ed25519": "1f407f10dac4c058703b56549e9bd7c6abb45406d74cff31727f5e5aafa7d91e",
-      "pubkey_x25519": "d283377ad1ef7c8de630ecdf2355c43719a6a8880814fb68721985e2351d476a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "26ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22108,
-      "pubkey_ed25519": "1f408f02f1dae7bf8cbd705f4f9747e09b5bb852d78abdc7f0afbc965fd9f7b0",
-      "pubkey_x25519": "b9699f825a1b725b204ea2615f7e0f36ade14765eab379088c123876746f5944",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d7fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22109,
-      "pubkey_ed25519": "1f409f1fec6878e234d7f15af4e6953c4ab3719ed83b9b465dc26b5ef62b212b",
-      "pubkey_x25519": "b77e7a8440f3bde1fce62cab308e00a6c4da1969d50aa3ed8685e3a800e54c4d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "15ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22110,
-      "pubkey_ed25519": "1f410f0adb541dca82692af066c4b306c77f7b120c572c23ebf554d762122ce1",
-      "pubkey_x25519": "86c17d9a95428baf320e427bc9889cacada078f77b79c74314569af01f7b690c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "427fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22111,
-      "pubkey_ed25519": "1f411f0db9b2cce68de7de4d9138dca01b749fd51a9eb092c1b92b886a1d6fa7",
-      "pubkey_x25519": "0781a80b42e20b3c5601a40314a8dd673daabc01699fc7afeb200c6ac9d9a15f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e8ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22112,
-      "pubkey_ed25519": "1f412f05fef2b20621e6a00a021ea7c1f9515c79cb6baf0481f100fa15441ff3",
-      "pubkey_x25519": "197976f7601c65d97400d3775b7f3315f98662a625c6f700b9aaf18d6f0e8154",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2bffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22113,
-      "pubkey_ed25519": "1f413f009b489ae560dbcdca23659690b962fe40169d928dc2a1ca8611339730",
-      "pubkey_x25519": "5cf4c32454fbda9fe78fc853e6941fdb0d45e094374c87cf37b059702be8b27a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5affffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22114,
-      "pubkey_ed25519": "1f414f02e4e3ef85c517c81afb0402a980f937a5b43a686aba502d7bc6728976",
-      "pubkey_x25519": "12e2f86e9adc980c64029cb544fec9f4a1ef3347502c5f6113b7987ad5198909",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "24ffffffffffffff"
-    },
-    {
       "public_ip": "172.93.103.156",
       "storage_port": 22100,
       "pubkey_ed25519": "1f500f17d77c1972d08a0afbc35b558b2c39276258ad67204a27373e7d6a0ecd",
@@ -4352,7 +3666,7 @@
         11,
         2
       ],
-      "swarm": "247fffffffffffff"
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4394,7 +3708,7 @@
         11,
         2
       ],
-      "swarm": "137fffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4562,7 +3876,7 @@
         11,
         2
       ],
-      "swarm": "f0ffffffffffffff"
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4576,7 +3890,7 @@
         11,
         2
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4590,7 +3904,7 @@
         11,
         2
       ],
-      "swarm": "427fffffffffffff"
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4688,7 +4002,7 @@
         11,
         2
       ],
-      "swarm": "51ffffffffffffff"
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4761,20 +4075,6 @@
       "swarm": "247fffffffffffff"
     },
     {
-      "public_ip": "80.83.124.173",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1f69a9e69725c552d6c4d43406321597c7bae52b7dbf2745d7160085ae5d787b",
-      "pubkey_x25519": "46af3e8f16b69d4f6cb9e95714a4f00f7c3d01b5e36f726a3383c35db6564b45",
-      "requested_unlock_height": 2085234,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "5effffffffffffff"
-    },
-    {
       "public_ip": "206.221.184.74",
       "storage_port": 22108,
       "pubkey_ed25519": "1faca0bbcb3e365156f6e600eadd1ca168835049e60a5c1e6d3adf1f8dbb39b9",
@@ -4817,60 +4117,32 @@
       "swarm": "39ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.232",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2031cde9c462205c7cfe7a876db11c060ee12fe3f78e73b52fa42dbe405cf62f",
-      "pubkey_x25519": "c4d20ff5068efe2161e68140f55a2d17475ce8f4036c969bab9a21cb16cf474a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "467fffffffffffff"
-    },
-    {
       "public_ip": "50.114.206.167",
       "storage_port": 22021,
       "pubkey_ed25519": "2080fb3ed7662aa7efceff772f4c61bdcb66ac7e4ebd8b0125fb3e4d56b8ed5e",
       "pubkey_x25519": "3f79c124011249351aa04a1a3c43ea8fd4c3c2c6c0d7b34cf43c31eafcb1e24b",
-      "requested_unlock_height": 2085152,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c5ffffffffffffff"
-    },
-    {
-      "public_ip": "193.22.147.127",
-      "storage_port": 22021,
-      "pubkey_ed25519": "209aa14eb13bdf97155a6b0141affad8b081761a67184791889ef0112a5960d1",
-      "pubkey_x25519": "bc78be47e82a71ada8b47298329daf86474df716dba2008143c57fa27f8da348",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "eeffffffffffffff"
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "209.222.98.114",
       "storage_port": 22111,
       "pubkey_ed25519": "209afbcc7c730a8a56dfd2b349e6d4c0dff29135711f1ea6273d41abae3adf35",
       "pubkey_x25519": "3b24253907b84b2782d1a9d58bde65f05ed649555e11ddb311a6b8fe36c46858",
-      "requested_unlock_height": 2086578,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 20211,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "227fffffffffffff"
+      "swarm": "4cffffffffffffff"
     },
     {
       "public_ip": "167.114.129.231",
@@ -4901,34 +4173,6 @@
       "swarm": "6effffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22103,
-      "pubkey_ed25519": "21255829a52faf4fc85e02b8b95dfc5b12a168fa5119c86b6b3774e325bf321e",
-      "pubkey_x25519": "dc5cfad8c96a2ac9bac0d488ee2ea615848d243b3d5b25773d891ab7630f237c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d8ffffffffffffff"
-    },
-    {
-      "public_ip": "204.44.125.247",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2141f276d1ea0cc312d193ce040738db362ed7cc11c9d4653f0f3336d7d9f635",
-      "pubkey_x25519": "b17bd16061306906112db8297e8acbadeae9863afc16d9cc022e13a1cda37708",
-      "requested_unlock_height": 2091014,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "97fffffffffffff"
-    },
-    {
       "public_ip": "147.135.208.118",
       "storage_port": 22021,
       "pubkey_ed25519": "214c77122474bebeac79d2ba4f97f8abb267236a34bd887b1e7088c5f8c48fd3",
@@ -4941,6 +4185,20 @@
         2
       ],
       "swarm": "eaffffffffffffff"
+    },
+    {
+      "public_ip": "37.27.212.116",
+      "storage_port": 22101,
+      "pubkey_ed25519": "215fb80968d76c1d6f38aa94807e40914f9125f8d74e3fd2256294bd7f568659",
+      "pubkey_x25519": "98d26d83309f0d13c2fcbca423c79f9e6d1f7631fc0049c62e92761fa8af412a",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20201,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "66.179.243.81",
@@ -4985,25 +4243,11 @@
       "swarm": "cffffffffffffff"
     },
     {
-      "public_ip": "50.114.206.219",
-      "storage_port": 22021,
-      "pubkey_ed25519": "22c52f8bc17befaa4e841171cc639b733991767be7a03b5e2572c6df94f1dda3",
-      "pubkey_x25519": "96883ab11199c0d7e948af9a6ec86200316e915660fb53e8be936b89052b0579",
-      "requested_unlock_height": 2094200,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "0"
-    },
-    {
       "public_ip": "185.150.190.48",
       "storage_port": 22101,
       "pubkey_ed25519": "236f600393c47dca1c970a9377d291720d987133b1eaebc3c818f1f6f400f6ca",
       "pubkey_x25519": "d213cae41cebd3c8e5cc5733407a3ca0ca8e56549f90bdd26c94bdae823bb813",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2108731,
       "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
@@ -5031,7 +4275,7 @@
       "storage_port": 22121,
       "pubkey_ed25519": "2378e991e294cc80594b761390f7b0157b831d402f3c24d7cd7f9cbb3d93c4a5",
       "pubkey_x25519": "a94656b5ced27067d161deb5271bdeb6642653fd430db57e4a52ab5a8a660871",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099925,
       "storage_lmq_port": 20221,
       "storage_server_version": [
         2,
@@ -5045,14 +4289,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "237fadadf715673ef4ba4c08bdabdfc8473ff451d315385eb7db35b6f877dbb7",
       "pubkey_x25519": "a772f687fabc87e9ff6a127794af6f9ad820f4ab40b2863bf3a9f92021cdfa67",
-      "requested_unlock_height": 2085137,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "fbffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "77.74.199.94",
@@ -5083,20 +4327,6 @@
       "swarm": "f3ffffffffffffff"
     },
     {
-      "public_ip": "95.111.238.80",
-      "storage_port": 22021,
-      "pubkey_ed25519": "23bf357027a42a8ad426bdc0350413d002338d0532d8d93ebaedcb6490bd2da9",
-      "pubkey_x25519": "dbd07f991ddd04b481c5ee7c316dd7a25b6bbd8d81d32e37b6a10e3434ac6a5b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "90ffffffffffffff"
-    },
-    {
       "public_ip": "88.198.244.201",
       "storage_port": 22100,
       "pubkey_ed25519": "23c572c4bb4c5d2eea42cedc85cc14d1e7fecfaafc554c6181915e1437f209b9",
@@ -5115,7 +4345,7 @@
       "storage_port": 22116,
       "pubkey_ed25519": "23c89d932e1fea811e7b33ab88956f8550ede291596fac160504771e8a479aab",
       "pubkey_x25519": "2650029714955e63fa2326fe6b32a3beef72e8e264790a3e822d9cc772d56530",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099929,
       "storage_lmq_port": 20216,
       "storage_server_version": [
         2,
@@ -5136,7 +4366,7 @@
         11,
         3
       ],
-      "swarm": "38ffffffffffffff"
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "141.105.130.209",
@@ -5150,7 +4380,7 @@
         11,
         3
       ],
-      "swarm": "feffffffffffffff"
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "96.9.214.20",
@@ -5185,7 +4415,7 @@
       "storage_port": 22100,
       "pubkey_ed25519": "243a9ee2a38e533ae6fca0abf08527e38d6f43bf71e23c4786311505a2e3d859",
       "pubkey_x25519": "8c408c4a77875f04904fbc65efab10181e255fb6b4d3a428ed6616d132a7706e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099923,
       "storage_lmq_port": 20200,
       "storage_server_version": [
         2,
@@ -5206,7 +4436,7 @@
         11,
         2
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "158.69.206.52",
@@ -5283,7 +4513,7 @@
       "storage_port": 22110,
       "pubkey_ed25519": "25fa58b2fb5dfbbbbaf67af4f72bfe9d8dd755de5a0787fccdce8c7f128e77c8",
       "pubkey_x25519": "217bf21ef1f16f262b9d80c263f61df4a48b58f7dcb1e689f9a7471fd2f3c45d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099927,
       "storage_lmq_port": 20210,
       "storage_server_version": [
         2,
@@ -5304,49 +4534,21 @@
         11,
         3
       ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.107.170",
-      "storage_port": 22021,
-      "pubkey_ed25519": "271b7a41f97804ac0fea0ddf9bd80156e383aae90e36190e4bffd59688d66aef",
-      "pubkey_x25519": "a822c34f2212db3c61646c3f9cee1823d083b832fc7e260b9419a9bea144b103",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b6ffffffffffffff"
-    },
-    {
-      "public_ip": "86.106.182.17",
-      "storage_port": 22021,
-      "pubkey_ed25519": "27dae0e56f2caff4519bff5de4c1161fd027ea80505a4fc622932af46edb9be9",
-      "pubkey_x25519": "83806dd728f4af6871bff03a15e5df5b23ef6186e2d69977813449a2abd1e15a",
-      "requested_unlock_height": 2090263,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "42ffffffffffffff"
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22100,
       "pubkey_ed25519": "282358b3517b1839a9b9d4c751832fd18689b4b2a8e91b38cc7c16fdc25ec196",
       "pubkey_x25519": "396c09d2441dec7a0c81de3f2e90b0c045dd8958307a6aa423e589e49a87bd1e",
-      "requested_unlock_height": 2088391,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "19ffffffffffffff"
+      "swarm": "0"
     },
     {
       "public_ip": "199.195.249.188",
@@ -5361,20 +4563,6 @@
         3
       ],
       "swarm": "daffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22124,
-      "pubkey_ed25519": "288bd454a590ee935cef7843108ab0ac0c821eedca04e2df95b394d9abf8d2d8",
-      "pubkey_x25519": "451133762c1a1a706472bfdc66e1eb8ea53b3050688dc0458d4c2d6bd2a8cc65",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20224,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "51.68.137.38",
@@ -5416,7 +4604,7 @@
         11,
         0
       ],
-      "swarm": "44ffffffffffffff"
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
@@ -5431,20 +4619,6 @@
         2
       ],
       "swarm": "adffffffffffffff"
-    },
-    {
-      "public_ip": "206.189.109.173",
-      "storage_port": 22021,
-      "pubkey_ed25519": "291788c52c713eb7f6ecbb70a0683b8cc4a2d8e2ce1805261392b48af562c2b8",
-      "pubkey_x25519": "11e9506436ffe090935d40ebecf841df676843cb519dac2e6155e731bbfb171a",
-      "requested_unlock_height": 2094236,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
@@ -5493,28 +4667,14 @@
       "storage_port": 22115,
       "pubkey_ed25519": "29d5fb74d3126042c8dab58525f4ef57529c054ed10484e411b5131e9e7cad78",
       "pubkey_x25519": "9eba5dc959b6ebcb4d2b18a1e80137c40d8d40ae4fd4cb29315ee8f28c2d9f43",
-      "requested_unlock_height": 2090303,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 20215,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "32ffffffffffffff"
-    },
-    {
-      "public_ip": "212.56.45.2",
-      "storage_port": 22021,
-      "pubkey_ed25519": "29ea7c458ffee249178431a22353b76da73eded11d3fac5735cfdf88305bbff8",
-      "pubkey_x25519": "74032af37c64a141e36f7db9ad36c86ce8ff57f77c53c75720b17ec2f735c364",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "6effffffffffffff"
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "95.111.245.253",
@@ -5573,20 +4733,6 @@
       "swarm": "a6ffffffffffffff"
     },
     {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22106,
-      "pubkey_ed25519": "2a6eadce8cccd1b4cbddfe337986554a8bef52b964c1c0853a47dd37932e5271",
-      "pubkey_x25519": "14d110262914e349a0daa6a2d8fcb3ca5e5f68dd25beba5c5f6edd5d515c316e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a1ffffffffffffff"
-    },
-    {
       "public_ip": "91.231.182.72",
       "storage_port": 22021,
       "pubkey_ed25519": "2b15f7759564d0a2c7d60b04f8c7b5604b793cdd570fd0754a38d5738e919dad",
@@ -5640,35 +4786,21 @@
         11,
         3
       ],
-      "swarm": "afffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.164",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2bc44824399be5323296534ead917cfde0a47911ecc9d81571a3f7496566d064",
-      "pubkey_x25519": "b65fd9d9320d93493a033d5166b33d924cb750a069bfc9622ceb2d098db36450",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d6ffffffffffffff"
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "217.156.50.127",
       "storage_port": 22021,
       "pubkey_ed25519": "2c28c8698e15684885eabcb4520481735089ba6a42f31c087d0892938e5737fa",
       "pubkey_x25519": "1ec4e32809898005a334e2cc127ff38e5c1d66d1a8a53e2c7241d2b25da92953",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2104024,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "b3ffffffffffffff"
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
@@ -5699,20 +4831,6 @@
       "swarm": "e2ffffffffffffff"
     },
     {
-      "public_ip": "135.181.105.205",
-      "storage_port": 22108,
-      "pubkey_ed25519": "2d8b7e8a865f7aa9325fc2579c7dda7bf2e6517261383a46d75da1c51cb849cb",
-      "pubkey_x25519": "a54cededee1324b168ee6dd8fca7fe10b457522a4ed83a7408995cfaa662583f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22408,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "66ffffffffffffff"
-    },
-    {
       "public_ip": "141.105.130.184",
       "storage_port": 22021,
       "pubkey_ed25519": "2d9baeac32d5930a00a1037a7e678cfae9419057427e82e7eb218b421d33863b",
@@ -5725,20 +4843,6 @@
         3
       ],
       "swarm": "407fffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.59",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2da7e93a82f751bff4d57c7e22530828de181717172ab0f9c89862cfb105046e",
-      "pubkey_x25519": "c4798a461fcb4f7badb45bae73a769dd511316b9923d124addd97731b75b5f05",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "213.199.41.115",
@@ -5773,14 +4877,14 @@
       "storage_port": 22119,
       "pubkey_ed25519": "2e2f73e3d12ca86981fa2621b54222d7bb47f1bd0a2c66314684b00394f1a14c",
       "pubkey_x25519": "185ca1221f3136f8ace71352a4b502b1dad2d2daf7208fae43613fe35e69cc26",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099919,
       "storage_lmq_port": 20219,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "1f7fffffffffffff"
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
@@ -5811,20 +4915,6 @@
       "swarm": "14ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22132,
-      "pubkey_ed25519": "2f11e443d4a5122393d3b0f25c952028a40a03fd120b4fdebf7380cef72c742e",
-      "pubkey_x25519": "49e0b2461dc1f7a97991bece0e012dbc321209b6f9de900daa40a18d0e665361",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20232,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "38ffffffffffffff"
-    },
-    {
       "public_ip": "209.145.54.198",
       "storage_port": 22021,
       "pubkey_ed25519": "2f55897e0cc1982dbc8ed2a281ef11f6bed9826ddf2b9d883071ad6f5a2930e6",
@@ -5839,32 +4929,18 @@
       "swarm": "e1ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22120,
-      "pubkey_ed25519": "2f617b7a434ae3d76878864920310ef0d3563ff259ade25c4cb9721b0af9c7ee",
-      "pubkey_x25519": "71a69cdd70d440255a00143b6129cf7507fa0ed0bba8d0c2184634186abbdc37",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "297fffffffffffff"
-    },
-    {
       "public_ip": "130.255.77.179",
       "storage_port": 22021,
       "pubkey_ed25519": "2f6b05d12ceddae4e68c6a1a5056b13e72538d94b801487e1c5132280f1c7ffd",
       "pubkey_x25519": "269bbb978a0e856acb9f63a9e66df14252667d1640814b85827f55dd33e3e11f",
-      "requested_unlock_height": 2088900,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "51.195.252.72",
@@ -5878,7 +4954,7 @@
         11,
         2
       ],
-      "swarm": "a0ffffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "193.160.96.243",
@@ -5892,7 +4968,7 @@
         11,
         3
       ],
-      "swarm": "e2ffffffffffffff"
+      "swarm": "137fffffffffffff"
     },
     {
       "public_ip": "38.242.142.248",
@@ -5906,7 +4982,7 @@
         11,
         3
       ],
-      "swarm": "c4ffffffffffffff"
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "95.111.204.25",
@@ -5941,14 +5017,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "30c10f9e118ba68945c2473748b9e67e715ba53e9edddd4dc3c0b69e285c6fa0",
       "pubkey_x25519": "f6ba804b0bf483c395025f9688602e4873b7e923a8fa2b28a0621cbd686e7b37",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2104258,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "2d7fffffffffffff"
+      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "209.126.77.237",
@@ -5993,39 +5069,11 @@
       "swarm": "f4ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.235",
-      "storage_port": 22021,
-      "pubkey_ed25519": "31f4bb3a2baf824481db2429303ce38ff89bdf9a4a44dc2c532428c466796f44",
-      "pubkey_x25519": "39f4f5787b0a68b3b423c4bcc730e408d866073fbdcb3c42c03edab1b484ae13",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "27ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22104,
-      "pubkey_ed25519": "3234bdcbca860cfb704eca2578dc9fe228906a490e82e444001e320b937b21a6",
-      "pubkey_x25519": "8d258d8c3f67f23a17bb3be13bdf3f9265db072429d136c870f20c7c31f8cb1c",
-      "requested_unlock_height": 2088776,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "edffffffffffffff"
-    },
-    {
       "public_ip": "93.95.231.60",
       "storage_port": 22117,
       "pubkey_ed25519": "3249dc023773ec1cec8d7eb84b591b04965a59b41c300b40d702ee14a9d7dde8",
       "pubkey_x25519": "086700ac027423c8844fa586a24af7d81ec7ae9072cc0fa852dfadb6d998ac04",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099930,
       "storage_lmq_port": 20217,
       "storage_server_version": [
         2,
@@ -6046,7 +5094,7 @@
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "141.105.130.141",
@@ -6061,20 +5109,6 @@
         3
       ],
       "swarm": "427fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.184",
-      "storage_port": 22021,
-      "pubkey_ed25519": "32f244d823356bf9dbffc85c83f530dfd6f1f3f26ef572410452d390927b7f8b",
-      "pubkey_x25519": "abc49d581d5f5b9413f1f4fa1244bbb3c5c172b184ae80e4a29a9ebf6c2eda47",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -6105,20 +5139,6 @@
       "swarm": "4cffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22126,
-      "pubkey_ed25519": "338ab9f6005b211a036684f620a605ea171f40ff73a6a56ae1910e64bb8497db",
-      "pubkey_x25519": "7372c84ee9264e7f69ddbcfc42baa3c2a64b244d345c4c7dceec57be246cea5e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20226,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f2ffffffffffffff"
-    },
-    {
       "public_ip": "198.98.49.206",
       "storage_port": 22021,
       "pubkey_ed25519": "3440684d377a7a04409bb125f6dca7512fc5c3ecdecaec6016a75124c8965b1b",
@@ -6145,34 +5165,6 @@
         0
       ],
       "swarm": "9fffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.117.25",
-      "storage_port": 22021,
-      "pubkey_ed25519": "34a6b321c62f466224f1cad153915daff8075d8b339e7fa47712b311f1509567",
-      "pubkey_x25519": "b4d71359920c827836a378d147e2c09c94d0456c24f973472e15b76a06e2f625",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b1ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.90",
-      "storage_port": 22021,
-      "pubkey_ed25519": "34af438910a54fcac12ae70efb92a609434cc2793638ae81767e2b08f82da57d",
-      "pubkey_x25519": "a4a35ccc8a0f85071171a822e25ed04527f6cf62d5f7c13229698a6e6e840357",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "207.180.241.240",
@@ -6242,7 +5234,7 @@
         11,
         0
       ],
-      "swarm": "257fffffffffffff"
+      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "167.114.128.82",
@@ -6326,21 +5318,7 @@
         11,
         2
       ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
-      "public_ip": "173.249.193.95",
-      "storage_port": 22021,
-      "pubkey_ed25519": "368215a3027a3ce78d3c51d09d37adcb39efc00804b297865393d828fbbfb872",
-      "pubkey_x25519": "1887099b8f7acda328fc77d21d8ae65b1276de157257ed7535d9411bd4c42739",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2effffffffffffff"
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "51.83.69.65",
@@ -6385,39 +5363,25 @@
       "swarm": "26ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22129,
-      "pubkey_ed25519": "36c5f6af0c769a5f35ea2f89a62c8bcc879ba656bd6b2a23477a100c2a292fb0",
-      "pubkey_x25519": "9d78254dabe7df8979eb4b87178b62a19469e1fbc395faebd28ad0d27c08dd25",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20229,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
       "public_ip": "46.225.78.111",
       "storage_port": 22021,
       "pubkey_ed25519": "36ca3e9680e66c2966c062c9cb6883bb192cc62878860824f7cdd94710fbc8e0",
       "pubkey_x25519": "be50753eff2b356e51bf8b67acace22bc04ef4d5316e74d07aac0f15ca3b9d78",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2102666,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "67ffffffffffffff"
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "192.9.182.60",
       "storage_port": 22102,
       "pubkey_ed25519": "36da0a69008a6cc9be515b88e61219addffddc7dbad7050d7aa2ad71501e41b6",
       "pubkey_x25519": "42b7397ceebc43ba0103b0b26cc854a6ae7f29773fd4fff9192f717527b3d640",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099498,
       "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
@@ -6469,48 +5433,6 @@
       "swarm": "a5ffffffffffffff"
     },
     {
-      "public_ip": "164.68.126.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3741de3e63c724cf9d809370dd080b5e7363ff3fc7a5866581bf19d7178e4f8b",
-      "pubkey_x25519": "8c1130fd882a4280561000a339166dcd99b50519d9ab8146e757942a90038058",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b6ffffffffffffff"
-    },
-    {
-      "public_ip": "86.107.168.156",
-      "storage_port": 22021,
-      "pubkey_ed25519": "37613127a287e0de9aaf9eb1e0947b406eef3546c9387c6200e0c80ef33ec090",
-      "pubkey_x25519": "3aa3678fc25c293ae976c3c803fb46212860b859475a4ffcf3a7ec1ef7cfc43b",
-      "requested_unlock_height": 2085139,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3dffffffffffffff"
-    },
-    {
-      "public_ip": "164.90.200.74",
-      "storage_port": 22021,
-      "pubkey_ed25519": "37681c2bf8f7845c2683eab2fe68fb33c031618d861d990286dc77579d4ddf00",
-      "pubkey_x25519": "e54faed443627ca05956be2b5395ebcb7084dc609e066165123704e342e8d077",
-      "requested_unlock_height": 2094228,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "90ffffffffffffff"
-    },
-    {
       "public_ip": "107.189.6.53",
       "storage_port": 22021,
       "pubkey_ed25519": "37b733e56f3f670a57052c610403547fb317af86c252f0b68bd1ddf8d293e70f",
@@ -6536,7 +5458,7 @@
         11,
         0
       ],
-      "swarm": "d6ffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "46.250.249.103",
@@ -6565,20 +5487,6 @@
         0
       ],
       "swarm": "b3ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.100",
-      "storage_port": 22021,
-      "pubkey_ed25519": "386fff69caf0102034063bb1f6ee4e86a919266964a5027bb4c1e3d8f3e701f5",
-      "pubkey_x25519": "6c52330ebd889c924e7bd8ca9b82d3b0c312beb17a746c121d9eaf50152f7c7a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -6627,7 +5535,7 @@
       "storage_port": 22105,
       "pubkey_ed25519": "3a0e99d7a7ffcf1c00dfd61277b1461f8c06ade1a5b41f9bd116ba9f73d5e2ad",
       "pubkey_x25519": "ff5d13e42517d82368ee5cb1b9e23011dc4575973ec4d43fadf2643f1f007b5a",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099930,
       "storage_lmq_port": 20205,
       "storage_server_version": [
         2,
@@ -6662,7 +5570,7 @@
         11,
         2
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
@@ -6707,20 +5615,6 @@
       "swarm": "e6ffffffffffffff"
     },
     {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22103,
-      "pubkey_ed25519": "3b11f1a0b1c39ac2f3d197d63c5eab8157e1ae380831b8bf3f6cd3bf62ebca27",
-      "pubkey_x25519": "5b2e70445510215b4380650ba11e2779bc62faa5d606a06ca5058dbe3610cd2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8bffffffffffffff"
-    },
-    {
       "public_ip": "209.141.42.118",
       "storage_port": 22021,
       "pubkey_ed25519": "3b6679361b2fdcb059a2ad8919d00c273c6f8cdbb7c46eae61e7f0f5cd050277",
@@ -6749,20 +5643,6 @@
       "swarm": "eaffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22123,
-      "pubkey_ed25519": "3c3e35c2fdb0a55863d7b87ad0b0a4e546ddb67bd281dc0f82e8368b4c302929",
-      "pubkey_x25519": "4e38bce3434c5517debdd49e49ae90cf3f717627b636a7d0b91b404cf3c47354",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20223,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
       "public_ip": "45.79.83.44",
       "storage_port": 22021,
       "pubkey_ed25519": "3c658e7f88877159750967c046aa180694dd90acfe9dfcc9ce9231996aac9469",
@@ -6781,7 +5661,7 @@
       "storage_port": 22117,
       "pubkey_ed25519": "3c835b74f025cb47a86640eee50d986b8955f7a7e75c0104925ee1005f026ed3",
       "pubkey_x25519": "e36b651d834d7205a86c3199aeefe3bc12f0c9708db17bcb3ba5562d0ff5ea09",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099930,
       "storage_lmq_port": 20217,
       "storage_server_version": [
         2,
@@ -6795,14 +5675,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "3c91e4300084de95863a7e37df69de0d1abc936b35bb9e162824bc29b04c29a5",
       "pubkey_x25519": "304e99ba102024086a9d303b790a40779a9b6dc1f168edc390adf9636de0d024",
-      "requested_unlock_height": 2091006,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "33ffffffffffffff"
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "107.189.12.253",
@@ -6823,14 +5703,14 @@
       "storage_port": 22118,
       "pubkey_ed25519": "3cc5dc7270e47461955f60e43fa08c671705d03289b68ac4a000f3a652aae430",
       "pubkey_x25519": "a8eb55062d8769aea7909d2c9e733fa5c7a5a024df9026bc6ea8194dbf27f76d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099926,
       "storage_lmq_port": 20218,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "68ffffffffffffff"
+      "swarm": "afffffffffffffff"
     },
     {
       "public_ip": "95.111.246.120",
@@ -6858,7 +5738,7 @@
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "51.79.173.171",
@@ -6872,7 +5752,7 @@
         11,
         0
       ],
-      "swarm": "147fffffffffffff"
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "154.12.242.153",
@@ -6893,28 +5773,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "3d6ac7d7395434d57b852c3b5ffdbb4be57932e847229b463bb355b5b42a3b30",
       "pubkey_x25519": "b6fb2c2671ee81d79a7755f237ce68dd2a66199ae56cc03a67b321c9a253357c",
-      "requested_unlock_height": 2084489,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "48ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22127,
-      "pubkey_ed25519": "3d940eb1f9384984541045253b0e1786c1a99dddfaff384f9497766889f5bd1f",
-      "pubkey_x25519": "0214af794c1aeaf01c1ba7c4d77dafb234d43d55f849b557c107010fd0fe8f5a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20227,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "daffffffffffffff"
+      "swarm": "2fffffffffffffff"
     },
     {
       "public_ip": "38.242.155.130",
@@ -6935,7 +5801,7 @@
       "storage_port": 22107,
       "pubkey_ed25519": "3df57dd30732957c5826bda84a653c6dc5695613e031ba30642ba5d1480c1279",
       "pubkey_x25519": "eae611e8e3645b684f250c6224a14827503a3ec75c75f8e5b27b26fe36334e30",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099931,
       "storage_lmq_port": 20207,
       "storage_server_version": [
         2,
@@ -6956,49 +5822,7 @@
         11,
         3
       ],
-      "swarm": "cbffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.83",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3e45521c1dc8f9ad3f7d09db98d0454608c441985747f6144058da1d0e9053db",
-      "pubkey_x25519": "4a427f84971b41ecd56260e80db959670223714402f75d2fb5c4c8fc7ab03805",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "287fffffffffffff"
-    },
-    {
-      "public_ip": "152.53.207.147",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3e6974b216498ac13e8d75dbb687805816aac6043230c6a5485df03045d289bb",
-      "pubkey_x25519": "cc1a69b65e625641ae6c3afe28b4aed07d4f8001e8f282f70dfbc2d71027de3a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22107,
-      "pubkey_ed25519": "3e6a169bdd87f1249f97fc1a43d996c147569a4a831e9dcc17843185d7c07ff7",
-      "pubkey_x25519": "f7c156f6b11d0f09a27300e4d05a75adedf5308c8ef852a060feb7f2556f2648",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "45.33.57.4",
@@ -7071,20 +5895,6 @@
       "swarm": "dbffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.58",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3f4e1c8eb34b2da55f402a8ec612f1df109d2f6ebf37d898d564dcb21d553504",
-      "pubkey_x25519": "7d1b54500494e30a2b410257734d6076e9afaf9f11cb13f50fd99ab16786f146",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "91ffffffffffffff"
-    },
-    {
       "public_ip": "135.181.109.199",
       "storage_port": 22104,
       "pubkey_ed25519": "3f62700094f5548ecdd5eb8d9ab15af47812069e58a87d7655d03a7c25258001",
@@ -7110,7 +5920,7 @@
         11,
         3
       ],
-      "swarm": "377fffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "159.223.233.23",
@@ -7127,20 +5937,6 @@
       "swarm": "48ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.253",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3fd8f2a71c8fd9f191f64d2efc6627773e9946bca548805dc178a468eed38c66",
-      "pubkey_x25519": "aa6f343ce07aea4ce9c0b107eee8099ce60ee19c894c6df6d3e732b7e9e83905",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "20ffffffffffffff"
-    },
-    {
       "public_ip": "104.244.73.67",
       "storage_port": 22021,
       "pubkey_ed25519": "3ff9e8f5b9ca1aef803cad9cdfb707727a03d68078d7820e4adf3664a379598a",
@@ -7155,20 +5951,6 @@
       "swarm": "57fffffffffffff"
     },
     {
-      "public_ip": "23.94.63.201",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3ffce1e4052e2d21ab90a90d7c9ae241d79c88579ef81f4489bc203d294e3204",
-      "pubkey_x25519": "721d4bb98e09690045b8d992e9aa3682eb6733d442081867d095519652062737",
-      "requested_unlock_height": 2085164,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "78ffffffffffffff"
-    },
-    {
       "public_ip": "116.203.146.221",
       "storage_port": 22101,
       "pubkey_ed25519": "4045ffbaa9b98530cae71b9c4534a39470ab81a0b1d3fac007240497af9c3cc7",
@@ -7180,21 +5962,7 @@
         11,
         0
       ],
-      "swarm": "78ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.61",
-      "storage_port": 22021,
-      "pubkey_ed25519": "40f414650f59cbcf87d507f4d03dade9c88de047ec256556893ac23e337cf877",
-      "pubkey_x25519": "27f557158751212c3ca097237c3a29212260fe9371f35b29d397f50cf39fb603",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "1bffffffffffffff"
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "135.148.138.18",
@@ -7223,20 +5991,6 @@
         3
       ],
       "swarm": "aaffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.238",
-      "storage_port": 22021,
-      "pubkey_ed25519": "422ac0256c5451b78ebe39178e8a0919547c4ff4cd1f79fd2cfda4013d4f27fc",
-      "pubkey_x25519": "d52ec783fd12d9c7236b7f2a1ecaef6f88c9eea31390c97c1fa3c4a7cae41855",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
@@ -7313,14 +6067,14 @@
       "storage_port": 22110,
       "pubkey_ed25519": "433d5571d204c41f31effa3e77b6e5a7b17eff57f2b9bf1f42ce642a65b2bb19",
       "pubkey_x25519": "da0c397043d8bba11d0ad213c7a8f3bb2897155d81afa541e1069f9e1534a46a",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2108731,
       "storage_lmq_port": 20210,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.73",
@@ -7334,7 +6088,7 @@
         11,
         3
       ],
-      "swarm": "fcffffffffffffff"
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "91.250.249.165",
@@ -7407,20 +6161,6 @@
       "swarm": "74ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.57",
-      "storage_port": 22021,
-      "pubkey_ed25519": "43fe958c80251ca0deb255a316a60669578775eb595f8c86d3c3e57c4248c828",
-      "pubkey_x25519": "cd413e0468b9a7cc503f03d9d1705e3a00e9bc1af91829c01d4c154e94f5105a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "227fffffffffffff"
-    },
-    {
       "public_ip": "37.27.247.192",
       "storage_port": 22021,
       "pubkey_ed25519": "44315c76a244700b72eb76017278404b3b9e599dd00ad44cf969aff56170ea51",
@@ -7432,21 +6172,7 @@
         11,
         2
       ],
-      "swarm": "ecffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.66",
-      "storage_port": 22021,
-      "pubkey_ed25519": "445f4c906bce8cb76f245d119311bffe1c22579ab280c62f5a55c5436f6b8499",
-      "pubkey_x25519": "793f639ea1f25d1128bf28d2f2f66b7de8e5b0c56fba41443fd30b379cf04315",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6dffffffffffffff"
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "194.32.79.192",
@@ -7467,7 +6193,7 @@
       "storage_port": 22122,
       "pubkey_ed25519": "44e2ef67983dd3c1a1452cf82d352c5da3e949ec66eb5aaac1f672670eb59e1f",
       "pubkey_x25519": "20282c8e8dc149039c88de87381617b8d4865afe1b6631e2a3aef83877d29d67",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099919,
       "storage_lmq_port": 20222,
       "storage_server_version": [
         2,
@@ -7516,7 +6242,7 @@
         11,
         1
       ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "51.79.173.216",
@@ -7586,7 +6312,7 @@
         11,
         2
       ],
-      "swarm": "cdffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -7614,7 +6340,21 @@
         11,
         2
       ],
-      "swarm": "1d7fffffffffffff"
+      "swarm": "c4ffffffffffffff"
+    },
+    {
+      "public_ip": "185.245.83.77",
+      "storage_port": 22021,
+      "pubkey_ed25519": "46202f511ff1d5152ea036f9c76a995dfd22ce13d08421966fd3eef5656056d3",
+      "pubkey_x25519": "f91e71a0cd3e70a324d5ef7592026edd41983a246425d2c38130e26ff1a59436",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "152.69.167.181",
@@ -7635,7 +6375,7 @@
       "storage_port": 22104,
       "pubkey_ed25519": "4690761ab657da924df341d30549091b81382743fa12496d34cca50ef31d2f58",
       "pubkey_x25519": "66569cfbfaec6ccc65b27c20e127d70d9e49b69baf48de1e46cc617211d56337",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099926,
       "storage_lmq_port": 20204,
       "storage_server_version": [
         2,
@@ -7656,7 +6396,7 @@
         11,
         2
       ],
-      "swarm": "aaffffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "159.65.106.23",
@@ -7684,7 +6424,7 @@
         11,
         2
       ],
-      "swarm": "60ffffffffffffff"
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "51.89.165.64",
@@ -7701,25 +6441,11 @@
       "swarm": "48ffffffffffffff"
     },
     {
-      "public_ip": "193.22.147.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "47a6cb09dfd8d3ad123188f4e19d8299c4bf5ae35c19c10527db353c14319815",
-      "pubkey_x25519": "c6c52af3153fadae833f7ad27af2708aaff58199d4d9061eea77d811c649e709",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "77ffffffffffffff"
-    },
-    {
       "public_ip": "89.147.110.157",
       "storage_port": 22114,
       "pubkey_ed25519": "47c9bfdb6f388d15890ff37e8da50da8353e1734fb641cb30927f006e50a3543",
       "pubkey_x25519": "27da7270b02a383906fd1359ba9e6f04a10f20e76e671ce638a4dbf2c0559954",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099932,
       "storage_lmq_port": 20214,
       "storage_server_version": [
         2,
@@ -7785,20 +6511,6 @@
       "swarm": "beffffffffffffff"
     },
     {
-      "public_ip": "23.94.92.223",
-      "storage_port": 22021,
-      "pubkey_ed25519": "48e0f89725ec8259b8e725b857909eb5fabe7bea9b7f019b64f2e0167fb69f8c",
-      "pubkey_x25519": "a46e8c73a367c59b01398aea196f2c4d191c1713b921614d4e2cb3145de9b745",
-      "requested_unlock_height": 2086494,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a7ffffffffffffff"
-    },
-    {
       "public_ip": "91.98.68.87",
       "storage_port": 22021,
       "pubkey_ed25519": "495954e51f35907aa1085ee8b20e649f1261d681187f951dc90ac62979287348",
@@ -7852,7 +6564,7 @@
         11,
         2
       ],
-      "swarm": "b2ffffffffffffff"
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -7894,7 +6606,7 @@
         11,
         0
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -7978,14 +6690,14 @@
         11,
         0
       ],
-      "swarm": "147fffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22108,
       "pubkey_ed25519": "4affc306c1e0b0798de1f890b95e8f3d25435c2af36a7f5942c00c8aaf806611",
       "pubkey_x25519": "10664f702883b05b604a474181817cab1d208741fe6648a94beedd8fe8c59e0d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099925,
       "storage_lmq_port": 20208,
       "storage_server_version": [
         2,
@@ -8013,14 +6725,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "4b6701c1d084af70e941741a311d95e211592dee04f9830b4ccd117545dd5094",
       "pubkey_x25519": "e138708486b8118ab3a4a07b89560c855518fcb27408163392b68c7290b30018",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2102666,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "b3ffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
@@ -8034,7 +6746,7 @@
         11,
         3
       ],
-      "swarm": "bcffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "134.122.63.223",
@@ -8051,20 +6763,6 @@
       "swarm": "36ffffffffffffff"
     },
     {
-      "public_ip": "164.68.101.57",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4bec65bb9ff4f3873021d52ec78185efb7aa10973083adda469d67449626c7db",
-      "pubkey_x25519": "c5c4296ce669c28b345b32166f6765e6d6ea6f0cfd3435972336b99849f5c95c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "daffffffffffffff"
-    },
-    {
       "public_ip": "51.79.65.165",
       "storage_port": 22021,
       "pubkey_ed25519": "4c006480165132e0bed3756f17bf1b7fb0c606c694fd2dd49dbd4514c0f03739",
@@ -8076,7 +6774,7 @@
         11,
         0
       ],
-      "swarm": "c7fffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
@@ -8097,56 +6795,14 @@
       "storage_port": 22108,
       "pubkey_ed25519": "4cf7430310e4ea8534f9bdc183f29fdd0077382bd0839167c7d2907737cfb688",
       "pubkey_x25519": "d06c3ae78721a83de0398c369032b6fecc9a34e1508e2b0d726efa2be6725276",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099500,
       "storage_lmq_port": 20208,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22130,
-      "pubkey_ed25519": "4d1867319c182dd7e6bb6c156575c50ca657969af94ace5ca677dfc599323a56",
-      "pubkey_x25519": "1d648f25a46559b39bd423f4b60f1e591307906a2841c40adf9d5312ed55ca78",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20230,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
-      "public_ip": "103.199.19.138",
-      "storage_port": 22101,
-      "pubkey_ed25519": "4d78084b08c447143400b48c90b6f6b6827e1bff8fc08f93002657044e93fcca",
-      "pubkey_x25519": "a71528ca1dee396f20c7e238dbd886855af69637cf969c7fbef04e3d8cb72842",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "9affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.116.129",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4daaede2511b28e2a7cd1595474088bd165eff7df9168f125dd7983071ed0a63",
-      "pubkey_x25519": "3fcceda5280527094ec7cb8710608131e8b6b7ffc6c0a576eb937525c223ed04",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "128.140.87.239",
@@ -8163,20 +6819,6 @@
       "swarm": "9bffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.87",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4dc3abd888b6c71b255b95cbdcc0b8b7ac76c0b24d48869e5f1f9ffb7a3e7829",
-      "pubkey_x25519": "c4b57bc952d11501d807f6c44ca0f956a924c2f9d395282de746f1774ad4c960",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "2effffffffffffff"
-    },
-    {
       "public_ip": "104.243.41.194",
       "storage_port": 22113,
       "pubkey_ed25519": "4dcf7b92fc43c0202dc628aaf9d1a57f209a901bc0a31fbb55a0954ef8195872",
@@ -8188,21 +6830,7 @@
         11,
         3
       ],
-      "swarm": "317fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22116,
-      "pubkey_ed25519": "4e4055c383ee7f8f61e956ad2ab1a4904b07e254d4ee308175dc6341e4935189",
-      "pubkey_x25519": "8e53a486b21bc127e6453964d584971eb9f1cf79517b75e616239e077207113d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20216,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "199.195.252.42",
@@ -8230,14 +6858,14 @@
         11,
         3
       ],
-      "swarm": "deffffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22110,
       "pubkey_ed25519": "4e91707683562c298ebdb25de8b91a860663f8a10f31c19a2bf96bc1afec5c4c",
       "pubkey_x25519": "d46a9c125e3d66a14147d1910814b6275e0a66158f404afdd0ab7387f9702119",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099931,
       "storage_lmq_port": 20210,
       "storage_server_version": [
         2,
@@ -8258,7 +6886,7 @@
         11,
         3
       ],
-      "swarm": "6cffffffffffffff"
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "66.94.125.216",
@@ -8273,20 +6901,6 @@
         2
       ],
       "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.143",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4f0cffb44f43e99517a8beac742e57ab2df559e7591c33ec0291158c42ce66ea",
-      "pubkey_x25519": "858c07f0c7c605f68ef7287638034b6be26fe71fbdc5608578d5786b5201e716",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "37.27.212.116",
@@ -8331,20 +6945,6 @@
       "swarm": "13ffffffffffffff"
     },
     {
-      "public_ip": "65.109.140.246",
-      "storage_port": 22100,
-      "pubkey_ed25519": "4fe324e4eb85d40d8d2899ddd7865237f8c3248d1415f6ea1a9192024507ac9c",
-      "pubkey_x25519": "2eee9d8a84a787eb6e2f044619b682d927016d0e4c5ebb1c2fae87b8c4f24363",
-      "requested_unlock_height": 2090113,
-      "storage_lmq_port": 22400,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "e7ffffffffffffff"
-    },
-    {
       "public_ip": "102.222.20.141",
       "storage_port": 22021,
       "pubkey_ed25519": "4ff4dbed33408522f1e6a91325eb8d4ff402ba0258c172be9d97787922e676b0",
@@ -8371,6 +6971,20 @@
         3
       ],
       "swarm": "3bffffffffffffff"
+    },
+    {
+      "public_ip": "155.103.66.130",
+      "storage_port": 22021,
+      "pubkey_ed25519": "502dfca22ce0801a400b06a9e675a3977d947bb17b111f63c5f7dbecc2f2ffcf",
+      "pubkey_x25519": "dd7a3a20673923232ce71ffaffaa1cebdc3e44dc3e7c87f11490f2fa367ec55f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -8419,14 +7033,14 @@
       "storage_port": 22105,
       "pubkey_ed25519": "50c6a0746f7bbb26307d1a2bba9ee769aaad399e5ebe7406aa294bc797edb0d2",
       "pubkey_x25519": "fd9d8e0fcec1b46ad51ed37b5a7ae8e16323a96ba8ab8f27c14269fac742e272",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099931,
       "storage_lmq_port": 20205,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "c6ffffffffffffff"
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "65.109.4.149",
@@ -8443,20 +7057,6 @@
       "swarm": "99ffffffffffffff"
     },
     {
-      "public_ip": "213.136.74.26",
-      "storage_port": 22021,
-      "pubkey_ed25519": "51a0ab02885fdf749cf05de9b2ec0962251ea21ea2c020fb6a1f7475f84ee6ce",
-      "pubkey_x25519": "43d1ac3147ad69068bde99d357e2850a587566c3607b2b0caa7ccbedfd0d641f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f4ffffffffffffff"
-    },
-    {
       "public_ip": "49.12.220.221",
       "storage_port": 22021,
       "pubkey_ed25519": "51c68cad2fc39f477f5dba3f62c513430b1da9bf9bbd0e7275afe2a48d8f94a0",
@@ -8469,20 +7069,6 @@
         2
       ],
       "swarm": "f9ffffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.50",
-      "storage_port": 22021,
-      "pubkey_ed25519": "51c7aeb2ae9cd60dcaf9dc91c24ccbca274466d5b75ec04f91cc0de12cc3049a",
-      "pubkey_x25519": "58f1790dcc220a26353d1cdcaed3bbe4dfbd97345e780b8818885c6ed591275a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "104.244.79.28",
@@ -8513,62 +7099,6 @@
       "swarm": "89ffffffffffffff"
     },
     {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22109,
-      "pubkey_ed25519": "51ee1a8999060d18c8194a73dde126aeab521d780c8ed57fd6324f9eb99df641",
-      "pubkey_x25519": "6d39403b5d77c37937b8e927ccbc67c04b92bb24b7a8145d09b4f6ca595a6160",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "98ffffffffffffff"
-    },
-    {
-      "public_ip": "89.167.117.100",
-      "storage_port": 22101,
-      "pubkey_ed25519": "522d3366aa0f1a8c58e02bc9fb57e0bb2b2b7387dc155bc382397986211ab344",
-      "pubkey_x25519": "84173783dfe2578d92632c1937210f9e3bb4d178a6ec2bf71a57c930c2c2783e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "fdffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.25",
-      "storage_port": 22021,
-      "pubkey_ed25519": "523d1ff49ab1dbc42c8432a15eeca2a42c631de419ac5321a84f7ab7f76dc85c",
-      "pubkey_x25519": "b93170bc5c217b4dd0a0b3e8db5e6be7551fc02d58628685f715753a7479fe79",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "bfffffffffffffff"
-    },
-    {
-      "public_ip": "129.80.36.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "525ba5bc2d64eff0be94649b4b8d49a6a4de6bd94c4fff0dbef907b4ff4d83ef",
-      "pubkey_x25519": "b35dbb7edf569a74719b1f4665069c2d6ef5680629a4c049dd5db375884af458",
-      "requested_unlock_height": 2091319,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e6ffffffffffffff"
-    },
-    {
       "public_ip": "198.98.52.166",
       "storage_port": 22021,
       "pubkey_ed25519": "528ffd5434596a237a39c93e1290d3377c51501b9e7bd95593b28dcacdeb2861",
@@ -8580,7 +7110,7 @@
         11,
         3
       ],
-      "swarm": "2dffffffffffffff"
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "51.79.84.33",
@@ -8636,7 +7166,7 @@
         11,
         3
       ],
-      "swarm": "e4ffffffffffffff"
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "192.155.85.128",
@@ -8693,20 +7223,6 @@
         2
       ],
       "swarm": "d4ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.164",
-      "storage_port": 22021,
-      "pubkey_ed25519": "543d539a12a5ed5932a169d44f1de64aa6d6e9dcaf200854bbda4c61bc55c9c1",
-      "pubkey_x25519": "2c390f6dc48e3b4fa63f93867c94c4c70110097552aef5112d3f94368465a804",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "41ffffffffffffff"
     },
     {
       "public_ip": "5.253.31.4",
@@ -8793,20 +7309,6 @@
       "swarm": "8dffffffffffffff"
     },
     {
-      "public_ip": "23.81.40.224",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5566cd614f23ddb17fec8db75f0f6614c95332013c670bd3efe56c3bb0fa9a37",
-      "pubkey_x25519": "327b15bf7e7196660233dedfd8c6d0d37ec44fb1b8a7128f314c3a63b9caa031",
-      "requested_unlock_height": 2085899,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "feffffffffffffff"
-    },
-    {
       "public_ip": "84.21.171.110",
       "storage_port": 22021,
       "pubkey_ed25519": "557dacb62f2f2169093f58228a5433cd6efb9f59ec09dc58a623850e65a9ae56",
@@ -8819,34 +7321,6 @@
         2
       ],
       "swarm": "207fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22128,
-      "pubkey_ed25519": "559f7debe1814f51412987c2d7302ea30ced1bae06f0c2070fbf42a5da5a8dfc",
-      "pubkey_x25519": "ec1269421fec16e8bc3e964795244c4015f264177fefe150131b27ec5b3ecc48",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20228,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "20ffffffffffffff"
-    },
-    {
-      "public_ip": "207.180.229.183",
-      "storage_port": 22021,
-      "pubkey_ed25519": "55b68e059454eb1036849a60816054bf5e31f163ba5605d8c8bee5d4818ba1a2",
-      "pubkey_x25519": "45dcfed7bf3a0398ed5ba59add0feb5d525b9c927f798fefc01a2ae848cea534",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "161.97.68.140",
@@ -8867,7 +7341,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "55e842b077f8fbe643a08d1c687195ecca8ee06b9c10d0f5b8ad306eb875f70c",
       "pubkey_x25519": "c3946514e4f577c2ddd05b3f7fe90166ca3a8ddc4f8b040ad8b1a05ce535685f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2104258,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -8888,35 +7362,21 @@
         11,
         0
       ],
-      "swarm": "f8ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22134,
-      "pubkey_ed25519": "562a9f53323515b7ed22a88467e0b1fe68e166a42dc95f7371a403b0d2f54781",
-      "pubkey_x25519": "682488349468e9eccd33f1442e72fd31ac9e72b0f70ba5f7cb211f7813f2c61c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20234,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "31ffffffffffffff"
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
       "storage_port": 22135,
       "pubkey_ed25519": "565a450700bf8fd2319fad851fa2f68fb932f77edf743abdea79a3665a75fed3",
       "pubkey_x25519": "fba711b7cb0f6b92f54887f1caad22304decfc7004cdc92585e0bce447f58040",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099499,
       "storage_lmq_port": 20235,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "0"
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "107.189.11.153",
@@ -8930,7 +7390,7 @@
         11,
         2
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "57.129.67.254",
@@ -9003,20 +7463,6 @@
       "swarm": "b7fffffffffffff"
     },
     {
-      "public_ip": "128.199.51.252",
-      "storage_port": 22021,
-      "pubkey_ed25519": "57288b6ca34c8e2288d5eed8445967cbcd9a5a1b14c8debc6720879f67e36188",
-      "pubkey_x25519": "8ba06ed00d8adab821c697bfafe2db909da56afd1c7ed5117e8b05127c09ce41",
-      "requested_unlock_height": 2094234,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b1ffffffffffffff"
-    },
-    {
       "public_ip": "51.38.187.113",
       "storage_port": 22021,
       "pubkey_ed25519": "5750b08db37b3ec8e4a4d8df0ccf912fd30344b663e225642007349f0490dae1",
@@ -9043,6 +7489,20 @@
         2
       ],
       "swarm": "1effffffffffffff"
+    },
+    {
+      "public_ip": "185.150.191.68",
+      "storage_port": 22108,
+      "pubkey_ed25519": "57a25334bbd11d8b1e8d0de7b7e3d9e62caefc08a6dcb239cb4910cf0deb3749",
+      "pubkey_x25519": "51d071c16661316406d74964f2305326abe94783aa0197fb253c915cafbcb261",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20208,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "192.155.85.177",
@@ -9073,34 +7533,6 @@
       "swarm": "53ffffffffffffff"
     },
     {
-      "public_ip": "91.99.120.185",
-      "storage_port": 22102,
-      "pubkey_ed25519": "58074f4db735b3e81d972053bd54595dc788666c6caeb773fdc781fcc64cf5ee",
-      "pubkey_x25519": "b95bb3518e1cb1105edeb212cdc3fa5544e0fabaa44dcf30b763cf9c2725ff7f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "6dffffffffffffff"
-    },
-    {
-      "public_ip": "89.125.187.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5809717acc8ba54c40ea1337d4f57433d9b16fe5d540be18e877ca8c7bd5198e",
-      "pubkey_x25519": "71e1fc29f8b97092ba1545d4de88c45b6145839971784e2ca9b85e7bef695a39",
-      "requested_unlock_height": 2085143,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
       "public_ip": "167.86.118.4",
       "storage_port": 22021,
       "pubkey_ed25519": "5814e7d7be5f920204f757003e63483525afbb10907f096587d064ad81956d57",
@@ -9119,7 +7551,7 @@
       "storage_port": 22115,
       "pubkey_ed25519": "586f0fe35e764b6bb02e91d00f3ba9bb6aab0bfa3531bb8560fc3cd8588d0c8a",
       "pubkey_x25519": "af87d107a995a6a75a54033350d0bd6fe14be35e56994be9601e7e604db27d41",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099932,
       "storage_lmq_port": 20215,
       "storage_server_version": [
         2,
@@ -9168,7 +7600,7 @@
         11,
         2
       ],
-      "swarm": "15ffffffffffffff"
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "51.79.173.224",
@@ -9227,20 +7659,6 @@
       "swarm": "5affffffffffffff"
     },
     {
-      "public_ip": "164.68.113.100",
-      "storage_port": 22021,
-      "pubkey_ed25519": "59dc26e5ea8f91fba91725a85d7cd2537284f85a3e8f651b31d5330c15cb31cf",
-      "pubkey_x25519": "882262ed1a73ab1097e95fe04d8fa8bce0e26c0e125690afc5846103aec35f14",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "1ffffffffffffff"
-    },
-    {
       "public_ip": "94.23.19.49",
       "storage_port": 20608,
       "pubkey_ed25519": "59f3d7e6f9525a6970e712b72368f51dfe341c6dbd39810b95b64802260d3df0",
@@ -9253,20 +7671,6 @@
         2
       ],
       "swarm": "b5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.81",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5a22bcc8187e03d3c8b037f927d6be1d8cec391686ab3addfd5a33942e5f5b2e",
-      "pubkey_x25519": "ac8da9648a8929458a76696e0338d1a6d07e0ec05ad242f6e5ada95157126160",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "217.15.163.107",
@@ -9283,20 +7687,6 @@
       "swarm": "88ffffffffffffff"
     },
     {
-      "public_ip": "38.45.67.191",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5a558ea86464ca91f94d6fe72dc1c4164d15c6d4de4bfb7c66531df159f84823",
-      "pubkey_x25519": "77edc58aa74bc020c6c99ae49849c94fb7261b1136daa260d503e4d5e09b304e",
-      "requested_unlock_height": 2090346,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "38ffffffffffffff"
-    },
-    {
       "public_ip": "188.245.112.98",
       "storage_port": 22021,
       "pubkey_ed25519": "5a7ca4360b82c934a407d85f9f22d33db73464232c86328271a34ec9173def8f",
@@ -9308,21 +7698,21 @@
         11,
         2
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "f7ffffffffffffff"
     },
     {
       "public_ip": "206.221.184.74",
       "storage_port": 22106,
       "pubkey_ed25519": "5b46dc00f0e8c471a295d0f23caf86a6f4afa6197b5f8c00b87d29d7cf1b3d0d",
       "pubkey_x25519": "d32fea2fcd186c7fa7a6f762a7224c3d7a178bfa625f8727923e2debd96e036e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2103319,
       "storage_lmq_port": 20206,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "f3ffffffffffffff"
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "209.50.241.202",
@@ -9350,7 +7740,7 @@
         11,
         3
       ],
-      "swarm": "e4ffffffffffffff"
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "139.59.29.239",
@@ -9365,20 +7755,6 @@
         0
       ],
       "swarm": "ddffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.35",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5b753bf1f67575737848a791b315743f9081d4198a86543132d1b4a2068b8135",
-      "pubkey_x25519": "76adb626b0ad64ca1040d51fa608ff1dd5859c4f51f7757f2806275e2ca21a47",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.68",
@@ -9451,39 +7827,11 @@
       "swarm": "a5ffffffffffffff"
     },
     {
-      "public_ip": "84.247.128.91",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5d13bed998a7feb450c20fbd6d780b6be87c751b5083adf9774ec4610e78c5cc",
-      "pubkey_x25519": "e8987cfab527bd02fa4aadc62fb76fbcf4851643bf6aac1d4e9e48f0429df579",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3fffffffffffffff"
-    },
-    {
-      "public_ip": "45.13.38.196",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5d1dff53e9263e18c5a287dee444c0c847987553047af373b319db21bbc8fec9",
-      "pubkey_x25519": "4c2e929c42399914f7d985d891477a3bbc6967f501cfb4de03026f17ef6a4e27",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2dffffffffffffff"
-    },
-    {
       "public_ip": "93.95.231.60",
       "storage_port": 22119,
       "pubkey_ed25519": "5d45a825a407571c1b46a6dc1133d755c56d686fcba4de605bf664f9ee8026ec",
       "pubkey_x25519": "3f1359074066fc80e664856a4896e6d09fd6cca0f927e9747c0cb06f59dfa01d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099926,
       "storage_lmq_port": 20219,
       "storage_server_version": [
         2,
@@ -9504,7 +7852,7 @@
         11,
         3
       ],
-      "swarm": "caffffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "57.129.121.198",
@@ -9560,7 +7908,21 @@
         11,
         1
       ],
-      "swarm": "d7fffffffffffff"
+      "swarm": "a7ffffffffffffff"
+    },
+    {
+      "public_ip": "15.204.94.233",
+      "storage_port": 22021,
+      "pubkey_ed25519": "5df18a1383368e6cfe05bf008c50cfe2992681584273ea587166633a1f4ea0b9",
+      "pubkey_x25519": "2b1bfe6fe76fa315d517331a774c92c248cc6a48370ac35a14b33e123fc11c7b",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "66.94.111.4",
@@ -9589,20 +7951,6 @@
         0
       ],
       "swarm": "71ffffffffffffff"
-    },
-    {
-      "public_ip": "135.181.105.205",
-      "storage_port": 22106,
-      "pubkey_ed25519": "5e3203890a5fed140ae1edd3ecff845a5410e070e6364985941f6a8386803475",
-      "pubkey_x25519": "ebe75e963cc30ef949b8f1c889ac90e28c1ae7ee96cbb013149dbcf69e321c6c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22406,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "193.219.97.56",
@@ -9644,21 +7992,7 @@
         11,
         2
       ],
-      "swarm": "92ffffffffffffff"
-    },
-    {
-      "public_ip": "51.178.47.243",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5eb475d5722b48db6308eb7f3a7a415e500884ef4cdc614fe979ca1cd75916ae",
-      "pubkey_x25519": "39c72130082c4fe026dedabd992dcf31efa1444d6e3a42e30f22399496e2fe35",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "9effffffffffffff"
+      "swarm": "397fffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
@@ -9689,20 +8023,6 @@
       "swarm": "efffffffffffffff"
     },
     {
-      "public_ip": "159.223.212.143",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5f200e2f93459808f8545d4d5570a6b2292b7d5e2c3c96a93400357a9a6b7560",
-      "pubkey_x25519": "b5e75e60a6da0ce34068d423423d533ebad6daddf1b08c4fe0c364d9bcc15457",
-      "requested_unlock_height": 2094233,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "59ffffffffffffff"
-    },
-    {
       "public_ip": "65.109.140.246",
       "storage_port": 22101,
       "pubkey_ed25519": "5f2f2e96a46db255a96ca5886156617dd295cea289b945fa3b95e0e49fdb893c",
@@ -9729,20 +8049,6 @@
         3
       ],
       "swarm": "7cffffffffffffff"
-    },
-    {
-      "public_ip": "94.177.9.41",
-      "storage_port": 22021,
-      "pubkey_ed25519": "603fb587db235158727a642604465a3272a80a34712010fcd79af55aa40ebd18",
-      "pubkey_x25519": "4de72af6e9380f9e0859d61b859db92d53a51ff35a88392212d1e48e70becc4b",
-      "requested_unlock_height": 2091645,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -9773,20 +8079,6 @@
       "swarm": "32ffffffffffffff"
     },
     {
-      "public_ip": "217.160.4.10",
-      "storage_port": 22021,
-      "pubkey_ed25519": "60d10db9233ab22dadc890607dd78ed994cebcec3ea27a6c6dfe9fdd98fccdd3",
-      "pubkey_x25519": "6bd53902ec9d799b544b4ca84d5d5d4b59c7c950097263525921eb666a4dc323",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d9ffffffffffffff"
-    },
-    {
       "public_ip": "51.38.146.242",
       "storage_port": 22021,
       "pubkey_ed25519": "60de372a20e9393642d90e8d4943a1cda40cc4d4aec56ea6723c7b0beb5bc0c0",
@@ -9805,7 +8097,7 @@
       "storage_port": 22103,
       "pubkey_ed25519": "60e50c0904bcdc68d7f607893924f9ac0d5acc553cbe0770aef236f7788c0f5a",
       "pubkey_x25519": "cacae59b879897e8ce81b27ba7636bf17988a0bf9422c9f52a77a0103a328a53",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2109075,
       "storage_lmq_port": 22403,
       "storage_server_version": [
         2,
@@ -9840,49 +8132,7 @@
         11,
         2
       ],
-      "swarm": "f3ffffffffffffff"
-    },
-    {
-      "public_ip": "152.53.46.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "61e968067edebbb4f2747bf64fd29a9046bf5092d63884a5e9a0174b7e1c8b35",
-      "pubkey_x25519": "66881337e7641215615265f4734dc3fe994024ef514f3b6fb5e0d3910ca6b62d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "17ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22137,
-      "pubkey_ed25519": "622e7c6d748a4330e6abb247d8b828daac0dbf00e52fef29b8cc70d78503993f",
-      "pubkey_x25519": "2f869d85119113f8cc6818ecea2b9a22e25f951e04cfa6f5bc9cfd31c6fd490c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20237,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "efffffffffffffff"
-    },
-    {
-      "public_ip": "91.99.230.225",
-      "storage_port": 22021,
-      "pubkey_ed25519": "62348503949d28a0b083a481106c4e3084175664fd10fff84fb3e1393439e335",
-      "pubkey_x25519": "f09831906e45138b26d9906e087ec1f53fd773f39245220f6a765365be6c7937",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "31.57.218.208",
@@ -9924,21 +8174,7 @@
         11,
         0
       ],
-      "swarm": "94ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22133,
-      "pubkey_ed25519": "632bbcac42d758e17d5ae5f9ce79c1938b13582155795628b95bca3ce427daf6",
-      "pubkey_x25519": "6ee2fc255f5a2779c4f346991ede5292516a7d6d450dde80a4617c3516cb0678",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20233,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -9981,20 +8217,6 @@
         3
       ],
       "swarm": "45ffffffffffffff"
-    },
-    {
-      "public_ip": "161.97.123.136",
-      "storage_port": 22021,
-      "pubkey_ed25519": "640b1c376a1efd7de2776b0cf02584f7cbe10ba025049e16d951928cf28c6dc6",
-      "pubkey_x25519": "0a3becee4752ce462e026a26a12f9648f9d1d1cf560d776cf47e47ddc3f6242e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.89",
@@ -10081,20 +8303,6 @@
       "swarm": "9bffffffffffffff"
     },
     {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22103,
-      "pubkey_ed25519": "65332d49d1cca74d360b67353b3867715491f359644e60560543f87593ca8630",
-      "pubkey_x25519": "a9141d57f56fded007a90f49c0fca485ff353d914c893cd94cdd65374faadc0d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "bbffffffffffffff"
-    },
-    {
       "public_ip": "176.96.138.97",
       "storage_port": 22021,
       "pubkey_ed25519": "655d94100583c5a9b4d9f2540cd2cb4a8fc295b2728d737c25bca3561b55e880",
@@ -10134,14 +8342,14 @@
         11,
         3
       ],
-      "swarm": "77fffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22105,
       "pubkey_ed25519": "660460492d9c8f519c521d7b0c20b3c8bd8c68ebf008731887610ed82138ab2d",
       "pubkey_x25519": "52ecdba4938b3b79909631353719058a93f96f829aa6c1ba2f581d09cf473f1f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099940,
       "storage_lmq_port": 20205,
       "storage_server_version": [
         2,
@@ -10163,20 +8371,6 @@
         2
       ],
       "swarm": "447fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.219",
-      "storage_port": 22021,
-      "pubkey_ed25519": "66bbbb5fb31fe5006a30bb61f2a780b2946c30f02f705c1374d1555a0e2b7c73",
-      "pubkey_x25519": "31238a1c129250e451d0a303cc9cbb89954f033eac3a608fbea82548605bdd60",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "80.241.220.222",
@@ -10246,7 +8440,7 @@
         11,
         2
       ],
-      "swarm": "b9ffffffffffffff"
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -10281,7 +8475,7 @@
       "storage_port": 22103,
       "pubkey_ed25519": "68bfd9c95e854e195d1ecf227514ef754ac4dcfc1a87150fb51e769789023f89",
       "pubkey_x25519": "bf0780ee83667357a15343f097588024d206590e0514d6b7e8ca07681c056337",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099927,
       "storage_lmq_port": 20203,
       "storage_server_version": [
         2,
@@ -10289,62 +8483,6 @@
         3
       ],
       "swarm": "a7ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.175",
-      "storage_port": 22021,
-      "pubkey_ed25519": "68c495f37887f9888944033ca112a121d84fe9660040ad65ee69b7a45da77dde",
-      "pubkey_x25519": "9b664bf5efefa502d8c892c8d37a721e4b8354896adc10fa95f47927f4e82122",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.99.13",
-      "storage_port": 22021,
-      "pubkey_ed25519": "68c993a16315d3ac4343ce021a99bcf2f12700874840b06ea8a6c1621e76dc9e",
-      "pubkey_x25519": "6cb451e4341bcc5d426c0b91f4057f0a6c16cee4726c29794b13a9d44d6f8266",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "65ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.4",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6941c9cb4d8ed0ec8305765ce91acd5bf05ddf6f0ec99f67593ee1a24e04b1d8",
-      "pubkey_x25519": "8bde5d1d341e4fe5ef418c5e8b8897c34ae2c763d10a10b7d3b1ea843c1fc111",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "feffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22104,
-      "pubkey_ed25519": "695273a98049df7dd349549b33bfbd079bb8ea185ae9daacf922a512301a5319",
-      "pubkey_x25519": "0794c947b5d78a09942d220c556f5dc5dbefaed94ffb9f8bbab605a5ebe89d74",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "70ffffffffffffff"
     },
     {
       "public_ip": "38.54.97.133",
@@ -10361,20 +8499,6 @@
       "swarm": "faffffffffffffff"
     },
     {
-      "public_ip": "193.219.97.167",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6a2a1481de72f311f15ba3d81ee6ddca31561f729fbd1774b1764c2900633c63",
-      "pubkey_x25519": "7287986914669c0bfa80c684ff2d3c344d597984a790fd43aa97feb1f428fd4e",
-      "requested_unlock_height": 2090261,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "47ffffffffffffff"
-    },
-    {
       "public_ip": "185.150.189.71",
       "storage_port": 22112,
       "pubkey_ed25519": "6a72800c140776ff299a50133194dbe7d17d3cbd6e78b2a502be1b93ab852cae",
@@ -10386,35 +8510,7 @@
         11,
         3
       ],
-      "swarm": "ceffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22108,
-      "pubkey_ed25519": "6a743c1bbc9dfb89f69845d3170606ff44dc8caaf6b1f229341f585e3ff3d620",
-      "pubkey_x25519": "0ec91e54ecc96d855897c184a018856d7c97a6af8f266b5e1da889dc2bc59469",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.139",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6ac0a76a1bd6c396ea28e95a93a009ab3ec5fa708d7054572edec7b2e029208a",
-      "pubkey_x25519": "79fab392dc41bfe24c767b6a80e30e9316da8e84a918264c8383e0c7b7cae143",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3ffffffffffffff"
+      "swarm": "17ffffffffffffff"
     },
     {
       "public_ip": "5.223.77.132",
@@ -10428,14 +8524,14 @@
         11,
         3
       ],
-      "swarm": "4effffffffffffff"
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22109,
       "pubkey_ed25519": "6ae986969ca872ecdc57bb42d3b48faba612338fb4777434ca2d63923513577d",
       "pubkey_x25519": "b84a02fbd193b39d6885ff8fb805e40861726e8e9a74f280f4a48d314965f046",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099914,
       "storage_lmq_port": 20209,
       "storage_server_version": [
         2,
@@ -10457,34 +8553,6 @@
         0
       ],
       "swarm": "28ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22110,
-      "pubkey_ed25519": "6b237aa4ae15ac6114b2d72e4eeef9ac22d35778f56c1cd2d6f1fa30ed7ac2d3",
-      "pubkey_x25519": "7111e232dfe45a86550177fa979786261b2836424d39ca25d6a6052e0b8e7736",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.112.220",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6b7c8c01e55997409f236b4817d7b560f573e5d6f2e06f09e70c26dd44d74490",
-      "pubkey_x25519": "e421ed51f58b900a47280258400ba9fd2d8deada28151e59f40c2deeb2809c11",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "66.175.216.182",
@@ -10533,7 +8601,7 @@
       "storage_port": 22107,
       "pubkey_ed25519": "6c0ce736fe225f159c0888096a0f0d5249e3c4db15917bf3b3157ded39ec84a4",
       "pubkey_x25519": "1f52a777b4bf7a4126733d459d64c55c9e9ad65eaae49c3aaf1f131575391926",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099940,
       "storage_lmq_port": 20207,
       "storage_server_version": [
         2,
@@ -10541,20 +8609,6 @@
         3
       ],
       "swarm": "3bffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22141,
-      "pubkey_ed25519": "6cd1b6456b7c6bb094705ec4b851c9f13edfb6ed4267bb40e0d22cfd6872bc71",
-      "pubkey_x25519": "5c12c6563553c0020210cd1664d9c77d61b697997339d803036c84c071bb9563",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20241,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -10603,14 +8657,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "6d87954b0a92c3ed3e227bca88f9fc943d30afeaaf0019b021af1c43e62c0a2e",
       "pubkey_x25519": "131cabc6daedb1616a67bc9ebd887c81fd1956f3e7dc307b1a98b62d31b1673e",
-      "requested_unlock_height": 2084490,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "247fffffffffffff"
     },
     {
       "public_ip": "51.81.161.230",
@@ -10641,20 +8695,6 @@
       "swarm": "237fffffffffffff"
     },
     {
-      "public_ip": "75.119.145.248",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6dbfc3e985f816f4221f100450864d3f97e1451b6de1558331d1db515f8de37f",
-      "pubkey_x25519": "adedb89e9871ab0bff66e46300092c1c9ac641ff88e642cef87891752d296920",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "c3ffffffffffffff"
-    },
-    {
       "public_ip": "104.243.32.47",
       "storage_port": 22109,
       "pubkey_ed25519": "6e5bd1bc4ae3f7341d338d67d1e918ee47a31f36506dd36a5f47a5de942d2fba",
@@ -10669,18 +8709,18 @@
       "swarm": "4dffffffffffffff"
     },
     {
-      "public_ip": "193.219.97.206",
+      "public_ip": "212.147.239.136",
       "storage_port": 22021,
-      "pubkey_ed25519": "6ecee30b54e452d330ef857ede73296264fff2d28fc0e210d1113d470fe60bb4",
-      "pubkey_x25519": "66a1856f8a45a792fe78a71c0ffc301067bfa7c2b3a768ddfe6b2a143a96266e",
-      "requested_unlock_height": 2090259,
+      "pubkey_ed25519": "6e643ca7c248381005da157036751a5b8626690471858cdaac5cd4ae38a65bd7",
+      "pubkey_x25519": "57d0047cc8126790b66077ee9f3e4c9b95efa6bf92b4ab91db7e5e0c155ac518",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -10729,7 +8769,7 @@
       "storage_port": 22113,
       "pubkey_ed25519": "6f43b305fa35d050966749e1828b7b4b194d5e0a6814f42fc73036c4af417415",
       "pubkey_x25519": "ebdbb7c0f9d37fe8f51f34de867660bb9c8f72cb47b0ddadc9b445e29582f007",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099895,
       "storage_lmq_port": 20213,
       "storage_server_version": [
         2,
@@ -10781,34 +8821,6 @@
       "swarm": "93ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.230",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6fb6a0bf218a86d8ef890bcac96b8d1007bf458c6d0bca144a75af468b7bdcde",
-      "pubkey_x25519": "66cecbeddd1d81eabd4fce527a1fe7d70812f34edffde1f8b37ef7fad0f3ee13",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "abffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22118,
-      "pubkey_ed25519": "6fb898bfe143ce0de7b20b287c1f459d96b7a55329e83fe3be27892d1ebd638b",
-      "pubkey_x25519": "33ce36b1dcadf6dfa28c7200088043215f7941485e6a742d7054625e3feefd6c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20218,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ffffffffffffff"
-    },
-    {
       "public_ip": "95.217.209.146",
       "storage_port": 22021,
       "pubkey_ed25519": "6fc529a9cdb94eec11676077e799a5fb8289a7c6a4e097eb5a0dd33d2b97086f",
@@ -10848,7 +8860,7 @@
         11,
         2
       ],
-      "swarm": "bcffffffffffffff"
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -10879,20 +8891,6 @@
       "swarm": "377fffffffffffff"
     },
     {
-      "public_ip": "5.78.83.111",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7075a7e2d48c124c5210b400060595956b72a7e9cde29fd4211f1abc233da21f",
-      "pubkey_x25519": "3a57516e177011c9ae65c5e258ccf70cdfbba0b0f4834008a304f9764088cb42",
-      "requested_unlock_height": 2086490,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b9ffffffffffffff"
-    },
-    {
       "public_ip": "152.53.231.2",
       "storage_port": 22021,
       "pubkey_ed25519": "70b4d84ee4f20ffdad273b7c01df46d3174942ba4a7751587f9bdfe4fbbdca3f",
@@ -10905,20 +8903,6 @@
         3
       ],
       "swarm": "3cffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22113,
-      "pubkey_ed25519": "70c108f1c9c04c4ce9b004fefa0258c5f37c3ace8c574cf228a4b49c032ae787",
-      "pubkey_x25519": "cb5e40d5d1730eb2e50464545935ac8988baa25afe13bee16f2f92c168ac8109",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "198.74.51.223",
@@ -10977,34 +8961,6 @@
       "swarm": "8fffffffffffffff"
     },
     {
-      "public_ip": "102.208.228.250",
-      "storage_port": 22100,
-      "pubkey_ed25519": "72869d428bd97630f0e1a874eaa20c5a7f531239497eca1b7d8aa65c0053b152",
-      "pubkey_x25519": "4bb906b70fa9c1ec241e3549c1701656a4ded6d6ace6133bebdf076fe6b2d24a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.39",
-      "storage_port": 22021,
-      "pubkey_ed25519": "728f925b17284c7dca6533cd9349e532b7490dc13afc3561efc19057d4016950",
-      "pubkey_x25519": "b205b0ab86472cb685e0d9d1793fcecb95a6ff46b63af937adb8c82afb999e03",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "bbffffffffffffff"
-    },
-    {
       "public_ip": "167.86.111.71",
       "storage_port": 22021,
       "pubkey_ed25519": "72a4e8c409f98ab294fe831460440c65215a21a6b98dddd2e43a266ae9b2bc6c",
@@ -11017,34 +8973,6 @@
         3
       ],
       "swarm": "237fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22110,
-      "pubkey_ed25519": "72f038b38273cc83b2d71d85e729a3a1b32e370762f4a967cf7caf029b640f20",
-      "pubkey_x25519": "cbdc2b74534bacb97022b6a06e322279d8df28179da8ddf4a5601637c81d9363",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4cffffffffffffff"
-    },
-    {
-      "public_ip": "102.219.85.93",
-      "storage_port": 22101,
-      "pubkey_ed25519": "7322f8e32d7e86f922728267dcd6d44553192effeab4035c1718f172baa5dea1",
-      "pubkey_x25519": "2f8be1fb9e09e31e20b7969e9af749527d1381b423985ea1fccdec64110e791d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "145.239.90.154",
@@ -11072,14 +9000,14 @@
         11,
         2
       ],
-      "swarm": "3a7fffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22120,
       "pubkey_ed25519": "738cdd0a5459fc3db65dd8f682daace3f89eb7ea873ef940b1440cf0537db4c9",
       "pubkey_x25519": "5bf7132dc9e8c0aa4dc1168f03befd568efb05083f7b7d467919da5ff9a94238",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099925,
       "storage_lmq_port": 20220,
       "storage_server_version": [
         2,
@@ -11087,20 +9015,6 @@
         3
       ],
       "swarm": "bdffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.17",
-      "storage_port": 22021,
-      "pubkey_ed25519": "73ec9ea886e34de7932593a1456514fc4d242f2b9f73b6bc54a32d051d2db2b0",
-      "pubkey_x25519": "5dbb3647162eaedc0ac97b10b11d8494347ef2310ac0a22ca2b726827dce3f00",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -11170,7 +9084,7 @@
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "54.39.148.196",
@@ -11268,21 +9182,7 @@
         11,
         3
       ],
-      "swarm": "307fffffffffffff"
-    },
-    {
-      "public_ip": "129.153.135.111",
-      "storage_port": 22103,
-      "pubkey_ed25519": "7713f3443ec4d8be755d408d2b3430e64b87072af4dc44d1c0cd3b406c347560",
-      "pubkey_x25519": "d55ac0c5f998adb6dee7542c1b25924bb9d65595442c17ab9714bdca2a719947",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1affffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -11310,7 +9210,7 @@
         11,
         2
       ],
-      "swarm": "237fffffffffffff"
+      "swarm": "adffffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
@@ -11324,21 +9224,21 @@
         11,
         3
       ],
-      "swarm": "2d7fffffffffffff"
+      "swarm": "3fffffffffffffff"
     },
     {
-      "public_ip": "206.189.101.37",
-      "storage_port": 22021,
-      "pubkey_ed25519": "786b02512f46f81e03ae359eee24bcc813230f3490467928ccebe3bff99b330a",
-      "pubkey_x25519": "6ecbc59d153c7a906ad88fb9502bf47a5326e40d784b3786233a353fcc02805c",
-      "requested_unlock_height": 2094233,
-      "storage_lmq_port": 22020,
+      "public_ip": "57.129.102.67",
+      "storage_port": 22106,
+      "pubkey_ed25519": "782892a9bdcded41f2612180ca34534408b567e611b41539214a0e2a764aba16",
+      "pubkey_x25519": "4e7fc42eab1263d0aea553f494253f9aa88355dcf9feaac2313ec6ff73ec813b",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
       "storage_server_version": [
         2,
         11,
-        3
+        2
       ],
-      "swarm": "e6ffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "213.136.90.84",
@@ -11355,20 +9255,6 @@
       "swarm": "37ffffffffffffff"
     },
     {
-      "public_ip": "164.68.114.8",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7894c58e0f77408a8bfda9f07ef1eb4fa7114616ac848beaea214191ace22d48",
-      "pubkey_x25519": "f39b6c41fc2e7d76faba49314edcb2daddd9c7968e7fa9d264e000996c5e303c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "acffffffffffffff"
-    },
-    {
       "public_ip": "91.99.239.106",
       "storage_port": 22021,
       "pubkey_ed25519": "792e99e97792df4c78fdfdeee0382173890f967c6ecc8d2ecdbf52758d0449ff",
@@ -11380,7 +9266,7 @@
         11,
         2
       ],
-      "swarm": "99ffffffffffffff"
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "130.94.44.4",
@@ -11394,7 +9280,7 @@
         11,
         3
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "209.141.45.115",
@@ -11408,7 +9294,7 @@
         11,
         3
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "107.189.4.130",
@@ -11436,7 +9322,7 @@
         11,
         3
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "197fffffffffffff"
     },
     {
       "public_ip": "95.111.226.201",
@@ -11453,20 +9339,6 @@
       "swarm": "317fffffffffffff"
     },
     {
-      "public_ip": "74.50.118.192",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7a187a0dfadfb130d1f48d4d8ca10af4834484e046aea99a07b600ada2c89ec3",
-      "pubkey_x25519": "3f01400349899c396867e5a4ac8dba3a86641a5f13209855a82659bc212d345b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9bffffffffffffff"
-    },
-    {
       "public_ip": "135.148.41.196",
       "storage_port": 22021,
       "pubkey_ed25519": "7a624cecce6322cc0ef6c2d76425dafbe9a5f0e11d6fd79237e450b48b3d7ceb",
@@ -11478,7 +9350,7 @@
         11,
         2
       ],
-      "swarm": "d4ffffffffffffff"
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -11506,7 +9378,7 @@
         11,
         2
       ],
-      "swarm": "bffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -11551,25 +9423,11 @@
       "swarm": "beffffffffffffff"
     },
     {
-      "public_ip": "164.68.104.72",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7bbf133aab2ecfbdd6f12b1eb63701aa63de91a34253d06ae8f8a2161b3a312c",
-      "pubkey_x25519": "ab644ff9c87fdfa603d360b76de0eccc66382ea7497c7a191f6df316b6bc5959",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "c0ffffffffffffff"
-    },
-    {
       "public_ip": "93.95.231.60",
       "storage_port": 22112,
       "pubkey_ed25519": "7c2faaba7e81c269f00e24e18a8b1ded20fbd6143c26b36f3f10a8b94e85509e",
       "pubkey_x25519": "8520482a53c242a01624630bbedc3d23e29e69ff2a87b4c8a0a5903c0481ed09",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099922,
       "storage_lmq_port": 20212,
       "storage_server_version": [
         2,
@@ -11577,20 +9435,6 @@
         3
       ],
       "swarm": "12ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22131,
-      "pubkey_ed25519": "7c798b31027f48ca09a1402befcc05ff5f7ce6f36eab726e7fb22d1fbf316157",
-      "pubkey_x25519": "716e05ec5ec6325a3efe693ae87ae62e3e0e14d901d755285889d4e3fc26311d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20231,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -11604,7 +9448,7 @@
         11,
         0
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "57.128.252.8",
@@ -11649,60 +9493,18 @@
       "swarm": "fcffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22112,
-      "pubkey_ed25519": "7d0b4132ac85589d5a61f5f5fd4e19ddd592a7055cba0dcb0b6afbf3c1cc226f",
-      "pubkey_x25519": "f39622b61baa77e2c27001447f94ea1c7db5b0d2f815388f4aa23c68a2a13b50",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "75ffffffffffffff"
-    },
-    {
-      "public_ip": "100.42.179.195",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7d6ffd56b5cb5c28193829b0980793d8b0a0a2fac8d68a48fbd17a8a71979c5f",
-      "pubkey_x25519": "81f9e985b651df9b19d2a60e5d78c9290dc77b8f13e25b8fbdc44c7a5fd2b010",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "53ffffffffffffff"
-    },
-    {
       "public_ip": "169.197.82.161",
       "storage_port": 22021,
       "pubkey_ed25519": "7e0198af12c844712a1679e86841698d2b3a158451ff367635f7a1df830f92e7",
       "pubkey_x25519": "466928e6e457c1b00c092ee71d51cb1a28032d476ce9eb7b58597a550ac99b7c",
-      "requested_unlock_height": 2085894,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "20ffffffffffffff"
-    },
-    {
-      "public_ip": "164.90.194.228",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7e416014f5f0b284e11ee8f44db13ac1b92f308325fa836d94b6afdb73a4ea2d",
-      "pubkey_x25519": "745423298127e2300c62a07d4030f1763135ec29c050708675046e9150c05407",
-      "requested_unlock_height": 2094228,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "c5ffffffffffffff"
+      "swarm": "97fffffffffffff"
     },
     {
       "public_ip": "91.231.182.38",
@@ -11717,20 +9519,6 @@
         3
       ],
       "swarm": "487fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22127,
-      "pubkey_ed25519": "7ea5090d54d527c2fea65576e041e41367944d10a17c0e97cd35392f11f57fbe",
-      "pubkey_x25519": "dafb8b67193e698965597dd2fb9a8a5d5b10551d1d10723c411a1aecb3d53d20",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20227,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "84.46.250.250",
@@ -11803,20 +9591,6 @@
       "swarm": "d0ffffffffffffff"
     },
     {
-      "public_ip": "164.68.101.96",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7f6f2ddbad8de39a2def4e2116da396d44ddc5467e3878008cfe225a08600f8f",
-      "pubkey_x25519": "21ccb7467cf4358f2b8068209529c314c504a939325c24e8838e20214c004268",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "eeffffffffffffff"
-    },
-    {
       "public_ip": "202.61.247.98",
       "storage_port": 22021,
       "pubkey_ed25519": "7fcddde8ffb12751d54df358051dc252a2cc43c4b1ff44e116f325972156e3fe",
@@ -11835,14 +9609,14 @@
       "storage_port": 22110,
       "pubkey_ed25519": "7fea4387c12d9ff9960983bb2b35bd8cde7df7e32c785eeb2d7eea808c8e068a",
       "pubkey_x25519": "9b9300578024a944d155bbaaaa4069f2fe88a7f2b13da291c3834d2923823a10",
-      "requested_unlock_height": 2086578,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 20210,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "1effffffffffffff"
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "95.111.207.165",
@@ -11856,7 +9630,7 @@
         11,
         3
       ],
-      "swarm": "b2ffffffffffffff"
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "89.117.23.203",
@@ -11870,7 +9644,7 @@
         11,
         2
       ],
-      "swarm": "94ffffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "51.75.79.57",
@@ -11885,20 +9659,6 @@
         2
       ],
       "swarm": "b7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.172",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8079ba6747154a3a5e746e7de10c5d27051ac8280563a460bdc34f9d3d8c91a8",
-      "pubkey_x25519": "580b5e0589b89542d2d89e88b53f6b67875f7aa29bcb661db5897d879a767e03",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "198.98.52.4",
@@ -11929,21 +9689,7 @@
       "swarm": "7affffffffffffff"
     },
     {
-      "public_ip": "164.68.98.89",
-      "storage_port": 22021,
-      "pubkey_ed25519": "815007c26559625e7c230394d6fdaeed0bc64f75caca228bda15446f7d7b4ccf",
-      "pubkey_x25519": "14d3b9339cffb9abb6372b1266c4307694b03f18312c31aaf33aa02942e5b95e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "e2ffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.65.103",
+      "public_ip": "23.81.40.224",
       "storage_port": 22021,
       "pubkey_ed25519": "81ac347100b677657b1475ed96898df4be8651114d42db9a7d238dc47ee993fb",
       "pubkey_x25519": "00c8299f292d9a16c2a63f1c7e3067f488d0efcc697787161b2fef27a495254c",
@@ -11968,7 +9714,7 @@
         11,
         0
       ],
-      "swarm": "a1ffffffffffffff"
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "144.24.165.22",
@@ -12010,7 +9756,7 @@
         11,
         0
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "46.62.196.12",
@@ -12038,7 +9784,7 @@
         11,
         2
       ],
-      "swarm": "c6ffffffffffffff"
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "94.16.107.50",
@@ -12055,20 +9801,6 @@
       "swarm": "5dffffffffffffff"
     },
     {
-      "public_ip": "164.68.113.98",
-      "storage_port": 22021,
-      "pubkey_ed25519": "83199327cbb14cd9029a3c688c127a86ad24e1463def82f5ecf186b297e90774",
-      "pubkey_x25519": "4ce279ccb8e443be32f959889ba7b5eb4872a6d001dd8161fe3585a64d6d222d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d2ffffffffffffff"
-    },
-    {
       "public_ip": "104.243.41.194",
       "storage_port": 22101,
       "pubkey_ed25519": "836494385a48386cf5d04c2af9f5000ed376d83da38e51ad51170d1559ba6552",
@@ -12080,7 +9812,7 @@
         11,
         3
       ],
-      "swarm": "67fffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -12111,18 +9843,18 @@
       "swarm": "477fffffffffffff"
     },
     {
-      "public_ip": "185.13.148.8",
-      "storage_port": 22021,
-      "pubkey_ed25519": "846c4f739d7450c4cee8817b0888bc452e52297a24a1f6fb9564aa96830b1654",
-      "pubkey_x25519": "b09e31e5b13b40d05c655018457ae6667edf0d0b2ba1c85902d9f29c87e39960",
-      "requested_unlock_height": 2093346,
-      "storage_lmq_port": 22020,
+      "public_ip": "88.198.244.201",
+      "storage_port": 22106,
+      "pubkey_ed25519": "84ca870519182305480354ac6492f570ea72f1aadd7a8012842ed5887404bae8",
+      "pubkey_x25519": "921a21ec9789114c71c26afe92643e0ba1092fce8e30d710d8a597b095eba73b",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
         11,
-        3
+        0
       ],
-      "swarm": "447fffffffffffff"
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "45.79.95.210",
@@ -12167,20 +9899,6 @@
       "swarm": "67fffffffffffff"
     },
     {
-      "public_ip": "144.91.76.204",
-      "storage_port": 22021,
-      "pubkey_ed25519": "852bdfe8849679de83c876fecfc4de83a3bdca8e1054505ec0c893e15017af45",
-      "pubkey_x25519": "bc150853ef3eff27e1ea4fc33a0d6b1ca4fc71b7d36d530cd28219ed2b0df23e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "337fffffffffffff"
-    },
-    {
       "public_ip": "85.9.214.176",
       "storage_port": 22021,
       "pubkey_ed25519": "85956aea65dfb12c05aee39b043d58672d01d7cbb9ab5f614b4e423cbeb62968",
@@ -12192,7 +9910,7 @@
         11,
         3
       ],
-      "swarm": "9effffffffffffff"
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "135.125.112.182",
@@ -12251,34 +9969,6 @@
       "swarm": "51ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.22",
-      "storage_port": 22021,
-      "pubkey_ed25519": "877eb2c2313b0b964386cbf26a9370612350c0d5eb9db58e05d4e21cce24e0ff",
-      "pubkey_x25519": "887f53006d088118ad3cac971d19295a0ecfbd31207f021ed6af541587a29f56",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "fdffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22101,
-      "pubkey_ed25519": "87cd28e535ccdb096b5e807788c741dde96f9884c117b1cc2ddb1e54b59eea4b",
-      "pubkey_x25519": "a162525f611b9e269173cd42fab6477efaa6459361225b3be9ee281766a5c665",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "adffffffffffffff"
-    },
-    {
       "public_ip": "167.114.156.20",
       "storage_port": 22112,
       "pubkey_ed25519": "87d62cff1e5ac4004c10fbd0d166773e77ccd5cb2690f5090ddb4a058911591f",
@@ -12291,20 +9981,6 @@
         0
       ],
       "swarm": "3ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22113,
-      "pubkey_ed25519": "8848539cc1354bdc9abd29e6ab0b073208d699071b4c66a5622f16996b411539",
-      "pubkey_x25519": "a38519528620afb3797e71cb8ca6e0bf2e9ac76b57f8b3f98c40af02e1c2ac65",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "2.59.133.234",
@@ -12360,35 +10036,7 @@
         11,
         2
       ],
-      "swarm": "daffffffffffffff"
-    },
-    {
-      "public_ip": "107.175.49.159",
-      "storage_port": 22021,
-      "pubkey_ed25519": "892c05f37dd8eb29be1cb658cb7cf9819441e2a91929adae23cf620dc4538310",
-      "pubkey_x25519": "581309c8b807846f1f71e9d428bf2e7d9f3d0ea02e766546596f75fae118f361",
-      "requested_unlock_height": 2085166,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c4ffffffffffffff"
-    },
-    {
-      "public_ip": "64.235.61.16",
-      "storage_port": 22021,
-      "pubkey_ed25519": "895360bde86788dd31453217e7bf338cfb7b4d4200d33d276600da38c8a6ab30",
-      "pubkey_x25519": "f296b3f9bf58c028744df86371c0daacf02a0a75480adf678ba2a9f10818000d",
-      "requested_unlock_height": 2086491,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "abffffffffffffff"
+      "swarm": "7ffffffffffffff"
     },
     {
       "public_ip": "51.79.161.47",
@@ -12403,20 +10051,6 @@
         0
       ],
       "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22138,
-      "pubkey_ed25519": "89e12490290fc846e0f94d8394cfea6f0d0a39e6bfec2b8fec271e0fd0461ccd",
-      "pubkey_x25519": "098203db37ab1c046a6a2c851c46f654dd81cf48bb53471e0944865951cd485f",
-      "requested_unlock_height": 2088776,
-      "storage_lmq_port": 20238,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "205.185.122.57",
@@ -12472,7 +10106,7 @@
         11,
         2
       ],
-      "swarm": "beffffffffffffff"
+      "swarm": "d7fffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
@@ -12489,25 +10123,11 @@
       "swarm": "1c7fffffffffffff"
     },
     {
-      "public_ip": "64.227.69.108",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8ae307d9d796f59b6c37bda86101d65a3d062a083cd134d7c1918404325534b3",
-      "pubkey_x25519": "21da188c49abd3ba9d63025922ef49474e6d46b009b79e4115ac67ef1cb0d10b",
-      "requested_unlock_height": 2094234,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "5fffffffffffffff"
-    },
-    {
       "public_ip": "93.95.231.60",
       "storage_port": 22118,
       "pubkey_ed25519": "8af0d990c8fac42829db9e2b7fa434c417a095c064d8098a7a21a7a991231fc3",
       "pubkey_x25519": "ea11eac805e1e1dd87239a5075278b0bdd6668fd2194704c7eb5d4c3921eaa2e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099922,
       "storage_lmq_port": 20218,
       "storage_server_version": [
         2,
@@ -12542,7 +10162,7 @@
         11,
         2
       ],
-      "swarm": "24ffffffffffffff"
+      "swarm": "86ffffffffffffff"
     },
     {
       "public_ip": "129.213.162.17",
@@ -12584,14 +10204,14 @@
         11,
         0
       ],
-      "swarm": "48ffffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22103,
       "pubkey_ed25519": "8c673b74801ba27a2c23596d681ddfe77fbe17ff852a922f93de410b23721eaa",
       "pubkey_x25519": "52958f5feacc4243466a9074815d1780fecbfff363f7463367982727921ed464",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099923,
       "storage_lmq_port": 20203,
       "storage_server_version": [
         2,
@@ -12613,20 +10233,6 @@
         3
       ],
       "swarm": "d6ffffffffffffff"
-    },
-    {
-      "public_ip": "89.58.2.184",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8cd885c7bec503b32a21da48e568aca72b6f83b8769557cd23a754c37304645e",
-      "pubkey_x25519": "4061b4e84cb446866091bf0469b917d3c2bd0096e500b338de55152c078bb36c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "88.99.195.142",
@@ -12668,7 +10274,7 @@
         11,
         1
       ],
-      "swarm": "ddffffffffffffff"
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "147.182.176.227",
@@ -12766,7 +10372,7 @@
         11,
         2
       ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "198.98.48.151",
@@ -12822,7 +10428,7 @@
         11,
         3
       ],
-      "swarm": "93ffffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.33",
@@ -12836,7 +10442,7 @@
         11,
         3
       ],
-      "swarm": "33ffffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "45.33.56.54",
@@ -12851,34 +10457,6 @@
         0
       ],
       "swarm": "72ffffffffffffff"
-    },
-    {
-      "public_ip": "142.248.28.45",
-      "storage_port": 22021,
-      "pubkey_ed25519": "909b82b2a7212c1810027fadc912054d7fc6ed2ec2575ab0773383d280c3f207",
-      "pubkey_x25519": "641d90b6d9bbb5a2d596390158d6e01cf75c767f34bd1910273ea297ee483624",
-      "requested_unlock_height": 2084493,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "cbffffffffffffff"
-    },
-    {
-      "public_ip": "65.21.240.249",
-      "storage_port": 22101,
-      "pubkey_ed25519": "90a74727ec61674fc013228927276187fb9fc42c8e7bc4012192dfd7bf00dee7",
-      "pubkey_x25519": "5a4ccbeaae8ba04273c67d1a3be82ce275356d7f21853f0b5e6f283ca286ed41",
-      "requested_unlock_height": 2094670,
-      "storage_lmq_port": 22401,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "198.98.55.4",
@@ -12913,7 +10491,7 @@
       "storage_port": 22112,
       "pubkey_ed25519": "9147c04478c28527f5b4a54479c6f139d803646767cf0190b3bd2cb62aff2fd6",
       "pubkey_x25519": "68eca17af350821424b42f14d9247728ee2cdbeaec988f9352fdc620ddf8bd3e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099918,
       "storage_lmq_port": 20212,
       "storage_server_version": [
         2,
@@ -12948,7 +10526,7 @@
         11,
         3
       ],
-      "swarm": "287fffffffffffff"
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "2.59.133.53",
@@ -12963,20 +10541,6 @@
         1
       ],
       "swarm": "14ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.123",
-      "storage_port": 22021,
-      "pubkey_ed25519": "91f3bc97d4b0e7ed309d977060f5b0d1f55fb7e559010eb0ca2f737360e86c5a",
-      "pubkey_x25519": "990ed567bcc45d327588fbfda92c967ccca93cd93177d16616d152526138cd0b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.111",
@@ -13025,42 +10589,14 @@
       "storage_port": 22106,
       "pubkey_ed25519": "92c4e00b8a69a749c575075be0353e7f9f53eeab0748ee8050467ae688917efb",
       "pubkey_x25519": "da7562d40b916ede47ca7874387e061dafd9323e6c597293756c35d3aae40f24",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099941,
       "storage_lmq_port": 20206,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "5bffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.67.208",
-      "storage_port": 22021,
-      "pubkey_ed25519": "92f6d3fc8b83eaab3ada73e1119fcf647eeb8fe419e1103eb2fcae290ef348a0",
-      "pubkey_x25519": "af4ecc945c802cd8ec5b243b0f00073c2cb6e0db1ec6240954bad05ad594e010",
-      "requested_unlock_height": 2090347,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "30ffffffffffffff"
-    },
-    {
-      "public_ip": "50.114.206.217",
-      "storage_port": 22021,
-      "pubkey_ed25519": "931fed63fef8fc81f768c25b317bd57afa361724ea7fc8a90ae5cf01b6029ee1",
-      "pubkey_x25519": "d0817807d701124875ee85ee65cb6e610653f6c08beebed7a030a9a9b259a464",
-      "requested_unlock_height": 2091682,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "89ffffffffffffff"
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "130.162.50.158",
@@ -13091,20 +10627,6 @@
       "swarm": "2bffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.105",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9353d7d130edcf285b08845e1edd45dcfb9e70c80d1ecc2f1ac575cec7f5f535",
-      "pubkey_x25519": "92f4ac9d8482af346c0bb27d63b3f5e218f816bcbae3937948cac8386060174f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
       "public_ip": "45.136.28.239",
       "storage_port": 22021,
       "pubkey_ed25519": "937af3c2767bf9608919dc1954d6e18a60efded35d0e032138ae8fac8a3d0b2c",
@@ -13117,20 +10639,6 @@
         2
       ],
       "swarm": "2a7fffffffffffff"
-    },
-    {
-      "public_ip": "5.189.152.176",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9381e658bab25a7b52371b0966dc9ab8e493bee98780fdb2e6fdd2074661064b",
-      "pubkey_x25519": "0b5e8c9df69c9c7191b86fdebcf54c4bfa1984ae91c0b85a7d3199ce080ec972",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "107.189.7.179",
@@ -13151,7 +10659,7 @@
       "storage_port": 22109,
       "pubkey_ed25519": "93bd41c0e972696d86bb66e6962263bffb8a81c67d0983ef2425a1e78a7eb2bb",
       "pubkey_x25519": "5d48ea8b4c4ac1ca369f82b6fab5bbd9b01f676a2e78719b322a173feb44104a",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099918,
       "storage_lmq_port": 20209,
       "storage_server_version": [
         2,
@@ -13217,34 +10725,6 @@
       "swarm": "3f7fffffffffffff"
     },
     {
-      "public_ip": "164.68.101.160",
-      "storage_port": 22021,
-      "pubkey_ed25519": "94543f863a76ba6160524bc02ba2c788cbaf230f4deab2e5f6599211f6f3a7f8",
-      "pubkey_x25519": "86c8a9de9ae483898c4a5513447827d11fd8fdd22f1fd1b8862a3be8b9bede49",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "42ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22108,
-      "pubkey_ed25519": "94b567dbfd83312790a76b95c45f0835f7f531cca2b054588157d5e64d149d8a",
-      "pubkey_x25519": "18f27411ae6ca6cd4ea91c44ab7d246192cb5872ec34b9b9f159a707110dba0a",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "18ffffffffffffff"
-    },
-    {
       "public_ip": "5.196.114.122",
       "storage_port": 22021,
       "pubkey_ed25519": "94c446fc486dccd33d7dafafc0c084f2937e77096fb855790e44649ff1c5f5b0",
@@ -13273,6 +10753,20 @@
       "swarm": "4cffffffffffffff"
     },
     {
+      "public_ip": "216.22.27.30",
+      "storage_port": 22106,
+      "pubkey_ed25519": "95e2259a3825c86782528bbae43ee1c5800cc3b83aaaa9b271fe5d2623bc686c",
+      "pubkey_x25519": "a903cf9f7c2cadde16ac007cc4b572914334d6c66b5801741ca2c487ce9dc471",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "b8ffffffffffffff"
+    },
+    {
       "public_ip": "209.141.33.235",
       "storage_port": 22021,
       "pubkey_ed25519": "9605c916463a0db24c527512d7b5a6e3d82b23eef24e3450d225b72e24bb253a",
@@ -13291,14 +10785,14 @@
       "storage_port": 22100,
       "pubkey_ed25519": "960a62165cfee99f128b4997a804ae792292125f7fec98b2b2821230ce2b0d32",
       "pubkey_x25519": "03f6a50e8df03540a39a160fa16885bf9cc961789305b535e7012f54bf754c57",
-      "requested_unlock_height": 2090029,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "baffffffffffffff"
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "198.71.58.236",
@@ -13329,20 +10823,6 @@
       "swarm": "edffffffffffffff"
     },
     {
-      "public_ip": "107.173.244.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "96c051516c0dac60022fd5f9163e131025dcfaa519a1d8fe9728545c43618d0f",
-      "pubkey_x25519": "44f8347f0741923d505be9eea51f3b320d6b8783b723e7a6b41acf8cc67a6f37",
-      "requested_unlock_height": 2085167,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "dfffffffffffffff"
-    },
-    {
       "public_ip": "46.62.169.159",
       "storage_port": 22021,
       "pubkey_ed25519": "96e1b538f4b7e43fe2318296253b2bdcaac29b8dd766ccdbbd5793926809f775",
@@ -13371,25 +10851,11 @@
       "swarm": "33ffffffffffffff"
     },
     {
-      "public_ip": "159.65.196.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9801c7dbabfeea5675b2b6f8bcbccbaeb653fbd07177d575adb73ec7aa260f3b",
-      "pubkey_x25519": "26153c6eb0af127dee7bbaec4a40ec5b9aa1b702fdb256d71ff82ff79f357e58",
-      "requested_unlock_height": 2094229,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "14ffffffffffffff"
-    },
-    {
       "public_ip": "167.114.156.20",
       "storage_port": 22120,
       "pubkey_ed25519": "982f54b09c8a817489c0b9a68a023182415a4d0a14a4beeabae54be8b10c8d80",
       "pubkey_x25519": "3faeac009e0cb1f85b1633b7fff298fa608958e07dea6029eb6947ffe999fe2d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2101178,
       "storage_lmq_port": 20220,
       "storage_server_version": [
         2,
@@ -13397,20 +10863,6 @@
         0
       ],
       "swarm": "15ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22103,
-      "pubkey_ed25519": "9867e3c0c319062a1fe5bc6aa25ae8ae0e0a78e1c11e7ecd9826cb9fba159dbc",
-      "pubkey_x25519": "be3c64b6cc9a34f9e10d421cc468e1e5938d9af340217a7eb2158a2f802dca7f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "159.69.19.204",
@@ -13424,10 +10876,10 @@
         11,
         2
       ],
-      "swarm": "efffffffffffffff"
+      "swarm": "74ffffffffffffff"
     },
     {
-      "public_ip": "38.45.65.60",
+      "public_ip": "89.125.187.65",
       "storage_port": 22021,
       "pubkey_ed25519": "98b1932491c42797481dcd9068d3dbf53de2b3cf61ae85a33d29c3b0c9843485",
       "pubkey_x25519": "ab802c2f10f2ffb3d016505ef2577eb512203c06c836c15da9d5886521bbc16d",
@@ -13455,20 +10907,6 @@
       "swarm": "e5ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22113,
-      "pubkey_ed25519": "98ce73b325859a16b906d7d1a0d568b4fed2b1def950ffa07d07f037455ebd79",
-      "pubkey_x25519": "1399501c0e94bd1f8dc7f7a1e13bb031437b646fdf9271a42d3502fe74ce593d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d2ffffffffffffff"
-    },
-    {
       "public_ip": "31.25.10.140",
       "storage_port": 22021,
       "pubkey_ed25519": "9905f753f4a98e4c1cf2b538d71fcb6bef04f4c84e803df5cd86f2e46277009b",
@@ -13494,7 +10932,7 @@
         11,
         3
       ],
-      "swarm": "67fffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "91.231.182.121",
@@ -13571,14 +11009,14 @@
       "storage_port": 22106,
       "pubkey_ed25519": "9a2cedc085daf9fd7657d697296c3f9f16c69546b33c572d9d3bdb123e599bf4",
       "pubkey_x25519": "956006352fb70f90a56055002b5ec98817390dca32556ddc462424ff83d8dd4b",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099921,
       "storage_lmq_port": 20206,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "51ffffffffffffff"
+      "swarm": "487fffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -13623,20 +11061,6 @@
       "swarm": "e0ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22113,
-      "pubkey_ed25519": "9ae0be5d75076b694e8b5463ee586b3321fbc176bf67b9bb6efb0215eeb37e18",
-      "pubkey_x25519": "ae7429e21e57f5a57a9509e11892b02737cfa0a604ccda3ff57ac8190294bd2e",
-      "requested_unlock_height": 2093821,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "22ffffffffffffff"
-    },
-    {
       "public_ip": "23.88.103.210",
       "storage_port": 22021,
       "pubkey_ed25519": "9aeab67aa26c531e6ee877273dc043f4a53fc7c9346b4b2d3f2531f44668e07f",
@@ -13669,7 +11093,7 @@
       "storage_port": 22104,
       "pubkey_ed25519": "9b088fc6da3fd916830f885f20500fc9e40cee5b625ea2765fa4bed590e7151e",
       "pubkey_x25519": "6e0f96b8087f8d03605314f7c37cdec13b86b314921754b147d0d23f9ced2d17",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099940,
       "storage_lmq_port": 20204,
       "storage_server_version": [
         2,
@@ -13690,7 +11114,7 @@
         11,
         2
       ],
-      "swarm": "72ffffffffffffff"
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "192.99.169.55",
@@ -13760,7 +11184,7 @@
         11,
         2
       ],
-      "swarm": "6dffffffffffffff"
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "108.171.193.114",
@@ -13781,7 +11205,7 @@
       "storage_port": 22110,
       "pubkey_ed25519": "9c29514b20632df0afbabcdef88b1bf0befd8946d99e51bb13e8b8754b48dd58",
       "pubkey_x25519": "baa4685cdce3f5812deba90fb384d2bd7c2ae1710fdbe38dc15131fbe6bbb655",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099921,
       "storage_lmq_port": 20210,
       "storage_server_version": [
         2,
@@ -13802,7 +11226,7 @@
         11,
         0
       ],
-      "swarm": "407fffffffffffff"
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "217.182.206.34",
@@ -13833,34 +11257,6 @@
       "swarm": "76ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22110,
-      "pubkey_ed25519": "9e5f61296a2ee627efe30b17a580c1709b2844f7f47294cb898e11d767707253",
-      "pubkey_x25519": "c43d387695d4a8d6051ee42e97b3ded6733f938180a9c28c1121d917b160b83a",
-      "requested_unlock_height": 2093820,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "fbffffffffffffff"
-    },
-    {
-      "public_ip": "193.22.147.70",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9e932ffcc0018054ece1f65f8de756cd30c540d9ba06aec8d9ca41bc59022dbe",
-      "pubkey_x25519": "b781a29667fe8054691e8b585471a61bb18a96e4ced9d7cc494227eaa4d99b7d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "50ffffffffffffff"
-    },
-    {
       "public_ip": "139.162.25.130",
       "storage_port": 22021,
       "pubkey_ed25519": "9ed94ce28b048d4eb50a0d6dd46baeb7c8b7bd7ed87dd75f93ec22b30adcd69b",
@@ -13872,7 +11268,7 @@
         11,
         2
       ],
-      "swarm": "aaffffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "138.197.173.72",
@@ -13900,7 +11296,7 @@
         11,
         0
       ],
-      "swarm": "67ffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "192.53.126.238",
@@ -13928,7 +11324,7 @@
         11,
         3
       ],
-      "swarm": "56ffffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "140.238.126.154",
@@ -13977,7 +11373,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "a0cbe49dbbda77d81e6f3972a0714bf62cbf09035d1c1113529a1d7904004b89",
       "pubkey_x25519": "8beaf910738a79aa16233489ee44591dbb4aebc6bcd55d3ad70c810438cb8657",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2100439,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -13991,7 +11387,7 @@
       "storage_port": 22102,
       "pubkey_ed25519": "a0de8baa2406d7f52e133e0fce76ef7f802955d313145431c72cb6a30e729eec",
       "pubkey_x25519": "8389159f413d38fde834764250daae62380ac2fb415abbe6acf9c05309067d33",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099941,
       "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
@@ -14015,20 +11411,6 @@
       "swarm": "a7ffffffffffffff"
     },
     {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22101,
-      "pubkey_ed25519": "a113fb884ec0cd7f7cb44d4a09749e823b1bc7042fb9d487c4de113d57563f2e",
-      "pubkey_x25519": "9d1f58fe0839d2da5ed4e3662e275d1837582093c8e5ca32b4f2fd70927e4c73",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "69ffffffffffffff"
-    },
-    {
       "public_ip": "193.70.87.174",
       "storage_port": 22021,
       "pubkey_ed25519": "a117e74e36eabf2753425bcdf614125cef972a346759ee2c2c03f1e3852c1b3f",
@@ -14043,7 +11425,7 @@
       "swarm": "87ffffffffffffff"
     },
     {
-      "public_ip": "146.71.85.210",
+      "public_ip": "185.173.235.108",
       "storage_port": 22021,
       "pubkey_ed25519": "a135bc2e3926a5106f0d53c88440fa7e7e02ce9857538eaf1e8ba5d921867a5a",
       "pubkey_x25519": "395671df134817717e75423cac4eeda971b3666b80c04ec0b6a5a52ce53dc933",
@@ -14052,9 +11434,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "447fffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "176.96.136.161",
@@ -14099,20 +11481,6 @@
       "swarm": "2bffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22142,
-      "pubkey_ed25519": "a1662109e074e4b4d4526386856bb4ee1e01f7680a3ae652c84479c5f4ec5273",
-      "pubkey_x25519": "5c207a04021f1703bf491c5ef53378aba0e2272a1f8b7c4ca726b099130a4a4f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20242,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "67ffffffffffffff"
-    },
-    {
       "public_ip": "164.90.166.150",
       "storage_port": 22021,
       "pubkey_ed25519": "a16f614c5c9f40b00342848f5e95478a8163c24698bc936157f8aa139327b65c",
@@ -14125,48 +11493,6 @@
         0
       ],
       "swarm": "b5ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22104,
-      "pubkey_ed25519": "a173901071dbec2acd419589c91cf0b82e9a10f4c3516391c314fa733ca8a8f6",
-      "pubkey_x25519": "063214661aabd097871dd23832f9d364755e0b9bcf8e6b5cf43ec8691cd1c211",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b8ffffffffffffff"
-    },
-    {
-      "public_ip": "104.234.124.143",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a1ba2f493993eeb93ceec6676fa6c530f24ca468c6c2ee8387a4667a5ceea511",
-      "pubkey_x25519": "05579b15cb9582bee032be9d2a5c419c1d3b173603772dab994d18056c117503",
-      "requested_unlock_height": 2094541,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "57fffffffffffff"
-    },
-    {
-      "public_ip": "5.189.160.68",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a1f0fffd63e19d5b0b21d2a8176f0911aa2a7c4c5ff85cb1d3fd6e063710c002",
-      "pubkey_x25519": "9b544525bf1d540f0f7e2e4147d5b3c12c10aff80f7fa4f5e0521c5192af3b57",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "104.244.77.81",
@@ -14192,7 +11518,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "307fffffffffffff"
     },
@@ -14222,7 +11548,7 @@
         11,
         3
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.149",
@@ -14243,14 +11569,14 @@
       "storage_port": 22105,
       "pubkey_ed25519": "a306100cda33b27fe3788b2bc8f069d2d127d9ff377b1fb6ddfe9460d608a39e",
       "pubkey_x25519": "d41bb113a7936f2ee26f4abffcd6aca357aed42831c695429535f7fa7ed39052",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099499,
       "storage_lmq_port": 20205,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "18ffffffffffffff"
+      "swarm": "92ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -14306,7 +11632,7 @@
         11,
         3
       ],
-      "swarm": "257fffffffffffff"
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "64.44.157.112",
@@ -14327,17 +11653,17 @@
       "storage_port": 22119,
       "pubkey_ed25519": "a3e416ccc22bf0a5ded68095db8e7b7abaf71c05cc3d1557ccb5d165200e32bb",
       "pubkey_x25519": "547ba473d0e78e64ffba98b9c3f207357285ff1444b9783452217d9d352ad669",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099922,
       "storage_lmq_port": 20219,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
-      "public_ip": "104.233.210.18",
+      "public_ip": "185.13.148.8",
       "storage_port": 22021,
       "pubkey_ed25519": "a43531db111ccb300d5608bfba41a182b13c6400008997b29343d326a64d9bae",
       "pubkey_x25519": "f9502184266881042c0c2d67d071c0ff53cd4fd4e90e67e28ba563762b442c18",
@@ -14348,7 +11674,7 @@
         11,
         3
       ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "207fffffffffffff"
     },
     {
       "public_ip": "205.185.123.189",
@@ -14453,7 +11779,7 @@
       "storage_port": 22111,
       "pubkey_ed25519": "a64f4e45218281c8a0e3c910b0d503ea2af1ca5277e0ec34915be060d4bb3f64",
       "pubkey_x25519": "c0d3b72355ec40ea2768de422fcc92c49ecc8bea96588fe9e465706c0ddbae11",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099920,
       "storage_lmq_port": 20211,
       "storage_server_version": [
         2,
@@ -14491,20 +11817,6 @@
       "swarm": "397fffffffffffff"
     },
     {
-      "public_ip": "216.230.232.35",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a714443c233bb87090215ab3efa7d72a9f29eaba6b5796e4422cf05fcb4e070d",
-      "pubkey_x25519": "543c4afe5b063e423cc674f0e6563130d7a140251a06296442545e03b6420225",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "477fffffffffffff"
-    },
-    {
       "public_ip": "57.129.102.67",
       "storage_port": 22102,
       "pubkey_ed25519": "a73f40f7babd2cdef0f6dc027dae92fdbd70f54780260ab85005d15ea1270d88",
@@ -14517,20 +11829,6 @@
         2
       ],
       "swarm": "75ffffffffffffff"
-    },
-    {
-      "public_ip": "216.108.230.145",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a74e0c7ec31d8ad0f1d5a55282180e4e9a63196d8ea1ab0ddec6e32e1c0cfc96",
-      "pubkey_x25519": "e5a883e76e9f76eaad819755cb724e39c03efb5fadf4b2a87c2bbe92ba3e6668",
-      "requested_unlock_height": 2086492,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "45.79.76.51",
@@ -14559,20 +11857,6 @@
         0
       ],
       "swarm": "227fffffffffffff"
-    },
-    {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22104,
-      "pubkey_ed25519": "a8473cd0789ebb7cfdca48a6c3ba5bddb6fd42a02da910a64d6b9393bb19f327",
-      "pubkey_x25519": "b2bafab8939686446c1fd96b3835ea54d1a7d0fbfffd38b64ad1bb0f48f8743b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "95.216.199.207",
@@ -14614,35 +11898,7 @@
         11,
         2
       ],
-      "swarm": "96ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.218",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a8af759b0b6ce0beed24823dad981dc7811b7d19744d83c19c57459187cb5fd0",
-      "pubkey_x25519": "7c52b44f4d7dec431efe982ba6b71222e3a3091bee94a714804844cd0879ec1c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "39ffffffffffffff"
-    },
-    {
-      "public_ip": "46.102.157.155",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a90d2f6041457941c6a34605562207938a9db89f875e4588fa2f23429d3096bb",
-      "pubkey_x25519": "0945149c5be833dc158d882a7df2e769fec407f9c5ac0e0172dd1a4796ac8c7a",
-      "requested_unlock_height": 2091002,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "eaffffffffffffff"
+      "swarm": "15ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -14657,20 +11913,6 @@
         2
       ],
       "swarm": "31ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.72",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a93d5bcb6f337c3dca6545ebfc3894d2f16b4ce93081f5c3b6d70ddfe905ceeb",
-      "pubkey_x25519": "d888b92823ae8d13f75389a30473375ec7d6b7314e484e30dd1d23a8d2734a15",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "107.189.2.69",
@@ -14699,34 +11941,6 @@
         2
       ],
       "swarm": "bcffffffffffffff"
-    },
-    {
-      "public_ip": "100.42.181.126",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a972f3e8b4068120ce7225cb3bf0715c182444872f00f878160e35c01d404480",
-      "pubkey_x25519": "c16fba1c7311a6ae102caebf41c5ad3184bf23a72a63dbd88994aec542474f45",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "31ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.19",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a983cd3c0b2699e4729516a3b5c63be01f1b134c22fdf0eb1011a43e5cb75198",
-      "pubkey_x25519": "17aed0ecb10ebfdc0752150990e189d66be4bf9253bed7a0deba48f44b0a4345",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
@@ -14799,20 +12013,6 @@
       "swarm": "f7ffffffffffffff"
     },
     {
-      "public_ip": "64.235.61.138",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ab154c8cdaf5afcc0e590a860319ef2868426743d1b82a2c9f3db2b9c53fe3a6",
-      "pubkey_x25519": "ee5d921f06dd14107a9698ab910d2513a5263e5d2fd2ba7ee6512525ee72e44d",
-      "requested_unlock_height": 2092383,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "bbffffffffffffff"
-    },
-    {
       "public_ip": "62.171.160.88",
       "storage_port": 22021,
       "pubkey_ed25519": "ab26bb821f414022db5f27ea72ec788be3a35b3174d1285c912e645d8095e7ab",
@@ -14824,7 +12024,7 @@
         11,
         3
       ],
-      "swarm": "1bffffffffffffff"
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "107.189.12.37",
@@ -14869,20 +12069,6 @@
       "swarm": "f1ffffffffffffff"
     },
     {
-      "public_ip": "64.227.78.106",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ac339bdd44da77dd39086d04b7c1235b81b4323943f38cfffa4a4940aaca4998",
-      "pubkey_x25519": "7e22ad688876979b5be5a8310a4420a769fc3c6ee5bfaeca41a8cc9512eb930b",
-      "requested_unlock_height": 2094230,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "407fffffffffffff"
-    },
-    {
       "public_ip": "209.141.43.224",
       "storage_port": 22021,
       "pubkey_ed25519": "ac3f41e83bd28de52ff671d61aafb7cac8385739b56e6cf948f0de45af78d384",
@@ -14895,20 +12081,6 @@
         3
       ],
       "swarm": "d2ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.112.212",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ac6d0d3cb63303c13ecfcbfafa64ccbbec25242d45a5b97973f167dd52c3dda9",
-      "pubkey_x25519": "33ac95be69b8220e78c86417ea0fd14079b5263f900e5883cf329b9f09b0b932",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "95.216.159.12",
@@ -14978,7 +12150,7 @@
         11,
         2
       ],
-      "swarm": "b5ffffffffffffff"
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "198.98.57.68",
@@ -15055,7 +12227,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "ade6e10994dfaeb4c5c0a0a4d4db9f2f2f796f022020ab928dc493ceeac81fe7",
       "pubkey_x25519": "b656830fc6604def5a996e8c2ade423032a50df54a39a455b05a80e5f93ad824",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099499,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -15076,7 +12248,7 @@
         11,
         2
       ],
-      "swarm": "aaffffffffffffff"
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "107.189.5.113",
@@ -15091,6 +12263,20 @@
         2
       ],
       "swarm": "15ffffffffffffff"
+    },
+    {
+      "public_ip": "206.221.184.74",
+      "storage_port": 22113,
+      "pubkey_ed25519": "ae0a4e5f85a65b33a3c797d2884af2671554f40a07a9cf64ad346080df3e20da",
+      "pubkey_x25519": "b5f1036c3e463b217af46301ca1569df6792a7e87a2232ddc93a9aa92686f822",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "135.181.32.244",
@@ -15146,7 +12332,7 @@
         11,
         2
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "135.181.32.244",
@@ -15177,60 +12363,18 @@
       "swarm": "91ffffffffffffff"
     },
     {
-      "public_ip": "77.74.199.107",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ae3cec0036d407af9a78a2e001183ef5a9adc0fc03d4a84141886300802be0f0",
-      "pubkey_x25519": "b1b160b9c0eb62c0f85bfa9e476e92f63455f53fd832f661ba429fef66f8ec50",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "38ffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.112",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ae8274ddd194c42c13ff541fd0d4b7956810a2103915f86db980ccd4492e815d",
-      "pubkey_x25519": "a0e4eaf20f8268d1dddc8c6e799f4bd2ec9b764b9e8958b83d567ae46cc87224",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.57",
-      "storage_port": 22021,
-      "pubkey_ed25519": "af58e0466038d918d95b387e372474fcb4849e1fd23f3aa216b88fbbdb8ab632",
-      "pubkey_x25519": "d828cda380e6b5f5b1b9a6c9eaa5110403ef0d2a2ace9e651ea9ae17b6ba1617",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "dffffffffffffff"
-    },
-    {
       "public_ip": "195.246.230.27",
       "storage_port": 22114,
       "pubkey_ed25519": "af9f27ff07b890a3496a93fd8dd9b5452f3c704c8697b0b5bb5e62cdb178ef8e",
       "pubkey_x25519": "8f16164b8674bacd3ddb6e79dcda0dc9fc9fbf0e1cf0119f3c5b469bd62f710b",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099922,
       "storage_lmq_port": 20214,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "3d7fffffffffffff"
+      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "168.138.102.244",
@@ -15275,20 +12419,6 @@
       "swarm": "21ffffffffffffff"
     },
     {
-      "public_ip": "45.149.204.19",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b008756229b91e1fa71a555a16eac4b9f863938113cc63cd9afebc26b94b2eae",
-      "pubkey_x25519": "a2297b850624131529052c0bbc7381b13d4fb2d47d0d51cef86ec7d6d937395f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "78ffffffffffffff"
-    },
-    {
       "public_ip": "205.185.114.108",
       "storage_port": 22021,
       "pubkey_ed25519": "b01fcc83aea88583647066c1e6529386375269e86f011299abfc5732092ac0fa",
@@ -15314,7 +12444,7 @@
         11,
         3
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "b5ffffffffffffff"
     },
     {
       "public_ip": "165.22.51.13",
@@ -15370,7 +12500,7 @@
         11,
         3
       ],
-      "swarm": "73ffffffffffffff"
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15468,7 +12598,7 @@
         11,
         3
       ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15566,7 +12696,7 @@
         11,
         3
       ],
-      "swarm": "3bffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15615,7 +12745,7 @@
       "storage_port": 22107,
       "pubkey_ed25519": "b171c788f264c7cc2997171d4c2e6a23d7767e995311c564d70aa6fd9d646edd",
       "pubkey_x25519": "2b283f912898dc87e89c93b003d4b5c3a0eb74adf3aad8ca2649971e8aa1d36c",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099921,
       "storage_lmq_port": 20207,
       "storage_server_version": [
         2,
@@ -15643,35 +12773,21 @@
       "storage_port": 22021,
       "pubkey_ed25519": "b1d0dc87a9e8ed9bd17ad6f87a98780a50e8e41badbdb3f0b609ebd4378a51e4",
       "pubkey_x25519": "9887aa615c073f6d43926596f37f102062779157987f8404208b3a6cc305832f",
-      "requested_unlock_height": 2091004,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f7ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.60",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b289716dd31f39d23838993fda6ed9dadc3d70d02a85029cac36343206a7cd36",
-      "pubkey_x25519": "5ff3953b26f0c23b594447ea598e457435211294da84cb8cbb15cccbca0e6364",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "317fffffffffffff"
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22118,
       "pubkey_ed25519": "b2d0b5665d0cee2685a640cafea6e69c9ccf15817a491c524bf4777cd7c9760e",
       "pubkey_x25519": "91e36f89b8e8695edee590c2d548a4fbeea3654830b7f030c371a96ae56b1813",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099893,
       "storage_lmq_port": 20218,
       "storage_server_version": [
         2,
@@ -15706,7 +12822,7 @@
         11,
         3
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "46.62.139.87",
@@ -15721,34 +12837,6 @@
         2
       ],
       "swarm": "d1ffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.116",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b41a90d471ddf71b07c8d02e05ec4b32a841ef6269c2277ba6a2567be0ec7421",
-      "pubkey_x25519": "3846de12d20294e051f83ffec53b3aa6c219893f9607998f402974a8b872ed27",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "caffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.95",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b451a384d75d106917e610b532605d96e7812a0324d6664be3e7024167c397f0",
-      "pubkey_x25519": "ac17bce8453412a9e6575902460137dc8a0db61c54c3caf053d14a0dc65e9726",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "185.150.189.71",
@@ -15776,7 +12864,7 @@
         11,
         3
       ],
-      "swarm": "2f7fffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -15793,25 +12881,11 @@
       "swarm": "93ffffffffffffff"
     },
     {
-      "public_ip": "172.93.167.59",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b52ee4fe875702d5a83c280aeaf32fdbcfff4922a6c2e8cf1243d4921043005a",
-      "pubkey_x25519": "78702bf131bba499786fa2d149ff3654864301d3b1bf068ddc1c513af5a8b35c",
-      "requested_unlock_height": 2091681,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "edffffffffffffff"
-    },
-    {
       "public_ip": "195.246.230.27",
       "storage_port": 22106,
       "pubkey_ed25519": "b5715524948bb0bc31baa2fa5f7aa98ee5f0b26142ce0b4cb6ffa5dc4056ef43",
       "pubkey_x25519": "1c8f28766ee72df57f12e5204882a57e139db16910d33af52c0fe6d49e2b7674",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099924,
       "storage_lmq_port": 20206,
       "storage_server_version": [
         2,
@@ -15839,7 +12913,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "b5b3bb394826976ee1a95fe7601adf5d07f8ced78263643619b6542bed491945",
       "pubkey_x25519": "6f09accaf672cae6c0fa602d55b7b04b3e9181ff8e49381b1ca27ef30cb5597b",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2104259,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -15847,20 +12921,6 @@
         0
       ],
       "swarm": "2fffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.127.19",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5ea3b383ae4218d1a7bb796a73ee2265a03224154db0c133a8dfb9a4f30a28e",
-      "pubkey_x25519": "d99b8fdb95b0923b2a47548ea813cf392673f33a28d0551157f61daac6255b6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "135.125.112.188",
@@ -15877,20 +12937,6 @@
       "swarm": "abffffffffffffff"
     },
     {
-      "public_ip": "77.74.199.80",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5f299e59f51b84f9c2e443ea5a73d5b51f127b0c9070a384345f2f330ebff77",
-      "pubkey_x25519": "918be7aa7af2811edabebdff1ffffbe8588a030ee3974115f99931442abb767b",
-      "requested_unlock_height": 2093347,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "76ffffffffffffff"
-    },
-    {
       "public_ip": "45.79.94.226",
       "storage_port": 22021,
       "pubkey_ed25519": "b5f35c99b058f6a53c2d91b0dca7196fcb3641528d882b4bb0cae203b1e10103",
@@ -15905,20 +12951,6 @@
       "swarm": "bfffffffffffffff"
     },
     {
-      "public_ip": "164.68.113.85",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5fc4d8a5c25f9947aae0aabecc953f368c90c1d413ad6f35e434d38da9ee8a5",
-      "pubkey_x25519": "072f91ef34b730e5b488036bc8371458f8081f48598f708db48801a7d7512441",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f7ffffffffffffff"
-    },
-    {
       "public_ip": "95.217.21.148",
       "storage_port": 22102,
       "pubkey_ed25519": "b637ce1e8040557c827de06bfa9c3a86e5e95a30cb0749517cae7ad3332ef91b",
@@ -15930,14 +12962,14 @@
         11,
         0
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22109,
       "pubkey_ed25519": "b68ec51f664c35ae81280d5c7fd3d3bbc419bee63db0921a7c504fec7c10c39a",
       "pubkey_x25519": "275473d18bcaf4fae6aecfb9e7c2c70aaae83c13f2f454aa35de542bd2e9043f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099920,
       "storage_lmq_port": 20209,
       "storage_server_version": [
         2,
@@ -15945,48 +12977,6 @@
         3
       ],
       "swarm": "1c7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.77",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b6cb4b5c8e9be7a3dda05a18f004612350eba3debddc1940f143bb6174a1df61",
-      "pubkey_x25519": "52d2142f98d8fd53efbca863c5f8e1fac59408e4cc4d64af3faf84a013853a04",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "c3ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.214",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b6ed86d800f829b314fb49fe81a920c7459e6b02426e78159f0ab354e7e10370",
-      "pubkey_x25519": "2465c4603f54976a92e458d727a7cd693f448f61a9acdd88c14656d39d711e54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22102,
-      "pubkey_ed25519": "b72142bf9a847fb9de1f97845bfa69f146d9aea2bcdc433137d8d089a31b00e7",
-      "pubkey_x25519": "f7965297353736dd8a892683408445930a64ac379ae4077fb4d51a2060243225",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -16012,7 +13002,7 @@
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
       "swarm": "3f7fffffffffffff"
     },
@@ -16059,20 +13049,6 @@
       "swarm": "caffffffffffffff"
     },
     {
-      "public_ip": "176.126.86.31",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b8fc7b2fa596392a6b17bca28d00c034ceba696510cbacd4d3923bcceb4288c5",
-      "pubkey_x25519": "51551a38a1941e39f59e0dc3e2d957441907629d0ebd0bc4394061a7bfcfbf03",
-      "requested_unlock_height": 2090219,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "197fffffffffffff"
-    },
-    {
       "public_ip": "152.89.29.20",
       "storage_port": 22021,
       "pubkey_ed25519": "b95d6e3360f19aafb2a016cb3623f8afe28600dfe4a8cba2944fce7023e40f29",
@@ -16084,14 +13060,14 @@
         11,
         3
       ],
-      "swarm": "1effffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "93.95.231.60",
       "storage_port": 22114,
       "pubkey_ed25519": "b9c8b5c2f4fd418a82300673352e911e7e4bc035441cb2ea932d69211b3cd536",
       "pubkey_x25519": "a401d0837838f6ab54d0be6420cb67129b9bb05d2bf86c6fe40dac76e8e18e5e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099932,
       "storage_lmq_port": 20214,
       "storage_server_version": [
         2,
@@ -16099,20 +13075,6 @@
         3
       ],
       "swarm": "7effffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22106,
-      "pubkey_ed25519": "b9ce05d9a464a0b276c480d6ebac2439dde75c308897b4e7b70179edd39b7c1a",
-      "pubkey_x25519": "bcac23e1c2edefb4855d0a9efede77ce6815cd918d7d51d0c151b0f8d44bae0c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "178.156.181.213",
@@ -16140,21 +13102,7 @@
         11,
         2
       ],
-      "swarm": "187fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.71",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b9f9a8336ee4e6a91d6fcfe264e2535fd38e7f7d2d7abb3a36aaefed92903cc8",
-      "pubkey_x25519": "89682badaa2b505633ee9a1fba40078ee76248a590527ccf986b3a314ca0d435",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6bffffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "157.90.226.160",
@@ -16213,20 +13161,6 @@
       "swarm": "93ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.66",
-      "storage_port": 22021,
-      "pubkey_ed25519": "bad52b8338107d4f4181cf0d9f353b83df41f91d3eaeb29b56ff4b6fc66c45ed",
-      "pubkey_x25519": "680bc30efa3c5cc076bfa123c72df96390c13723c02ea6c16e06c7ef6ed59211",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b6ffffffffffffff"
-    },
-    {
       "public_ip": "157.90.226.160",
       "storage_port": 22100,
       "pubkey_ed25519": "bb4f3d7a01548b99f7b64ddb521e84c583e4a2c8b9865b328a934576bac6a94f",
@@ -16245,28 +13179,14 @@
       "storage_port": 22113,
       "pubkey_ed25519": "bb581b7ee8b6a2a1869fcc6c877e45d5d0952fee2a1a76d99e939743e21e9376",
       "pubkey_x25519": "368faa6fc52f32e774bd724d7a1aced1eaa1d32683355bda0a9f73f0c542f61a",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099921,
       "storage_lmq_port": 20213,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22114,
-      "pubkey_ed25519": "bb5c2c2509213f30e1c155ece0b58bc0c704b7a2f11a63e00b71859647608817",
-      "pubkey_x25519": "864a9868885391a15695172b9e1d88767c6671c35e2d7e993ab56872cda3c243",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "40ffffffffffffff"
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -16280,7 +13200,7 @@
         11,
         1
       ],
-      "swarm": "adffffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "23.239.23.208",
@@ -16295,20 +13215,6 @@
         0
       ],
       "swarm": "affffffffffffff"
-    },
-    {
-      "public_ip": "144.91.74.95",
-      "storage_port": 22021,
-      "pubkey_ed25519": "bbe12b70327f94e9b408ff1c10a43aa9424ac888369aff07a16c394c9d8139cc",
-      "pubkey_x25519": "7a436ac1f6120677eedb26d95c610894dec9ab9368d214458a6aed715d245e16",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "20ffffffffffffff"
     },
     {
       "public_ip": "185.135.137.82",
@@ -16343,7 +13249,7 @@
       "storage_port": 22021,
       "pubkey_ed25519": "bc67c993dbf95c416bf65cf7ad8e1ef28e6c93e9a09b58132b0333b8ef1a26d1",
       "pubkey_x25519": "a3393a557fd9bdfe96a92eb42a19390053278bfe8329440b44c1a4166c340845",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2102666,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -16351,20 +13257,6 @@
         2
       ],
       "swarm": "4bffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22105,
-      "pubkey_ed25519": "bc6b8368a98cc93db5ce5586ef8429f274d5ccab15029c4ca52885a9139ffd21",
-      "pubkey_x25519": "332ddc0250754558b97682a78ddf6a6a79fd82144181615db100118600acde64",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "193.219.97.159",
@@ -16392,7 +13284,7 @@
         11,
         0
       ],
-      "swarm": "4cffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "104.244.79.249",
@@ -16413,14 +13305,14 @@
       "storage_port": 22101,
       "pubkey_ed25519": "bd5025557aa3f96670a4f460e2d75d8d24e013ab0e4eb612d9403aaef8fa08c1",
       "pubkey_x25519": "542be3c0f51ae7e3b9680bd424106b987d8fd83f62a58e6252c60105a3cf147e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099896,
       "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "287fffffffffffff"
+      "swarm": "37fffffffffffff"
     },
     {
       "public_ip": "51.81.202.55",
@@ -16462,7 +13354,7 @@
         11,
         2
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "65.108.251.24",
@@ -16505,20 +13397,6 @@
         3
       ],
       "swarm": "83ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.116.136",
-      "storage_port": 22021,
-      "pubkey_ed25519": "becac7961948a24d271554ffb0b4b5f736498d3da05caf769aa49f55ae41f03b",
-      "pubkey_x25519": "3d49b1cdf0cb13e28bbacac7c9bd46532c82fa6ab8610791ff8281050b35ea1f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "107.189.4.161",
@@ -16623,14 +13501,14 @@
       "storage_port": 22100,
       "pubkey_ed25519": "bfbb58bf0f34e2dada5916aaf412fa3bb1d131b0328cb9f3824da8c3c7f16659",
       "pubkey_x25519": "55b61203d0625de9e5c2c19a84fd721b80c2aa08059f4e6a8184429c8784ed2f",
-      "requested_unlock_height": 2086613,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "227fffffffffffff"
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
@@ -16672,7 +13550,7 @@
         11,
         2
       ],
-      "swarm": "d4ffffffffffffff"
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "172.236.51.205",
@@ -16700,7 +13578,7 @@
         11,
         3
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "139.162.158.65",
@@ -16840,21 +13718,7 @@
         11,
         3
       ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.78",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c23b705f48a639efcb3a9b3c3688e0c8936f8a29236272ba42a384b3820aac5a",
-      "pubkey_x25519": "89540e88d985a1316beb575390a9afefe4c0222674e5649218359bc9e784856a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "15ffffffffffffff"
+      "swarm": "1cffffffffffffff"
     },
     {
       "public_ip": "205.185.122.236",
@@ -16883,20 +13747,6 @@
         2
       ],
       "swarm": "2affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.96",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c27f243185b5a2bf8eea91efcdcad478d94fb5bec74ee585584bdf0fd4696f7a",
-      "pubkey_x25519": "f1f70270cbae3193af90699d6ca275821182eca9f261f135a08be18e4f5c9f07",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "94.130.15.33",
@@ -16983,20 +13833,6 @@
       "swarm": "d0ffffffffffffff"
     },
     {
-      "public_ip": "164.68.104.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c46e4bddf47dc6616c88633bf57ae5afb126f25e36541fce95b504f6eb4abea3",
-      "pubkey_x25519": "e3c0a8628bd82aa0318630978e3421ff51525eb8f8f12293c613d7c30245402a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3e7fffffffffffff"
-    },
-    {
       "public_ip": "185.150.190.48",
       "storage_port": 22114,
       "pubkey_ed25519": "c47e06207a9c0753fa47f08432aa4ca61f55445631d44cca9058381761e13f10",
@@ -17008,7 +13844,7 @@
         11,
         3
       ],
-      "swarm": "2dffffffffffffff"
+      "swarm": "0"
     },
     {
       "public_ip": "188.245.98.109",
@@ -17043,7 +13879,7 @@
       "storage_port": 22111,
       "pubkey_ed25519": "c5475090d21281693c55f19ea4eec1d537f79918226f42b38217c753977b3a38",
       "pubkey_x25519": "3dea491458c6cee76dd86aac02110e1836991fe7020601afb3898ed9949d630c",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099919,
       "storage_lmq_port": 20211,
       "storage_server_version": [
         2,
@@ -17123,20 +13959,6 @@
       "swarm": "77ffffffffffffff"
     },
     {
-      "public_ip": "45.130.104.239",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c5c3365df3e71f72fe37cd02e0fff7a07b475deab4e87ab15ce51ea816adeec0",
-      "pubkey_x25519": "47c82fec270dcf6ac2c26345036eb1482235121248af2d4efe702920b0027f10",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d7fffffffffffff"
-    },
-    {
       "public_ip": "91.231.182.106",
       "storage_port": 22021,
       "pubkey_ed25519": "c5c42bbbca36ed6e1e41b6de05629cb2c834b900d869839d338d466e6d308a57",
@@ -17148,7 +13970,7 @@
         11,
         3
       ],
-      "swarm": "48ffffffffffffff"
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "185.2.101.84",
@@ -17225,14 +14047,14 @@
       "storage_port": 22103,
       "pubkey_ed25519": "c6714dfc45fe1ebeb3bb0f0568b6f6a9578caa6d4acd14275aaf1e4204ebac16",
       "pubkey_x25519": "87e29c19828f6699ed8e7cd4afe1974fd9bbe21d9406397e620cf1b939354e00",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099920,
       "storage_lmq_port": 20203,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "76ffffffffffffff"
+      "swarm": "8ffffffffffffff"
     },
     {
       "public_ip": "141.144.243.51",
@@ -17246,7 +14068,7 @@
         11,
         3
       ],
-      "swarm": "6fffffffffffffff"
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "178.157.91.231",
@@ -17275,20 +14097,6 @@
         0
       ],
       "swarm": "b4ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.32",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c6c6c819fb205253864a971feb163e95ae8ab19b847316f4ac0e9ef58d0d083b",
-      "pubkey_x25519": "d34478dfd8bfe6a47692f8973a46324837b0f6f5f955eb39497e256fafe16142",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "427fffffffffffff"
     },
     {
       "public_ip": "193.160.96.235",
@@ -17347,25 +14155,11 @@
       "swarm": "b7fffffffffffff"
     },
     {
-      "public_ip": "164.68.125.174",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c9375215b4e119fc5ffc86744e605262f7910e2d2256a8e502cdb8ff51b39eb3",
-      "pubkey_x25519": "a4157863fba1578b2fad5842c0768566941f6a79e67610ef6ee4dccf8b486874",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
       "public_ip": "93.95.231.60",
       "storage_port": 22111,
       "pubkey_ed25519": "c9673a2677ab5423ff575b8943fbad20bc7ac56e5a7f079a2f1c137fd092e8e9",
       "pubkey_x25519": "d673a1fbe533546ae0cb2cd32f892bb233c66276cbe9d601c8ed901851589433",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099928,
       "storage_lmq_port": 20211,
       "storage_server_version": [
         2,
@@ -17403,7 +14197,7 @@
       "swarm": "9ffffffffffffff"
     },
     {
-      "public_ip": "38.45.71.55",
+      "public_ip": "172.93.167.59",
       "storage_port": 22021,
       "pubkey_ed25519": "c9cfb8a5d5064fd35c8c7faccdb0280705a70b19e3249be7ea1d852317de5d19",
       "pubkey_x25519": "2d99b6e337aecb3ef970923eaa48d98220f96be146dbcb9427a37ffa65983e5f",
@@ -17412,7 +14206,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "3b7fffffffffffff"
     },
@@ -17443,34 +14237,6 @@
         2
       ],
       "swarm": "c5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.235",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ca92601b37b881bd3c653bf45d9b222143fa10de9cc84a44c1afec38dc65ad00",
-      "pubkey_x25519": "14f96f9d7665c39105ae12b237f0742e5f03cfc23d743839017351d644a00b48",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "74ffffffffffffff"
-    },
-    {
-      "public_ip": "23.95.134.153",
-      "storage_port": 22021,
-      "pubkey_ed25519": "caab86dd10e727964594fb93838c5a31fd0e0eb9e7ddc201d69330f4e62a6fe4",
-      "pubkey_x25519": "f68116b735cf343ab2ba4ed5ece91471a7a60853127354e714d55fff93769c3c",
-      "requested_unlock_height": 2091652,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "5.189.129.195",
@@ -17512,7 +14278,7 @@
         11,
         2
       ],
-      "swarm": "42ffffffffffffff"
+      "swarm": "77ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
@@ -17582,7 +14348,7 @@
         11,
         2
       ],
-      "swarm": "dbffffffffffffff"
+      "swarm": "f6ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
@@ -17638,7 +14404,7 @@
         11,
         2
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17652,7 +14418,7 @@
         11,
         2
       ],
-      "swarm": "4dffffffffffffff"
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17708,7 +14474,7 @@
         11,
         2
       ],
-      "swarm": "50ffffffffffffff"
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17862,7 +14628,7 @@
         11,
         3
       ],
-      "swarm": "74ffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17876,7 +14642,7 @@
         11,
         3
       ],
-      "swarm": "387fffffffffffff"
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17890,7 +14656,7 @@
         11,
         3
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "467fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17904,7 +14670,7 @@
         11,
         3
       ],
-      "swarm": "dcffffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17918,7 +14684,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17977,34 +14743,6 @@
       "swarm": "e0ffffffffffffff"
     },
     {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22104,
-      "pubkey_ed25519": "cbb86e70216308f23ee06be7311cf17a0ff61405ddadcf7dcbe1e1926400d31d",
-      "pubkey_x25519": "033407504cd198ac9829d06998c44ce581f5e2657f1a55b5c637dd814e72982a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "caffffffffffffff"
-    },
-    {
-      "public_ip": "161.97.137.219",
-      "storage_port": 22021,
-      "pubkey_ed25519": "cbeaa9f1115254c2ce225018908c2166d4f4b3f3f624ff5750c65387f4ce98b6",
-      "pubkey_x25519": "6636e95eb46e39c7d44bcfcf39c95dbf6e3cffc1c387bc13d88d68b8cc6ecd4c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b5ffffffffffffff"
-    },
-    {
       "public_ip": "91.229.245.243",
       "storage_port": 22021,
       "pubkey_ed25519": "cc1d12b3fcdff3a00d098abda9ed3ebbed062a902788142a826c018706f4eb68",
@@ -18030,7 +14768,7 @@
         11,
         0
       ],
-      "swarm": "377fffffffffffff"
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "185.209.228.134",
@@ -18047,20 +14785,6 @@
       "swarm": "a7fffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22125,
-      "pubkey_ed25519": "cc70f6135c51a9bfa365580cf2ce94076174c728a0ada570627a2c62abae4b62",
-      "pubkey_x25519": "da17610e7de606e87c27313b894228e28913b623a7e751bae2d1dd3ba398f579",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20225,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "4bffffffffffffff"
-    },
-    {
       "public_ip": "94.72.125.80",
       "storage_port": 22021,
       "pubkey_ed25519": "ccba88dc9c24db706f961de688265791f7ed4650acc1c180983a32bc8726574e",
@@ -18075,20 +14799,6 @@
       "swarm": "9ffffffffffffff"
     },
     {
-      "public_ip": "31.22.111.5",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ccbef169a13b207bbe4ba6b26ef137fbed788f670a7d1913d19beb60a43d5e35",
-      "pubkey_x25519": "945aa11c17cff249da87efeccd2c0e8d8fb4405fd3ec8cdfb2348d6610bda46f",
-      "requested_unlock_height": 2085897,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a4ffffffffffffff"
-    },
-    {
       "public_ip": "5.189.189.215",
       "storage_port": 22021,
       "pubkey_ed25519": "cd37c634b475723556e1d6881e99052f11db55dff7987889340610d894326ced",
@@ -18100,7 +14810,7 @@
         11,
         3
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "135.125.140.64",
@@ -18131,34 +14841,6 @@
       "swarm": "15ffffffffffffff"
     },
     {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22115,
-      "pubkey_ed25519": "cd88528e1bdf2a49228c6101fde62a099367d315464127eaecb531575ab0c6cd",
-      "pubkey_x25519": "0b2d9e4d421efdcdd5318978f302eb2d40a5f12e140555cf1f5b70e0b5272c3c",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1c7fffffffffffff"
-    },
-    {
-      "public_ip": "185.198.27.134",
-      "storage_port": 22021,
-      "pubkey_ed25519": "cdb274d473fa5bf03edb1f24b9c12b6d0ef768d9644571b5c567f0de6ae4a467",
-      "pubkey_x25519": "1b1d36fec1f04b67222a623605c56484a7c4082f001f0567a5c58a6c57a03133",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "6dffffffffffffff"
-    },
-    {
       "public_ip": "199.127.62.234",
       "storage_port": 22108,
       "pubkey_ed25519": "cddbed1373b83dc946bcc944b97db03a8b67c8cc126f66147b828184e46e564e",
@@ -18170,28 +14852,14 @@
         11,
         3
       ],
-      "swarm": "8affffffffffffff"
-    },
-    {
-      "public_ip": "207.58.175.90",
-      "storage_port": 22021,
-      "pubkey_ed25519": "cdfbcdae2de00da6058312a88e05249840168e8725847a0a12e4b3818d6ae037",
-      "pubkey_x25519": "97f72b77d9cab72ed659244c1a1968e30555955ad898534322c48b44a1139940",
-      "requested_unlock_height": 2090245,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "144.24.179.149",
       "storage_port": 22102,
       "pubkey_ed25519": "ce0e9dff3877faa6011cb3aa89bd2a58a568a667fc33295f012d45fc246dbf40",
       "pubkey_x25519": "5339b037e574cf03a16faa737251cd65e251388dc0c444392960c426d1999f41",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099498,
       "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
@@ -18213,34 +14881,6 @@
         2
       ],
       "swarm": "adffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22115,
-      "pubkey_ed25519": "cf0e87e03b7621f4c9f439c69601e708557f353f0608bda2578e9f0907f9b185",
-      "pubkey_x25519": "4ab4d5b030018fd5e98f484851da433e722f61c416cb13366a31f72a444eac64",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d3ffffffffffffff"
-    },
-    {
-      "public_ip": "102.219.85.93",
-      "storage_port": 22100,
-      "pubkey_ed25519": "cf446948060ecd12fe12b5fbc28e67d1251d0ec33d522a8c9ac31121724a8588",
-      "pubkey_x25519": "e9add909986d043a326469f3b5941160e75a7886aca724f8409b6f0d34312e42",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
@@ -18285,34 +14925,6 @@
       "swarm": "94ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.136",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d0358a902f237f44f6c75948783e69c98b8092f76c6d5e20f16e5ba4c17b4cb7",
-      "pubkey_x25519": "960dd6bc935c3a6a4c086afb0e06f10a5660009ecd35baa9e8b1fa4efd6c6970",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
-      "public_ip": "208.87.129.102",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d03738f8a4d3e49a45e104d14775e8fab9e3e81927a81178e550dbda41e31b9a",
-      "pubkey_x25519": "e90c345863dc50cff06cdaf6d68c9c3cfa2e3933491609b9cb7de480c47d3a7e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6bffffffffffffff"
-    },
-    {
       "public_ip": "185.150.190.48",
       "storage_port": 22106,
       "pubkey_ed25519": "d079d0acfb611764675e770b79a41d4c6fb930ac65b0ab02d5904e65128b4bd7",
@@ -18331,14 +14943,14 @@
       "storage_port": 22112,
       "pubkey_ed25519": "d0989e60ec38e6447d97410b87eaaf8843367419a978e7d5b222d561ffe159d0",
       "pubkey_x25519": "f9b33a6c72e6b26a2f3b4774323fe33e24cd3e86a56b42075896061988d50b36",
-      "requested_unlock_height": 2084500,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 20212,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "3fffffffffffffff"
+      "swarm": "98ffffffffffffff"
     },
     {
       "public_ip": "109.234.36.164",
@@ -18366,7 +14978,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "33ffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
@@ -18380,35 +14992,7 @@
         11,
         3
       ],
-      "swarm": "21ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22121,
-      "pubkey_ed25519": "d10097cdd26e57bc6162d75b231f449d6cb31dc798261ba9d592acddd42e78c8",
-      "pubkey_x25519": "b568d529dae3ca9f820334d409806a214ce252d99746f744ddcf49c5be612b24",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20221,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ecffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.98",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d103b5ccd3aef4283e0ef4780d7db44090694f13feb7fec830d5b2d8b1865590",
-      "pubkey_x25519": "5d603a1fae0a6304e11131bb0554b4f3c132891e7d03be49cce5ec335bf5c006",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7affffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "104.248.163.43",
@@ -18437,20 +15021,6 @@
         3
       ],
       "swarm": "7dffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.76.191",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d19783f75bc0e87cad4b8a9d63696ffb0122edf495da6d5c3a627512e485bc85",
-      "pubkey_x25519": "777aa868c8315a23ff15ed6053f9d4172c0ca4f4ae77468b8d835c266f44e74a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
@@ -18495,20 +15065,6 @@
       "swarm": "69ffffffffffffff"
     },
     {
-      "public_ip": "192.3.63.197",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d29251a5ee2c8f7022b47488e3defc6b6184117c9e455ed800ac60f9c1388fb3",
-      "pubkey_x25519": "6c68ff631e64f09c48170b9e5d576531b4a5fa8ea4580d583eccda989eb1e973",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "7dffffffffffffff"
-    },
-    {
       "public_ip": "85.239.247.57",
       "storage_port": 22021,
       "pubkey_ed25519": "d299056394d9e52a9c3c8633cd801a42f5ab0ba72d9d44d296388f0ccb216ed2",
@@ -18520,21 +15076,7 @@
         11,
         2
       ],
-      "swarm": "477fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22102,
-      "pubkey_ed25519": "d2a5ef4f952b15f4562b44d024a6bc8b0058513a8f782b2dd76a68c4e97cc459",
-      "pubkey_x25519": "2979d41330544b72f61f1240e3c2ea5838b28cdb8b2d46529d2b87c5f9dda41a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "cdffffffffffffff"
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -18562,7 +15104,7 @@
         11,
         3
       ],
-      "swarm": "3dffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "104.243.41.194",
@@ -18583,14 +15125,14 @@
       "storage_port": 22109,
       "pubkey_ed25519": "d2db0142725c139d494207619ac348c72eaaedf6383bd0a10df5ec1a52bb3bb2",
       "pubkey_x25519": "5f0e4398604c06f02869dd96abc9a2b98b3def2ee65796cf33ae1bedd2ec8b42",
-      "requested_unlock_height": 2086578,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 20209,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "a8ffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -18635,20 +15177,6 @@
       "swarm": "a9ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22119,
-      "pubkey_ed25519": "d3a1b5cb29572409d479e21f0fd3c3ecab56f0910488f73e17c6703485a38d49",
-      "pubkey_x25519": "502de7e4551d6b8ac3315638d201a933be27a0d3fae901aa3f32e6581e169f04",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3c7fffffffffffff"
-    },
-    {
       "public_ip": "149.56.128.86",
       "storage_port": 22021,
       "pubkey_ed25519": "d45736c371ff2a272f59c56a1089eed5a1e38f119bcac4ed5c596f1305345480",
@@ -18674,21 +15202,7 @@
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.123.162",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d4b1e879d9ad4c8e5278cbfc8711d4e739b499cb2ced29c0065439d7f45b4757",
-      "pubkey_x25519": "69f922608ac561e2991be8f3162e3ad20919563e73e63d4b5d7ea5586710e815",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7ffffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "198.98.53.254",
@@ -18733,20 +15247,6 @@
       "swarm": "d6ffffffffffffff"
     },
     {
-      "public_ip": "31.22.111.227",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d53130ee19018c7f2223675cd5d7c9f7a6a7b3694cc0cc37a2b34ae03f7e2a9b",
-      "pubkey_x25519": "d85b379bcba84278504410a2c70884b86e52d84b7e7179c50e0a7bf25337000a",
-      "requested_unlock_height": 2088816,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e7fffffffffffff"
-    },
-    {
       "public_ip": "139.99.135.156",
       "storage_port": 22021,
       "pubkey_ed25519": "d624df8573ffd69e45949223657df772df29dcac2e9c675804be1cf099a071e4",
@@ -18758,14 +15258,14 @@
         11,
         2
       ],
-      "swarm": "bfffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "195.246.230.27",
       "storage_port": 22113,
       "pubkey_ed25519": "d627de06cc2d4820cbf4df5b7ade2392b684dcf470e9ca9cd7a198032e1f8ee3",
       "pubkey_x25519": "7d426e94ac42f00ffb47c5f1d0c324b253bb8d2867cc2202e011d2dad718df2b",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099917,
       "storage_lmq_port": 20213,
       "storage_server_version": [
         2,
@@ -18775,25 +15275,11 @@
       "swarm": "247fffffffffffff"
     },
     {
-      "public_ip": "164.68.126.68",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d65a221b38bb7f1285bcdb64d4b03490c36487e54a1331b430256a7643914247",
-      "pubkey_x25519": "a066b671eb6cffee0709632d9326727fb1434a12d1e7d46232b6a998b8cd554b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "aeffffffffffffff"
-    },
-    {
       "public_ip": "89.147.110.157",
       "storage_port": 22112,
       "pubkey_ed25519": "d69d45b83cd34ebd394e761561d4feb0ad7a47daa8f198d0997cbea3a7622858",
       "pubkey_x25519": "41548b2d0c9774e8682412d3207f3379807a128a200f74e9c87572885aecae08",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099916,
       "storage_lmq_port": 20212,
       "storage_server_version": [
         2,
@@ -18801,34 +15287,6 @@
         3
       ],
       "swarm": "e5ffffffffffffff"
-    },
-    {
-      "public_ip": "64.235.37.175",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d6eeb243a84c55190514188084a69da2393213921aa169c11e8e5424256a5915",
-      "pubkey_x25519": "d8a04a6821ab35f790a23dfbc95b93c709bc2a13964023930a9ad114c472a013",
-      "requested_unlock_height": 2084583,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.220",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d72ea1a6d387d9242a47b21839ae81c99e3569dae96196661ae2ee2c2f654c43",
-      "pubkey_x25519": "b73a9771fee04c99b91f09d853833eccf072cff4a220452ccc58a2c2e1c7ef52",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "15.204.87.227",
@@ -18840,7 +15298,7 @@
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
       "swarm": "98ffffffffffffff"
     },
@@ -18870,7 +15328,7 @@
         11,
         2
       ],
-      "swarm": "bffffffffffffff"
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -18929,20 +15387,6 @@
       "swarm": "fffffffffffffff"
     },
     {
-      "public_ip": "169.197.86.232",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d8081e0f5c1ee1687b0dbb7de7b12d38f778046e35cb75142122a7309e200220",
-      "pubkey_x25519": "cdaa0515139b54ebfc3313a30206d5e04eef5a12777446af179daad05354e869",
-      "requested_unlock_height": 2090338,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2a7fffffffffffff"
-    },
-    {
       "public_ip": "193.123.76.22",
       "storage_port": 22103,
       "pubkey_ed25519": "d86c877d04b1e2beef1ea3b78f05253e95fb843b6edd687ce4c12c34d6228696",
@@ -18955,20 +15399,6 @@
         3
       ],
       "swarm": "3dffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22106,
-      "pubkey_ed25519": "d8af8c1f0af2bd69a12f0a1cad98bce41814f1295635a1db73771e7615811d4f",
-      "pubkey_x25519": "8b68b322b6774771e1aecd6e1bfb12349456b20641db6a514219d10b80cbc672",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "89.58.0.228",
@@ -19041,39 +15471,11 @@
       "swarm": "187fffffffffffff"
     },
     {
-      "public_ip": "158.220.126.109",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d9ef91ebd50315ebe2cee7ed3add941b44aa83629f932e0d0768d7e526628e18",
-      "pubkey_x25519": "5dc8bbc77d5a57d3b11e8bac2161d5b4bb203247e3455df76a3ba79e4dd5be1d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d1ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.16",
-      "storage_port": 22021,
-      "pubkey_ed25519": "da280f677391f00244d5e7b13859a56e5347cee5f2fc0d9bb5e7e78d6ca8270a",
-      "pubkey_x25519": "c11ece75669e5284f2f977d3258e247acfe42e20c11afccd756ba06567caae73",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b5ffffffffffffff"
-    },
-    {
       "public_ip": "149.56.12.216",
       "storage_port": 22021,
       "pubkey_ed25519": "da4d23826f98bc7075aa368ab411ec021d1205500f912c4c5b96d3ac9aae0d88",
       "pubkey_x25519": "bd215150d2f9ad848f7b70b66d3dc64aa718a9767a37afd4737c793cfb39da72",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2101178,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -19081,6 +15483,20 @@
         2
       ],
       "swarm": "d1ffffffffffffff"
+    },
+    {
+      "public_ip": "155.103.66.138",
+      "storage_port": 22021,
+      "pubkey_ed25519": "da5c2b2cfc541987093c589abc0c736531dcfe1cae5b276cd95f3ba4770e3f59",
+      "pubkey_x25519": "40160a04eb710525a283a9359d4b39a4bdcb5d7c81779d850430d7b69d75f039",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "135.148.27.21",
@@ -19129,7 +15545,7 @@
       "storage_port": 22108,
       "pubkey_ed25519": "db4e72005254ef0ace19567d8734802458d9af895953fbadc7e904225394f29f",
       "pubkey_x25519": "e953c575ddee59a6653a79fac31a732a7d00fb89589a79ef1dbfedec52cb6849",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099916,
       "storage_lmq_port": 20208,
       "storage_server_version": [
         2,
@@ -19164,35 +15580,7 @@
         11,
         3
       ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.233",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dbea94b570ea06818323067a618b1a88ac24b18a16cd9aeacd97b132e3cf2f00",
-      "pubkey_x25519": "eb05d0fe7260907db89e1bc3398f5d2628e113b0de1379e2586c65bd9aa44822",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "67ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22105,
-      "pubkey_ed25519": "dc548201343c40baf0d5017891359606c3cc936be64143bb1b1bc59046230514",
-      "pubkey_x25519": "40e0ee30d7ceab7fe93598c4bf95a6332d3f5ab704bf50a0ed8dce09163f3f23",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "287fffffffffffff"
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -19237,34 +15625,6 @@
       "swarm": "e7fffffffffffff"
     },
     {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22109,
-      "pubkey_ed25519": "dd75931ac08255af80ade2c1e56d3924f8f4edc368b660796c6165dad7c7fa9d",
-      "pubkey_x25519": "05b9c22bcfb2131e5003b69feb3381c96510c391eac07fea2bd2f839826d9b54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3d7fffffffffffff"
-    },
-    {
-      "public_ip": "142.248.29.61",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dd7a27c830745d8f304f8e2f505cc1d9bf6255ca48bb70c7867bd8992035d7bb",
-      "pubkey_x25519": "a015243bb21c72e1b1c18903da5002d1dc0de1846cb4fa9c6fc78d07c5021952",
-      "requested_unlock_height": 2085149,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "beffffffffffffff"
-    },
-    {
       "public_ip": "37.27.38.161",
       "storage_port": 22021,
       "pubkey_ed25519": "ddb6e0665652287203c1d4108ca13c5a31ba8411a911244b734afb8a4ed4d5e0",
@@ -19277,6 +15637,20 @@
         2
       ],
       "swarm": "72ffffffffffffff"
+    },
+    {
+      "public_ip": "87.106.7.132",
+      "storage_port": 22021,
+      "pubkey_ed25519": "de16cc6a072bdbdb378753a3a98d5bee437ecc7ab310beae87b295f392e9bbf7",
+      "pubkey_x25519": "f54c0f17707e6b5bbf7a1c95b76db18d32cc46aabe2b26225f76cd0d0f6b4864",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "85.9.211.140",
@@ -19307,20 +15681,6 @@
       "swarm": "dbffffffffffffff"
     },
     {
-      "public_ip": "164.68.104.155",
-      "storage_port": 22021,
-      "pubkey_ed25519": "df3b644169a37f816519a87d8858efa636da5483a25b2a62abd02f9ff24adb59",
-      "pubkey_x25519": "b80f35bba920e7715ab924928bf0a23a01eec1e7fe32480acae629a04e585832",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f1ffffffffffffff"
-    },
-    {
       "public_ip": "95.216.32.189",
       "storage_port": 22106,
       "pubkey_ed25519": "df5f041f59b9b01f12d3e325cde945fb64e3366e80fb99212478a9f943798aba",
@@ -19335,7 +15695,7 @@
       "swarm": "52ffffffffffffff"
     },
     {
-      "public_ip": "167.17.40.236",
+      "public_ip": "31.22.111.229",
       "storage_port": 22021,
       "pubkey_ed25519": "df65f3baee7170efbc3ff263cc034b1f18c71cc52be0bcbfedd2acac266c6a0d",
       "pubkey_x25519": "86afa90c299b209f358b30764de2f2ad9a0d9d8c9b958c2765d8ae431795260e",
@@ -19344,16 +15704,16 @@
       "storage_server_version": [
         2,
         11,
-        3
+        2
       ],
-      "swarm": "34ffffffffffffff"
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "89.147.110.157",
       "storage_port": 22115,
       "pubkey_ed25519": "df7907cf6d967bcef4374424b9326308086acb5044899e01e39f41eb2590c592",
       "pubkey_x25519": "18e920b93119f1e658a859619d6a62af56068db1ded7e6ee82484ce3bab9116d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099942,
       "storage_lmq_port": 20215,
       "storage_server_version": [
         2,
@@ -19377,20 +15737,6 @@
       "swarm": "a8ffffffffffffff"
     },
     {
-      "public_ip": "158.220.127.207",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dfb4d131046af3b03ed213ea360e5f7fdab240d0de692cbb735220cd85ae3f3f",
-      "pubkey_x25519": "f9f8f9c209f9ac93559b0697859745bc459abbff685f2c2b043820a951087e21",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "47fffffffffffff"
-    },
-    {
       "public_ip": "199.127.62.234",
       "storage_port": 22101,
       "pubkey_ed25519": "dfe854814ace9c1a8eaac9bc8b47f747548db973c737d6be5655e157cbb6b73a",
@@ -19402,7 +15748,7 @@
         11,
         3
       ],
-      "swarm": "fbffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "194.5.248.48",
@@ -19447,34 +15793,6 @@
       "swarm": "4bffffffffffffff"
     },
     {
-      "public_ip": "77.74.199.82",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e0f259d5620e7c6d16bcbe470d53f8e900c06eb5c00ab021c6f0e8d3028ef7d6",
-      "pubkey_x25519": "570718d983f4fb66303c690abe2e57481e90f7ca7d800a68f9d5b0bd0f6e9574",
-      "requested_unlock_height": 2091685,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "1cffffffffffffff"
-    },
-    {
-      "public_ip": "85.209.48.151",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e0f6eaba6ba08e32befea4b0bc6a74216630a97fed944eb38c52946a6545d494",
-      "pubkey_x25519": "174cfc72aa9405732305ce53f61102565deda3d004d5e19d49f668b264730633",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3fffffffffffffff"
-    },
-    {
       "public_ip": "91.99.144.21",
       "storage_port": 22021,
       "pubkey_ed25519": "e162cca9dd71a73add7491c44c833387526d61ba0e6a2da9bb81cfb3e50273b7",
@@ -19500,14 +15818,14 @@
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "193.26.157.116",
       "storage_port": 22021,
       "pubkey_ed25519": "e1af541c255ccfa56f63185e9aab06e8afd7b3c385bea4f21dd2b3f6bdd3a8ff",
       "pubkey_x25519": "af04e07bf6237645122961dd91170fa595446db9e55d195c53f3eb27f63c723f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2107057,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -19542,7 +15860,7 @@
         11,
         2
       ],
-      "swarm": "36ffffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "144.76.74.2",
@@ -19563,14 +15881,14 @@
       "storage_port": 22106,
       "pubkey_ed25519": "e29106d27e4c43de76e66a38d743761afc89ec2af04756e6db637cf080d6c505",
       "pubkey_x25519": "8510e9e535d020b1ea06e9b4d55a0a10c1f5be98e8efabf80dae207dd25a045d",
-      "requested_unlock_height": 2086864,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "c3ffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "45.153.186.74",
@@ -19599,20 +15917,6 @@
         2
       ],
       "swarm": "daffffffffffffff"
-    },
-    {
-      "public_ip": "141.140.12.182",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e34245544f2dd7b0ad4c9e2b3fe31a2d614b4342f7af02218644bd193bbfbfe2",
-      "pubkey_x25519": "4afed8fee0a65934ce5be75ba7cd32af78158d901adbe04be4870e9f0c032f6e",
-      "requested_unlock_height": 2085162,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "0"
     },
     {
       "public_ip": "185.150.189.71",
@@ -19671,20 +15975,6 @@
       "swarm": "457fffffffffffff"
     },
     {
-      "public_ip": "173.212.204.166",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e42e1d5ddac8f002be1584f902ca59251fe08e05f1280bd62427cc419fafa23c",
-      "pubkey_x25519": "c999d3b15d67a548ad1692e707e77cffc9ce346aa41f627576303f733da2e856",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "acffffffffffffff"
-    },
-    {
       "public_ip": "72.60.178.74",
       "storage_port": 22021,
       "pubkey_ed25519": "e45e3cf39aedcacc4413a9032d4806f9291985783f5f946b768ebd93ef8f7910",
@@ -19697,20 +15987,6 @@
         3
       ],
       "swarm": "17ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.213",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e468e032835ff7b08b100efca8b1231fe3340d266e7f968a62504c7e1177edee",
-      "pubkey_x25519": "d1eb2475fbf3446cc3ffe367a7c9646025cba86cf392986ca3e333b245974132",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
@@ -19759,14 +16035,14 @@
       "storage_port": 22112,
       "pubkey_ed25519": "e53edbe54fa6a3f6b701d356c444d6772475dec15ee0a353c1c7351187d11f5c",
       "pubkey_x25519": "15d69ae50e61b90e6b79c3b645e109841b2cc052b952851d2c4afd09d4225024",
-      "requested_unlock_height": 2086578,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 20212,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "ccffffffffffffff"
+      "swarm": "89ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -19850,7 +16126,7 @@
         11,
         0
       ],
-      "swarm": "c8ffffffffffffff"
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.48",
@@ -19871,28 +16147,14 @@
       "storage_port": 22105,
       "pubkey_ed25519": "e6562fb8845232c190130c5b2698ea0c868c7b8b28972dfd3bba900b82db5198",
       "pubkey_x25519": "2e58a08d45b5f060b3b24ea33e351eeac432736ce6ae720745697e7c45cb9b29",
-      "requested_unlock_height": 2084751,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22405,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "ccffffffffffffff"
-    },
-    {
-      "public_ip": "158.220.127.144",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e6655f0d8f58c8d8994132dad121d04a1d309566b775914c1dd4bc99625e1219",
-      "pubkey_x25519": "d19c93fc49858a8c018866cc21ae3f51c9d9fa19cf35006638720a52732b4a62",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "68ffffffffffffff"
+      "swarm": "c0ffffffffffffff"
     },
     {
       "public_ip": "209.141.52.233",
@@ -19920,7 +16182,7 @@
         11,
         2
       ],
-      "swarm": "c9ffffffffffffff"
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "185.216.178.30",
@@ -19941,7 +16203,7 @@
       "storage_port": 22117,
       "pubkey_ed25519": "e78edb02540e1130c57ead0a1e8603549c9e23c507740131b61b153e7c722970",
       "pubkey_x25519": "5f7f70229b98af0e2a66b4044d0be5dce4df255b927304c589ebecaa15683c7f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2099913,
       "storage_lmq_port": 20217,
       "storage_server_version": [
         2,
@@ -19976,7 +16238,7 @@
         11,
         2
       ],
-      "swarm": "71ffffffffffffff"
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "129.213.211.207",
@@ -20004,7 +16266,7 @@
         11,
         3
       ],
-      "swarm": "387fffffffffffff"
+      "swarm": "44ffffffffffffff"
     },
     {
       "public_ip": "46.254.214.27",
@@ -20033,20 +16295,6 @@
         3
       ],
       "swarm": "37fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.145",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e89ecaceb83c158ce2f962024c6eaeeb26ea5f97c6a09f65eb33828c19e13b45",
-      "pubkey_x25519": "6cea696149fc8d54f5068bf8c3bcb9d2f6064b19015e846d7657e44e994f0277",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "172.93.167.217",
@@ -20091,20 +16339,6 @@
       "swarm": "98ffffffffffffff"
     },
     {
-      "public_ip": "107.175.74.23",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e95eada37853f449a448fde3d190422c8401108c51477000a692b91821df5c0c",
-      "pubkey_x25519": "a136e8e9d3580863f4eb4fd3468e7d89059cb51ea396f3444abbf6dcc273a528",
-      "requested_unlock_height": 2084488,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2dffffffffffffff"
-    },
-    {
       "public_ip": "199.195.250.36",
       "storage_port": 22021,
       "pubkey_ed25519": "e9635600825bb63f44a7b1ffc07e208cf0a11b625eb2ad96243914666655fdf7",
@@ -20131,20 +16365,6 @@
         3
       ],
       "swarm": "deffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.170",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e9a65df172ef366752bd6ba29dcfbcbc35bed13feb1ebe070917f68c0f3604ef",
-      "pubkey_x25519": "3eb04ee15b3001025951efddc25211a2f7817827624e3c587505e8f44f73f434",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "198.98.51.211",
@@ -20186,21 +16406,7 @@
         11,
         3
       ],
-      "swarm": "2effffffffffffff"
-    },
-    {
-      "public_ip": "103.146.222.77",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e9ea4c8afcbe0157ebf2a46fae481788f2f990b35737971fca8ddae6bec2bae8",
-      "pubkey_x25519": "a29630c1ae8b26c24f90785bc968145ae583825d677e0e01bcd1586a055b3e51",
-      "requested_unlock_height": 2085135,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5fffffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "45.33.57.47",
@@ -20284,7 +16490,7 @@
         11,
         3
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "89.58.27.224",
@@ -20326,7 +16532,21 @@
         11,
         3
       ],
-      "swarm": "a7fffffffffffff"
+      "swarm": "68ffffffffffffff"
+    },
+    {
+      "public_ip": "209.222.98.114",
+      "storage_port": 22104,
+      "pubkey_ed25519": "ec2ff31de1aca6abc8ad06cd97c575e539057601759b6890fb775e5f80f61857",
+      "pubkey_x25519": "8d85ae50a6859edf24ee0c8b11f3854193968e248768a0bb9ef135ee79bcc151",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20204,
+      "storage_server_version": [
+        2,
+        11,
+        2
+      ],
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "154.26.159.141",
@@ -20371,20 +16591,6 @@
       "swarm": "4effffffffffffff"
     },
     {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22100,
-      "pubkey_ed25519": "ec6e2c3e74ce5d95d2697923641adfb71faae5bfce79416021a4d43c6091c426",
-      "pubkey_x25519": "88792b56a861aa71e0cb2b2b159224603454d9f7a4407006f3a60451f9e42b24",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "13ffffffffffffff"
-    },
-    {
       "public_ip": "206.221.184.74",
       "storage_port": 22109,
       "pubkey_ed25519": "ec86eab297c04a232a7e8a30341e60151dcee5ec4f3f8489250476b8a660bfa2",
@@ -20424,7 +16630,7 @@
         11,
         0
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.68",
@@ -20439,34 +16645,6 @@
         2
       ],
       "swarm": "477fffffffffffff"
-    },
-    {
-      "public_ip": "104.248.87.76",
-      "storage_port": 22021,
-      "pubkey_ed25519": "edf3cecaef192da0e0c4360b81fe1a16b55be3ca7e9ac37112950b9d26753e5d",
-      "pubkey_x25519": "ff0381d5510485bac05d560d739665f84b63dbb64e6f0200eeee7ccefb577275",
-      "requested_unlock_height": 2094233,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "99ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.135",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ee2b833abf4edae2112a124087e7b269f7e8f741d6e3920a2f1bb969f45dcf7f",
-      "pubkey_x25519": "010c45545333eef36cf74320f84bcafa87bbb04f8d6f7037d91e845155f72b4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "107.189.1.148",
@@ -20501,14 +16679,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "eebf79d43b94a520fdb58de202ab41ccc76b48eac7a9b3347d4a4f47d0287177",
       "pubkey_x25519": "c5a3ff2e53f18e1fb33713488b44b85f9f2e3d597dafb8ca64ec365f0bec4236",
-      "requested_unlock_height": 2084498,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "13ffffffffffffff"
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "209.141.50.48",
@@ -20536,7 +16714,7 @@
         11,
         3
       ],
-      "swarm": "4bffffffffffffff"
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "199.127.62.234",
@@ -20550,7 +16728,7 @@
         11,
         3
       ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "0"
     },
     {
       "public_ip": "217.216.86.165",
@@ -20585,14 +16763,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "ef79ee74a68130282865be957158ab54b602508045ce9120af43262d168bff62",
       "pubkey_x25519": "964e2d9a901319f47398cdf2dcf8f0b127f0ba2ba09aa29ad4495d649e90a851",
-      "requested_unlock_height": 2085896,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "57.129.102.67",
@@ -20605,48 +16783,6 @@
         2,
         11,
         2
-      ],
-      "swarm": "e7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22107,
-      "pubkey_ed25519": "efbf1a56df9f7aec0bb411285f2ce1f927079d38033d775694a9039bed9924dd",
-      "pubkey_x25519": "8316322d124d69757968107110ee807d2819c7c411d8f829672b3521be752c24",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2a7fffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.9",
-      "storage_port": 22021,
-      "pubkey_ed25519": "efc8d1c0cc2ef97bafc210dc2bdc6bed4cbe0435cbf365ce8f3083c4b0b87dd7",
-      "pubkey_x25519": "6036c72b6ab909b83bad43c80cbb6cbab9a43edaaf29256340a5fd07573b1a4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "13ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.76.126",
-      "storage_port": 22021,
-      "pubkey_ed25519": "efd13cd61671588c11841414563cd2d467888543047b6e2d893211ec96ad96ea",
-      "pubkey_x25519": "ae300831d1cc08700797be71ffc65eab92ce13f9a9ef29386a78895599980d4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
       ],
       "swarm": "e7fffffffffffff"
     },
@@ -20677,20 +16813,6 @@
         2
       ],
       "swarm": "1bffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.217",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f112e19a5b0d77cbd3b33a682fea3aac5c446a209423ec0c6d794e61bc616cd6",
-      "pubkey_x25519": "ce818b001c840e0c3bd06506dc945bca4db701a2d5d3368f774c93568b3a2028",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "205.185.113.44",
@@ -20749,20 +16871,6 @@
       "swarm": "a6ffffffffffffff"
     },
     {
-      "public_ip": "152.53.139.17",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f1f9bee0ade678cdbe8f969e8a44c0d9f6677d172f0e4aaf1d73718c25d88136",
-      "pubkey_x25519": "cf094e210af7afb114ecff72c89aeefd95d271d7ca97c512057bb4d4e51ebb54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "45ffffffffffffff"
-    },
-    {
       "public_ip": "202.61.195.129",
       "storage_port": 22021,
       "pubkey_ed25519": "f21281a5ad0d34dbed6cffacfa189ab0b9f35593a2d6cfd1736c65ed3f6b5630",
@@ -20774,14 +16882,14 @@
         11,
         3
       ],
-      "swarm": "207fffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22107,
       "pubkey_ed25519": "f216172aaeb75b20faf92a679e6fc1b9bf92988104ebfa8bedf58c99910806ca",
       "pubkey_x25519": "7756ab2d05552f1d1984d7c6741e5a53fbcbed3acc257d1c819a73424a44f22b",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2109431,
       "storage_lmq_port": 22407,
       "storage_server_version": [
         2,
@@ -20858,7 +16966,7 @@
         11,
         3
       ],
-      "swarm": "3c7fffffffffffff"
+      "swarm": "1c7fffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -20872,7 +16980,7 @@
         11,
         0
       ],
-      "swarm": "5dffffffffffffff"
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -20903,20 +17011,6 @@
       "swarm": "6cffffffffffffff"
     },
     {
-      "public_ip": "164.68.126.243",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f43964325ae9452b6ca6f01a6be6d344adc5cf82deb2ac1045e28d00b6366fba",
-      "pubkey_x25519": "ad052ed8c0f890f8b6dfa58091cdb251d2650dda5492b2b872e5cfaa63483e5b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "207fffffffffffff"
-    },
-    {
       "public_ip": "173.249.205.185",
       "storage_port": 22021,
       "pubkey_ed25519": "f4468e7b89d772cca2648f0fe3dd7b38aa9cd08850911f2b4ae053533bebbf58",
@@ -20928,7 +17022,7 @@
         11,
         2
       ],
-      "swarm": "22ffffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "209.141.42.160",
@@ -20956,7 +17050,7 @@
         11,
         2
       ],
-      "swarm": "2d7fffffffffffff"
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "5.189.146.159",
@@ -21005,7 +17099,7 @@
       "storage_port": 22102,
       "pubkey_ed25519": "f61fe86cd412ce3f94b3545c6d1f29804fded6b8b1a0846ae190fe8e2d3e5e34",
       "pubkey_x25519": "f1a06ddd3ed1f4317b70710870819f34830a230d565d3e11a0451eee2ff9fc77",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2102945,
       "storage_lmq_port": 22402,
       "storage_server_version": [
         2,
@@ -21043,20 +17137,6 @@
       "swarm": "8fffffffffffffff"
     },
     {
-      "public_ip": "164.68.113.43",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f6e2f1ec801b0d39cfc61acd43dc3314024ae1837c00fad2c899ea64be5c0363",
-      "pubkey_x25519": "f25f5732437af35f363a6b08faa9fa45b96f999c8566505158176723cc998777",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3fffffffffffffff"
-    },
-    {
       "public_ip": "104.244.76.155",
       "storage_port": 22021,
       "pubkey_ed25519": "f6ebfc815af4ac2d444781f2ccd43bf5f2b192f9434185076a2bbd425f56f738",
@@ -21089,7 +17169,7 @@
       "storage_port": 22106,
       "pubkey_ed25519": "f70b16935cce36a78a3db75ba6656666e9ba48adc5fa39d1c01e7e0943f5ae31",
       "pubkey_x25519": "186bc491a4d3847ea1c863d3940c60e44968d5a13be21c6a925a38272f820515",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2109076,
       "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
@@ -21124,7 +17204,7 @@
         11,
         2
       ],
-      "swarm": "e4ffffffffffffff"
+      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
@@ -21180,7 +17260,7 @@
         11,
         3
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "51.81.241.138",
@@ -21239,20 +17319,6 @@
       "swarm": "19ffffffffffffff"
     },
     {
-      "public_ip": "193.22.147.69",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f8f02a167d3b291fbcf8ec72b9a98dca06973009be0f0fc1caa5ea8f07b7560e",
-      "pubkey_x25519": "bc54576d3b968a0812f4555423b16b71abd4ab37e849206ba03dc885d821b11a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d7fffffffffffff"
-    },
-    {
       "public_ip": "107.189.3.58",
       "storage_port": 22021,
       "pubkey_ed25519": "f92c938fd525c1950dc89e6949327b96fcbcfc5eca265d38a9881d850d4fb98f",
@@ -21264,7 +17330,7 @@
         11,
         2
       ],
-      "swarm": "fdffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -21281,20 +17347,6 @@
       "swarm": "c9ffffffffffffff"
     },
     {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22114,
-      "pubkey_ed25519": "f9c5b2fb1e5684bef1e46ff03df49a67fde22ad2e1dd8fde4f510c000c34559f",
-      "pubkey_x25519": "308b9b6747021a066427476ea38866696849f13658dfaf8ce936665cb2404c2d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "73ffffffffffffff"
-    },
-    {
       "public_ip": "45.153.187.108",
       "storage_port": 22021,
       "pubkey_ed25519": "f9eebe1f987f5c084cae3627ef9ad7145f59cc06621b0448e1c63b7cb84356e9",
@@ -21307,20 +17359,6 @@
         2
       ],
       "swarm": "c8ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22111,
-      "pubkey_ed25519": "fa3e6151f161e88f711e695df4f5929572767459961a6c5f83fa0d0cc6110435",
-      "pubkey_x25519": "e1740fa7781dfa75894d7267b909b95aa753493ac1497f8bc3728235f2b06e26",
-      "requested_unlock_height": 2093820,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "107.182.173.179",
@@ -21348,7 +17386,7 @@
         11,
         3
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -21404,35 +17442,7 @@
         11,
         3
       ],
-      "swarm": "8fffffffffffffff"
-    },
-    {
-      "public_ip": "64.44.157.64",
-      "storage_port": 22021,
-      "pubkey_ed25519": "fc1890b2602949d9d2587688a05aa435ff8f65ebb118f903be95fb326c67659d",
-      "pubkey_x25519": "17b5dc154af3584019128ad27f9db00161efa411f01cd827f82a31567fd6c145",
-      "requested_unlock_height": 2085236,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d8ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22107,
-      "pubkey_ed25519": "fc3043fed6350b2c2da2e70243eb6a08a0cd1a61ec97b31707b7216e9da65bc8",
-      "pubkey_x25519": "f15f1535739b035618b3d53c563ab1d312a51c818906dc51286a2052743a3411",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "ecffffffffffffff"
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "142.91.105.130",
@@ -21463,34 +17473,6 @@
       "swarm": "1bffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22115,
-      "pubkey_ed25519": "fc9f51ffa5c70885049c278805339c44dc164bfda5301e5de33c9cb7215d94ff",
-      "pubkey_x25519": "139d3c3424086919ae809f567acd5fd8aa9fb9c14150054e94d4269605a96119",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b9ffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.65.93",
-      "storage_port": 22021,
-      "pubkey_ed25519": "fcbcd7644525b776d34ea295ca48927431ac3e07edb4c3e969af4f1bf1a0dc18",
-      "pubkey_x25519": "703727ccf46b1025793bbd9a93415dc406c0778270572c1bdb51a39113f8ef5e",
-      "requested_unlock_height": 2085136,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "337fffffffffffff"
-    },
-    {
       "public_ip": "45.33.32.101",
       "storage_port": 22021,
       "pubkey_ed25519": "fd3754c38a7b291de9d1210bc74480149548deec8109e4860cc60a98b53c60a5",
@@ -21503,34 +17485,6 @@
         0
       ],
       "swarm": "387fffffffffffff"
-    },
-    {
-      "public_ip": "102.208.228.249",
-      "storage_port": 22100,
-      "pubkey_ed25519": "fe5abebdb75955b38348b62b444e6782f6e47a8352c17eb02c736e6029703479",
-      "pubkey_x25519": "6fe061c926d995b251b86a4f9df7e7f5c677b49915f57c1c5f81d0d907ff810d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d9ffffffffffffff"
-    },
-    {
-      "public_ip": "104.233.210.13",
-      "storage_port": 22021,
-      "pubkey_ed25519": "fe67e78ae24cb6cccbaa1e5b1282ca95d2a7447bf61a3e97cb4ad974d60c6631",
-      "pubkey_x25519": "c2fbade0f4d54c6a216a2b0a9bbb167471e61a150dbfebe281ed451260010a0c",
-      "requested_unlock_height": 2088902,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "104.243.32.47",
@@ -21614,7 +17568,7 @@
         11,
         3
       ],
-      "swarm": "63ffffffffffffff"
+      "swarm": "f2ffffffffffffff"
     },
     {
       "public_ip": "146.71.85.145",
@@ -21629,34 +17583,6 @@
         3
       ],
       "swarm": "257fffffffffffff"
-    },
-    {
-      "public_ip": "185.187.170.128",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ffa2f50dc5f741f9a53cf4677faee365a02110152f01dec20a3747c188a69bc6",
-      "pubkey_x25519": "8900619c8fad516966341d949b93ef687e4b7205c82f7302572b17f4216efd77",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        1
-      ],
-      "swarm": "437fffffffffffff"
-    },
-    {
-      "public_ip": "31.22.111.20",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ffafecd0441a56f7e0f2b6c0771bb10c8c0aa2fbe4b03c9850b19bed2b0b262f",
-      "pubkey_x25519": "c14d53836199af7f96257f005881e4ee4f9b4f0e3af78a976007317ada88be5b",
-      "requested_unlock_height": 2085155,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "68ffffffffffffff"
     },
     {
       "public_ip": "159.223.228.183",
@@ -21698,7 +17624,7 @@
         11,
         1
       ],
-      "swarm": "76ffffffffffffff"
+      "swarm": "5fffffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
@@ -21712,7 +17638,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "157.180.47.65",
@@ -21743,5 +17669,5 @@
       "swarm": "a7fffffffffffff"
     }
   ],
-  "height": 2084231
+  "height": 2098640
 }

--- a/Session/Meta/service-nodes-cache.json
+++ b/Session/Meta/service-nodes-cache.json
@@ -10,9 +10,9 @@
       "storage_server_version": [
         2,
         11,
-        1
+        3
       ],
-      "swarm": "b1ffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "209.141.32.170",
@@ -26,21 +26,7 @@
         11,
         3
       ],
-      "swarm": "aeffffffffffffff"
-    },
-    {
-      "public_ip": "94.237.91.42",
-      "storage_port": 22021,
-      "pubkey_ed25519": "00b4c93c08e44a14485ee2ec9e72e1e0acff1707c07f08884875b68730d69f69",
-      "pubkey_x25519": "8ed66b9fdcca690542bdff7a3038ef6a78a6ef48cd16d778bf946a4f03614a25",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "71ffffffffffffff"
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "145.239.82.149",
@@ -54,21 +40,21 @@
         11,
         2
       ],
-      "swarm": "53ffffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22136,
-      "pubkey_ed25519": "00d2971121a55b9c023b2e8b03ea5c1af4d256ecf7528f311524fc5d0eea621d",
-      "pubkey_x25519": "0dc73bb26715f373d232c54462606895fa75c30ef7af4ed90bb88632b1315719",
+      "public_ip": "192.255.201.59",
+      "storage_port": 22021,
+      "pubkey_ed25519": "0106b88a0d1b3edd2b8fc59fe46da59922b42f332123d310ed3bcc5e371c7e69",
+      "pubkey_x25519": "236244216e4e40183e37ca514c33eaca65200837fb07645e567ef0d0b863251e",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20236,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "41ffffffffffffff"
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "199.195.254.208",
@@ -82,7 +68,7 @@
         11,
         3
       ],
-      "swarm": "397fffffffffffff"
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -96,7 +82,7 @@
         11,
         3
       ],
-      "swarm": "427fffffffffffff"
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "102.208.228.250",
@@ -110,21 +96,7 @@
         11,
         2
       ],
-      "swarm": "e0ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.151",
-      "storage_port": 22021,
-      "pubkey_ed25519": "01b2d3a58ed4a10eaed8b7450de21bb0b63abd37b9862caaa188a36093099b66",
-      "pubkey_x25519": "bbd68b82f24404d4c22cb5eb2939f1cdb2d638dd683d13d1036975e5e6ba980f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f8ffffffffffffff"
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "184.107.141.171",
@@ -136,7 +108,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "1ffffffffffffff"
     },
@@ -152,21 +124,7 @@
         11,
         2
       ],
-      "swarm": "6fffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22115,
-      "pubkey_ed25519": "02713c311c82faae85a92480bd1db6dc1b230cb05be47388dae1cb2cd60b5626",
-      "pubkey_x25519": "37360c1e11478f6ad961d5e1e5fbc84c0d81cec34ff2ed3d76f679ed3c83e35f",
-      "requested_unlock_height": 2086601,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "66.175.222.15",
@@ -194,7 +152,7 @@
         11,
         2
       ],
-      "swarm": "afffffffffffffff"
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -208,7 +166,7 @@
         11,
         3
       ],
-      "swarm": "b1ffffffffffffff"
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "165.22.195.5",
@@ -222,7 +180,7 @@
         11,
         0
       ],
-      "swarm": "f3ffffffffffffff"
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -236,7 +194,7 @@
         11,
         0
       ],
-      "swarm": "d2ffffffffffffff"
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "205.185.117.229",
@@ -253,6 +211,20 @@
       "swarm": "8bffffffffffffff"
     },
     {
+      "public_ip": "173.249.45.119",
+      "storage_port": 22021,
+      "pubkey_ed25519": "032a2ce3d4125024749339004ac9c721175e1d3833a571dbbabee1622b668808",
+      "pubkey_x25519": "90263146ea1d4ac1930ad754c8ccb0ff3869e80a02bda38a7a2f3666746e8939",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "297fffffffffffff"
+    },
+    {
       "public_ip": "79.143.190.38",
       "storage_port": 22021,
       "pubkey_ed25519": "032f54b2558819cb61597b99f5bb3dd3c38596c45ef134520939735db1bfd1a2",
@@ -262,9 +234,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "affffffffffffff"
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "5.189.184.134",
@@ -278,21 +250,7 @@
         11,
         3
       ],
-      "swarm": "44ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22102,
-      "pubkey_ed25519": "038e065e65d87493e5fe737875425250a638bb4b50ccc04506fe3d6de35f6843",
-      "pubkey_x25519": "76d109dfa5178e5e1b5945d1160cf715a33741120a3c439956582ef0febd426c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ddffffffffffffff"
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.32",
@@ -313,14 +271,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "03db3754a432b305d980b6644bdefa9af72675ecbd90b257d92e925402ec3c00",
       "pubkey_x25519": "df4a6a515c35d261f696a7e0184bb037722090128b5b47cdfe1f1367e9afac25",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2164432,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "99ffffffffffffff"
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
@@ -334,7 +292,7 @@
         11,
         3
       ],
-      "swarm": "197fffffffffffff"
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
@@ -348,7 +306,7 @@
         11,
         3
       ],
-      "swarm": "89ffffffffffffff"
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "49.12.14.203",
@@ -379,34 +337,6 @@
       "swarm": "edffffffffffffff"
     },
     {
-      "public_ip": "107.174.102.142",
-      "storage_port": 22021,
-      "pubkey_ed25519": "04732ca016ab612f00c98bf5716b59ddfe4c683ab7eb7158090b573274f1660a",
-      "pubkey_x25519": "ce597e20cba3193dc897d0fbc2e200faa90a53a614ba93eb962e9d101e85161d",
-      "requested_unlock_height": 2090292,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "aeffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.39",
-      "storage_port": 22021,
-      "pubkey_ed25519": "04cd78d5cf6b615aa33505797d163ed55a739d6b6989e5737cdf5c7c13d52bde",
-      "pubkey_x25519": "c359717548ef06f57609f11d8033feab4ba9e45b70fb0465adaa83f6eee4c75b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3d7fffffffffffff"
-    },
-    {
       "public_ip": "150.230.150.46",
       "storage_port": 22101,
       "pubkey_ed25519": "04ea9eb5eeb7114329118dfbd5f7cb3b1f8681272edc327bc137e86017e59024",
@@ -432,21 +362,7 @@
         11,
         0
       ],
-      "swarm": "fffffffffffffff"
-    },
-    {
-      "public_ip": "31.22.111.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "05272906543a9cb53a6fab6585dafe5f6f29dda44b847bd90000138b5f4df378",
-      "pubkey_x25519": "97405551f5af15a0b01afed91ffe8cb4718a5c088eeaf64e998edc45c07aa532",
-      "requested_unlock_height": 2090314,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "89ffffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -460,7 +376,7 @@
         11,
         0
       ],
-      "swarm": "c6ffffffffffffff"
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "23.239.0.240",
@@ -488,35 +404,21 @@
         11,
         0
       ],
-      "swarm": "89ffffffffffffff"
-    },
-    {
-      "public_ip": "157.180.78.109",
-      "storage_port": 22021,
-      "pubkey_ed25519": "05710220ea9c4bf526b46289df01d69f8dcba9aaace7c99fea799affc6971830",
-      "pubkey_x25519": "96a0316f9438b95e4eb0c0ab9d582b54378c8e6e27ceb8bc645d3e497bdf4745",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "387fffffffffffff"
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22105,
       "pubkey_ed25519": "0573143e0290cee1891edaacfb461861662fb9358504d950c971b61e3f0bee62",
       "pubkey_x25519": "d654a347cfaf332af91530de7607afe747c6ab33dee7b1d985e711e1b049d65a",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2169393,
       "storage_lmq_port": 22405,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "9effffffffffffff"
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "145.239.89.180",
@@ -530,21 +432,7 @@
         11,
         2
       ],
-      "swarm": "247fffffffffffff"
-    },
-    {
-      "public_ip": "116.203.91.99",
-      "storage_port": 22021,
-      "pubkey_ed25519": "059078ddf563e94964a7165f3571d3cf4244c0abe433ab538fc34cfe0f166951",
-      "pubkey_x25519": "bf1f00960bb0e0fc460bf12f30e246a039726260c8532903aab580575c090e3c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "69ffffffffffffff"
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "152.89.29.131",
@@ -561,6 +449,20 @@
       "swarm": "f1ffffffffffffff"
     },
     {
+      "public_ip": "95.217.21.148",
+      "storage_port": 22100,
+      "pubkey_ed25519": "05e684c9c9148cc06b09a1abef50945aa260ed6324b391a039de139fdb25f78b",
+      "pubkey_x25519": "fe46faaba80a8a55b0682189fcb5107888b9ec142a69876cce8eb6199d16c629",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "26ffffffffffffff"
+    },
+    {
       "public_ip": "164.90.199.112",
       "storage_port": 22021,
       "pubkey_ed25519": "0607deb29b2f20248ca87a6f5058b9d3dca0e799703288472b4df639631b6ef4",
@@ -572,21 +474,7 @@
         11,
         0
       ],
-      "swarm": "5dffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.53",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0625c01f284086f659e9a2ba4b94d2b6eec4ddcd971fedffa858d2c2d833fa1e",
-      "pubkey_x25519": "00ff7385815ff0753bdae126a5028d90f6bc2cc94b942a7635fb25c2dd3a986e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f8ffffffffffffff"
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "173.255.248.132",
@@ -600,21 +488,7 @@
         11,
         0
       ],
-      "swarm": "6cffffffffffffff"
-    },
-    {
-      "public_ip": "149.102.144.201",
-      "storage_port": 22021,
-      "pubkey_ed25519": "06623be5bcfa9c4100f40a3c6355fe77d2c9336fb1360950d2ca93a4c55bf79b",
-      "pubkey_x25519": "aff8f62367b245005927607c71ffff901c1da749e9038b6f8976d53cad54a83b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "8bffffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "104.244.78.225",
@@ -628,7 +502,7 @@
         11,
         2
       ],
-      "swarm": "affffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "128.140.43.94",
@@ -642,21 +516,7 @@
         11,
         2
       ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22112,
-      "pubkey_ed25519": "075ae7ca288dd0cfef558933f467d9b254d3e469920ccff1b97354a3d9c2393c",
-      "pubkey_x25519": "4ed7e27d680ad469b063004c60c4297ecd39bcdae8b566d9426fe538efdd0a70",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e6ffffffffffffff"
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "75.119.157.196",
@@ -668,23 +528,9 @@
       "storage_server_version": [
         2,
         11,
-        1
-      ],
-      "swarm": "b5ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22115,
-      "pubkey_ed25519": "07675c83ec30537c296f622cf38b8df50f2a4bbb11daa8a65ce562930a680e97",
-      "pubkey_x25519": "a927c2abcfe231926b5bd0fd5294b716bc577a3bdf1be5fd3a93743c95d9ae6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "437fffffffffffff"
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "194.26.213.177",
@@ -698,35 +544,7 @@
         11,
         2
       ],
-      "swarm": "38ffffffffffffff"
-    },
-    {
-      "public_ip": "207.180.201.59",
-      "storage_port": 22021,
-      "pubkey_ed25519": "07ad3ce46d0a87255011798c636406681a092d72885adc6b10517d5050253b77",
-      "pubkey_x25519": "88faeab5dc8358e29b4199d1c01d2545735a629fa11c54c5bb581b7673cf7c13",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3dffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.8",
-      "storage_port": 22021,
-      "pubkey_ed25519": "07c6170434e3a96512288d8a2fb3246afe2e58292b413421930de463352dd3c0",
-      "pubkey_x25519": "692d7b2c95c6354c5e6021e5e214829355b2ae0960f25514908fe8dd8f1c1344",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f8ffffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "188.166.57.188",
@@ -741,20 +559,6 @@
         0
       ],
       "swarm": "dcffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22101,
-      "pubkey_ed25519": "07cc2d5c96f177c20d62d80d11fab8b1c4e738d5c8d30b05b63099e7ed47c19c",
-      "pubkey_x25519": "12c7ed1f305c95b68f009d1a7d067cd40a24ad317aba3be4f0c72be15a19a162",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "54.38.65.27",
@@ -782,7 +586,7 @@
         11,
         3
       ],
-      "swarm": "41ffffffffffffff"
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -796,21 +600,7 @@
         11,
         0
       ],
-      "swarm": "90ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.9",
-      "storage_port": 22021,
-      "pubkey_ed25519": "084a2d45603ac18b1f1f10c547d85c6a140271366500f34be361577d54bc6411",
-      "pubkey_x25519": "823f5eb1d57769c452cf7f3135185df70065bd69e85c987892d66a0f5557990b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "87ffffffffffffff"
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "95.216.89.43",
@@ -824,49 +614,7 @@
         11,
         3
       ],
-      "swarm": "1cffffffffffffff"
-    },
-    {
-      "public_ip": "62.72.45.244",
-      "storage_port": 22021,
-      "pubkey_ed25519": "087b62c32ef17c79f627fc25536d76201eb8ac174ec2aa191a452e09658404ee",
-      "pubkey_x25519": "0c6f007eb8300397eef8b885573c02cb87e6fa1e38d78b6594c6bc75b816a175",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e0ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22108,
-      "pubkey_ed25519": "08c5f20aa9be8a0470926225a73c565d8d140b306826f2cd36483f0abab49752",
-      "pubkey_x25519": "7a076e4ff4e31f4be973f9e5de363346bcc2d6c51034ebc0b703ce09c1e25e6d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "45ffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22101,
-      "pubkey_ed25519": "08ff8a8bf860aee0aeba6c5ebf5f7ca0e0480228f5ff50b70f2e04916c176739",
-      "pubkey_x25519": "be0ecef4b2996cc4027de95945cc2b299da465c0473b7e40673f80343444b72e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "18ffffffffffffff"
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "198.98.52.68",
@@ -897,46 +645,18 @@
       "swarm": "2ffffffffffffff"
     },
     {
-      "public_ip": "95.217.21.148",
-      "storage_port": 22107,
-      "pubkey_ed25519": "0935646d07ac65020a45e1ca1b09cea44dbb8ca5064d16f7311c5616a58191ce",
-      "pubkey_x25519": "76f505ca264c3ae31b8e1e1356e2a9f486b688c2143a72cec3a640d8ccbd3609",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22407,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b8ffffffffffffff"
-    },
-    {
       "public_ip": "135.181.109.199",
       "storage_port": 22102,
       "pubkey_ed25519": "094a13930303fd8403cca54a7df979ce5cada6e3302e0f5a2c2edd6e274ffff4",
       "pubkey_x25519": "dda327c89668a64fd2be25a80e799a4eded52cf67f9a216045f5eafdf3f50514",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161188,
       "storage_lmq_port": 22402,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "f9ffffffffffffff"
-    },
-    {
-      "public_ip": "62.72.42.149",
-      "storage_port": 22021,
-      "pubkey_ed25519": "096ea812834d10406d788cfa78a6a86f1770535327aa646b200be358e4b49c06",
-      "pubkey_x25519": "a9e841c77e795f0827e0598d676d793a0d58c54ee02ef7012d77d53ec3d9d667",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "187fffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "15.204.247.48",
@@ -950,91 +670,7 @@
         11,
         2
       ],
-      "swarm": "457fffffffffffff"
-    },
-    {
-      "public_ip": "154.38.180.45",
-      "storage_port": 22021,
-      "pubkey_ed25519": "09e62f283d614ff88506b6c5c830ea3ae9e6a65ff60d1606b1f6714476133d23",
-      "pubkey_x25519": "839cf6f87d9021355b1c13f985ffab276118817bcdd5e679aebe0f5a628bed24",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "76ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22105,
-      "pubkey_ed25519": "0a4ce4f851f79b0539d124ce65c71f1433089e43e62fcffff9f9ea500328aecc",
-      "pubkey_x25519": "20c53232ea383142f56156f5275991298bca1460b011ec8162208ae6aa2ffa32",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b3ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22114,
-      "pubkey_ed25519": "0a6c543d698f4b2a74dcbdbdb5582bf486ad5201f2c94992a771a2f86355495c",
-      "pubkey_x25519": "a8050c63f8354d9c2c10a348eb79bee8523cff72b4959095044694672fd9d913",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "187fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.130",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0ad04d2e4d73382336cedda832e86cffa1235342a534d775e6191e292b4c31d6",
-      "pubkey_x25519": "ce707b65f6440c1af8666844b910596a2f35003ae4718afc1ee57e761457e703",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "71ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.76.172",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0ad6d50b6cc25ec48e1322b2806978c517c4b012dc6fb8cfeea2801f7efec0ed",
-      "pubkey_x25519": "33b29cd764290467a946d3b1829b8ebd6ae56efc68ab956a18f2f9de5eebea6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "42ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22111,
-      "pubkey_ed25519": "0b5e1b69725af866240d1ba59a39220a8bb176f04715d73ace35b6894b50ca30",
-      "pubkey_x25519": "743902fb0212e41d78fe66ab29e22864e3505f4cbe5940ff3c8bb586e170fb69",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "6effffffffffffff"
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "89.58.30.52",
@@ -1076,7 +712,7 @@
         11,
         2
       ],
-      "swarm": "97ffffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "45.79.66.109",
@@ -1090,7 +726,7 @@
         11,
         0
       ],
-      "swarm": "59ffffffffffffff"
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "49.12.96.107",
@@ -1104,7 +740,7 @@
         11,
         2
       ],
-      "swarm": "a9ffffffffffffff"
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "107.189.13.56",
@@ -1125,56 +761,42 @@
       "storage_port": 22021,
       "pubkey_ed25519": "0cf0d9581388fca85566ccd6f40de93f14521f01bb41b841337b662ee633a3f3",
       "pubkey_x25519": "fc0052ebb9a44f03f3c21e249b7aebd3412b0530dfd40d37e2c8a6150b3c7a58",
-      "requested_unlock_height": 2090336,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22101,
       "pubkey_ed25519": "0d04257018b89e991b5a27848bd2a6e9574981e5c244c317f8661733f300f099",
       "pubkey_x25519": "9b74721df1dcae71d15f2561a76b5714f8d5984b955d68962acba36672543c18",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161186,
       "storage_lmq_port": 22401,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "20ffffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
-      "public_ip": "154.53.62.195",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0d08373838d99fd08603bd38f813203772a415b61ece78efdf0abd2cc85ed831",
-      "pubkey_x25519": "933d3f4c2593bb225a17c87212e6ac0fce77ef37e9b9f85d4c79c65f5fef3077",
+      "public_ip": "128.140.94.83",
+      "storage_port": 22102,
+      "pubkey_ed25519": "0d8efa7ef36844351621af0bf3e3ab1d717b982ec88ed6080c55875ea288712b",
+      "pubkey_x25519": "6913d5c10b2f4cd8d63fa961f598b440ee34cabb6b357d9a7b59f03678232c7a",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "67ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.97.254",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0d56fb3e3a0239a54c48b40f42e64a2d7b7d6043cbc7a7ecc768fc15a3fcbfd3",
-      "pubkey_x25519": "eb191d7eeb84300dc5c7f2cf621490f8bcd66614ca62205b068e92e974c7d20d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 22402,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "b8ffffffffffffff"
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "139.99.133.148",
@@ -1188,21 +810,7 @@
         11,
         2
       ],
-      "swarm": "6cffffffffffffff"
-    },
-    {
-      "public_ip": "5.22.219.119",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0da720a2bb5d9a896c665c19a0bf2f3dbd8dc9ea70173b985d1f0aa21a1f36eb",
-      "pubkey_x25519": "14f75e01812fd2c888c04cea4284be6ec430da2202c6edf3187a8a9e3b60a94c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "147fffffffffffff"
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "51.81.34.178",
@@ -1230,49 +838,7 @@
         11,
         3
       ],
-      "swarm": "39ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22117,
-      "pubkey_ed25519": "0e3b2c5bc03e0a42c16f2930f7a4b1e5a2885d5ba7025648d7e0aec08a0b7930",
-      "pubkey_x25519": "e2c22fe6cc5556432a49c55dac93e15dbc0cf7cc1a88ae9b7be06b5d1963592d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20217,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "7fffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.109",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0e48a182ee2670f3f078911288286e6d9141e02c6d845668181d28c0456c0111",
-      "pubkey_x25519": "0e0171ce4b0a5ebe5063a6221510c2493085ce7d105e6c60e592bf6c5490c321",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "96ffffffffffffff"
-    },
-    {
-      "public_ip": "100.42.178.63",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0e89abd7ee561131be4e52539da9134d4b3d3faa5798e2b1975db002bfc0b2c7",
-      "pubkey_x25519": "dfff5e78a86586074316bd05a873650aa87b639c1a80358b3dcd21ad4f59427d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b2ffffffffffffff"
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -1286,7 +852,7 @@
         11,
         1
       ],
-      "swarm": "20ffffffffffffff"
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "198.98.48.221",
@@ -1300,7 +866,7 @@
         11,
         3
       ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "104.248.196.63",
@@ -1314,7 +880,7 @@
         11,
         0
       ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "142.91.105.124",
@@ -1328,63 +894,21 @@
         11,
         3
       ],
-      "swarm": "4cffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
-      "public_ip": "46.254.214.27",
-      "storage_port": 22120,
-      "pubkey_ed25519": "0edf48cfbce29f71da6ba60b213c89dc1d44703fa69949c66e31b664e37942a2",
-      "pubkey_x25519": "b057a4fd95d172583776fa362de9ea51e2349fe78d59fd673f398257a8b0824e",
+      "public_ip": "89.167.117.100",
+      "storage_port": 22104,
+      "pubkey_ed25519": "0f20eca5da2ae335b6a0c1f167b69e7bb3cfc118e527d302205f2495dd22d88f",
+      "pubkey_x25519": "d252987a75126fb318fdfdf95132842e7b769b3273ac04c2a8b5abbfed2dfe38",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.26",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0f19d169658d7b3ab8e417332a48abe5edfc0e34352d002c04dec8a4be49c8cd",
-      "pubkey_x25519": "57348059d7706b4d81aaeb3cb19cd0c86239ee4dec327621b9fb207f2ea34f2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "1effffffffffffff"
-    },
-    {
-      "public_ip": "154.12.235.135",
-      "storage_port": 22021,
-      "pubkey_ed25519": "0f366f78ee4fe0f0a9a0b029f5730eea53dc84989604f1e327212e36495d192f",
-      "pubkey_x25519": "4f987e735190fe2eca5ed2d55ce9442687768ed478224dceb0917bf98224c162",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "257fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22112,
-      "pubkey_ed25519": "0fbd9df5e56f5e9224d4bbb0645d465caca803fd2c8907dec40b210aba82f55a",
-      "pubkey_x25519": "eb9187b75e48e9d8285517acb60774ea5c5121c72b48dd472671a671c3d04b09",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
+      "storage_lmq_port": 20204,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "faffffffffffffff"
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "91.99.186.114",
@@ -1398,7 +922,7 @@
         11,
         2
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -1412,21 +936,7 @@
         11,
         0
       ],
-      "swarm": "c8ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22135,
-      "pubkey_ed25519": "104b26541826a2fdb4ee22d5feffe7b69e9b4e6e0bcd03b7651b0538aa686cea",
-      "pubkey_x25519": "ad792ccf84ad0ca2d48c3cd4d97ab27293d9552fa9d4f141a459982638101a68",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20235,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "49ffffffffffffff"
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.224",
@@ -1440,7 +950,7 @@
         11,
         0
       ],
-      "swarm": "c8ffffffffffffff"
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "86.48.5.122",
@@ -1454,7 +964,7 @@
         11,
         2
       ],
-      "swarm": "7dffffffffffffff"
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "158.69.223.154",
@@ -1468,49 +978,7 @@
         11,
         2
       ],
-      "swarm": "d8ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22131,
-      "pubkey_ed25519": "10a4d8acf7e3ad406d91555b26016f0fa4f032ef5f40be33f72aa7662407c161",
-      "pubkey_x25519": "a82887fbb40f980b4960acf27be1b03b442078c7d3a64b11012f62a889088f74",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20231,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "23ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22103,
-      "pubkey_ed25519": "10b46912786df3d81d4d0c4bb2b2702974d4d3269ed683d22f624d0f8c751d8d",
-      "pubkey_x25519": "0f4fcf424263f9253dbc7029fcee50b2f28d1367e6ef1d353b3fb9d22aab5178",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "4ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22111,
-      "pubkey_ed25519": "10d4fa524947c94844b1c9b5f851d0713a68b4fee09a2355599f2ce36be3248c",
-      "pubkey_x25519": "d7f98675ced5c3f0103513de3e9bb1f471b3395824cd54a15c98ee7d30065743",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "bffffffffffffff"
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "89.117.59.152",
@@ -1541,21 +1009,7 @@
       "swarm": "357fffffffffffff"
     },
     {
-      "public_ip": "86.107.168.151",
-      "storage_port": 22021,
-      "pubkey_ed25519": "11444fd6b1aa725a9d975571eb26804626e6ab8640e7e3fb2a8516cb327b0414",
-      "pubkey_x25519": "422021db6824aa39f0d9f0fada5a54bd13d6f8ba692237707204d9f55cfae639",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "affffffffffffff"
-    },
-    {
-      "public_ip": "51.91.96.230",
+      "public_ip": "51.79.85.184",
       "storage_port": 22021,
       "pubkey_ed25519": "11525f4493e01f1ccc840a3afe9cfb3240d25737473e0c4b412c52d1262439e2",
       "pubkey_x25519": "d879b768ab46c9b0f4c0b02808cd6f3576f4d0fd0ffdb6ddddac413defa5ac45",
@@ -1564,9 +1018,9 @@
       "storage_server_version": [
         2,
         11,
-        0
+        2
       ],
-      "swarm": "8dffffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "138.197.206.211",
@@ -1578,9 +1032,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "97fffffffffffff"
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "91.98.16.40",
@@ -1594,7 +1048,7 @@
         11,
         2
       ],
-      "swarm": "71ffffffffffffff"
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "38.242.141.83",
@@ -1608,77 +1062,21 @@
         11,
         3
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "19ffffffffffffff"
     },
     {
-      "public_ip": "3.215.58.127",
-      "storage_port": 22021,
-      "pubkey_ed25519": "11ab4e1e14271f3760b9e6ddc445a4e37d78b4e9ab7be8618e557b8d4eb5e487",
-      "pubkey_x25519": "6aee149dbb9420e35d3ea25b5d868b97a1ead8abba10d0d08f34f6175a146a18",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "147fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.218",
-      "storage_port": 22021,
-      "pubkey_ed25519": "11ad1ed83f3904d8594bb41b7cf8de6aaa6b1ccf8eb5719d2addcbb0efc2ae5c",
-      "pubkey_x25519": "7cca5e137e0bf98ee0841e365561977c93605d359c3dee84e656ae53aef7d12f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "237fffffffffffff"
-    },
-    {
-      "public_ip": "91.231.182.75",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.135",
+      "storage_port": 22147,
       "pubkey_ed25519": "11b5e9ac538c4663b1db96b7d7059eefcd50f9ad84789cce3fb3ab391724b7c7",
       "pubkey_x25519": "c572890b9aa69647a5031460c0e768c204475b5c6d23d616422b226b88bd206e",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20247,
       "storage_server_version": [
         2,
         11,
         3
       ],
       "swarm": "3a7fffffffffffff"
-    },
-    {
-      "public_ip": "139.185.46.77",
-      "storage_port": 22102,
-      "pubkey_ed25519": "11d6e04e3bfe5591d98966962aae348bd020989f361b22223bfa2db0e1f05939",
-      "pubkey_x25519": "877d41b484bcb205950f5548174f07a36ec77f1fc487b0088c49a1aa2dfb6816",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e0ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22102,
-      "pubkey_ed25519": "11ebfbfc6e7555e5fd813206c80f67f8034871613f907c7b9d4e0eff65fdc130",
-      "pubkey_x25519": "49be509b2c01f32b6d3d77d387a519f2eb71ff950cd92ad64c4a3b8baa00d37a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "158.178.195.222",
@@ -1692,7 +1090,7 @@
         11,
         2
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -1704,9 +1102,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "81ffffffffffffff"
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "35.236.80.3",
@@ -1720,7 +1118,7 @@
         11,
         0
       ],
-      "swarm": "56ffffffffffffff"
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "136.144.244.103",
@@ -1734,21 +1132,7 @@
         11,
         3
       ],
-      "swarm": "377fffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22107,
-      "pubkey_ed25519": "13bcf57199294a788c7b4999ac4139ef1f6c8ffc3eac8444e7ea57870527f174",
-      "pubkey_x25519": "e6095fe6113f48dae53451bd9feca54c91741923092bf283f866f33b66406333",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2affffffffffffff"
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "5.223.66.134",
@@ -1762,21 +1146,21 @@
         11,
         3
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.167",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1439c118e7726865a3efc2141b443d5e05a2b2e03f37a74403c1144752001acd",
-      "pubkey_x25519": "13487305ef955acd111483f22ebe16c2eb50cfa65a102e3fa8203cfdbd39a920",
+      "public_ip": "95.217.218.66",
+      "storage_port": 22103,
+      "pubkey_ed25519": "14ee48fb4bc6fbd58f34e1064d496dfb0b0b1fa7fe2e1af082b943796b1c1456",
+      "pubkey_x25519": "3c3420967184be279f24bd9d8ca8488685dd60624d626f875b5018fc31a5401f",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 22403,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "91.99.10.205",
@@ -1790,35 +1174,7 @@
         11,
         2
       ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.12",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1554eb566edb0c1d4423d35ee20a5ab173f43a2d2d8a5334b61ea9f5723cdea2",
-      "pubkey_x25519": "d956e6aea43065a3384dfff86efc82e75bfa6ac8625842babe574e8b1b50e179",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d0ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22114,
-      "pubkey_ed25519": "15950224de750eadf0b013f9cdd86f97e62306ac51670ff26406dedd3ed685ea",
-      "pubkey_x25519": "a5111e2b116b250270d00201406b276a28aecfdbff9044971e3581911245e72e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "207fffffffffffff"
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
@@ -1832,7 +1188,7 @@
         11,
         0
       ],
-      "swarm": "247fffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "51.79.173.182",
@@ -1849,6 +1205,20 @@
       "swarm": "36ffffffffffffff"
     },
     {
+      "public_ip": "95.217.218.66",
+      "storage_port": 22101,
+      "pubkey_ed25519": "15d5aff81157128e0a5d9c3dc278c0b8c23f5ad734b3627a15d708e9bd50eb21",
+      "pubkey_x25519": "d4620c192bb23eea61d64451b59ecf10a8f17fd32240dca030a76d2a6acdf56f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "237fffffffffffff"
+    },
+    {
       "public_ip": "198.98.54.28",
       "storage_port": 22021,
       "pubkey_ed25519": "15d848d64c5eeac37618849c8b6885115fefa79f79e3d42653da8e056717a143",
@@ -1860,7 +1230,7 @@
         11,
         3
       ],
-      "swarm": "467fffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "205.185.124.31",
@@ -1874,21 +1244,7 @@
         11,
         3
       ],
-      "swarm": "d1ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.46",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1636d40eea2639088b11affaed8ddcf8650377019d4385559cd6f205e645ea33",
-      "pubkey_x25519": "8d3c61bcc0d7f23c21ccf35efe9551612e30b0d54bca3aa26207b55c84b82a08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b5ffffffffffffff"
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "38.60.156.237",
@@ -1902,21 +1258,21 @@
         11,
         3
       ],
-      "swarm": "147fffffffffffff"
+      "swarm": "dfffffffffffffff"
     },
     {
-      "public_ip": "185.45.113.185",
+      "public_ip": "207.180.206.137",
       "storage_port": 22021,
-      "pubkey_ed25519": "165b15e05cbe2cf946c45222f8ab65006043b3586faf6d0f648651a2b3ff059c",
-      "pubkey_x25519": "e78c268b5ec7a37792acc8884ba92cbfb558e9062306290733b7de3e7a1d703a",
-      "requested_unlock_height": 2085210,
+      "pubkey_ed25519": "173871961c9684ba3fbb50915612d5bc8642cafc07862c0b349041b8068473a1",
+      "pubkey_x25519": "d2b5bcfa3b396b4727af1a9878ae4d39c06d35c0d1a880f72a9ab9b78d4d8678",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "198.98.59.173",
@@ -1930,7 +1286,7 @@
         11,
         3
       ],
-      "swarm": "59ffffffffffffff"
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "51.222.107.179",
@@ -1944,35 +1300,7 @@
         11,
         2
       ],
-      "swarm": "afffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.10",
-      "storage_port": 22021,
-      "pubkey_ed25519": "178a0447573738dea4e83a1897292b2d711072aad6d44bc39565ce791efcefa3",
-      "pubkey_x25519": "c90c18bc6f778fdf8128cc781afdcaf5585cc86dd0816f942485fe91b4c86163",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "179042eb07305f608bbd3a371067593aecd77d1fb3da9fd551ecfc58f6066421",
-      "pubkey_x25519": "1c220712693c434832d03f5f8c516a2215db7abd33818d60b3416cd2fba1c735",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "397fffffffffffff"
+      "swarm": "21ffffffffffffff"
     },
     {
       "public_ip": "173.249.30.151",
@@ -1986,21 +1314,7 @@
         11,
         2
       ],
-      "swarm": "bffffffffffffff"
-    },
-    {
-      "public_ip": "45.88.188.183",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1812103cfa87f63f5cee3d1f731ed12e8c2d2810c0bfd927990e4c474bc80909",
-      "pubkey_x25519": "f8b934ef918bd080de946d5335a8f23507da86caaf597a9f08dc5c2809b0fe6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "357fffffffffffff"
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "51.195.117.60",
@@ -2017,20 +1331,6 @@
       "swarm": "47fffffffffffff"
     },
     {
-      "public_ip": "85.9.208.51",
-      "storage_port": 22021,
-      "pubkey_ed25519": "187f643e572dbd5babdb713825f13048950d11be71d38e79ab2c80031f57ba65",
-      "pubkey_x25519": "3de19cd48c19eb9cfef61dff5840694e85f16068fe6567b9f3c184b8fd236a1b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "397fffffffffffff"
-    },
-    {
       "public_ip": "141.145.218.202",
       "storage_port": 22021,
       "pubkey_ed25519": "1880c36b3e5689d4e067d98ea8678597b0912bf9023d1761165490b778a51bf2",
@@ -2042,7 +1342,7 @@
         11,
         2
       ],
-      "swarm": "3d7fffffffffffff"
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "45.79.65.63",
@@ -2056,49 +1356,7 @@
         11,
         0
       ],
-      "swarm": "f0ffffffffffffff"
-    },
-    {
-      "public_ip": "159.195.84.13",
-      "storage_port": 22021,
-      "pubkey_ed25519": "18e50a127bc94a3b3bd89c61258cb5469473d6e9b327e95ce09781198e720f91",
-      "pubkey_x25519": "147cb685c85e4d9eaca49fa789a0a25836c52ab4ce4eecefd8360f55fe9a3861",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "257fffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22101,
-      "pubkey_ed25519": "191c854219fba4405c244c7c750fff910f6ce669b0e72c444b8912a29cac1806",
-      "pubkey_x25519": "67c85b06822a12526bf484b77b0ddfc54415bf74e314f7d0549fb9f97516496a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "beffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22110,
-      "pubkey_ed25519": "1937502909c139ab200ae9603c365ccea9c6d7342f213e07bcc9890fe19055e3",
-      "pubkey_x25519": "5d427d2cb787d65663c908a8414696b3ed48163db18e159358d24199d33e7978",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9bffffffffffffff"
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -2112,49 +1370,35 @@
         11,
         0
       ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "8effffffffffffff"
     },
     {
-      "public_ip": "64.44.168.82",
-      "storage_port": 22021,
+      "public_ip": "62.171.172.43",
+      "storage_port": 22101,
       "pubkey_ed25519": "19bae8ba0ba256f2e4b5863cfe75424ab5450191c5b905e59649acbdd63fc596",
       "pubkey_x25519": "c11ec5fa69afc2053810e9fb590fb1320bd494a8ea774aedc9e28e1c5c004126",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "357fffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22116,
-      "pubkey_ed25519": "19c03fffa95753fda1b41bfb226ac47f4ad3788fa5472157e798015edc042042",
-      "pubkey_x25519": "23a9bb5a1233dd1e0529f9ba3a697e8f402c1d5f1c2cb880c07e0ac3c0b88061",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20216,
+      "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "1bffffffffffffff"
+      "swarm": "d4ffffffffffffff"
     },
     {
-      "public_ip": "185.45.114.9",
+      "public_ip": "167.17.40.236",
       "storage_port": 22021,
       "pubkey_ed25519": "19e50188acb58de0ba43e1ff2f2eb8381f964718e327d8b591eb8fde413ea296",
       "pubkey_x25519": "85b430a9f8f0c174e8b0579fe860b96b08db580c96e9be9112b6c0510695ca0d",
-      "requested_unlock_height": 2086519,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "487fffffffffffff"
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "104.244.79.204",
@@ -2168,7 +1412,7 @@
         11,
         2
       ],
-      "swarm": "77fffffffffffff"
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -2210,21 +1454,7 @@
         11,
         2
       ],
-      "swarm": "dcffffffffffffff"
-    },
-    {
-      "public_ip": "5.78.41.67",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1ad52a6c993ad15a58e5fd8297e794f91fc7a63d3ee4144b4480ee906d6638aa",
-      "pubkey_x25519": "9f590093f4029c0ff9d58e17b3d08a92cc631f20304cf2d0b120a67d0c0eb930",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        1
-      ],
-      "swarm": "d5ffffffffffffff"
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "184.107.141.170",
@@ -2236,7 +1466,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "e3ffffffffffffff"
     },
@@ -2252,21 +1482,7 @@
         11,
         2
       ],
-      "swarm": "77ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22120,
-      "pubkey_ed25519": "1ba159a878cfcc649f7118783ab45b819da125037490934f744dc7d2da8e8fe3",
-      "pubkey_x25519": "b4b1b0b93e38d33097cafe0b1896fdea350b0325c4d491e423f43d81f08bcc26",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -2280,21 +1496,7 @@
         11,
         0
       ],
-      "swarm": "66ffffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.37",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1bc939df19403acbb796ccbf18c0f96a97b931074e2d3fc81494a318c04df794",
-      "pubkey_x25519": "3a67ac7f8073a93f79dc9a0505d4d8b0bbf4241e9c70b392aabc8a03ad017850",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "44ffffffffffffff"
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "205.185.123.63",
@@ -2322,35 +1524,21 @@
         11,
         2
       ],
-      "swarm": "4cffffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22102,
       "pubkey_ed25519": "1c0d8f50a45f05dc7af22a66e45e16d403d571d26a669f5dc04f34255fde2c1c",
       "pubkey_x25519": "92a1992cf7b92a8d741c8b27cac2e28925a391ecea58d4c8f1b6cb7ba389614c",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2169393,
       "storage_lmq_port": 22402,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22107,
-      "pubkey_ed25519": "1c94dff689af043df1baeea6cb007b6d89689a8e1897e2023ccabdc33e20c7e1",
-      "pubkey_x25519": "50e5f22ceaeacf4ad2e4dd3dd295072a3cb6e3ef48a7f64dfe952b40dbbe2c22",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a7ffffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "93.115.20.135",
@@ -2364,7 +1552,7 @@
         11,
         2
       ],
-      "swarm": "efffffffffffffff"
+      "swarm": "e7fffffffffffff"
     },
     {
       "public_ip": "130.162.189.88",
@@ -2378,7 +1566,7 @@
         11,
         3
       ],
-      "swarm": "ddffffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -2392,21 +1580,21 @@
         11,
         0
       ],
-      "swarm": "e5ffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "23.137.248.143",
       "storage_port": 22021,
       "pubkey_ed25519": "1d1fffa3ff915362c5f82e294397ca365b19f413d46223a667305fda78d66332",
       "pubkey_x25519": "69f71c493c1fb30fab81f5f568ef29fbc6da13d6de21c5b32de521d470beb237",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2164432,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "c7ffffffffffffff"
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.228",
@@ -2420,77 +1608,7 @@
         11,
         0
       ],
-      "swarm": "edffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22104,
-      "pubkey_ed25519": "1d782d8ded9c13207bbca671a3e7beba86e7a45aea16f1643584bad34ace81c0",
-      "pubkey_x25519": "1801914a37a0a2bb802e0561dc077b19c96346867ce6bdb8dccd3af1a6392a0a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "79ffffffffffffff"
-    },
-    {
-      "public_ip": "159.69.27.54",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1d7b5f82e0c06673945ae609dfb88fc4ec39343b121ac7b1d43f69d3075b36e3",
-      "pubkey_x25519": "0b2f1934ae5c34a403e255f29a9f7734996bc94fdef14d8fbb6621b4e42a1d1b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "71ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22102,
-      "pubkey_ed25519": "1d8ae98bdb603edc55f1b39af84e8a2f0fc776fdec4e501783513ad4f12c77cb",
-      "pubkey_x25519": "1f000e20c69bafd68b34460de78d58055477a326a6cd6cd8e128f13ee4bf7639",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "52ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.12",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1de39c84ec9dbbb00ed47034b24d93a76f171c7ea0339b769d62e0d21e0b2691",
-      "pubkey_x25519": "0a7ab47efc9653f7659c813fddfd137a5094ab0e44ba249decfaa98d47205b54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "297fffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22100,
-      "pubkey_ed25519": "1e01d3e756fccd9aec0f2cad477547cb09bd58d2707c251aab15587bffedce46",
-      "pubkey_x25519": "0087048a1929e7989ada5cba3e3cba5dc65a8b822d919f5cb2a69af0c70dd649",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "51ffffffffffffff"
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "5.255.121.55",
@@ -2502,9 +1620,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "457fffffffffffff"
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "152.89.29.28",
@@ -2518,7 +1636,7 @@
         11,
         3
       ],
-      "swarm": "e6ffffffffffffff"
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "135.181.38.28",
@@ -2532,21 +1650,7 @@
         11,
         0
       ],
-      "swarm": "a1ffffffffffffff"
-    },
-    {
-      "public_ip": "157.180.92.87",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1e5c4f86d16ca72e173d1cf7478eede99a4ae702a0e03e8c6fa8857d559d47d7",
-      "pubkey_x25519": "5c530e6383bacb5a58c7fc7561d576a6b9dbda7454f1129337093554b50e9125",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2effffffffffffff"
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -2560,21 +1664,7 @@
         11,
         2
       ],
-      "swarm": "c5ffffffffffffff"
-    },
-    {
-      "public_ip": "5.189.153.18",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1ee6bf85168b76cbd20a563ebdb142c73e92a2ec4123a8dc8a3837b4b928b7ef",
-      "pubkey_x25519": "51cecb0465fba1ac8362c97a57a4d6d134f07df497512ffc9f313dbfcf1c6905",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e7fffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2602,7 +1692,7 @@
         11,
         3
       ],
-      "swarm": "2fffffffffffffff"
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2616,7 +1706,7 @@
         11,
         3
       ],
-      "swarm": "1cffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2630,7 +1720,7 @@
         11,
         3
       ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2658,7 +1748,7 @@
         11,
         3
       ],
-      "swarm": "307fffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2672,7 +1762,7 @@
         11,
         3
       ],
-      "swarm": "a4ffffffffffffff"
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2700,7 +1790,7 @@
         11,
         3
       ],
-      "swarm": "30ffffffffffffff"
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2714,7 +1804,7 @@
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2728,7 +1818,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2742,7 +1832,7 @@
         11,
         3
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2770,7 +1860,7 @@
         11,
         3
       ],
-      "swarm": "fcffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2784,7 +1874,7 @@
         11,
         3
       ],
-      "swarm": "e3ffffffffffffff"
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2798,7 +1888,7 @@
         11,
         3
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2826,7 +1916,7 @@
         11,
         3
       ],
-      "swarm": "fdffffffffffffff"
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2840,7 +1930,7 @@
         11,
         3
       ],
-      "swarm": "afffffffffffffff"
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2854,7 +1944,7 @@
         11,
         3
       ],
-      "swarm": "8effffffffffffff"
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2882,7 +1972,7 @@
         11,
         3
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2896,7 +1986,7 @@
         11,
         3
       ],
-      "swarm": "67ffffffffffffff"
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2910,7 +2000,7 @@
         11,
         3
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2924,7 +2014,7 @@
         11,
         3
       ],
-      "swarm": "54ffffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2938,7 +2028,7 @@
         11,
         3
       ],
-      "swarm": "7cffffffffffffff"
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -2952,7 +2042,7 @@
         11,
         3
       ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "95.216.33.113",
@@ -3008,7 +2098,7 @@
         11,
         2
       ],
-      "swarm": "65ffffffffffffff"
+      "swarm": "337fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3050,7 +2140,7 @@
         11,
         2
       ],
-      "swarm": "98ffffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3064,7 +2154,7 @@
         11,
         2
       ],
-      "swarm": "17ffffffffffffff"
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3078,7 +2168,7 @@
         11,
         2
       ],
-      "swarm": "7dffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3148,7 +2238,7 @@
         11,
         2
       ],
-      "swarm": "39ffffffffffffff"
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3162,7 +2252,7 @@
         11,
         2
       ],
-      "swarm": "98ffffffffffffff"
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3204,7 +2294,7 @@
         11,
         2
       ],
-      "swarm": "b3ffffffffffffff"
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3218,7 +2308,7 @@
         11,
         2
       ],
-      "swarm": "d9ffffffffffffff"
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "37.27.236.229",
@@ -3260,7 +2350,7 @@
         11,
         2
       ],
-      "swarm": "487fffffffffffff"
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3302,7 +2392,7 @@
         11,
         2
       ],
-      "swarm": "50ffffffffffffff"
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3316,7 +2406,7 @@
         11,
         2
       ],
-      "swarm": "3c7fffffffffffff"
+      "swarm": "f9ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3330,7 +2420,7 @@
         11,
         2
       ],
-      "swarm": "7affffffffffffff"
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3344,7 +2434,7 @@
         11,
         2
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3400,7 +2490,7 @@
         11,
         2
       ],
-      "swarm": "467fffffffffffff"
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3414,7 +2504,7 @@
         11,
         2
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "1affffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3428,7 +2518,7 @@
         11,
         2
       ],
-      "swarm": "e7fffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3442,7 +2532,7 @@
         11,
         2
       ],
-      "swarm": "26ffffffffffffff"
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3456,7 +2546,7 @@
         11,
         2
       ],
-      "swarm": "beffffffffffffff"
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "104.243.35.225",
@@ -3484,7 +2574,7 @@
         11,
         2
       ],
-      "swarm": "287fffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3498,7 +2588,7 @@
         11,
         2
       ],
-      "swarm": "e5ffffffffffffff"
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3512,7 +2602,7 @@
         11,
         2
       ],
-      "swarm": "3b7fffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3526,7 +2616,7 @@
         11,
         2
       ],
-      "swarm": "a0ffffffffffffff"
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3554,7 +2644,7 @@
         11,
         2
       ],
-      "swarm": "1c7fffffffffffff"
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3568,7 +2658,7 @@
         11,
         2
       ],
-      "swarm": "96ffffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "185.150.190.170",
@@ -3582,7 +2672,7 @@
         11,
         2
       ],
-      "swarm": "44ffffffffffffff"
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3610,7 +2700,7 @@
         11,
         2
       ],
-      "swarm": "15ffffffffffffff"
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3624,7 +2714,7 @@
         11,
         2
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3708,7 +2798,7 @@
         11,
         2
       ],
-      "swarm": "dcffffffffffffff"
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3750,7 +2840,7 @@
         11,
         2
       ],
-      "swarm": "2ffffffffffffff"
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3764,7 +2854,7 @@
         11,
         2
       ],
-      "swarm": "deffffffffffffff"
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3792,7 +2882,7 @@
         11,
         2
       ],
-      "swarm": "49ffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3862,7 +2952,7 @@
         11,
         2
       ],
-      "swarm": "3d7fffffffffffff"
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3876,7 +2966,7 @@
         11,
         2
       ],
-      "swarm": "3a7fffffffffffff"
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3890,7 +2980,7 @@
         11,
         2
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3904,7 +2994,7 @@
         11,
         2
       ],
-      "swarm": "80ffffffffffffff"
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3918,7 +3008,7 @@
         11,
         2
       ],
-      "swarm": "e8ffffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3960,7 +3050,7 @@
         11,
         2
       ],
-      "swarm": "acffffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3974,7 +3064,7 @@
         11,
         2
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "8dffffffffffffff"
     },
     {
       "public_ip": "208.73.207.54",
@@ -3991,20 +3081,6 @@
       "swarm": "7fffffffffffffff"
     },
     {
-      "public_ip": "107.175.39.131",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1f342e94214bcdefca880d6172ec2618f47ed826898b61bc3932cd1b35c28721",
-      "pubkey_x25519": "2b3b7352adca324f426092ab83284af1faeae512aad828e3429e365c3d4d681e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c4ffffffffffffff"
-    },
-    {
       "public_ip": "91.99.120.185",
       "storage_port": 22103,
       "pubkey_ed25519": "1f3c49b0b3a3cf092bc37131aab2d49eee526aa9c05b7e9de82c43134bdf1517",
@@ -4016,217 +3092,7 @@
         11,
         3
       ],
-      "swarm": "3e7fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22100,
-      "pubkey_ed25519": "1f400f199a4d0242a05a26e952264042646bbbe0333ddbb4aac1628512f44558",
-      "pubkey_x25519": "77eb13516e0efbfb7baf60d27e5cfb6b7c5b8f03ffdb64881fcf93493f759b58",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5effffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22101,
-      "pubkey_ed25519": "1f401f2773e8bdf07cf14b4f57adf58a63e63a98b14033ebebd4e0b635035f67",
-      "pubkey_x25519": "1e2ad5a2d031815ae56bb684f049d284834e4a6bf9e3df0cb11c75ac912a5218",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f3ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22102,
-      "pubkey_ed25519": "1f402f0373679c687e9a1ef4f38e113e8a16392677629da2d8bf6fd4874fb897",
-      "pubkey_x25519": "af024db1ae94ef750bd0f250c86f76ba0b75c49ffa57015e9c4429d9da573873",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "467fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22103,
-      "pubkey_ed25519": "1f403f10a864e3e08b14412b5cef75b2f682b38bf9894a9f26fd4210785d4f7c",
-      "pubkey_x25519": "216740f91b74d7357f9acbdb850cf12f664aabdd965b6aa99f0fd661d00aed08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "19ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22104,
-      "pubkey_ed25519": "1f404f113d471d0b89369fc27a9edf1831c6f83d9ed7ad7bf9c7f66c88b77d4b",
-      "pubkey_x25519": "c264bdd1102a0bcbc3f0339f35292c19cd6a1da9df7f432cc55956929c38ab49",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "487fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22105,
-      "pubkey_ed25519": "1f405f0060d775717a1343db333847de070d0779b85e1e0a4115e41ffae59ef9",
-      "pubkey_x25519": "eab1c2dc9d52babadacc80c30a30e9c072b9eb5a06b5f86f596fba5e10e75f53",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "59ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22106,
-      "pubkey_ed25519": "1f406f26f2e3382043eda8a2ba163182a38812f4f7d04dc31599701367860dde",
-      "pubkey_x25519": "4af54f327a65c35882be6b6ba5ef6f279c54a576c0055a25d692a5015369bc37",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "0"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22107,
-      "pubkey_ed25519": "1f407f10dac4c058703b56549e9bd7c6abb45406d74cff31727f5e5aafa7d91e",
-      "pubkey_x25519": "d283377ad1ef7c8de630ecdf2355c43719a6a8880814fb68721985e2351d476a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "26ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22108,
-      "pubkey_ed25519": "1f408f02f1dae7bf8cbd705f4f9747e09b5bb852d78abdc7f0afbc965fd9f7b0",
-      "pubkey_x25519": "b9699f825a1b725b204ea2615f7e0f36ade14765eab379088c123876746f5944",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d7fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22109,
-      "pubkey_ed25519": "1f409f1fec6878e234d7f15af4e6953c4ab3719ed83b9b465dc26b5ef62b212b",
-      "pubkey_x25519": "b77e7a8440f3bde1fce62cab308e00a6c4da1969d50aa3ed8685e3a800e54c4d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "15ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22110,
-      "pubkey_ed25519": "1f410f0adb541dca82692af066c4b306c77f7b120c572c23ebf554d762122ce1",
-      "pubkey_x25519": "86c17d9a95428baf320e427bc9889cacada078f77b79c74314569af01f7b690c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "427fffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22111,
-      "pubkey_ed25519": "1f411f0db9b2cce68de7de4d9138dca01b749fd51a9eb092c1b92b886a1d6fa7",
-      "pubkey_x25519": "0781a80b42e20b3c5601a40314a8dd673daabc01699fc7afeb200c6ac9d9a15f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e8ffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22112,
-      "pubkey_ed25519": "1f412f05fef2b20621e6a00a021ea7c1f9515c79cb6baf0481f100fa15441ff3",
-      "pubkey_x25519": "197976f7601c65d97400d3775b7f3315f98662a625c6f700b9aaf18d6f0e8154",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2bffffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22113,
-      "pubkey_ed25519": "1f413f009b489ae560dbcdca23659690b962fe40169d928dc2a1ca8611339730",
-      "pubkey_x25519": "5cf4c32454fbda9fe78fc853e6941fdb0d45e094374c87cf37b059702be8b27a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5affffffffffffff"
-    },
-    {
-      "public_ip": "205.209.114.66",
-      "storage_port": 22114,
-      "pubkey_ed25519": "1f414f02e4e3ef85c517c81afb0402a980f937a5b43a686aba502d7bc6728976",
-      "pubkey_x25519": "12e2f86e9adc980c64029cb544fec9f4a1ef3347502c5f6113b7987ad5198909",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "24ffffffffffffff"
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4240,7 +3106,7 @@
         11,
         2
       ],
-      "swarm": "7effffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4254,7 +3120,7 @@
         11,
         2
       ],
-      "swarm": "4effffffffffffff"
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4324,7 +3190,7 @@
         11,
         2
       ],
-      "swarm": "bffffffffffffff"
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4338,7 +3204,7 @@
         11,
         2
       ],
-      "swarm": "dcffffffffffffff"
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4352,7 +3218,7 @@
         11,
         2
       ],
-      "swarm": "247fffffffffffff"
+      "swarm": "d4ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4366,7 +3232,7 @@
         11,
         2
       ],
-      "swarm": "71ffffffffffffff"
+      "swarm": "cbffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4380,7 +3246,7 @@
         11,
         2
       ],
-      "swarm": "247fffffffffffff"
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4394,7 +3260,7 @@
         11,
         2
       ],
-      "swarm": "137fffffffffffff"
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4450,7 +3316,7 @@
         11,
         2
       ],
-      "swarm": "18ffffffffffffff"
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4478,7 +3344,7 @@
         11,
         2
       ],
-      "swarm": "197fffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4492,7 +3358,7 @@
         11,
         2
       ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "172.93.103.156",
@@ -4562,7 +3428,7 @@
         11,
         2
       ],
-      "swarm": "f0ffffffffffffff"
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4576,7 +3442,7 @@
         11,
         2
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4590,7 +3456,7 @@
         11,
         2
       ],
-      "swarm": "427fffffffffffff"
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4646,7 +3512,7 @@
         11,
         2
       ],
-      "swarm": "b3ffffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4674,7 +3540,7 @@
         11,
         2
       ],
-      "swarm": "13ffffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4688,7 +3554,7 @@
         11,
         2
       ],
-      "swarm": "51ffffffffffffff"
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4730,7 +3596,7 @@
         11,
         2
       ],
-      "swarm": "ceffffffffffffff"
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "104.194.8.115",
@@ -4758,49 +3624,7 @@
         11,
         2
       ],
-      "swarm": "247fffffffffffff"
-    },
-    {
-      "public_ip": "80.83.124.173",
-      "storage_port": 22021,
-      "pubkey_ed25519": "1f69a9e69725c552d6c4d43406321597c7bae52b7dbf2745d7160085ae5d787b",
-      "pubkey_x25519": "46af3e8f16b69d4f6cb9e95714a4f00f7c3d01b5e36f726a3383c35db6564b45",
-      "requested_unlock_height": 2085234,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "5effffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22108,
-      "pubkey_ed25519": "1faca0bbcb3e365156f6e600eadd1ca168835049e60a5c1e6d3adf1f8dbb39b9",
-      "pubkey_x25519": "c009e7da9f168864418e1ad32613ee74515a55120b84c92f83033194303fab02",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "65ffffffffffffff"
-    },
-    {
-      "public_ip": "195.200.17.130",
-      "storage_port": 22021,
-      "pubkey_ed25519": "201e0b7855c076227c6c47919ed4544d9a5d64e0aa35d6cde048d8458c23ff99",
-      "pubkey_x25519": "ba2d8e8a9535e376aaa9c43eb8b3b5ec18a2b753e14b31509973411d6d208814",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "67fffffffffffff"
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "161.35.151.220",
@@ -4814,63 +3638,21 @@
         11,
         0
       ],
-      "swarm": "39ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.232",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2031cde9c462205c7cfe7a876db11c060ee12fe3f78e73b52fa42dbe405cf62f",
-      "pubkey_x25519": "c4d20ff5068efe2161e68140f55a2d17475ce8f4036c969bab9a21cb16cf474a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "467fffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "50.114.206.167",
       "storage_port": 22021,
       "pubkey_ed25519": "2080fb3ed7662aa7efceff772f4c61bdcb66ac7e4ebd8b0125fb3e4d56b8ed5e",
       "pubkey_x25519": "3f79c124011249351aa04a1a3c43ea8fd4c3c2c6c0d7b34cf43c31eafcb1e24b",
-      "requested_unlock_height": 2085152,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c5ffffffffffffff"
-    },
-    {
-      "public_ip": "193.22.147.127",
-      "storage_port": 22021,
-      "pubkey_ed25519": "209aa14eb13bdf97155a6b0141affad8b081761a67184791889ef0112a5960d1",
-      "pubkey_x25519": "bc78be47e82a71ada8b47298329daf86474df716dba2008143c57fa27f8da348",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "eeffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22111,
-      "pubkey_ed25519": "209afbcc7c730a8a56dfd2b349e6d4c0dff29135711f1ea6273d41abae3adf35",
-      "pubkey_x25519": "3b24253907b84b2782d1a9d58bde65f05ed649555e11ddb311a6b8fe36c46858",
-      "requested_unlock_height": 2086578,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "227fffffffffffff"
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "167.114.129.231",
@@ -4884,7 +3666,7 @@
         11,
         2
       ],
-      "swarm": "53ffffffffffffff"
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -4898,35 +3680,7 @@
         11,
         0
       ],
-      "swarm": "6effffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22103,
-      "pubkey_ed25519": "21255829a52faf4fc85e02b8b95dfc5b12a168fa5119c86b6b3774e325bf321e",
-      "pubkey_x25519": "dc5cfad8c96a2ac9bac0d488ee2ea615848d243b3d5b25773d891ab7630f237c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d8ffffffffffffff"
-    },
-    {
-      "public_ip": "204.44.125.247",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2141f276d1ea0cc312d193ce040738db362ed7cc11c9d4653f0f3336d7d9f635",
-      "pubkey_x25519": "b17bd16061306906112db8297e8acbadeae9863afc16d9cc022e13a1cda37708",
-      "requested_unlock_height": 2091014,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "97fffffffffffff"
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "147.135.208.118",
@@ -4940,21 +3694,21 @@
         11,
         2
       ],
-      "swarm": "eaffffffffffffff"
+      "swarm": "f9ffffffffffffff"
     },
     {
-      "public_ip": "66.179.243.81",
-      "storage_port": 22021,
-      "pubkey_ed25519": "21d0ba87a6d1b4ef8c26bfd0a21d32e526a12ba12e8a04aa95a843cc2afd186f",
-      "pubkey_x25519": "1ee96e21b7a944dea960d64e8823f0e1afe04a2e9837bc6552f12c56f0d8e864",
+      "public_ip": "37.27.212.116",
+      "storage_port": 22101,
+      "pubkey_ed25519": "215fb80968d76c1d6f38aa94807e40914f9125f8d74e3fd2256294bd7f568659",
+      "pubkey_x25519": "98d26d83309f0d13c2fcbca423c79f9e6d1f7631fc0049c62e92761fa8af412a",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "41ffffffffffffff"
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "139.99.238.151",
@@ -4985,34 +3739,6 @@
       "swarm": "cffffffffffffff"
     },
     {
-      "public_ip": "50.114.206.219",
-      "storage_port": 22021,
-      "pubkey_ed25519": "22c52f8bc17befaa4e841171cc639b733991767be7a03b5e2572c6df94f1dda3",
-      "pubkey_x25519": "96883ab11199c0d7e948af9a6ec86200316e915660fb53e8be936b89052b0579",
-      "requested_unlock_height": 2094200,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "0"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22101,
-      "pubkey_ed25519": "236f600393c47dca1c970a9377d291720d987133b1eaebc3c818f1f6f400f6ca",
-      "pubkey_x25519": "d213cae41cebd3c8e5cc5733407a3ca0ca8e56549f90bdd26c94bdae823bb813",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "aaffffffffffffff"
-    },
-    {
       "public_ip": "198.98.60.131",
       "storage_port": 22021,
       "pubkey_ed25519": "237604e4cf5f77156817a1ae9bed3fa6570fe54bf632cca87369a940471e0c9d",
@@ -5027,35 +3753,21 @@
       "swarm": "94ffffffffffffff"
     },
     {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22121,
-      "pubkey_ed25519": "2378e991e294cc80594b761390f7b0157b831d402f3c24d7cd7f9cbb3d93c4a5",
-      "pubkey_x25519": "a94656b5ced27067d161deb5271bdeb6642653fd430db57e4a52ab5a8a660871",
+      "public_ip": "172.93.167.92",
+      "storage_port": 22021,
+      "pubkey_ed25519": "237fadadf715673ef4ba4c08bdabdfc8473ff451d315385eb7db35b6f877dbb7",
+      "pubkey_x25519": "a772f687fabc87e9ff6a127794af6f9ad820f4ab40b2863bf3a9f92021cdfa67",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20221,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "99ffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
-      "public_ip": "172.93.167.92",
-      "storage_port": 22021,
-      "pubkey_ed25519": "237fadadf715673ef4ba4c08bdabdfc8473ff451d315385eb7db35b6f877dbb7",
-      "pubkey_x25519": "a772f687fabc87e9ff6a127794af6f9ad820f4ab40b2863bf3a9f92021cdfa67",
-      "requested_unlock_height": 2085137,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "fbffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.94",
+      "public_ip": "64.44.157.64",
       "storage_port": 22021,
       "pubkey_ed25519": "23830b819f995ad8e3a2ae272c9ff3badbb4b261794610b2cf408058a4e0cabc",
       "pubkey_x25519": "c00c5298d75fd3d4a46f1773c152bbb5de9362a7c12a3320812a4961eafe6353",
@@ -5064,37 +3776,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "86ffffffffffffff"
-    },
-    {
-      "public_ip": "94.237.45.1",
-      "storage_port": 22021,
-      "pubkey_ed25519": "23944ff096299ae3b343126fab9f591c215fc32d42c87c62f888bd804b5fc7e7",
-      "pubkey_x25519": "02ac96aa0877e56c3ec0dcecd56444d53fba80b288fafde61871c25386f8f33d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "f3ffffffffffffff"
-    },
-    {
-      "public_ip": "95.111.238.80",
-      "storage_port": 22021,
-      "pubkey_ed25519": "23bf357027a42a8ad426bdc0350413d002338d0532d8d93ebaedcb6490bd2da9",
-      "pubkey_x25519": "dbd07f991ddd04b481c5ee7c316dd7a25b6bbd8d81d32e37b6a10e3434ac6a5b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "90ffffffffffffff"
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -5108,21 +3792,7 @@
         11,
         0
       ],
-      "swarm": "d5ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22116,
-      "pubkey_ed25519": "23c89d932e1fea811e7b33ab88956f8550ede291596fac160504771e8a479aab",
-      "pubkey_x25519": "2650029714955e63fa2326fe6b32a3beef72e8e264790a3e822d9cc772d56530",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20216,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f6ffffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "209.141.62.119",
@@ -5136,21 +3806,21 @@
         11,
         3
       ],
-      "swarm": "38ffffffffffffff"
+      "swarm": "deffffffffffffff"
     },
     {
-      "public_ip": "141.105.130.209",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.64",
+      "storage_port": 22103,
       "pubkey_ed25519": "23fd4abe81af81d62f60f896de730903daeb5a81bbda2ad4f587b2fc9f22def2",
       "pubkey_x25519": "dd159e8dd55cdc60265fde71c472ea6ec14f127fdb0ed25c6f81bac3c087fb22",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20203,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "feffffffffffffff"
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "96.9.214.20",
@@ -5162,9 +3832,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "91.98.20.46",
@@ -5178,21 +3848,7 @@
         11,
         0
       ],
-      "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22100,
-      "pubkey_ed25519": "243a9ee2a38e533ae6fca0abf08527e38d6f43bf71e23c4786311505a2e3d859",
-      "pubkey_x25519": "8c408c4a77875f04904fbc65efab10181e255fb6b4d3a428ed6616d132a7706e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e7fffffffffffff"
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "104.244.74.160",
@@ -5206,7 +3862,7 @@
         11,
         2
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "158.69.206.52",
@@ -5220,7 +3876,7 @@
         11,
         2
       ],
-      "swarm": "c7fffffffffffff"
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "107.189.3.102",
@@ -5248,21 +3904,7 @@
         11,
         2
       ],
-      "swarm": "28ffffffffffffff"
-    },
-    {
-      "public_ip": "194.62.96.16",
-      "storage_port": 22021,
-      "pubkey_ed25519": "25d223ca4629c883f0612a956ee7684a5cfa2a5beb06755ba109362e150efb70",
-      "pubkey_x25519": "327a233eeac9d047a587978918fac97c4b1e05791f12558be69928678ae7ef16",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f3ffffffffffffff"
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -5276,21 +3918,7 @@
         11,
         0
       ],
-      "swarm": "33ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22110,
-      "pubkey_ed25519": "25fa58b2fb5dfbbbbaf67af4f72bfe9d8dd755de5a0787fccdce8c7f128e77c8",
-      "pubkey_x25519": "217bf21ef1f16f262b9d80c263f61df4a48b58f7dcb1e689f9a7471fd2f3c45d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "307fffffffffffff"
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "198.98.61.136",
@@ -5304,49 +3932,21 @@
         11,
         3
       ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.107.170",
-      "storage_port": 22021,
-      "pubkey_ed25519": "271b7a41f97804ac0fea0ddf9bd80156e383aae90e36190e4bffd59688d66aef",
-      "pubkey_x25519": "a822c34f2212db3c61646c3f9cee1823d083b832fc7e260b9419a9bea144b103",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b6ffffffffffffff"
-    },
-    {
-      "public_ip": "86.106.182.17",
-      "storage_port": 22021,
-      "pubkey_ed25519": "27dae0e56f2caff4519bff5de4c1161fd027ea80505a4fc622932af46edb9be9",
-      "pubkey_x25519": "83806dd728f4af6871bff03a15e5df5b23ef6186e2d69977813449a2abd1e15a",
-      "requested_unlock_height": 2090263,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "42ffffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22100,
       "pubkey_ed25519": "282358b3517b1839a9b9d4c751832fd18689b4b2a8e91b38cc7c16fdc25ec196",
       "pubkey_x25519": "396c09d2441dec7a0c81de3f2e90b0c045dd8958307a6aa423e589e49a87bd1e",
-      "requested_unlock_height": 2088391,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "19ffffffffffffff"
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "199.195.249.188",
@@ -5363,20 +3963,6 @@
       "swarm": "daffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22124,
-      "pubkey_ed25519": "288bd454a590ee935cef7843108ab0ac0c821eedca04e2df95b394d9abf8d2d8",
-      "pubkey_x25519": "451133762c1a1a706472bfdc66e1eb8ea53b3050688dc0458d4c2d6bd2a8cc65",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20224,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "81ffffffffffffff"
-    },
-    {
       "public_ip": "51.68.137.38",
       "storage_port": 22021,
       "pubkey_ed25519": "28c710aeeb4233186234189c6f6f1df1677537ba4fadf6d06b28eee6429a917d",
@@ -5388,7 +3974,7 @@
         11,
         2
       ],
-      "swarm": "f7ffffffffffffff"
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "194.107.126.33",
@@ -5402,63 +3988,21 @@
         11,
         2
       ],
-      "swarm": "97ffffffffffffff"
+      "swarm": "bfffffffffffffff"
     },
     {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22102,
-      "pubkey_ed25519": "28e9fe70f9d86bfa1b146898e53c167fafc1b8f694f0551257f0a3a9b079b110",
-      "pubkey_x25519": "986e9691341e6c2cce1a07e577769bbdb9b52d2f3d8608f201320ef12b97a627",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "44ffffffffffffff"
-    },
-    {
-      "public_ip": "46.254.214.27",
-      "storage_port": 22140,
+      "public_ip": "46.254.214.39",
+      "storage_port": 22150,
       "pubkey_ed25519": "29071ff562b42881d6cc1d3a904fefbf8f94d2358228589febfe646eedaf5c17",
       "pubkey_x25519": "9485d4f1ad6c5160c7b254ca8a32870141905be5490a25053c90ec0c721bd00c",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20240,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "adffffffffffffff"
-    },
-    {
-      "public_ip": "206.189.109.173",
-      "storage_port": 22021,
-      "pubkey_ed25519": "291788c52c713eb7f6ecbb70a0683b8cc4a2d8e2ce1805261392b48af562c2b8",
-      "pubkey_x25519": "11e9506436ffe090935d40ebecf841df676843cb519dac2e6155e731bbfb171a",
-      "requested_unlock_height": 2094236,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20250,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22114,
-      "pubkey_ed25519": "292e5b83fae4a75137f7e777cd9cd4518628648c5ee4799799b50ecd615e650a",
-      "pubkey_x25519": "c474cbfa1b8febd453813ce92495b42b91dcdebb10fce91b4afb20bb11772f66",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "feffffffffffffff"
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "5.161.114.96",
@@ -5475,6 +4019,20 @@
       "swarm": "daffffffffffffff"
     },
     {
+      "public_ip": "217.216.35.231",
+      "storage_port": 22021,
+      "pubkey_ed25519": "295816b3a1c7531a522c3be08a4c2b2f74a6ee087cc08b8b406ebf341b31a0af",
+      "pubkey_x25519": "a93a66ffb8e4e026a213b0db24d3b430dd972208678a77f6b6e7cbf8c9baa81f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "bdffffffffffffff"
+    },
+    {
       "public_ip": "194.32.77.75",
       "storage_port": 22021,
       "pubkey_ed25519": "298fb59e547e1e9fdbe6355b15f6937e84143248f66ef6d612ffe3fd7a9ed813",
@@ -5486,35 +4044,7 @@
         11,
         2
       ],
-      "swarm": "4ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22115,
-      "pubkey_ed25519": "29d5fb74d3126042c8dab58525f4ef57529c054ed10484e411b5131e9e7cad78",
-      "pubkey_x25519": "9eba5dc959b6ebcb4d2b18a1e80137c40d8d40ae4fd4cb29315ee8f28c2d9f43",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "32ffffffffffffff"
-    },
-    {
-      "public_ip": "212.56.45.2",
-      "storage_port": 22021,
-      "pubkey_ed25519": "29ea7c458ffee249178431a22353b76da73eded11d3fac5735cfdf88305bbff8",
-      "pubkey_x25519": "74032af37c64a141e36f7db9ad36c86ce8ff57f77c53c75720b17ec2f735c364",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "6effffffffffffff"
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "95.111.245.253",
@@ -5528,21 +4058,21 @@
         11,
         1
       ],
-      "swarm": "8dffffffffffffff"
+      "swarm": "56ffffffffffffff"
     },
     {
-      "public_ip": "141.105.130.4",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.195",
+      "storage_port": 22155,
       "pubkey_ed25519": "2a0a80eedde0ee2f0b5c619d4d3d7ea0304e1e987344a5e425696cab7cea1432",
       "pubkey_x25519": "feaaea1d69018de889fcde963e9c2ff595eab0e2787a1547cedbc0052bdae27d",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20255,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "c7fffffffffffff"
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "65.109.1.140",
@@ -5556,7 +4086,7 @@
         11,
         2
       ],
-      "swarm": "a6ffffffffffffff"
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "178.128.121.1",
@@ -5570,21 +4100,7 @@
         11,
         2
       ],
-      "swarm": "a6ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22106,
-      "pubkey_ed25519": "2a6eadce8cccd1b4cbddfe337986554a8bef52b964c1c0853a47dd37932e5271",
-      "pubkey_x25519": "14d110262914e349a0daa6a2d8fcb3ca5e5f68dd25beba5c5f6edd5d515c316e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a1ffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "91.231.182.72",
@@ -5601,20 +4117,6 @@
       "swarm": "5bffffffffffffff"
     },
     {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22111,
-      "pubkey_ed25519": "2b506782341cdbd3ca9d2d0af633865e5e9d482f2e5404e3a86e6aeb6c5b0c32",
-      "pubkey_x25519": "d63a3f5c8b312691bb20322b5bc35c888a80df7a7f60a973f05382bd76e3a674",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "97fffffffffffff"
-    },
-    {
       "public_ip": "167.86.119.129",
       "storage_port": 22021,
       "pubkey_ed25519": "2b9fa075f00a1625df989e6e803bb61d68f43bf78b84a4a52cc16dae5436cbf1",
@@ -5626,7 +4128,7 @@
         11,
         2
       ],
-      "swarm": "437fffffffffffff"
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "199.195.254.118",
@@ -5640,49 +4142,7 @@
         11,
         3
       ],
-      "swarm": "afffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.164",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2bc44824399be5323296534ead917cfde0a47911ecc9d81571a3f7496566d064",
-      "pubkey_x25519": "b65fd9d9320d93493a033d5166b33d924cb750a069bfc9622ceb2d098db36450",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d6ffffffffffffff"
-    },
-    {
-      "public_ip": "217.156.50.127",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2c28c8698e15684885eabcb4520481735089ba6a42f31c087d0892938e5737fa",
-      "pubkey_x25519": "1ec4e32809898005a334e2cc127ff38e5c1d66d1a8a53e2c7241d2b25da92953",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b3ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22108,
-      "pubkey_ed25519": "2c48937d32d9c90b0393bf3e6a2d3b89cd394891224bc75d831422f903f490ca",
-      "pubkey_x25519": "7719ef85ba0e71809dabfb9bdc2e1876b844ffeb82afaa356b2b51ba528b175f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "17ffffffffffffff"
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
@@ -5710,35 +4170,21 @@
         11,
         0
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "5dffffffffffffff"
     },
     {
-      "public_ip": "141.105.130.184",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.214",
+      "storage_port": 22108,
       "pubkey_ed25519": "2d9baeac32d5930a00a1037a7e678cfae9419057427e82e7eb218b421d33863b",
       "pubkey_x25519": "005b4d282ba7435b6adc3c88811533db3946dc9038e787ddcace4a9002d89437",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20208,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "407fffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.59",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2da7e93a82f751bff4d57c7e22530828de181717172ab0f9c89862cfb105046e",
-      "pubkey_x25519": "c4798a461fcb4f7badb45bae73a769dd511316b9923d124addd97731b75b5f05",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "7dffffffffffffff"
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "213.199.41.115",
@@ -5769,32 +4215,18 @@
       "swarm": "b3ffffffffffffff"
     },
     {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22119,
-      "pubkey_ed25519": "2e2f73e3d12ca86981fa2621b54222d7bb47f1bd0a2c66314684b00394f1a14c",
-      "pubkey_x25519": "185ca1221f3136f8ace71352a4b502b1dad2d2daf7208fae43613fe35e69cc26",
+      "public_ip": "150.230.119.99",
+      "storage_port": 22101,
+      "pubkey_ed25519": "2e2da65655209f9760dd0f83d02fd086001f883b6c0c91b47392201c5aaf64d1",
+      "pubkey_x25519": "4b572ae22c9efca09adfd50e9e4ca20d48d24c3f664945b739d9a4efa6c1235c",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
+      "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22112,
-      "pubkey_ed25519": "2e9c6a513402664b433c032b096cdabe76b0000c5d2d9b0e605bce3c54115e3a",
-      "pubkey_x25519": "4cd1007edb352a6a162b493f0cc19be703c555ac5bcc4893a9acfd4967a97629",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2ffffffffffffff"
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "157.254.221.25",
@@ -5806,65 +4238,23 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "14ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22132,
-      "pubkey_ed25519": "2f11e443d4a5122393d3b0f25c952028a40a03fd120b4fdebf7380cef72c742e",
-      "pubkey_x25519": "49e0b2461dc1f7a97991bece0e012dbc321209b6f9de900daa40a18d0e665361",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20232,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "38ffffffffffffff"
-    },
-    {
-      "public_ip": "209.145.54.198",
-      "storage_port": 22021,
-      "pubkey_ed25519": "2f55897e0cc1982dbc8ed2a281ef11f6bed9826ddf2b9d883071ad6f5a2930e6",
-      "pubkey_x25519": "c848d01edcc01eb41d82af743bcf668f6cddbc7935a8d4ee2748959bdd99836a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e1ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22120,
-      "pubkey_ed25519": "2f617b7a434ae3d76878864920310ef0d3563ff259ade25c4cb9721b0af9c7ee",
-      "pubkey_x25519": "71a69cdd70d440255a00143b6129cf7507fa0ed0bba8d0c2184634186abbdc37",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "130.255.77.179",
       "storage_port": 22021,
       "pubkey_ed25519": "2f6b05d12ceddae4e68c6a1a5056b13e72538d94b801487e1c5132280f1c7ffd",
       "pubkey_x25519": "269bbb978a0e856acb9f63a9e66df14252667d1640814b85827f55dd33e3e11f",
-      "requested_unlock_height": 2088900,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "51.195.252.72",
@@ -5878,10 +4268,24 @@
         11,
         2
       ],
-      "swarm": "a0ffffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
-      "public_ip": "193.160.96.243",
+      "public_ip": "37.60.231.244",
+      "storage_port": 22021,
+      "pubkey_ed25519": "2fdb02e4d57a8cae5aff0aa9cae3b7152fb5f6b2a08128c999797ff5645af8f2",
+      "pubkey_x25519": "2500555746218b1228d807ad44ecb6637fbd81fe50e47db368fa4b1e9105a62c",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "eeffffffffffffff"
+    },
+    {
+      "public_ip": "103.146.222.77",
       "storage_port": 22021,
       "pubkey_ed25519": "300a0c4fb1c23f8506b531a905948ef3b9ce8a799ecbad864c7ea40294c4f1b7",
       "pubkey_x25519": "0e8bb99b51caecc1131aaf3082e47ef4e7dab5e94c63d72ed8145dda339ced39",
@@ -5892,7 +4296,7 @@
         11,
         3
       ],
-      "swarm": "e2ffffffffffffff"
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "38.242.142.248",
@@ -5906,21 +4310,7 @@
         11,
         3
       ],
-      "swarm": "c4ffffffffffffff"
-    },
-    {
-      "public_ip": "95.111.204.25",
-      "storage_port": 22021,
-      "pubkey_ed25519": "306f6824f908b16687f04a799a0e9e0c31a76aeef1f48a530d386fb56bcc8408",
-      "pubkey_x25519": "1e1f5a0a3bb19aa6235d7ed269cfc0252dceedd19b2d660d43826081bba5d762",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e1ffffffffffffff"
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "51.81.187.85",
@@ -5934,35 +4324,7 @@
         11,
         3
       ],
-      "swarm": "2f7fffffffffffff"
-    },
-    {
-      "public_ip": "95.216.196.246",
-      "storage_port": 22021,
-      "pubkey_ed25519": "30c10f9e118ba68945c2473748b9e67e715ba53e9edddd4dc3c0b69e285c6fa0",
-      "pubkey_x25519": "f6ba804b0bf483c395025f9688602e4873b7e923a8fa2b28a0621cbd686e7b37",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
-      "public_ip": "209.126.77.237",
-      "storage_port": 22021,
-      "pubkey_ed25519": "30e74a81afbd87caf57138cf72be6e7b709462f1e863a6253d107a0ea4f23fb4",
-      "pubkey_x25519": "4a13b775f3709710f7303c1c8eaf297b36d5ec4c70ad215ea5f4a939be2cfa60",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "197fffffffffffff"
+      "swarm": "49ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.127",
@@ -5993,48 +4355,6 @@
       "swarm": "f4ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.235",
-      "storage_port": 22021,
-      "pubkey_ed25519": "31f4bb3a2baf824481db2429303ce38ff89bdf9a4a44dc2c532428c466796f44",
-      "pubkey_x25519": "39f4f5787b0a68b3b423c4bcc730e408d866073fbdcb3c42c03edab1b484ae13",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "27ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22104,
-      "pubkey_ed25519": "3234bdcbca860cfb704eca2578dc9fe228906a490e82e444001e320b937b21a6",
-      "pubkey_x25519": "8d258d8c3f67f23a17bb3be13bdf3f9265db072429d136c870f20c7c31f8cb1c",
-      "requested_unlock_height": 2088776,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "edffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22117,
-      "pubkey_ed25519": "3249dc023773ec1cec8d7eb84b591b04965a59b41c300b40d702ee14a9d7dde8",
-      "pubkey_x25519": "086700ac027423c8844fa586a24af7d81ec7ae9072cc0fa852dfadb6d998ac04",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20217,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "aeffffffffffffff"
-    },
-    {
       "public_ip": "141.105.130.62",
       "storage_port": 22021,
       "pubkey_ed25519": "32e023dadaaf3bc03ad02d272916192936c19f7540975c3f71a8932679a7facd",
@@ -6046,35 +4366,21 @@
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "e7fffffffffffff"
     },
     {
-      "public_ip": "141.105.130.141",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.47",
+      "storage_port": 22126,
       "pubkey_ed25519": "32ee60f5827e3045311a70ab4aa2c3452e866aba8aa76a1e41bd9de1dfcaf700",
       "pubkey_x25519": "fe3f29034196e03ce34437f179dbcc69f8f2d4c761fc2b9ab769024a34ad945a",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20226,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "427fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.184",
-      "storage_port": 22021,
-      "pubkey_ed25519": "32f244d823356bf9dbffc85c83f530dfd6f1f3f26ef572410452d390927b7f8b",
-      "pubkey_x25519": "abc49d581d5f5b9413f1f4fa1244bbb3c5c172b184ae80e4a29a9ebf6c2eda47",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8effffffffffffff"
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -6088,7 +4394,7 @@
         11,
         0
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "146.59.3.229",
@@ -6102,21 +4408,21 @@
         11,
         2
       ],
-      "swarm": "4cffffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22126,
-      "pubkey_ed25519": "338ab9f6005b211a036684f620a605ea171f40ff73a6a56ae1910e64bb8497db",
-      "pubkey_x25519": "7372c84ee9264e7f69ddbcfc42baa3c2a64b244d345c4c7dceec57be246cea5e",
+      "public_ip": "95.217.218.66",
+      "storage_port": 22102,
+      "pubkey_ed25519": "34279d2dcc6d5823723cd7e05ef37b8194ca8f29036977e229653c16dd67d0de",
+      "pubkey_x25519": "8169831345db5ab34d5c52d004d97ceca38c2a4bd28d913dac9e6d368c48a42e",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20226,
+      "storage_lmq_port": 22402,
       "storage_server_version": [
         2,
         11,
-        3
+        0
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "198.98.49.206",
@@ -6130,7 +4436,21 @@
         11,
         3
       ],
-      "swarm": "feffffffffffffff"
+      "swarm": "13ffffffffffffff"
+    },
+    {
+      "public_ip": "64.44.177.10",
+      "storage_port": 22021,
+      "pubkey_ed25519": "344e7da6b86976c1be3d992811b9172c085b1a0e8d3a093f9fc8bd43fa44a840",
+      "pubkey_x25519": "055525fef8a949d13493ad2c5e5b44c16e04f8ef9072939a24cb892933612672",
+      "requested_unlock_height": 2161748,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
@@ -6144,35 +4464,7 @@
         11,
         0
       ],
-      "swarm": "9fffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.117.25",
-      "storage_port": 22021,
-      "pubkey_ed25519": "34a6b321c62f466224f1cad153915daff8075d8b339e7fa47712b311f1509567",
-      "pubkey_x25519": "b4d71359920c827836a378d147e2c09c94d0456c24f973472e15b76a06e2f625",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b1ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.90",
-      "storage_port": 22021,
-      "pubkey_ed25519": "34af438910a54fcac12ae70efb92a609434cc2793638ae81767e2b08f82da57d",
-      "pubkey_x25519": "a4a35ccc8a0f85071171a822e25ed04527f6cf62d5f7c13229698a6e6e840357",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "47ffffffffffffff"
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "207.180.241.240",
@@ -6184,9 +4476,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "1bffffffffffffff"
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "51.83.187.20",
@@ -6200,7 +4492,7 @@
         11,
         2
       ],
-      "swarm": "afffffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "198.7.127.225",
@@ -6214,7 +4506,21 @@
         11,
         3
       ],
-      "swarm": "fdffffffffffffff"
+      "swarm": "1effffffffffffff"
+    },
+    {
+      "public_ip": "87.106.7.132",
+      "storage_port": 22021,
+      "pubkey_ed25519": "35253ff04f7c1b54d4fcf06ac4314c3f88f3bf88a6246f31df39e2ae772f4068",
+      "pubkey_x25519": "90b3fc233dd28f79884ad28baa0a41865b40f4d60102b259f4e5b7bbe751275f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "91.107.206.183",
@@ -6228,7 +4534,7 @@
         11,
         2
       ],
-      "swarm": "adffffffffffffff"
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "74.207.241.22",
@@ -6242,7 +4548,7 @@
         11,
         0
       ],
-      "swarm": "257fffffffffffff"
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "167.114.128.82",
@@ -6256,7 +4562,7 @@
         11,
         2
       ],
-      "swarm": "1affffffffffffff"
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "198.98.61.177",
@@ -6270,7 +4576,7 @@
         11,
         3
       ],
-      "swarm": "487fffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "89.168.85.187",
@@ -6284,7 +4590,7 @@
         11,
         3
       ],
-      "swarm": "77ffffffffffffff"
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "104.237.158.114",
@@ -6298,7 +4604,7 @@
         11,
         0
       ],
-      "swarm": "41ffffffffffffff"
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "199.195.248.217",
@@ -6312,7 +4618,7 @@
         11,
         3
       ],
-      "swarm": "9cffffffffffffff"
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "143.198.238.21",
@@ -6324,51 +4630,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
-      "public_ip": "173.249.193.95",
-      "storage_port": 22021,
-      "pubkey_ed25519": "368215a3027a3ce78d3c51d09d37adcb39efc00804b297865393d828fbbfb872",
-      "pubkey_x25519": "1887099b8f7acda328fc77d21d8ae65b1276de157257ed7535d9411bd4c42739",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2effffffffffffff"
-    },
-    {
-      "public_ip": "51.83.69.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "36a37f35c0b790ccaa6b0e20e95d196b3abb0284706e796cd46122b518efbe53",
-      "pubkey_x25519": "0404e848b9c6c28368102268775b4f5ae9df8741a7d49b63e3745ac52b24a413",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "1cffffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22110,
-      "pubkey_ed25519": "36b0496083c6e72eed24477009381b908050c25cd91bbd95f06f875919250772",
-      "pubkey_x25519": "65491acffb6e3cf9861542a46a28c6f6c53ee63102dc90c3ff4d3acb4e159c53",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "b1ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.222",
@@ -6380,51 +4644,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "26ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22129,
-      "pubkey_ed25519": "36c5f6af0c769a5f35ea2f89a62c8bcc879ba656bd6b2a23477a100c2a292fb0",
-      "pubkey_x25519": "9d78254dabe7df8979eb4b87178b62a19469e1fbc395faebd28ad0d27c08dd25",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20229,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
-      "public_ip": "46.225.78.111",
-      "storage_port": 22021,
-      "pubkey_ed25519": "36ca3e9680e66c2966c062c9cb6883bb192cc62878860824f7cdd94710fbc8e0",
-      "pubkey_x25519": "be50753eff2b356e51bf8b67acace22bc04ef4d5316e74d07aac0f15ca3b9d78",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "67ffffffffffffff"
-    },
-    {
-      "public_ip": "192.9.182.60",
-      "storage_port": 22102,
-      "pubkey_ed25519": "36da0a69008a6cc9be515b88e61219addffddc7dbad7050d7aa2ad71501e41b6",
-      "pubkey_x25519": "42b7397ceebc43ba0103b0b26cc854a6ae7f29773fd4fff9192f717527b3d640",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "caffffffffffffff"
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "167.99.46.232",
@@ -6455,62 +4677,6 @@
       "swarm": "3ffffffffffffff"
     },
     {
-      "public_ip": "207.180.205.249",
-      "storage_port": 22021,
-      "pubkey_ed25519": "373a589468bb62daaed1475a9eb041c99d962a9d272fd5dc3f15d718b6c70e58",
-      "pubkey_x25519": "7791f2cd4a1fa58a65232eb8c2ad7b794111ad686f657093391d06460e7fb628",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3741de3e63c724cf9d809370dd080b5e7363ff3fc7a5866581bf19d7178e4f8b",
-      "pubkey_x25519": "8c1130fd882a4280561000a339166dcd99b50519d9ab8146e757942a90038058",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b6ffffffffffffff"
-    },
-    {
-      "public_ip": "86.107.168.156",
-      "storage_port": 22021,
-      "pubkey_ed25519": "37613127a287e0de9aaf9eb1e0947b406eef3546c9387c6200e0c80ef33ec090",
-      "pubkey_x25519": "3aa3678fc25c293ae976c3c803fb46212860b859475a4ffcf3a7ec1ef7cfc43b",
-      "requested_unlock_height": 2085139,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3dffffffffffffff"
-    },
-    {
-      "public_ip": "164.90.200.74",
-      "storage_port": 22021,
-      "pubkey_ed25519": "37681c2bf8f7845c2683eab2fe68fb33c031618d861d990286dc77579d4ddf00",
-      "pubkey_x25519": "e54faed443627ca05956be2b5395ebcb7084dc609e066165123704e342e8d077",
-      "requested_unlock_height": 2094228,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "90ffffffffffffff"
-    },
-    {
       "public_ip": "107.189.6.53",
       "storage_port": 22021,
       "pubkey_ed25519": "37b733e56f3f670a57052c610403547fb317af86c252f0b68bd1ddf8d293e70f",
@@ -6536,49 +4702,7 @@
         11,
         0
       ],
-      "swarm": "d6ffffffffffffff"
-    },
-    {
-      "public_ip": "46.250.249.103",
-      "storage_port": 22021,
-      "pubkey_ed25519": "384c8abf99e596fff41e0e0efa34baa96b0cf6a39fc0c953437cfc9205baed53",
-      "pubkey_x25519": "260c029aeb0b39a73db660aee9919c087e7e83de32e2f3bf9be78a3b15c36328",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "387fffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22129,
-      "pubkey_ed25519": "3866a53df944880e84d8d99b42d9a37b227674f0cb00fe7dc61198b0a25922bb",
-      "pubkey_x25519": "c945f03d6ec6fbb043418aa6dc16872487219414b78415c71f32e9f3b2b8cc23",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20229,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b3ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.100",
-      "storage_port": 22021,
-      "pubkey_ed25519": "386fff69caf0102034063bb1f6ee4e86a919266964a5027bb4c1e3d8f3e701f5",
-      "pubkey_x25519": "6c52330ebd889c924e7bd8ca9b82d3b0c312beb17a746c121d9eaf50152f7c7a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f6ffffffffffffff"
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -6592,7 +4716,7 @@
         11,
         0
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "72ffffffffffffff"
     },
     {
       "public_ip": "167.86.69.151",
@@ -6620,21 +4744,7 @@
         11,
         3
       ],
-      "swarm": "a5ffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22105,
-      "pubkey_ed25519": "3a0e99d7a7ffcf1c00dfd61277b1461f8c06ade1a5b41f9bd116ba9f73d5e2ad",
-      "pubkey_x25519": "ff5d13e42517d82368ee5cb1b9e23011dc4575973ec4d43fadf2643f1f007b5a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9effffffffffffff"
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "185.188.249.168",
@@ -6646,9 +4756,23 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "8affffffffffffff"
+    },
+    {
+      "public_ip": "46.225.102.55",
+      "storage_port": 22102,
+      "pubkey_ed25519": "3a79cc940932738c83e1385ad767a100429fb9185522bb9163fbc8643b517bb9",
+      "pubkey_x25519": "e832ba22c93e83e73dad777736b73d4441def044f177f291065cb2a904da596c",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22402,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -6662,21 +4786,7 @@
         11,
         2
       ],
-      "swarm": "96ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22103,
-      "pubkey_ed25519": "3aa4cf67d374509280055c4ac96c97da89a827147c4f09d56b6edce19d097511",
-      "pubkey_x25519": "40121cb17443b25014022ef7bb6e1fb8e68e2ff544b5c99f010d1f95265e6a14",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "45ffffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -6691,34 +4801,6 @@
         0
       ],
       "swarm": "5affffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22109,
-      "pubkey_ed25519": "3af4a69fd764b3bf2c22ada8931975b8c7cb94568f3ee8d28c74023a1e57658f",
-      "pubkey_x25519": "b7017dfe27ea6d5fcf56b3d8a0b6e007dd232700b762f0480adcf48e29d48a2e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "e6ffffffffffffff"
-    },
-    {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22103,
-      "pubkey_ed25519": "3b11f1a0b1c39ac2f3d197d63c5eab8157e1ae380831b8bf3f6cd3bf62ebca27",
-      "pubkey_x25519": "5b2e70445510215b4380650ba11e2779bc62faa5d606a06ca5058dbe3610cd2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "209.141.42.118",
@@ -6746,21 +4828,7 @@
         11,
         2
       ],
-      "swarm": "eaffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22123,
-      "pubkey_ed25519": "3c3e35c2fdb0a55863d7b87ad0b0a4e546ddb67bd281dc0f82e8368b4c302929",
-      "pubkey_x25519": "4e38bce3434c5517debdd49e49ae90cf3f717627b636a7d0b91b404cf3c47354",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20223,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1f7fffffffffffff"
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "45.79.83.44",
@@ -6774,35 +4842,21 @@
         11,
         0
       ],
-      "swarm": "d9ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22117,
-      "pubkey_ed25519": "3c835b74f025cb47a86640eee50d986b8955f7a7e75c0104925ee1005f026ed3",
-      "pubkey_x25519": "e36b651d834d7205a86c3199aeefe3bc12f0c9708db17bcb3ba5562d0ff5ea09",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20217,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2effffffffffffff"
+      "swarm": "257fffffffffffff"
     },
     {
       "public_ip": "74.50.123.173",
       "storage_port": 22021,
       "pubkey_ed25519": "3c91e4300084de95863a7e37df69de0d1abc936b35bb9e162824bc29b04c29a5",
       "pubkey_x25519": "304e99ba102024086a9d303b790a40779a9b6dc1f168edc390adf9636de0d024",
-      "requested_unlock_height": 2091006,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "33ffffffffffffff"
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "107.189.12.253",
@@ -6819,20 +4873,6 @@
       "swarm": "dfffffffffffffff"
     },
     {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22118,
-      "pubkey_ed25519": "3cc5dc7270e47461955f60e43fa08c671705d03289b68ac4a000f3a652aae430",
-      "pubkey_x25519": "a8eb55062d8769aea7909d2c9e733fa5c7a5a024df9026bc6ea8194dbf27f76d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20218,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "68ffffffffffffff"
-    },
-    {
       "public_ip": "95.111.246.120",
       "storage_port": 22021,
       "pubkey_ed25519": "3cd52992fbf62ee50538e6412b1cf414061d30eefc8abcdf8cabdae2c3107212",
@@ -6844,7 +4884,7 @@
         11,
         3
       ],
-      "swarm": "2effffffffffffff"
+      "swarm": "f1ffffffffffffff"
     },
     {
       "public_ip": "91.231.182.167",
@@ -6858,7 +4898,7 @@
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "51.79.173.171",
@@ -6872,49 +4912,21 @@
         11,
         0
       ],
-      "swarm": "147fffffffffffff"
-    },
-    {
-      "public_ip": "154.12.242.153",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3d653841350d8131adab92025f22612e51997e86b3fed536df91cf06f5f455f7",
-      "pubkey_x25519": "d50dee6e8ff3f0ed1dd8623fae830cfd846dd1a7ac283d95265dfcc364f1aa7e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "53ffffffffffffff"
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "45.13.214.124",
       "storage_port": 22021,
       "pubkey_ed25519": "3d6ac7d7395434d57b852c3b5ffdbb4be57932e847229b463bb355b5b42a3b30",
       "pubkey_x25519": "b6fb2c2671ee81d79a7755f237ce68dd2a66199ae56cc03a67b321c9a253357c",
-      "requested_unlock_height": 2084489,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "48ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22127,
-      "pubkey_ed25519": "3d940eb1f9384984541045253b0e1786c1a99dddfaff384f9497766889f5bd1f",
-      "pubkey_x25519": "0214af794c1aeaf01c1ba7c4d77dafb234d43d55f849b557c107010fd0fe8f5a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20227,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "daffffffffffffff"
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "38.242.155.130",
@@ -6929,76 +4941,6 @@
         2
       ],
       "swarm": "ceffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22107,
-      "pubkey_ed25519": "3df57dd30732957c5826bda84a653c6dc5695613e031ba30642ba5d1480c1279",
-      "pubkey_x25519": "eae611e8e3645b684f250c6224a14827503a3ec75c75f8e5b27b26fe36334e30",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "237fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22109,
-      "pubkey_ed25519": "3e247afc0ab1ac2a62063bc8a1f7335de7dcfa66b01552f5d24528a6c6cfbe43",
-      "pubkey_x25519": "cef9d074e585054427fec3de1c2554a84d0c9fa6ebf0af7cb4c6def7222a9423",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "cbffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.83",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3e45521c1dc8f9ad3f7d09db98d0454608c441985747f6144058da1d0e9053db",
-      "pubkey_x25519": "4a427f84971b41ecd56260e80db959670223714402f75d2fb5c4c8fc7ab03805",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "287fffffffffffff"
-    },
-    {
-      "public_ip": "152.53.207.147",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3e6974b216498ac13e8d75dbb687805816aac6043230c6a5485df03045d289bb",
-      "pubkey_x25519": "cc1a69b65e625641ae6c3afe28b4aed07d4f8001e8f282f70dfbc2d71027de3a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22107,
-      "pubkey_ed25519": "3e6a169bdd87f1249f97fc1a43d996c147569a4a831e9dcc17843185d7c07ff7",
-      "pubkey_x25519": "f7c156f6b11d0f09a27300e4d05a75adedf5308c8ef852a060feb7f2556f2648",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "91ffffffffffffff"
     },
     {
       "public_ip": "45.33.57.4",
@@ -7026,7 +4968,7 @@
         11,
         3
       ],
-      "swarm": "6fffffffffffffff"
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "188.166.222.103",
@@ -7054,35 +4996,21 @@
         11,
         3
       ],
-      "swarm": "acffffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
-      "public_ip": "64.44.157.112",
-      "storage_port": 22100,
+      "public_ip": "107.182.173.179",
+      "storage_port": 22021,
       "pubkey_ed25519": "3f38d38259ee8f2a4853e2944418064413f1238904923451fe912f8c3b7324a0",
       "pubkey_x25519": "c3fb8188c3bb93babd59dafda77b3b7d3c0e875c9092d9a1e8a3038e0b647126",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
+      "requested_unlock_height": 2166448,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "dbffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.58",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3f4e1c8eb34b2da55f402a8ec612f1df109d2f6ebf37d898d564dcb21d553504",
-      "pubkey_x25519": "7d1b54500494e30a2b410257734d6076e9afaf9f11cb13f50fd99ab16786f146",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
@@ -7096,7 +5024,7 @@
         11,
         0
       ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "65.108.80.66",
@@ -7110,7 +5038,7 @@
         11,
         3
       ],
-      "swarm": "377fffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "159.223.233.23",
@@ -7127,20 +5055,6 @@
       "swarm": "48ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.253",
-      "storage_port": 22021,
-      "pubkey_ed25519": "3fd8f2a71c8fd9f191f64d2efc6627773e9946bca548805dc178a468eed38c66",
-      "pubkey_x25519": "aa6f343ce07aea4ce9c0b107eee8099ce60ee19c894c6df6d3e732b7e9e83905",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "20ffffffffffffff"
-    },
-    {
       "public_ip": "104.244.73.67",
       "storage_port": 22021,
       "pubkey_ed25519": "3ff9e8f5b9ca1aef803cad9cdfb707727a03d68078d7820e4adf3664a379598a",
@@ -7152,21 +5066,21 @@
         11,
         2
       ],
-      "swarm": "57fffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
-      "public_ip": "23.94.63.201",
+      "public_ip": "192.3.63.197",
       "storage_port": 22021,
       "pubkey_ed25519": "3ffce1e4052e2d21ab90a90d7c9ae241d79c88579ef81f4489bc203d294e3204",
       "pubkey_x25519": "721d4bb98e09690045b8d992e9aa3682eb6733d442081867d095519652062737",
-      "requested_unlock_height": 2085164,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "78ffffffffffffff"
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -7180,21 +5094,7 @@
         11,
         0
       ],
-      "swarm": "78ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.61",
-      "storage_port": 22021,
-      "pubkey_ed25519": "40f414650f59cbcf87d507f4d03dade9c88de047ec256556893ac23e337cf877",
-      "pubkey_x25519": "27f557158751212c3ca097237c3a29212260fe9371f35b29d397f50cf39fb603",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "1bffffffffffffff"
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "135.148.138.18",
@@ -7208,63 +5108,21 @@
         11,
         2
       ],
-      "swarm": "487fffffffffffff"
+      "swarm": "12ffffffffffffff"
     },
     {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22114,
-      "pubkey_ed25519": "41a95ce00abd5755b1ab46c5c6f82bc121147c005f623ee9d890f245496158e9",
-      "pubkey_x25519": "269190ba15a49bdf9ffda7c3d279c4e1cd29800735ca4a185b2f9ee78c17006c",
+      "public_ip": "46.254.214.39",
+      "storage_port": 22180,
+      "pubkey_ed25519": "419f10d19b5d551fdd450858bc9691787f4be19fac5c21373fc286e1669a8280",
+      "pubkey_x25519": "90c536a2d149195d5c53d042fae948b9ccb9502126532481fe63ea112daa881c",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
+      "storage_lmq_port": 20280,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "aaffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.238",
-      "storage_port": 22021,
-      "pubkey_ed25519": "422ac0256c5451b78ebe39178e8a0919547c4ff4cd1f79fd2cfda4013d4f27fc",
-      "pubkey_x25519": "d52ec783fd12d9c7236b7f2a1ecaef6f88c9eea31390c97c1fa3c4a7cae41855",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "49ffffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22105,
-      "pubkey_ed25519": "424bd42dec98469c34bba546c996318c730f297aac3534757bb76c43c0d3e6d9",
-      "pubkey_x25519": "a466ccff46c8787eb2c4c89fd77a5321ef64f17d9d6182074fd8248d9a41a01c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "28ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22115,
-      "pubkey_ed25519": "424c7d92374cd091f978a7f26e0ebb6ab3b19772d892e7f345a29b415658a1ba",
-      "pubkey_x25519": "ed6a5d3f0177c15178976e29bc4c484d608ea7d72bdda42a3ae30c57cb4d3654",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "198.98.55.158",
@@ -7292,35 +5150,7 @@
         11,
         3
       ],
-      "swarm": "3ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22106,
-      "pubkey_ed25519": "4286461dcb93c556a842ee599cd4caabcf717c874d818edd10d163484124fa33",
-      "pubkey_x25519": "6e1e84d9204bbeef17a03062083ae0f4227c8c35ecf8fac150b33c342d96cd0e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
       "swarm": "abffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22110,
-      "pubkey_ed25519": "433d5571d204c41f31effa3e77b6e5a7b17eff57f2b9bf1f42ce642a65b2bb19",
-      "pubkey_x25519": "da0c397043d8bba11d0ad213c7a8f3bb2897155d81afa541e1069f9e1534a46a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e9ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.73",
@@ -7334,7 +5164,7 @@
         11,
         3
       ],
-      "swarm": "fcffffffffffffff"
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "91.250.249.165",
@@ -7362,7 +5192,7 @@
         11,
         0
       ],
-      "swarm": "7effffffffffffff"
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "209.141.58.94",
@@ -7376,7 +5206,7 @@
         11,
         3
       ],
-      "swarm": "297fffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -7404,49 +5234,21 @@
         11,
         2
       ],
-      "swarm": "74ffffffffffffff"
+      "swarm": "45ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.57",
+      "public_ip": "144.217.12.193",
       "storage_port": 22021,
-      "pubkey_ed25519": "43fe958c80251ca0deb255a316a60669578775eb595f8c86d3c3e57c4248c828",
-      "pubkey_x25519": "cd413e0468b9a7cc503f03d9d1705e3a00e9bc1af91829c01d4c154e94f5105a",
+      "pubkey_ed25519": "443459049418988763d1b494c5dc90ca95752d3ed7685b67ff29943536ad018b",
+      "pubkey_x25519": "aea0f2b3c1bc97c39131ba2f7a3b91ba69f7389b595a54a11c0eb0d060a12343",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "227fffffffffffff"
-    },
-    {
-      "public_ip": "37.27.247.192",
-      "storage_port": 22021,
-      "pubkey_ed25519": "44315c76a244700b72eb76017278404b3b9e599dd00ad44cf969aff56170ea51",
-      "pubkey_x25519": "7d1b302d4ba137f83b4a90e3d74f71c122bd352793ad8bfaec2b7881d907ac71",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "ecffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.66",
-      "storage_port": 22021,
-      "pubkey_ed25519": "445f4c906bce8cb76f245d119311bffe1c22579ab280c62f5a55c5436f6b8499",
-      "pubkey_x25519": "793f639ea1f25d1128bf28d2f2f66b7de8e5b0c56fba41443fd30b379cf04315",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6dffffffffffffff"
+      "swarm": "8fffffffffffffff"
     },
     {
       "public_ip": "194.32.79.192",
@@ -7460,21 +5262,7 @@
         11,
         2
       ],
-      "swarm": "e2ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22122,
-      "pubkey_ed25519": "44e2ef67983dd3c1a1452cf82d352c5da3e949ec66eb5aaac1f672670eb59e1f",
-      "pubkey_x25519": "20282c8e8dc149039c88de87381617b8d4865afe1b6631e2a3aef83877d29d67",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20222,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "56ffffffffffffff"
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "89.117.59.169",
@@ -7502,7 +5290,7 @@
         11,
         2
       ],
-      "swarm": "b8ffffffffffffff"
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -7516,7 +5304,7 @@
         11,
         1
       ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "51.79.173.216",
@@ -7530,7 +5318,7 @@
         11,
         0
       ],
-      "swarm": "4ffffffffffffff"
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -7544,21 +5332,7 @@
         11,
         0
       ],
-      "swarm": "afffffffffffffff"
-    },
-    {
-      "public_ip": "95.111.207.142",
-      "storage_port": 22021,
-      "pubkey_ed25519": "459c605b42b4dd3198cc9631c0b684b512d239ad893f8561c22d49456c231864",
-      "pubkey_x25519": "cfd1700c9ee182292b135d3899d2e2ee8bf23e06fd2fe68d3702f40669eca656",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "4effffffffffffff"
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "209.50.254.148",
@@ -7586,7 +5360,7 @@
         11,
         2
       ],
-      "swarm": "cdffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -7600,7 +5374,7 @@
         11,
         0
       ],
-      "swarm": "2fffffffffffffff"
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "45.145.42.195",
@@ -7614,7 +5388,21 @@
         11,
         2
       ],
-      "swarm": "1d7fffffffffffff"
+      "swarm": "f4ffffffffffffff"
+    },
+    {
+      "public_ip": "185.245.83.77",
+      "storage_port": 22021,
+      "pubkey_ed25519": "46202f511ff1d5152ea036f9c76a995dfd22ce13d08421966fd3eef5656056d3",
+      "pubkey_x25519": "f91e71a0cd3e70a324d5ef7592026edd41983a246425d2c38130e26ff1a59436",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "152.69.167.181",
@@ -7628,35 +5416,7 @@
         11,
         3
       ],
-      "swarm": "a1ffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22104,
-      "pubkey_ed25519": "4690761ab657da924df341d30549091b81382743fa12496d34cca50ef31d2f58",
-      "pubkey_x25519": "66569cfbfaec6ccc65b27c20e127d70d9e49b69baf48de1e46cc617211d56337",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f1ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22103,
-      "pubkey_ed25519": "46cdad1dfc7c4f2c8483d6c54cb9894c09e0504883c38f3f68da53a8b8a471d7",
-      "pubkey_x25519": "5754373a2c8fba7981ed224950499d2eae6d0912490b09aa399126268655753b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "aaffffffffffffff"
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "159.65.106.23",
@@ -7668,9 +5428,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "6bffffffffffffff"
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "194.99.23.252",
@@ -7684,7 +5444,7 @@
         11,
         2
       ],
-      "swarm": "60ffffffffffffff"
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "51.89.165.64",
@@ -7701,34 +5461,6 @@
       "swarm": "48ffffffffffffff"
     },
     {
-      "public_ip": "193.22.147.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "47a6cb09dfd8d3ad123188f4e19d8299c4bf5ae35c19c10527db353c14319815",
-      "pubkey_x25519": "c6c52af3153fadae833f7ad27af2708aaff58199d4d9061eea77d811c649e709",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "77ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22114,
-      "pubkey_ed25519": "47c9bfdb6f388d15890ff37e8da50da8353e1734fb641cb30927f006e50a3543",
-      "pubkey_x25519": "27da7270b02a383906fd1359ba9e6f04a10f20e76e671ce638a4dbf2c0559954",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "357fffffffffffff"
-    },
-    {
       "public_ip": "192.99.168.74",
       "storage_port": 22021,
       "pubkey_ed25519": "47d4bd71d3c8eee6e99d6e4be73f96b8fc827a0028ac7b274b779ea11bdf1662",
@@ -7740,7 +5472,7 @@
         11,
         2
       ],
-      "swarm": "2a7fffffffffffff"
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "54.39.146.112",
@@ -7768,7 +5500,7 @@
         11,
         2
       ],
-      "swarm": "53ffffffffffffff"
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "157.254.18.36",
@@ -7782,21 +5514,35 @@
         11,
         3
       ],
-      "swarm": "beffffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "23.94.92.223",
       "storage_port": 22021,
       "pubkey_ed25519": "48e0f89725ec8259b8e725b857909eb5fabe7bea9b7f019b64f2e0167fb69f8c",
       "pubkey_x25519": "a46e8c73a367c59b01398aea196f2c4d191c1713b921614d4e2cb3145de9b745",
-      "requested_unlock_height": 2086494,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "a7ffffffffffffff"
+      "swarm": "aeffffffffffffff"
+    },
+    {
+      "public_ip": "95.217.21.148",
+      "storage_port": 22103,
+      "pubkey_ed25519": "48f8afa6477cce2474afec56094c100162a9ac6f021cc15d3f51ef51551fc467",
+      "pubkey_x25519": "c49164fbca1fa2bb0d1a712e8d754cad8f248fac7e4c3a97f06c5262e5cb4f24",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22403,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "91.98.68.87",
@@ -7810,7 +5556,7 @@
         11,
         2
       ],
-      "swarm": "4dffffffffffffff"
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "152.53.246.220",
@@ -7824,7 +5570,7 @@
         11,
         3
       ],
-      "swarm": "faffffffffffffff"
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "91.99.120.185",
@@ -7852,7 +5598,7 @@
         11,
         2
       ],
-      "swarm": "b2ffffffffffffff"
+      "swarm": "4dffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -7866,7 +5612,7 @@
         11,
         0
       ],
-      "swarm": "e4ffffffffffffff"
+      "swarm": "5effffffffffffff"
     },
     {
       "public_ip": "51.255.136.71",
@@ -7880,7 +5626,7 @@
         11,
         3
       ],
-      "swarm": "b6ffffffffffffff"
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "165.227.131.168",
@@ -7894,7 +5640,7 @@
         11,
         0
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -7908,7 +5654,7 @@
         11,
         1
       ],
-      "swarm": "7ffffffffffffff"
+      "swarm": "b4ffffffffffffff"
     },
     {
       "public_ip": "157.245.77.43",
@@ -7925,20 +5671,6 @@
       "swarm": "a7fffffffffffff"
     },
     {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22106,
-      "pubkey_ed25519": "4ac24691480799e6a599d095d72aab89b9aec171c84e424fbfe6b59620bfcc9f",
-      "pubkey_x25519": "5eef2029cbd1cee6b7070b6a14d4e3c8a058b7787f7b212dc5eb0b0290da6202",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "34ffffffffffffff"
-    },
-    {
       "public_ip": "95.217.21.148",
       "storage_port": 22106,
       "pubkey_ed25519": "4acbd494ef00e5eb4d5d01348fc3f6075b926fd661e4cec4c7863d53ff8da5b7",
@@ -7950,7 +5682,7 @@
         11,
         0
       ],
-      "swarm": "3fffffffffffffff"
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "161.97.103.88",
@@ -7964,7 +5696,7 @@
         11,
         2
       ],
-      "swarm": "2f7fffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -7978,24 +5710,10 @@
         11,
         0
       ],
-      "swarm": "147fffffffffffff"
+      "swarm": "bcffffffffffffff"
     },
     {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22108,
-      "pubkey_ed25519": "4affc306c1e0b0798de1f890b95e8f3d25435c2af36a7f5942c00c8aaf806611",
-      "pubkey_x25519": "10664f702883b05b604a474181817cab1d208741fe6648a94beedd8fe8c59e0d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a0ffffffffffffff"
-    },
-    {
-      "public_ip": "31.22.111.191",
+      "public_ip": "173.249.193.95",
       "storage_port": 22021,
       "pubkey_ed25519": "4b39adf79f6d6486ef8fadca8647b9331c7ae73de371849529e40760c814e351",
       "pubkey_x25519": "c6d27ab6f901ad09a54348cd4f7e9e1b5317a21dbc30e23d01bbf516b2df3422",
@@ -8004,37 +5722,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "dcffffffffffffff"
-    },
-    {
-      "public_ip": "46.225.128.110",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4b6701c1d084af70e941741a311d95e211592dee04f9830b4ccd117545dd5094",
-      "pubkey_x25519": "e138708486b8118ab3a4a07b89560c855518fcb27408163392b68c7290b30018",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b3ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22111,
-      "pubkey_ed25519": "4b8518654a0b443869cf33711a38db3de8dffd500f99dcabe498a1b40656f93f",
-      "pubkey_x25519": "00939476ec7ee4c23130a5a811c955abf858887948468899f727dd8d37b0227d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "bcffffffffffffff"
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "134.122.63.223",
@@ -8048,21 +5738,7 @@
         11,
         0
       ],
-      "swarm": "36ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.57",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4bec65bb9ff4f3873021d52ec78185efb7aa10973083adda469d67449626c7db",
-      "pubkey_x25519": "c5c4296ce669c28b345b32166f6765e6d6ea6f0cfd3435972336b99849f5c95c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "daffffffffffffff"
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "51.79.65.165",
@@ -8076,69 +5752,13 @@
         11,
         0
       ],
-      "swarm": "c7fffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22110,
-      "pubkey_ed25519": "4ceb5b7fdabf97db0b39c7d2bd966881eb159a20cc407f0d348de65189db5daf",
-      "pubkey_x25519": "0d2924bd7b4683e61f6cc302480203e966cc3306d29324351c8d0889970e4d0c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c8ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22108,
-      "pubkey_ed25519": "4cf7430310e4ea8534f9bdc183f29fdd0077382bd0839167c7d2907737cfb688",
-      "pubkey_x25519": "d06c3ae78721a83de0398c369032b6fecc9a34e1508e2b0d726efa2be6725276",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22130,
-      "pubkey_ed25519": "4d1867319c182dd7e6bb6c156575c50ca657969af94ace5ca677dfc599323a56",
-      "pubkey_x25519": "1d648f25a46559b39bd423f4b60f1e591307906a2841c40adf9d5312ed55ca78",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20230,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
-      "public_ip": "103.199.19.138",
-      "storage_port": 22101,
-      "pubkey_ed25519": "4d78084b08c447143400b48c90b6f6b6827e1bff8fc08f93002657044e93fcca",
-      "pubkey_x25519": "a71528ca1dee396f20c7e238dbd886855af69637cf969c7fbef04e3d8cb72842",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "9affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.116.129",
+      "public_ip": "91.99.230.225",
       "storage_port": 22021,
-      "pubkey_ed25519": "4daaede2511b28e2a7cd1595474088bd165eff7df9168f125dd7983071ed0a63",
-      "pubkey_x25519": "3fcceda5280527094ec7cb8710608131e8b6b7ffc6c0a576eb937525c223ed04",
+      "pubkey_ed25519": "4c6bc4d992954d50f049f13196cd48952db4b315f0df6f8e29ac5b393370ef51",
+      "pubkey_x25519": "5841594f6f571045a745795cfd53d838ed470a8b44c880d0e3bc462c3f68457e",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
@@ -8146,7 +5766,7 @@
         11,
         0
       ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "227fffffffffffff"
     },
     {
       "public_ip": "128.140.87.239",
@@ -8160,49 +5780,21 @@
         11,
         2
       ],
-      "swarm": "9bffffffffffffff"
+      "swarm": "73ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.87",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4dc3abd888b6c71b255b95cbdcc0b8b7ac76c0b24d48869e5f1f9ffb7a3e7829",
-      "pubkey_x25519": "c4b57bc952d11501d807f6c44ca0f956a924c2f9d395282de746f1774ad4c960",
+      "public_ip": "89.167.117.100",
+      "storage_port": 22103,
+      "pubkey_ed25519": "4deef20184e043fccf568a96352a0c0b0403d645027d3f66cc2cc9b6a34fb3a2",
+      "pubkey_x25519": "5d913c31d55a457c8bbc9efcb22ca7bbacec4f04cbd7161397a7521a28d7692e",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "2effffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22113,
-      "pubkey_ed25519": "4dcf7b92fc43c0202dc628aaf9d1a57f209a901bc0a31fbb55a0954ef8195872",
-      "pubkey_x25519": "b98fa18861c38d8e0b3d657d9ba9fd47c6f916727584080b0a9aaf496f75444c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
+      "storage_lmq_port": 20203,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "317fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22116,
-      "pubkey_ed25519": "4e4055c383ee7f8f61e956ad2ab1a4904b07e254d4ee308175dc6341e4935189",
-      "pubkey_x25519": "8e53a486b21bc127e6453964d584971eb9f1cf79517b75e616239e077207113d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20216,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "199.195.252.42",
@@ -8216,77 +5808,7 @@
         11,
         3
       ],
-      "swarm": "c9ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22107,
-      "pubkey_ed25519": "4e72e1ba86bfae915b3cd2e92580f1e52648251314c876a3d591646f0eae599d",
-      "pubkey_x25519": "fc5019edbd1c6ae1ebfb057be3cc49bd1f150f1145c2cfad58960c85c854da5f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "deffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22110,
-      "pubkey_ed25519": "4e91707683562c298ebdb25de8b91a860663f8a10f31c19a2bf96bc1afec5c4c",
-      "pubkey_x25519": "d46a9c125e3d66a14147d1910814b6275e0a66158f404afdd0ab7387f9702119",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "74ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22116,
-      "pubkey_ed25519": "4ebda71a9490c5c3111d74bb5d5b91c28df19ec98902f6d38bb2237cee00ce17",
-      "pubkey_x25519": "6f151f18a2946afcbcfe226d62ff3cb74f96a2608d8c6e517603628e54e5a921",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20216,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "6cffffffffffffff"
-    },
-    {
-      "public_ip": "66.94.125.216",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4ec7f541f6713675fad2293862c65e4f57207f45b8840b2a8b4b854963aea697",
-      "pubkey_x25519": "e065c1db87dbdddee29f9a992834fa6ce61f87feff276a4f5817dc35e7028974",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.143",
-      "storage_port": 22021,
-      "pubkey_ed25519": "4f0cffb44f43e99517a8beac742e57ab2df559e7591c33ec0291158c42ce66ea",
-      "pubkey_x25519": "858c07f0c7c605f68ef7287638034b6be26fe71fbdc5608578d5786b5201e716",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "bdffffffffffffff"
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "37.27.212.116",
@@ -8300,7 +5822,7 @@
         11,
         3
       ],
-      "swarm": "d1ffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "167.86.100.55",
@@ -8314,7 +5836,7 @@
         11,
         3
       ],
-      "swarm": "67fffffffffffff"
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -8335,17 +5857,17 @@
       "storage_port": 22100,
       "pubkey_ed25519": "4fe324e4eb85d40d8d2899ddd7865237f8c3248d1415f6ea1a9192024507ac9c",
       "pubkey_x25519": "2eee9d8a84a787eb6e2f044619b682d927016d0e4c5ebb1c2fae87b8c4f24363",
-      "requested_unlock_height": 2090113,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "e7ffffffffffffff"
+      "swarm": "2bffffffffffffff"
     },
     {
-      "public_ip": "102.222.20.141",
+      "public_ip": "178.105.185.245",
       "storage_port": 22021,
       "pubkey_ed25519": "4ff4dbed33408522f1e6a91325eb8d4ff402ba0258c172be9d97787922e676b0",
       "pubkey_x25519": "3d1c41074d01f91478012a9fa3cf90b4d8e7872514a6ef62ba90f3576d9bc169",
@@ -8354,9 +5876,9 @@
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "2affffffffffffff"
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -8373,6 +5895,20 @@
       "swarm": "3bffffffffffffff"
     },
     {
+      "public_ip": "155.103.66.130",
+      "storage_port": 22021,
+      "pubkey_ed25519": "502dfca22ce0801a400b06a9e675a3977d947bb17b111f63c5f7dbecc2f2ffcf",
+      "pubkey_x25519": "dd7a3a20673923232ce71ffaffaa1cebdc3e44dc3e7c87f11490f2fa367ec55f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "3e7fffffffffffff"
+    },
+    {
       "public_ip": "212.105.90.36",
       "storage_port": 22109,
       "pubkey_ed25519": "502fc33b9a19492d3daf34e5e19c795933bf58e39f02561345c4267c98110670",
@@ -8382,9 +5918,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "2fffffffffffffff"
+      "swarm": "60ffffffffffffff"
     },
     {
       "public_ip": "89.58.27.63",
@@ -8398,7 +5934,7 @@
         11,
         3
       ],
-      "swarm": "6bffffffffffffff"
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -8412,49 +5948,7 @@
         11,
         0
       ],
-      "swarm": "dffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22105,
-      "pubkey_ed25519": "50c6a0746f7bbb26307d1a2bba9ee769aaad399e5ebe7406aa294bc797edb0d2",
-      "pubkey_x25519": "fd9d8e0fcec1b46ad51ed37b5a7ae8e16323a96ba8ab8f27c14269fac742e272",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c6ffffffffffffff"
-    },
-    {
-      "public_ip": "65.109.4.149",
-      "storage_port": 22021,
-      "pubkey_ed25519": "514fa1a4817a2d492e434cda2d569707606ab797530d76ac9eb87551eeec34ae",
-      "pubkey_x25519": "91fd558466da26b81e2d46cf4822871861377927e00dcdffd651df9918a19630",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "99ffffffffffffff"
-    },
-    {
-      "public_ip": "213.136.74.26",
-      "storage_port": 22021,
-      "pubkey_ed25519": "51a0ab02885fdf749cf05de9b2ec0962251ea21ea2c020fb6a1f7475f84ee6ce",
-      "pubkey_x25519": "43d1ac3147ad69068bde99d357e2850a587566c3607b2b0caa7ccbedfd0d641f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f4ffffffffffffff"
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "49.12.220.221",
@@ -8468,21 +5962,7 @@
         11,
         2
       ],
-      "swarm": "f9ffffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.50",
-      "storage_port": 22021,
-      "pubkey_ed25519": "51c7aeb2ae9cd60dcaf9dc91c24ccbca274466d5b75ec04f91cc0de12cc3049a",
-      "pubkey_x25519": "58f1790dcc220a26353d1cdcaed3bbe4dfbd97345e780b8818885c6ed591275a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3b7fffffffffffff"
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "104.244.79.28",
@@ -8496,35 +5976,7 @@
         11,
         2
       ],
-      "swarm": "30ffffffffffffff"
-    },
-    {
-      "public_ip": "95.217.21.148",
-      "storage_port": 22105,
-      "pubkey_ed25519": "51e746428652c9950a78dea8e5ff3521871749268ff51705ca8b8c102e4e7d6f",
-      "pubkey_x25519": "9d92309bd19e09c121264d68e42342b459e8e49aacd2f4f7ace2bc5f381c387e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22405,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "89ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22109,
-      "pubkey_ed25519": "51ee1a8999060d18c8194a73dde126aeab521d780c8ed57fd6324f9eb99df641",
-      "pubkey_x25519": "6d39403b5d77c37937b8e927ccbc67c04b92bb24b7a8145d09b4f6ca595a6160",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "98ffffffffffffff"
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "89.167.117.100",
@@ -8538,35 +5990,21 @@
         11,
         3
       ],
-      "swarm": "fdffffffffffffff"
+      "swarm": "deffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.25",
+      "public_ip": "31.220.92.53",
       "storage_port": 22021,
-      "pubkey_ed25519": "523d1ff49ab1dbc42c8432a15eeca2a42c631de419ac5321a84f7ab7f76dc85c",
-      "pubkey_x25519": "b93170bc5c217b4dd0a0b3e8db5e6be7551fc02d58628685f715753a7479fe79",
+      "pubkey_ed25519": "5282cbfc69c50c68f55fe2cbfaa03c2e6310ed92923171ccade1905546742e53",
+      "pubkey_x25519": "2f25fcb0f54731a2d858cf89e1815a9dea27ad4a25e8c01aac04d92dc5987c54",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "bfffffffffffffff"
-    },
-    {
-      "public_ip": "129.80.36.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "525ba5bc2d64eff0be94649b4b8d49a6a4de6bd94c4fff0dbef907b4ff4d83ef",
-      "pubkey_x25519": "b35dbb7edf569a74719b1f4665069c2d6ef5680629a4c049dd5db375884af458",
-      "requested_unlock_height": 2091319,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e6ffffffffffffff"
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "198.98.52.166",
@@ -8580,7 +6018,7 @@
         11,
         3
       ],
-      "swarm": "2dffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "51.79.84.33",
@@ -8608,21 +6046,7 @@
         11,
         2
       ],
-      "swarm": "bbffffffffffffff"
-    },
-    {
-      "public_ip": "84.247.172.3",
-      "storage_port": 22021,
-      "pubkey_ed25519": "52ed1b930d4281ec42352f3caa81d9a01596f15d21d3cc809516f4ac44986a0e",
-      "pubkey_x25519": "e5a526d150e1bb3fb14a6afc8ffc99cbc01d95c2b264992983d6e314b8759d65",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "80ffffffffffffff"
+      "swarm": "57fffffffffffff"
     },
     {
       "public_ip": "209.141.47.183",
@@ -8636,7 +6060,7 @@
         11,
         3
       ],
-      "swarm": "e4ffffffffffffff"
+      "swarm": "cdffffffffffffff"
     },
     {
       "public_ip": "192.155.85.128",
@@ -8664,21 +6088,21 @@
         11,
         3
       ],
-      "swarm": "5bffffffffffffff"
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "89.58.29.25",
       "storage_port": 22021,
       "pubkey_ed25519": "53a7c11080ae90b5c9a71867c14f9028efdcf12ac71d974049246cb5b8ef1bec",
       "pubkey_x25519": "6c7a03453e2a5dfb49a124201656cc95584148a1355ff866c63eeda20464db74",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2170129,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "51.79.86.18",
@@ -8692,38 +6116,10 @@
         11,
         2
       ],
-      "swarm": "d4ffffffffffffff"
+      "swarm": "9ffffffffffffff"
     },
     {
-      "public_ip": "164.68.113.164",
-      "storage_port": 22021,
-      "pubkey_ed25519": "543d539a12a5ed5932a169d44f1de64aa6d6e9dcaf200854bbda4c61bc55c9c1",
-      "pubkey_x25519": "2c390f6dc48e3b4fa63f93867c94c4c70110097552aef5112d3f94368465a804",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "41ffffffffffffff"
-    },
-    {
-      "public_ip": "5.253.31.4",
-      "storage_port": 22021,
-      "pubkey_ed25519": "543da4217465cdbcee9b170735e9b15c78a3ab3d1a7d3e1af6748ca733d88b9b",
-      "pubkey_x25519": "f827b8774a0cbfac268505cb0637bf5210af2212cc7a943963b684025ce5ba0e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d6ffffffffffffff"
-    },
-    {
-      "public_ip": "188.227.250.71",
+      "public_ip": "94.237.117.117",
       "storage_port": 22021,
       "pubkey_ed25519": "549a5a7ac7265ff01b1fedeb818c0aefc0e20d7b35f5b62c73ea2ac2cdf67598",
       "pubkey_x25519": "f222db461fa79bcf148d684fd3fcb08307bbff382b76095fe8254ad31c0c6e48",
@@ -8732,9 +6128,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -8749,20 +6145,6 @@
         3
       ],
       "swarm": "49ffffffffffffff"
-    },
-    {
-      "public_ip": "194.62.97.192",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5534c3dfba4c7aa8c8125471c2ab2511780ffab311d7573a9b460f9b3ee199f8",
-      "pubkey_x25519": "1d716a5159dc320d436340a997179ac097e0fd28c0cef3309a3677c414041b56",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c6ffffffffffffff"
     },
     {
       "public_ip": "45.56.90.64",
@@ -8790,21 +6172,7 @@
         11,
         3
       ],
-      "swarm": "8dffffffffffffff"
-    },
-    {
-      "public_ip": "23.81.40.224",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5566cd614f23ddb17fec8db75f0f6614c95332013c670bd3efe56c3bb0fa9a37",
-      "pubkey_x25519": "327b15bf7e7196660233dedfd8c6d0d37ec44fb1b8a7128f314c3a63b9caa031",
-      "requested_unlock_height": 2085899,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "feffffffffffffff"
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "84.21.171.110",
@@ -8818,35 +6186,7 @@
         11,
         2
       ],
-      "swarm": "207fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22128,
-      "pubkey_ed25519": "559f7debe1814f51412987c2d7302ea30ced1bae06f0c2070fbf42a5da5a8dfc",
-      "pubkey_x25519": "ec1269421fec16e8bc3e964795244c4015f264177fefe150131b27ec5b3ecc48",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20228,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "20ffffffffffffff"
-    },
-    {
-      "public_ip": "207.180.229.183",
-      "storage_port": 22021,
-      "pubkey_ed25519": "55b68e059454eb1036849a60816054bf5e31f163ba5605d8c8bee5d4818ba1a2",
-      "pubkey_x25519": "45dcfed7bf3a0398ed5ba59add0feb5d525b9c927f798fefc01a2ae848cea534",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "80ffffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "161.97.68.140",
@@ -8860,21 +6200,7 @@
         11,
         1
       ],
-      "swarm": "bdffffffffffffff"
-    },
-    {
-      "public_ip": "159.69.52.66",
-      "storage_port": 22021,
-      "pubkey_ed25519": "55e842b077f8fbe643a08d1c687195ecca8ee06b9c10d0f5b8ad306eb875f70c",
-      "pubkey_x25519": "c3946514e4f577c2ddd05b3f7fe90166ca3a8ddc4f8b040ad8b1a05ce535685f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e8ffffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
@@ -8888,35 +6214,7 @@
         11,
         0
       ],
-      "swarm": "f8ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22134,
-      "pubkey_ed25519": "562a9f53323515b7ed22a88467e0b1fe68e166a42dc95f7371a403b0d2f54781",
-      "pubkey_x25519": "682488349468e9eccd33f1442e72fd31ac9e72b0f70ba5f7cb211f7813f2c61c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20234,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "31ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22135,
-      "pubkey_ed25519": "565a450700bf8fd2319fad851fa2f68fb932f77edf743abdea79a3665a75fed3",
-      "pubkey_x25519": "fba711b7cb0f6b92f54887f1caad22304decfc7004cdc92585e0bce447f58040",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20235,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "0"
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "107.189.11.153",
@@ -8930,7 +6228,7 @@
         11,
         2
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "57.129.67.254",
@@ -8944,7 +6242,7 @@
         11,
         2
       ],
-      "swarm": "c0ffffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "50.116.1.7",
@@ -8972,7 +6270,7 @@
         11,
         0
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "139.99.171.45",
@@ -8986,7 +6284,21 @@
         11,
         2
       ],
-      "swarm": "1d7fffffffffffff"
+      "swarm": "22ffffffffffffff"
+    },
+    {
+      "public_ip": "57.129.4.42",
+      "storage_port": 22021,
+      "pubkey_ed25519": "56e294cb430ebd88ecb9cbed1db91a1438c3f594639a9d972146ea0ac7e0247f",
+      "pubkey_x25519": "f37cb88aeda6a1e55abacf751554e113b98eefba9f93ff15d216c0a1b135a444",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -9003,34 +6315,6 @@
       "swarm": "b7fffffffffffff"
     },
     {
-      "public_ip": "128.199.51.252",
-      "storage_port": 22021,
-      "pubkey_ed25519": "57288b6ca34c8e2288d5eed8445967cbcd9a5a1b14c8debc6720879f67e36188",
-      "pubkey_x25519": "8ba06ed00d8adab821c697bfafe2db909da56afd1c7ed5117e8b05127c09ce41",
-      "requested_unlock_height": 2094234,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b1ffffffffffffff"
-    },
-    {
-      "public_ip": "51.38.187.113",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5750b08db37b3ec8e4a4d8df0ccf912fd30344b663e225642007349f0490dae1",
-      "pubkey_x25519": "d5e9de82c59a5f4c187e6707acd0c3c1b27b6c6ff22639553cb58678b6bb3775",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f0ffffffffffffff"
-    },
-    {
       "public_ip": "5.161.98.53",
       "storage_port": 22021,
       "pubkey_ed25519": "576e933dc3c50ab6d4dc04357ee613286c859e0f3164b978356130e35ee4c4bc",
@@ -9042,7 +6326,7 @@
         11,
         2
       ],
-      "swarm": "1effffffffffffff"
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "192.155.85.177",
@@ -9059,20 +6343,6 @@
       "swarm": "3bffffffffffffff"
     },
     {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22108,
-      "pubkey_ed25519": "57f508424ed724bdd3a826c0f09b7c957bd5e0a9aa22b44d08c0de216586e65f",
-      "pubkey_x25519": "4402004dc18404a32bca37f230bc9af14383af1e74604cf8e757c03dc8824720",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "53ffffffffffffff"
-    },
-    {
       "public_ip": "91.99.120.185",
       "storage_port": 22102,
       "pubkey_ed25519": "58074f4db735b3e81d972053bd54595dc788666c6caeb773fdc781fcc64cf5ee",
@@ -9084,49 +6354,7 @@
         11,
         3
       ],
-      "swarm": "6dffffffffffffff"
-    },
-    {
-      "public_ip": "89.125.187.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5809717acc8ba54c40ea1337d4f57433d9b16fe5d540be18e877ca8c7bd5198e",
-      "pubkey_x25519": "71e1fc29f8b97092ba1545d4de88c45b6145839971784e2ca9b85e7bef695a39",
-      "requested_unlock_height": 2085143,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
-      "public_ip": "167.86.118.4",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5814e7d7be5f920204f757003e63483525afbb10907f096587d064ad81956d57",
-      "pubkey_x25519": "084d3127c9d14d755f81a3ef6fe1a11d12624fcff5cb9a2a240969cb9559d526",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "68ffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22115,
-      "pubkey_ed25519": "586f0fe35e764b6bb02e91d00f3ba9bb6aab0bfa3531bb8560fc3cd8588d0c8a",
-      "pubkey_x25519": "af87d107a995a6a75a54033350d0bd6fe14be35e56994be9601e7e604db27d41",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "77fffffffffffff"
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "161.35.158.50",
@@ -9140,7 +6368,7 @@
         11,
         0
       ],
-      "swarm": "67fffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "31.220.94.51",
@@ -9152,9 +6380,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "37.60.241.162",
@@ -9166,9 +6394,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "15ffffffffffffff"
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "51.79.173.224",
@@ -9199,20 +6427,6 @@
       "swarm": "307fffffffffffff"
     },
     {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22101,
-      "pubkey_ed25519": "59ad9d5465fa4d6c81717d6a8a7634b5622eda69e1325fa3d884ed6665451a64",
-      "pubkey_x25519": "4810f7f537e9f1f5eeae00cc80b273b30de0be0ea54cc710b6bafaca43fd9838",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f4ffffffffffffff"
-    },
-    {
       "public_ip": "116.203.146.221",
       "storage_port": 22108,
       "pubkey_ed25519": "59cb676c77fc8b923026547301aacb7e5c9684186f0cd631e7da7fb5a7501084",
@@ -9224,21 +6438,7 @@
         11,
         0
       ],
-      "swarm": "5affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.100",
-      "storage_port": 22021,
-      "pubkey_ed25519": "59dc26e5ea8f91fba91725a85d7cd2537284f85a3e8f651b31d5330c15cb31cf",
-      "pubkey_x25519": "882262ed1a73ab1097e95fe04d8fa8bce0e26c0e125690afc5846103aec35f14",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -9252,49 +6452,7 @@
         11,
         2
       ],
-      "swarm": "b5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.81",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5a22bcc8187e03d3c8b037f927d6be1d8cec391686ab3addfd5a33942e5f5b2e",
-      "pubkey_x25519": "ac8da9648a8929458a76696e0338d1a6d07e0ec05ad242f6e5ada95157126160",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "cdffffffffffffff"
-    },
-    {
-      "public_ip": "217.15.163.107",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5a4962c4d9a2319e20ff01dc32f84d96f3ff7f303fe54b30345ef74c0af5439b",
-      "pubkey_x25519": "6a2f0e30f98d3a5b1f40631762c59dfdb9815ff41b297723a55fb315dd9c802f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "88ffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.67.191",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5a558ea86464ca91f94d6fe72dc1c4164d15c6d4de4bfb7c66531df159f84823",
-      "pubkey_x25519": "77edc58aa74bc020c6c99ae49849c94fb7261b1136daa260d503e4d5e09b304e",
-      "requested_unlock_height": 2090346,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "38ffffffffffffff"
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "188.245.112.98",
@@ -9308,21 +6466,21 @@
         11,
         2
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "3c7fffffffffffff"
     },
     {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22106,
-      "pubkey_ed25519": "5b46dc00f0e8c471a295d0f23caf86a6f4afa6197b5f8c00b87d29d7cf1b3d0d",
-      "pubkey_x25519": "d32fea2fcd186c7fa7a6f762a7224c3d7a178bfa625f8727923e2debd96e036e",
+      "public_ip": "212.227.188.96",
+      "storage_port": 22021,
+      "pubkey_ed25519": "5b36e858fdbe0830ce77bc5c7e971ca1a818adc1173a5d07ed597a39e5f28425",
+      "pubkey_x25519": "c8f6307101541f5c58be48c265058a8658cab0370f95b821c5500a5da7ff1610",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "f3ffffffffffffff"
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "209.50.241.202",
@@ -9339,7 +6497,7 @@
       "swarm": "3dffffffffffffff"
     },
     {
-      "public_ip": "212.105.90.36",
+      "public_ip": "212.105.90.34",
       "storage_port": 22104,
       "pubkey_ed25519": "5b5ce5b4fc2e71581956a402094e592cd1600a3b19d5312ab56f86b81c0d8b45",
       "pubkey_x25519": "f13a9a1c197b9c79c3c248df4256028c787fe84e77434064d88996a6079d1f52",
@@ -9350,49 +6508,7 @@
         11,
         3
       ],
-      "swarm": "e4ffffffffffffff"
-    },
-    {
-      "public_ip": "139.59.29.239",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5b6709b0b5b7fe02f508a39d047d73e336de9ddbf1526ee5562c3ade4aeaa6ca",
-      "pubkey_x25519": "a62f05815f7b323373dc7241ab0e5494a43192935ab619fbbcc101f4b93f0560",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "ddffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.35",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5b753bf1f67575737848a791b315743f9081d4198a86543132d1b4a2068b8135",
-      "pubkey_x25519": "76adb626b0ad64ca1040d51fa608ff1dd5859c4f51f7757f2806275e2ca21a47",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a0ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22107,
-      "pubkey_ed25519": "5bfa18daae5c335a9feaf0c52fac3eb8e63819397e4593c16f39b863da17a9a0",
-      "pubkey_x25519": "150e1b96e9c353a3b3f3f594b61c4a2fdafcc7a8bc278769fd915fef85155973",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5effffffffffffff"
+      "swarm": "c7ffffffffffffff"
     },
     {
       "public_ip": "38.43.93.173",
@@ -9406,7 +6522,7 @@
         11,
         3
       ],
-      "swarm": "a7fffffffffffff"
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "173.249.51.100",
@@ -9418,7 +6534,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "7effffffffffffff"
     },
@@ -9434,63 +6550,21 @@
         11,
         3
       ],
-      "swarm": "c0ffffffffffffff"
+      "swarm": "b3ffffffffffffff"
     },
     {
-      "public_ip": "172.93.167.217",
-      "storage_port": 22021,
+      "public_ip": "161.97.98.159",
+      "storage_port": 22100,
       "pubkey_ed25519": "5d0418ef3fd605ca98b07dfab4d4d32fad9f6351eafc6188d54b69ec519539ba",
       "pubkey_x25519": "5016c7bf1f6eca0c5bba91bbcc382600c7c4fefd30bf0b9366a73b60fa4f2911",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a5ffffffffffffff"
-    },
-    {
-      "public_ip": "84.247.128.91",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5d13bed998a7feb450c20fbd6d780b6be87c751b5083adf9774ec4610e78c5cc",
-      "pubkey_x25519": "e8987cfab527bd02fa4aadc62fb76fbcf4851643bf6aac1d4e9e48f0429df579",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3fffffffffffffff"
-    },
-    {
-      "public_ip": "45.13.38.196",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5d1dff53e9263e18c5a287dee444c0c847987553047af373b319db21bbc8fec9",
-      "pubkey_x25519": "4c2e929c42399914f7d985d891477a3bbc6967f501cfb4de03026f17ef6a4e27",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20200,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "2dffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22119,
-      "pubkey_ed25519": "5d45a825a407571c1b46a6dc1133d755c56d686fcba4de605bf664f9ee8026ec",
-      "pubkey_x25519": "3f1359074066fc80e664856a4896e6d09fd6cca0f927e9747c0cb06f59dfa01d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "70ffffffffffffff"
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
@@ -9504,7 +6578,7 @@
         11,
         3
       ],
-      "swarm": "caffffffffffffff"
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "57.129.121.198",
@@ -9518,10 +6592,10 @@
         11,
         2
       ],
-      "swarm": "1affffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
-      "public_ip": "31.22.111.217",
+      "public_ip": "169.197.86.232",
       "storage_port": 22021,
       "pubkey_ed25519": "5d973fdd6e7333fe83b9df8ace0a63e23e3137ea67c370107e9b5cb1dd03de62",
       "pubkey_x25519": "4216a208b5b3b74c30b16a63f84cdc245a2861cf78ca8d775c87ec8ba249c61c",
@@ -9535,20 +6609,6 @@
       "swarm": "d4ffffffffffffff"
     },
     {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22108,
-      "pubkey_ed25519": "5dbe55a55a6a72823dcd8f1102b1e9dd3ae16e11159c62ac9ba37b5e4d72b51d",
-      "pubkey_x25519": "ef109c6b608c8ee3aeb3677faedcf4fcf8b406f65f252030501bf9511e67680a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "44ffffffffffffff"
-    },
-    {
       "public_ip": "2.59.133.153",
       "storage_port": 22021,
       "pubkey_ed25519": "5dcdbf77141b93f32c5d268be5c5db09b8ac8d6fd881657690eb183b32421ebf",
@@ -9560,35 +6620,21 @@
         11,
         1
       ],
-      "swarm": "d7fffffffffffff"
+      "swarm": "79ffffffffffffff"
     },
     {
-      "public_ip": "66.94.111.4",
+      "public_ip": "15.204.94.233",
       "storage_port": 22021,
-      "pubkey_ed25519": "5e1bc2290698de3f538cce79d3804e3deadf0f19bd5a2b2d73096a79af229085",
-      "pubkey_x25519": "556fc9cd86bd9a0d2d1a192e4b0389bbba2d4a0e7bbcd89d8a07502d51579838",
+      "pubkey_ed25519": "5df18a1383368e6cfe05bf008c50cfe2992681584273ea587166633a1f4ea0b9",
+      "pubkey_x25519": "2b1bfe6fe76fa315d517331a774c92c248cc6a48370ac35a14b33e123fc11c7b",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "34ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22119,
-      "pubkey_ed25519": "5e1fe3e00d1b4834922c0ddc97b8fbffffa52bfd16286432c062b9b007528788",
-      "pubkey_x25519": "121e39dd7b52bfac3d0bdbd51239553b908119632ae37aeb96ebd91a44c6cb01",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "71ffffffffffffff"
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -9602,7 +6648,7 @@
         11,
         0
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "193.219.97.56",
@@ -9644,7 +6690,7 @@
         11,
         2
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "51.178.47.243",
@@ -9656,23 +6702,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "9effffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22115,
-      "pubkey_ed25519": "5eca47a9d7b8e047c68c3745796eaf605583bb649cc2091996b55657507c8315",
-      "pubkey_x25519": "149f50cd9d036163c21b30c8787f7ea7e48ffd24daa341c7a0fdea25cecfe661",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "467fffffffffffff"
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "188.40.83.187",
@@ -9686,35 +6718,21 @@
         11,
         2
       ],
-      "swarm": "efffffffffffffff"
-    },
-    {
-      "public_ip": "159.223.212.143",
-      "storage_port": 22021,
-      "pubkey_ed25519": "5f200e2f93459808f8545d4d5570a6b2292b7d5e2c3c96a93400357a9a6b7560",
-      "pubkey_x25519": "b5e75e60a6da0ce34068d423423d533ebad6daddf1b08c4fe0c364d9bcc15457",
-      "requested_unlock_height": 2094233,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "59ffffffffffffff"
+      "swarm": "e7ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
       "storage_port": 22101,
       "pubkey_ed25519": "5f2f2e96a46db255a96ca5886156617dd295cea289b945fa3b95e0e49fdb893c",
       "pubkey_x25519": "2706f44f25b45d6afb943568903173c8d78f00d405c43c5e38738003ce61d622",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2169392,
       "storage_lmq_port": 22401,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "e3ffffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -9728,35 +6746,21 @@
         11,
         3
       ],
-      "swarm": "7cffffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
-      "public_ip": "94.177.9.41",
+      "public_ip": "161.97.171.99",
       "storage_port": 22021,
-      "pubkey_ed25519": "603fb587db235158727a642604465a3272a80a34712010fcd79af55aa40ebd18",
-      "pubkey_x25519": "4de72af6e9380f9e0859d61b859db92d53a51ff35a88392212d1e48e70becc4b",
-      "requested_unlock_height": 2091645,
+      "pubkey_ed25519": "604b4a7347be562ba162b89be1459372b37bb79eebddb53685d689806c03eabd",
+      "pubkey_x25519": "395a36a0741ca7fef961c086c1d4203e8bb4be2189aa4c24c519db2baa70e827",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "faffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22108,
-      "pubkey_ed25519": "6045b0642f9d6ba333d8a0833bb90181ae833b268cf46e53b3ff83f7ed564a65",
-      "pubkey_x25519": "3d860e3f33d4e2d44f405faeb5500796b7c4946257871eab9047586d41469267",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "eaffffffffffffff"
+      "swarm": "b2ffffffffffffff"
     },
     {
       "public_ip": "51.79.147.2",
@@ -9770,21 +6774,7 @@
         11,
         0
       ],
-      "swarm": "32ffffffffffffff"
-    },
-    {
-      "public_ip": "217.160.4.10",
-      "storage_port": 22021,
-      "pubkey_ed25519": "60d10db9233ab22dadc890607dd78ed994cebcec3ea27a6c6dfe9fdd98fccdd3",
-      "pubkey_x25519": "6bd53902ec9d799b544b4ca84d5d5d4b59c7c950097263525921eb666a4dc323",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d9ffffffffffffff"
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "51.38.146.242",
@@ -9812,7 +6802,7 @@
         11,
         0
       ],
-      "swarm": "5fffffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "23.82.99.100",
@@ -9824,9 +6814,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "baffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "31.220.94.39",
@@ -9838,51 +6828,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "f3ffffffffffffff"
-    },
-    {
-      "public_ip": "152.53.46.65",
-      "storage_port": 22021,
-      "pubkey_ed25519": "61e968067edebbb4f2747bf64fd29a9046bf5092d63884a5e9a0174b7e1c8b35",
-      "pubkey_x25519": "66881337e7641215615265f4734dc3fe994024ef514f3b6fb5e0d3910ca6b62d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "17ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22137,
-      "pubkey_ed25519": "622e7c6d748a4330e6abb247d8b828daac0dbf00e52fef29b8cc70d78503993f",
-      "pubkey_x25519": "2f869d85119113f8cc6818ecea2b9a22e25f951e04cfa6f5bc9cfd31c6fd490c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20237,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "efffffffffffffff"
-    },
-    {
-      "public_ip": "91.99.230.225",
-      "storage_port": 22021,
-      "pubkey_ed25519": "62348503949d28a0b083a481106c4e3084175664fd10fff84fb3e1393439e335",
-      "pubkey_x25519": "f09831906e45138b26d9906e087ec1f53fd773f39245220f6a765365be6c7937",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "31.57.218.208",
@@ -9896,21 +6844,7 @@
         11,
         2
       ],
-      "swarm": "a0ffffffffffffff"
-    },
-    {
-      "public_ip": "194.62.98.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "62615f333dc215c1dd8bb3e0f0d3fd88c9cffbd7ee258d9687bb48792ee727a6",
-      "pubkey_x25519": "1cb12f9545aac05ae4efbbf4345f1bd3803531acf63e6c120a2c4b1c438fd01e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "7cffffffffffffff"
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.226",
@@ -9924,21 +6858,7 @@
         11,
         0
       ],
-      "swarm": "94ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22133,
-      "pubkey_ed25519": "632bbcac42d758e17d5ae5f9ce79c1938b13582155795628b95bca3ce427daf6",
-      "pubkey_x25519": "6ee2fc255f5a2779c4f346991ede5292516a7d6d450dde80a4617c3516cb0678",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20233,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -9952,7 +6872,7 @@
         11,
         0
       ],
-      "swarm": "1c7fffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "38.54.75.62",
@@ -9966,7 +6886,7 @@
         11,
         3
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "193.160.96.210",
@@ -9980,35 +6900,21 @@
         11,
         3
       ],
-      "swarm": "45ffffffffffffff"
+      "swarm": "3cffffffffffffff"
     },
     {
-      "public_ip": "161.97.123.136",
-      "storage_port": 22021,
-      "pubkey_ed25519": "640b1c376a1efd7de2776b0cf02584f7cbe10ba025049e16d951928cf28c6dc6",
-      "pubkey_x25519": "0a3becee4752ce462e026a26a12f9648f9d1d1cf560d776cf47e47ddc3f6242e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7ffffffffffffff"
-    },
-    {
-      "public_ip": "141.105.130.89",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.1",
+      "storage_port": 22166,
       "pubkey_ed25519": "642ea0e9b5a97694297902945765b69ee31c9f19767ef80335ac917900094cf2",
       "pubkey_x25519": "cfd0a0b4322eb7105ae9d8bd57a4c9b9651c485982f409c1913350277bfb7a1b",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20266,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "4bffffffffffffff"
+      "swarm": "a2ffffffffffffff"
     },
     {
       "public_ip": "89.58.30.106",
@@ -10022,7 +6928,7 @@
         11,
         2
       ],
-      "swarm": "8ffffffffffffff"
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "38.242.236.119",
@@ -10036,24 +6942,10 @@
         11,
         2
       ],
-      "swarm": "c9ffffffffffffff"
+      "swarm": "dfffffffffffffff"
     },
     {
-      "public_ip": "178.18.249.214",
-      "storage_port": 22021,
-      "pubkey_ed25519": "64835edf9845fb5f992edc787cb8349253d295a0bb7c16132d71ed30fd18b4bb",
-      "pubkey_x25519": "3823231c9ddcae6accfeaafcc41e11ac93561e7ea0f7b7815e737a6df457510c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c3ffffffffffffff"
-    },
-    {
-      "public_ip": "107.182.173.179",
+      "public_ip": "172.93.167.217",
       "storage_port": 22021,
       "pubkey_ed25519": "64ad6f437de8e9338d1e86e4c392c53844011e57e9647f770148ba76d1529ca2",
       "pubkey_x25519": "f256270c97a1ee97ba254dc92b950f884ebe1375c4e9f13f37869f76bd651558",
@@ -10064,7 +6956,7 @@
         11,
         2
       ],
-      "swarm": "4effffffffffffff"
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "194.32.78.254",
@@ -10078,21 +6970,21 @@
         11,
         2
       ],
-      "swarm": "9bffffffffffffff"
+      "swarm": "19ffffffffffffff"
     },
     {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22103,
-      "pubkey_ed25519": "65332d49d1cca74d360b67353b3867715491f359644e60560543f87593ca8630",
-      "pubkey_x25519": "a9141d57f56fded007a90f49c0fca485ff353d914c893cd94cdd65374faadc0d",
+      "public_ip": "98.142.250.231",
+      "storage_port": 22021,
+      "pubkey_ed25519": "65551141d2cd9a99692b4128cfc37ecad8f00a38333c0f686f184c40fdbdbdb4",
+      "pubkey_x25519": "68220f2e2cc1ea5c2a0396ac98efd3479bed7bf92e0d462deeb819a8598f1c08",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "bbffffffffffffff"
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "176.96.138.97",
@@ -10106,27 +6998,13 @@
         11,
         1
       ],
-      "swarm": "affffffffffffff"
+      "swarm": "3cffffffffffffff"
     },
     {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22115,
-      "pubkey_ed25519": "65746c8374dbfec2df202a7260c4573c97dc56271adb05fd3ec42eddb497a78e",
-      "pubkey_x25519": "e0f4f3203ac70dcc3b563cc0ceb50f02b2aea88caa315a3fbddcab385de63b50",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e8ffffffffffffff"
-    },
-    {
-      "public_ip": "92.112.124.92",
+      "public_ip": "95.111.235.51",
       "storage_port": 22021,
-      "pubkey_ed25519": "657d47a84d66867ac2fc28a65762fbd715e636e1996593c6caace8145f5dafb8",
-      "pubkey_x25519": "c07fafb7277df7f12b9e0cf4403138b97d5231f3539d4955f9138d76772f6e4c",
+      "pubkey_ed25519": "6572d459b690e03856cad6eefe25d87fcbebaf5e1dd1c9f586d332a2c2d886bd",
+      "pubkey_x25519": "ee9b26ac64ec7c19ba14548a0754a5b431d43b20635345beac8de4bbe6bce96d",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
@@ -10134,21 +7012,35 @@
         11,
         3
       ],
-      "swarm": "77fffffffffffff"
+      "swarm": "cdffffffffffffff"
     },
     {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22105,
-      "pubkey_ed25519": "660460492d9c8f519c521d7b0c20b3c8bd8c68ebf008731887610ed82138ab2d",
-      "pubkey_x25519": "52ecdba4938b3b79909631353719058a93f96f829aa6c1ba2f581d09cf473f1f",
+      "public_ip": "212.105.90.36",
+      "storage_port": 22116,
+      "pubkey_ed25519": "662deb8eae71e576054efa72eda01b732ace5bbed8706b743311d7852480721f",
+      "pubkey_x25519": "6191911780c3c8172fbb9405993c637a5ae754b7c88e6f5edcb5e1c88d533014",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
+      "storage_lmq_port": 20216,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "21ffffffffffffff"
+      "swarm": "2ffffffffffffff"
+    },
+    {
+      "public_ip": "167.233.29.139",
+      "storage_port": 22021,
+      "pubkey_ed25519": "6646e4032eb9696b4cc6fa591f45ed4c7bd7de30efab2bf23e7533fbe3d1dfd5",
+      "pubkey_x25519": "c1eadecf2246601a500129ba0fe73e9ca061d007e00cc4b66f74bb145253fb37",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "146.59.3.52",
@@ -10162,35 +7054,7 @@
         11,
         2
       ],
-      "swarm": "447fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.219",
-      "storage_port": 22021,
-      "pubkey_ed25519": "66bbbb5fb31fe5006a30bb61f2a780b2946c30f02f705c1374d1555a0e2b7c73",
-      "pubkey_x25519": "31238a1c129250e451d0a303cc9cbb89954f033eac3a608fbea82548605bdd60",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "57fffffffffffff"
-    },
-    {
-      "public_ip": "80.241.220.222",
-      "storage_port": 22021,
-      "pubkey_ed25519": "66c9effabe61a262abfe69bd96dd6c704d9836c60549562204a6868c9c41e7e2",
-      "pubkey_x25519": "ea9ed78679b391017b7ade17380848ac3ac18001eab4eafb7580a387e15ff851",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3a7fffffffffffff"
+      "swarm": "c9ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -10204,7 +7068,7 @@
         11,
         0
       ],
-      "swarm": "88ffffffffffffff"
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "209.141.37.73",
@@ -10218,7 +7082,7 @@
         11,
         3
       ],
-      "swarm": "c5ffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "167.86.86.191",
@@ -10232,7 +7096,7 @@
         11,
         0
       ],
-      "swarm": "d3ffffffffffffff"
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "185.208.206.67",
@@ -10246,7 +7110,7 @@
         11,
         2
       ],
-      "swarm": "b9ffffffffffffff"
+      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -10274,77 +7138,7 @@
         11,
         0
       ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22103,
-      "pubkey_ed25519": "68bfd9c95e854e195d1ecf227514ef754ac4dcfc1a87150fb51e769789023f89",
-      "pubkey_x25519": "bf0780ee83667357a15343f097588024d206590e0514d6b7e8ca07681c056337",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a7ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.175",
-      "storage_port": 22021,
-      "pubkey_ed25519": "68c495f37887f9888944033ca112a121d84fe9660040ad65ee69b7a45da77dde",
-      "pubkey_x25519": "9b664bf5efefa502d8c892c8d37a721e4b8354896adc10fa95f47927f4e82122",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.99.13",
-      "storage_port": 22021,
-      "pubkey_ed25519": "68c993a16315d3ac4343ce021a99bcf2f12700874840b06ea8a6c1621e76dc9e",
-      "pubkey_x25519": "6cb451e4341bcc5d426c0b91f4057f0a6c16cee4726c29794b13a9d44d6f8266",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "65ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.4",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6941c9cb4d8ed0ec8305765ce91acd5bf05ddf6f0ec99f67593ee1a24e04b1d8",
-      "pubkey_x25519": "8bde5d1d341e4fe5ef418c5e8b8897c34ae2c763d10a10b7d3b1ea843c1fc111",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "feffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22104,
-      "pubkey_ed25519": "695273a98049df7dd349549b33bfbd079bb8ea185ae9daacf922a512301a5319",
-      "pubkey_x25519": "0794c947b5d78a09942d220c556f5dc5dbefaed94ffb9f8bbab605a5ebe89d74",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "70ffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "38.54.97.133",
@@ -10358,63 +7152,21 @@
         11,
         2
       ],
-      "swarm": "faffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
-      "public_ip": "193.219.97.167",
+      "public_ip": "57.129.42.49",
       "storage_port": 22021,
-      "pubkey_ed25519": "6a2a1481de72f311f15ba3d81ee6ddca31561f729fbd1774b1764c2900633c63",
-      "pubkey_x25519": "7287986914669c0bfa80c684ff2d3c344d597984a790fd43aa97feb1f428fd4e",
-      "requested_unlock_height": 2090261,
+      "pubkey_ed25519": "6a8c4ba12ae3df68b5f18bfcc154cc6910d7050855cad20d737ed102bb45e589",
+      "pubkey_x25519": "590f5136e9cae2e86a77ea882b637f5a0cd25bd2b3e69621790df9f2a3341926",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "47ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22112,
-      "pubkey_ed25519": "6a72800c140776ff299a50133194dbe7d17d3cbd6e78b2a502be1b93ab852cae",
-      "pubkey_x25519": "85acbe1a30950c55159e8f1d93d9298652ff9fc427195947905c754e8687c41c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ceffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22108,
-      "pubkey_ed25519": "6a743c1bbc9dfb89f69845d3170606ff44dc8caaf6b1f229341f585e3ff3d620",
-      "pubkey_x25519": "0ec91e54ecc96d855897c184a018856d7c97a6af8f266b5e1da889dc2bc59469",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.139",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6ac0a76a1bd6c396ea28e95a93a009ab3ec5fa708d7054572edec7b2e029208a",
-      "pubkey_x25519": "79fab392dc41bfe24c767b6a80e30e9316da8e84a918264c8383e0c7b7cae143",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3ffffffffffffff"
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "5.223.77.132",
@@ -10428,63 +7180,7 @@
         11,
         3
       ],
-      "swarm": "4effffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22109,
-      "pubkey_ed25519": "6ae986969ca872ecdc57bb42d3b48faba612338fb4777434ca2d63923513577d",
-      "pubkey_x25519": "b84a02fbd193b39d6885ff8fb805e40861726e8e9a74f280f4a48d314965f046",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9cffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22125,
-      "pubkey_ed25519": "6afa99301bd73458f92ab68bfd21699bc5d17e674517f2a4e94a237e3b05f3f8",
-      "pubkey_x25519": "8f4a414ce9b99f74acfe69925804a965054e5c6f4ff7bc732e1396557c9e756f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20225,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "28ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22110,
-      "pubkey_ed25519": "6b237aa4ae15ac6114b2d72e4eeef9ac22d35778f56c1cd2d6f1fa30ed7ac2d3",
-      "pubkey_x25519": "7111e232dfe45a86550177fa979786261b2836424d39ca25d6a6052e0b8e7736",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.112.220",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6b7c8c01e55997409f236b4817d7b560f573e5d6f2e06f09e70c26dd44d74490",
-      "pubkey_x25519": "e421ed51f58b900a47280258400ba9fd2d8deada28151e59f40c2deeb2809c11",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "257fffffffffffff"
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "66.175.216.182",
@@ -10498,7 +7194,7 @@
         11,
         0
       ],
-      "swarm": "9cffffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "51.79.161.120",
@@ -10512,49 +7208,7 @@
         11,
         0
       ],
-      "swarm": "94ffffffffffffff"
-    },
-    {
-      "public_ip": "173.212.216.151",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6bd98418bf893bff7fe5a2188ca17d37d74e9bf7b20d787c4370b4b9e84ee1ca",
-      "pubkey_x25519": "a568a1d2929c8d14daca4e73cc291ce8d1e5fe8e15ac96bab090d56775979e31",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "9cffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22107,
-      "pubkey_ed25519": "6c0ce736fe225f159c0888096a0f0d5249e3c4db15917bf3b3157ded39ec84a4",
-      "pubkey_x25519": "1f52a777b4bf7a4126733d459d64c55c9e9ad65eaae49c3aaf1f131575391926",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3bffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22141,
-      "pubkey_ed25519": "6cd1b6456b7c6bb094705ec4b851c9f13edfb6ed4267bb40e0d22cfd6872bc71",
-      "pubkey_x25519": "5c12c6563553c0020210cd1664d9c77d61b697997339d803036c84c071bb9563",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20241,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "45ffffffffffffff"
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -10568,7 +7222,7 @@
         11,
         2
       ],
-      "swarm": "7cffffffffffffff"
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "23.239.20.166",
@@ -10585,32 +7239,18 @@
       "swarm": "efffffffffffffff"
     },
     {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22113,
-      "pubkey_ed25519": "6d51122ef91b659ff620591335b4f930a633d0955c0a113076719cbba9157e9d",
-      "pubkey_x25519": "23e353c2f5a21519d5bcf37f1c0e7038d1c923d6270540b2ba6bd537f9a6214a",
+      "public_ip": "204.44.125.247",
+      "storage_port": 22021,
+      "pubkey_ed25519": "6d87954b0a92c3ed3e227bca88f9fc943d30afeaaf0019b021af1c43e62c0a2e",
+      "pubkey_x25519": "131cabc6daedb1616a67bc9ebd887c81fd1956f3e7dc307b1a98b62d31b1673e",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "32ffffffffffffff"
-    },
-    {
-      "public_ip": "5.255.114.11",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6d87954b0a92c3ed3e227bca88f9fc943d30afeaaf0019b021af1c43e62c0a2e",
-      "pubkey_x25519": "131cabc6daedb1616a67bc9ebd887c81fd1956f3e7dc307b1a98b62d31b1673e",
-      "requested_unlock_height": 2084490,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "7affffffffffffff"
     },
     {
       "public_ip": "51.81.161.230",
@@ -10624,63 +7264,21 @@
         11,
         3
       ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "66ffffffffffffff"
     },
     {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22107,
-      "pubkey_ed25519": "6d8c7b0c2b499100b52d26ed3af082f7f72e56c5ae151d95c316d68ba9cb8108",
-      "pubkey_x25519": "9b6a76adcd6825e20e5299e39c6afe5a1b2071fe7efe895d17bbe9ad5d53dc19",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "237fffffffffffff"
-    },
-    {
-      "public_ip": "75.119.145.248",
+      "public_ip": "212.147.239.136",
       "storage_port": 22021,
-      "pubkey_ed25519": "6dbfc3e985f816f4221f100450864d3f97e1451b6de1558331d1db515f8de37f",
-      "pubkey_x25519": "adedb89e9871ab0bff66e46300092c1c9ac641ff88e642cef87891752d296920",
+      "pubkey_ed25519": "6e643ca7c248381005da157036751a5b8626690471858cdaac5cd4ae38a65bd7",
+      "pubkey_x25519": "57d0047cc8126790b66077ee9f3e4c9b95efa6bf92b4ab91db7e5e0c155ac518",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "c3ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22109,
-      "pubkey_ed25519": "6e5bd1bc4ae3f7341d338d67d1e918ee47a31f36506dd36a5f47a5de942d2fba",
-      "pubkey_x25519": "45707b1bf2b264005bd15cb73b1db8ff552133af69805810a54507e6ad58e70e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "4dffffffffffffff"
-    },
-    {
-      "public_ip": "193.219.97.206",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6ecee30b54e452d330ef857ede73296264fff2d28fc0e210d1113d470fe60bb4",
-      "pubkey_x25519": "66a1856f8a45a792fe78a71c0ffc301067bfa7c2b3a768ddfe6b2a143a96266e",
-      "requested_unlock_height": 2090259,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -10694,7 +7292,7 @@
         11,
         3
       ],
-      "swarm": "e8ffffffffffffff"
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "205.185.113.143",
@@ -10708,41 +7306,13 @@
         11,
         3
       ],
-      "swarm": "d5ffffffffffffff"
+      "swarm": "14ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22103,
-      "pubkey_ed25519": "6f2b25b10816672ad6963df7eb207f22f4ada9f6a8b942a14618b147e5376e21",
-      "pubkey_x25519": "763606c99c648ed44707370c8f4d173a1f4cc9037610c07c739a39e3b79eb32f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c7fffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22113,
-      "pubkey_ed25519": "6f43b305fa35d050966749e1828b7b4b194d5e0a6814f42fc73036c4af417415",
-      "pubkey_x25519": "ebdbb7c0f9d37fe8f51f34de867660bb9c8f72cb47b0ddadc9b445e29582f007",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "65ffffffffffffff"
-    },
-    {
-      "public_ip": "94.237.95.195",
+      "public_ip": "167.233.26.68",
       "storage_port": 22021,
-      "pubkey_ed25519": "6f75ad5718377b3a69ca3c65287a8b8038780adce28c254be5ba8c9297de4eaa",
-      "pubkey_x25519": "e45dd3958ab0cb1d781889abb94311b6949f224a91299124b49e87288e99be2d",
+      "pubkey_ed25519": "6f1d1f14888ae8082b9eae1a9ce97a27ae5b4aa3da39ddb310b9a5f82da1e075",
+      "pubkey_x25519": "5b3e8ac1b8cbf06110f5681dfaa84e7fa170ed1fe714cb0787ff4a9f9709e615",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
@@ -10750,21 +7320,7 @@
         11,
         3
       ],
-      "swarm": "d2ffffffffffffff"
-    },
-    {
-      "public_ip": "66.94.118.153",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6f8c3ec7a9c8ab14ab5c1943fb027fc926ffba378367a82523cfd7695e189532",
-      "pubkey_x25519": "3789f96e185844263bc85cf602efe7377ff603bad0c489941900bf23fb10a963",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "317fffffffffffff"
+      "swarm": "307fffffffffffff"
     },
     {
       "public_ip": "158.220.109.210",
@@ -10776,51 +7332,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "93ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.230",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6fb6a0bf218a86d8ef890bcac96b8d1007bf458c6d0bca144a75af468b7bdcde",
-      "pubkey_x25519": "66cecbeddd1d81eabd4fce527a1fe7d70812f34edffde1f8b37ef7fad0f3ee13",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "abffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22118,
-      "pubkey_ed25519": "6fb898bfe143ce0de7b20b287c1f459d96b7a55329e83fe3be27892d1ebd638b",
-      "pubkey_x25519": "33ce36b1dcadf6dfa28c7200088043215f7941485e6a742d7054625e3feefd6c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20218,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "ffffffffffffff"
-    },
-    {
-      "public_ip": "95.217.209.146",
-      "storage_port": 22021,
-      "pubkey_ed25519": "6fc529a9cdb94eec11676077e799a5fb8289a7c6a4e097eb5a0dd33d2b97086f",
-      "pubkey_x25519": "09381f2ad25bf9b2f754d9c8f6101558e51ae18caaddd160b3092c98bdd72f4b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3cffffffffffffff"
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "136.243.106.178",
@@ -10834,7 +7348,7 @@
         11,
         2
       ],
-      "swarm": "edffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "132.145.162.118",
@@ -10848,7 +7362,7 @@
         11,
         2
       ],
-      "swarm": "bcffffffffffffff"
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -10876,21 +7390,7 @@
         11,
         2
       ],
-      "swarm": "377fffffffffffff"
-    },
-    {
-      "public_ip": "5.78.83.111",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7075a7e2d48c124c5210b400060595956b72a7e9cde29fd4211f1abc233da21f",
-      "pubkey_x25519": "3a57516e177011c9ae65c5e258ccf70cdfbba0b0f4834008a304f9764088cb42",
-      "requested_unlock_height": 2086490,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "b9ffffffffffffff"
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "152.53.231.2",
@@ -10905,20 +7405,6 @@
         3
       ],
       "swarm": "3cffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22113,
-      "pubkey_ed25519": "70c108f1c9c04c4ce9b004fefa0258c5f37c3ace8c574cf228a4b49c032ae787",
-      "pubkey_x25519": "cb5e40d5d1730eb2e50464545935ac8988baa25afe13bee16f2f92c168ac8109",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a0ffffffffffffff"
     },
     {
       "public_ip": "198.74.51.223",
@@ -10949,60 +7435,18 @@
       "swarm": "a4ffffffffffffff"
     },
     {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22109,
-      "pubkey_ed25519": "7122180bc0815c17d46d9ce23497c20b62c5609ff10a421f9e0181cd951593e3",
-      "pubkey_x25519": "fe73a5bf01b1465839ee5d3c401bd75dacd190714dd11ff37e9f4c3518a3ad33",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "74ffffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22102,
-      "pubkey_ed25519": "7171cea426caee2214fe2e4c76d1ea684b477f8eae3083cb76db235080321abf",
-      "pubkey_x25519": "4d5867a9fbd86863cf3bdf3725085a4f4b60c66f383633a671d9e005582eaa42",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8fffffffffffffff"
-    },
-    {
-      "public_ip": "102.208.228.250",
-      "storage_port": 22100,
-      "pubkey_ed25519": "72869d428bd97630f0e1a874eaa20c5a7f531239497eca1b7d8aa65c0053b152",
-      "pubkey_x25519": "4bb906b70fa9c1ec241e3549c1701656a4ded6d6ace6133bebdf076fe6b2d24a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.39",
+      "public_ip": "217.217.250.41",
       "storage_port": 22021,
-      "pubkey_ed25519": "728f925b17284c7dca6533cd9349e532b7490dc13afc3561efc19057d4016950",
-      "pubkey_x25519": "b205b0ab86472cb685e0d9d1793fcecb95a6ff46b63af937adb8c82afb999e03",
+      "pubkey_ed25519": "7181ca23c5c338eb7a4fef57070c59794a6a5b60b128cd1d815728e3bcac5fb0",
+      "pubkey_x25519": "5879f835bb01c0f5c6088f619cbf86e1db138a43927bcc41a1479ddd00d6dc4d",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "bbffffffffffffff"
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "167.86.111.71",
@@ -11016,35 +7460,21 @@
         11,
         3
       ],
-      "swarm": "237fffffffffffff"
+      "swarm": "7fffffffffffffff"
     },
     {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22110,
-      "pubkey_ed25519": "72f038b38273cc83b2d71d85e729a3a1b32e370762f4a967cf7caf029b640f20",
-      "pubkey_x25519": "cbdc2b74534bacb97022b6a06e322279d8df28179da8ddf4a5601637c81d9363",
+      "public_ip": "51.222.30.236",
+      "storage_port": 22021,
+      "pubkey_ed25519": "72b6e9fb6cc4297ad50cb5742021aec3b70326433c63bb9dba74d380e109db10",
+      "pubkey_x25519": "8a7e1f987c339cac6d9119d35ea26ee4e3010ebbc795bd1d57a4f20907e9f31a",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "4cffffffffffffff"
-    },
-    {
-      "public_ip": "102.219.85.93",
-      "storage_port": 22101,
-      "pubkey_ed25519": "7322f8e32d7e86f922728267dcd6d44553192effeab4035c1718f172baa5dea1",
-      "pubkey_x25519": "2f8be1fb9e09e31e20b7969e9af749527d1381b423985ea1fccdec64110e791d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c9ffffffffffffff"
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "145.239.90.154",
@@ -11058,7 +7488,7 @@
         11,
         2
       ],
-      "swarm": "2fffffffffffffff"
+      "swarm": "edffffffffffffff"
     },
     {
       "public_ip": "116.203.134.197",
@@ -11072,35 +7502,7 @@
         11,
         2
       ],
-      "swarm": "3a7fffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22120,
-      "pubkey_ed25519": "738cdd0a5459fc3db65dd8f682daace3f89eb7ea873ef940b1440cf0537db4c9",
-      "pubkey_x25519": "5bf7132dc9e8c0aa4dc1168f03befd568efb05083f7b7d467919da5ff9a94238",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "bdffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.17",
-      "storage_port": 22021,
-      "pubkey_ed25519": "73ec9ea886e34de7932593a1456514fc4d242f2b9f73b6bc54a32d051d2db2b0",
-      "pubkey_x25519": "5dbb3647162eaedc0ac97b10b11d8494347ef2310ac0a22ca2b726827dce3f00",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6fffffffffffffff"
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -11114,10 +7516,10 @@
         11,
         0
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
-      "public_ip": "31.22.111.49",
+      "public_ip": "193.160.96.175",
       "storage_port": 22021,
       "pubkey_ed25519": "753c147de637918df24e4fc7822835a23497d217e124e42cbf80cb81324694e2",
       "pubkey_x25519": "eb442d0f59c7254c34ec5553c1840d41c2f7c9c271db8e097245edbe09340161",
@@ -11126,7 +7528,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "a7fffffffffffff"
     },
@@ -11142,7 +7544,7 @@
         11,
         0
       ],
-      "swarm": "457fffffffffffff"
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "69.164.194.93",
@@ -11156,7 +7558,7 @@
         11,
         2
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "45.145.41.130",
@@ -11170,7 +7572,7 @@
         11,
         3
       ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "54.39.148.196",
@@ -11184,7 +7586,7 @@
         11,
         2
       ],
-      "swarm": "ccffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "57.128.168.127",
@@ -11198,7 +7600,7 @@
         11,
         2
       ],
-      "swarm": "73ffffffffffffff"
+      "swarm": "b3ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -11215,20 +7617,6 @@
       "swarm": "36ffffffffffffff"
     },
     {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22107,
-      "pubkey_ed25519": "7679be90db63c4b1a66358442a748745bb9c568221022f53b8601530d6a3e83b",
-      "pubkey_x25519": "691488cb14fa27bd00d86628bb7f10c4f75e3e357f5f106be339fd05f4ed843d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "dbffffffffffffff"
-    },
-    {
       "public_ip": "155.103.66.146",
       "storage_port": 22021,
       "pubkey_ed25519": "768abfd30fb1346a42c85589bce3d94e334bbb67d9bfd7419fceadb969310bf2",
@@ -11238,9 +7626,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "ceffffffffffffff"
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "45.153.187.210",
@@ -11254,7 +7642,7 @@
         11,
         2
       ],
-      "swarm": "5fffffffffffffff"
+      "swarm": "77fffffffffffff"
     },
     {
       "public_ip": "15.204.235.189",
@@ -11268,21 +7656,7 @@
         11,
         3
       ],
-      "swarm": "307fffffffffffff"
-    },
-    {
-      "public_ip": "129.153.135.111",
-      "storage_port": 22103,
-      "pubkey_ed25519": "7713f3443ec4d8be755d408d2b3430e64b87072af4dc44d1c0cd3b406c347560",
-      "pubkey_x25519": "d55ac0c5f998adb6dee7542c1b25924bb9d65595442c17ab9714bdca2a719947",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1affffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "94.23.19.49",
@@ -11296,49 +7670,21 @@
         11,
         2
       ],
-      "swarm": "3fffffffffffffff"
+      "swarm": "7fffffffffffffff"
     },
     {
-      "public_ip": "102.208.228.248",
-      "storage_port": 22100,
-      "pubkey_ed25519": "772b436c009f56c3cb27b78541d27ba41d3c3ac839784dad2d0295689083a027",
-      "pubkey_x25519": "dd3649b11681729d3607239d68c0181c046dcba3e4357fe968a3b0b5247cac27",
+      "public_ip": "57.129.102.67",
+      "storage_port": 22106,
+      "pubkey_ed25519": "782892a9bdcded41f2612180ca34534408b567e611b41539214a0e2a764aba16",
+      "pubkey_x25519": "4e7fc42eab1263d0aea553f494253f9aa88355dcf9feaac2313ec6ff73ec813b",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
+      "storage_lmq_port": 20206,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "237fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22105,
-      "pubkey_ed25519": "773b0c59a1a87bfb7ee759d5834dfb94fc14b2a6ecf76b5632910817e7af67c1",
-      "pubkey_x25519": "c3dffd1287f03ed7cc7b9ab39f6c52a01b1bd2ad15c2088da62a886e478e7a11",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
-      "public_ip": "206.189.101.37",
-      "storage_port": 22021,
-      "pubkey_ed25519": "786b02512f46f81e03ae359eee24bcc813230f3490467928ccebe3bff99b330a",
-      "pubkey_x25519": "6ecbc59d153c7a906ad88fb9502bf47a5326e40d784b3786233a353fcc02805c",
-      "requested_unlock_height": 2094233,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e6ffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "213.136.90.84",
@@ -11352,21 +7698,7 @@
         11,
         1
       ],
-      "swarm": "37ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.8",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7894c58e0f77408a8bfda9f07ef1eb4fa7114616ac848beaea214191ace22d48",
-      "pubkey_x25519": "f39b6c41fc2e7d76faba49314edcb2daddd9c7968e7fa9d264e000996c5e303c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "acffffffffffffff"
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "91.99.239.106",
@@ -11380,7 +7712,7 @@
         11,
         2
       ],
-      "swarm": "99ffffffffffffff"
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "130.94.44.4",
@@ -11394,7 +7726,7 @@
         11,
         3
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "209.141.45.115",
@@ -11408,7 +7740,7 @@
         11,
         3
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "107.189.4.130",
@@ -11422,21 +7754,7 @@
         11,
         2
       ],
-      "swarm": "4ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22105,
-      "pubkey_ed25519": "7a0247e8fa3be265a41d7814c6f792ebe19ecc4205910913f35d7e74a968dc84",
-      "pubkey_x25519": "ae84b9c973b296377c6a6df80bbab298ade210bdbc7c5be29e39ad70377e075f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9affffffffffffff"
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "95.111.226.201",
@@ -11450,21 +7768,7 @@
         11,
         2
       ],
-      "swarm": "317fffffffffffff"
-    },
-    {
-      "public_ip": "74.50.118.192",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7a187a0dfadfb130d1f48d4d8ca10af4834484e046aea99a07b600ada2c89ec3",
-      "pubkey_x25519": "3f01400349899c396867e5a4ac8dba3a86641a5f13209855a82659bc212d345b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9bffffffffffffff"
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "135.148.41.196",
@@ -11478,7 +7782,7 @@
         11,
         2
       ],
-      "swarm": "d4ffffffffffffff"
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -11490,9 +7794,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "28ffffffffffffff"
+      "swarm": "deffffffffffffff"
     },
     {
       "public_ip": "107.189.13.3",
@@ -11506,7 +7810,7 @@
         11,
         2
       ],
-      "swarm": "bffffffffffffff"
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -11520,7 +7824,7 @@
         11,
         0
       ],
-      "swarm": "31ffffffffffffff"
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "51.195.119.137",
@@ -11534,7 +7838,21 @@
         11,
         2
       ],
-      "swarm": "e1ffffffffffffff"
+      "swarm": "49ffffffffffffff"
+    },
+    {
+      "public_ip": "212.105.90.36",
+      "storage_port": 22111,
+      "pubkey_ed25519": "7b021072fcaf7476ce880093464ef27b52da51e770b57b7ea43068a0ea9c064f",
+      "pubkey_x25519": "a82002ff29c0887b0b5199e20e1e4123b1703fb88fe8e67d46b3e97262eb5d26",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20211,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "167.86.83.21",
@@ -11548,49 +7866,7 @@
         11,
         2
       ],
-      "swarm": "beffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.72",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7bbf133aab2ecfbdd6f12b1eb63701aa63de91a34253d06ae8f8a2161b3a312c",
-      "pubkey_x25519": "ab644ff9c87fdfa603d360b76de0eccc66382ea7497c7a191f6df316b6bc5959",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "c0ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22112,
-      "pubkey_ed25519": "7c2faaba7e81c269f00e24e18a8b1ded20fbd6143c26b36f3f10a8b94e85509e",
-      "pubkey_x25519": "8520482a53c242a01624630bbedc3d23e29e69ff2a87b4c8a0a5903c0481ed09",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "12ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22131,
-      "pubkey_ed25519": "7c798b31027f48ca09a1402befcc05ff5f7ce6f36eab726e7fb22d1fbf316157",
-      "pubkey_x25519": "716e05ec5ec6325a3efe693ae87ae62e3e0e14d901d755285889d4e3fc26311d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20231,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "99ffffffffffffff"
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -11604,7 +7880,7 @@
         11,
         0
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "57.128.252.8",
@@ -11618,21 +7894,21 @@
         11,
         2
       ],
-      "swarm": "67fffffffffffff"
+      "swarm": "457fffffffffffff"
     },
     {
       "public_ip": "89.58.28.45",
       "storage_port": 22021,
       "pubkey_ed25519": "7ca44780a2ce74c0cbb5f19d2e3b9819de053f0b71b795d8839520beb71ba228",
       "pubkey_x25519": "148a024fbc1ee7e552a709863b12635b7a5cd6ce39c415497b6dc7b99694a527",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2170131,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "28ffffffffffffff"
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "107.189.3.227",
@@ -11649,88 +7925,32 @@
       "swarm": "fcffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22112,
-      "pubkey_ed25519": "7d0b4132ac85589d5a61f5f5fd4e19ddd592a7055cba0dcb0b6afbf3c1cc226f",
-      "pubkey_x25519": "f39622b61baa77e2c27001447f94ea1c7db5b0d2f815388f4aa23c68a2a13b50",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "75ffffffffffffff"
-    },
-    {
-      "public_ip": "100.42.179.195",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7d6ffd56b5cb5c28193829b0980793d8b0a0a2fac8d68a48fbd17a8a71979c5f",
-      "pubkey_x25519": "81f9e985b651df9b19d2a60e5d78c9290dc77b8f13e25b8fbdc44c7a5fd2b010",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "53ffffffffffffff"
-    },
-    {
       "public_ip": "169.197.82.161",
       "storage_port": 22021,
       "pubkey_ed25519": "7e0198af12c844712a1679e86841698d2b3a158451ff367635f7a1df830f92e7",
       "pubkey_x25519": "466928e6e457c1b00c092ee71d51cb1a28032d476ce9eb7b58597a550ac99b7c",
-      "requested_unlock_height": 2085894,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "20ffffffffffffff"
-    },
-    {
-      "public_ip": "164.90.194.228",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7e416014f5f0b284e11ee8f44db13ac1b92f308325fa836d94b6afdb73a4ea2d",
-      "pubkey_x25519": "745423298127e2300c62a07d4030f1763135ec29c050708675046e9150c05407",
-      "requested_unlock_height": 2094228,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "c5ffffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
-      "public_ip": "91.231.182.38",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.0",
+      "storage_port": 22140,
       "pubkey_ed25519": "7e4a23a85ca233eabf66eadc703655b739a4ea53901d7fcf14b0291acfa1cbaf",
       "pubkey_x25519": "4a0efc97126465f2fb68c57c48ed29a10e913b09642a2a097f1b22185df99153",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20240,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "487fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22127,
-      "pubkey_ed25519": "7ea5090d54d527c2fea65576e041e41367944d10a17c0e97cd35392f11f57fbe",
-      "pubkey_x25519": "dafb8b67193e698965597dd2fb9a8a5d5b10551d1d10723c411a1aecb3d53d20",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20227,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "dffffffffffffff"
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "84.46.250.250",
@@ -11784,7 +8004,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "f9ffffffffffffff"
     },
@@ -11800,21 +8020,7 @@
         11,
         2
       ],
-      "swarm": "d0ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.96",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7f6f2ddbad8de39a2def4e2116da396d44ddc5467e3878008cfe225a08600f8f",
-      "pubkey_x25519": "21ccb7467cf4358f2b8068209529c314c504a939325c24e8838e20214c004268",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "eeffffffffffffff"
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "202.61.247.98",
@@ -11831,48 +8037,6 @@
       "swarm": "357fffffffffffff"
     },
     {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22110,
-      "pubkey_ed25519": "7fea4387c12d9ff9960983bb2b35bd8cde7df7e32c785eeb2d7eea808c8e068a",
-      "pubkey_x25519": "9b9300578024a944d155bbaaaa4069f2fe88a7f2b13da291c3834d2923823a10",
-      "requested_unlock_height": 2086578,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "1effffffffffffff"
-    },
-    {
-      "public_ip": "95.111.207.165",
-      "storage_port": 22021,
-      "pubkey_ed25519": "7ff7137500c95b93eccfde27f96580eed08dd2306a13b2f980f76343cba4a2e3",
-      "pubkey_x25519": "d3449fe1080612dcfbc4b693fb3620fa685939679e451ee306e144dd443e0e6d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b2ffffffffffffff"
-    },
-    {
-      "public_ip": "89.117.23.203",
-      "storage_port": 22021,
-      "pubkey_ed25519": "800492614e5c7e791a87f9bca3c516189bd35c00d3e5cabf5700c833376a03b7",
-      "pubkey_x25519": "a1505c5f55c76f7068fe601350edd1622d773c73f4fdd5b5fb09403ae495120d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "94ffffffffffffff"
-    },
-    {
       "public_ip": "51.75.79.57",
       "storage_port": 22021,
       "pubkey_ed25519": "804fbd40d1b921ab20a30750741c09c409ecd52f3793b4a7e227bfcdb26430a9",
@@ -11884,21 +8048,7 @@
         11,
         2
       ],
-      "swarm": "b7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.172",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8079ba6747154a3a5e746e7de10c5d27051ac8280563a460bdc34f9d3d8c91a8",
-      "pubkey_x25519": "580b5e0589b89542d2d89e88b53f6b67875f7aa29bcb661db5897d879a767e03",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "fffffffffffffff"
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "198.98.52.4",
@@ -11912,38 +8062,24 @@
         11,
         3
       ],
-      "swarm": "3e7fffffffffffff"
+      "swarm": "beffffffffffffff"
     },
     {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22110,
-      "pubkey_ed25519": "80b458296bf2b16cae5f28217c89937acfd272d364d356501b889b8685442231",
-      "pubkey_x25519": "3337d731cfea580ad839f4b2dbd5eea08282589bbd42f25614578decc87df477",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "7affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.89",
+      "public_ip": "107.175.194.177",
       "storage_port": 22021,
-      "pubkey_ed25519": "815007c26559625e7c230394d6fdaeed0bc64f75caca228bda15446f7d7b4ccf",
-      "pubkey_x25519": "14d3b9339cffb9abb6372b1266c4307694b03f18312c31aaf33aa02942e5b95e",
+      "pubkey_ed25519": "81031175ab240df036e235a2e2c8e1c17a62c8d3268b87ea0f3e87e1d12bdcc0",
+      "pubkey_x25519": "283dc9128132508351e025367eb274043adc12e83507dae5931c4b2107ff4e78",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "e2ffffffffffffff"
+      "swarm": "a5ffffffffffffff"
     },
     {
-      "public_ip": "38.45.65.103",
+      "public_ip": "23.81.40.224",
       "storage_port": 22021,
       "pubkey_ed25519": "81ac347100b677657b1475ed96898df4be8651114d42db9a7d238dc47ee993fb",
       "pubkey_x25519": "00c8299f292d9a16c2a63f1c7e3067f488d0efcc697787161b2fef27a495254c",
@@ -11952,23 +8088,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "2affffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22111,
-      "pubkey_ed25519": "81c1b3edd43d94f10d445850908226b8f6a048ae4788d76ea6cabf1a469b9e1a",
-      "pubkey_x25519": "76177edaa0f9a3fdbb5b4b63331f60f83dd364d029db0ca69b5f2a84c637d56d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a1ffffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "144.24.165.22",
@@ -11982,7 +8104,7 @@
         11,
         3
       ],
-      "swarm": "8effffffffffffff"
+      "swarm": "a7ffffffffffffff"
     },
     {
       "public_ip": "198.98.61.187",
@@ -12010,20 +8132,6 @@
         11,
         0
       ],
-      "swarm": "327fffffffffffff"
-    },
-    {
-      "public_ip": "46.62.196.12",
-      "storage_port": 22021,
-      "pubkey_ed25519": "828cb764ec2b1ff07f620bb8f3a674db83f0e9b5a6361b6192fb35080c34951a",
-      "pubkey_x25519": "5b2b3926d5b601bde5602a8461aaada7ae143b4de17fcc3b484970a97a135d06",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
       "swarm": "75ffffffffffffff"
     },
     {
@@ -12038,7 +8146,7 @@
         11,
         2
       ],
-      "swarm": "c6ffffffffffffff"
+      "swarm": "40ffffffffffffff"
     },
     {
       "public_ip": "94.16.107.50",
@@ -12055,34 +8163,6 @@
       "swarm": "5dffffffffffffff"
     },
     {
-      "public_ip": "164.68.113.98",
-      "storage_port": 22021,
-      "pubkey_ed25519": "83199327cbb14cd9029a3c688c127a86ad24e1463def82f5ecf186b297e90774",
-      "pubkey_x25519": "4ce279ccb8e443be32f959889ba7b5eb4872a6d001dd8161fe3585a64d6d222d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d2ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22101,
-      "pubkey_ed25519": "836494385a48386cf5d04c2af9f5000ed376d83da38e51ad51170d1559ba6552",
-      "pubkey_x25519": "c4be6a0bbfa94e9ed858b23bab6a37734d6538a4424d3d94b1d7c66d85f9b52b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "67fffffffffffff"
-    },
-    {
       "public_ip": "135.181.105.205",
       "storage_port": 22104,
       "pubkey_ed25519": "83fc1ba78dc954dd7431eaa37e9c592ea977b020e220c9c8eb65d880dcb07f81",
@@ -12094,7 +8174,7 @@
         11,
         0
       ],
-      "swarm": "c6ffffffffffffff"
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "205.185.113.96",
@@ -12111,18 +8191,18 @@
       "swarm": "477fffffffffffff"
     },
     {
-      "public_ip": "185.13.148.8",
-      "storage_port": 22021,
-      "pubkey_ed25519": "846c4f739d7450c4cee8817b0888bc452e52297a24a1f6fb9564aa96830b1654",
-      "pubkey_x25519": "b09e31e5b13b40d05c655018457ae6667edf0d0b2ba1c85902d9f29c87e39960",
-      "requested_unlock_height": 2093346,
-      "storage_lmq_port": 22020,
+      "public_ip": "88.198.244.201",
+      "storage_port": 22106,
+      "pubkey_ed25519": "84ca870519182305480354ac6492f570ea72f1aadd7a8012842ed5887404bae8",
+      "pubkey_x25519": "921a21ec9789114c71c26afe92643e0ba1092fce8e30d710d8a597b095eba73b",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
         11,
-        3
+        0
       ],
-      "swarm": "447fffffffffffff"
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "45.79.95.210",
@@ -12150,7 +8230,7 @@
         11,
         3
       ],
-      "swarm": "cbffffffffffffff"
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "209.53.217.150",
@@ -12167,34 +8247,6 @@
       "swarm": "67fffffffffffff"
     },
     {
-      "public_ip": "144.91.76.204",
-      "storage_port": 22021,
-      "pubkey_ed25519": "852bdfe8849679de83c876fecfc4de83a3bdca8e1054505ec0c893e15017af45",
-      "pubkey_x25519": "bc150853ef3eff27e1ea4fc33a0d6b1ca4fc71b7d36d530cd28219ed2b0df23e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "337fffffffffffff"
-    },
-    {
-      "public_ip": "85.9.214.176",
-      "storage_port": 22021,
-      "pubkey_ed25519": "85956aea65dfb12c05aee39b043d58672d01d7cbb9ab5f614b4e423cbeb62968",
-      "pubkey_x25519": "60f33d25a275f12e7736d515c83c4d25ca7ae142151812ec8298dbc2fedfe925",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9effffffffffffff"
-    },
-    {
       "public_ip": "135.125.112.182",
       "storage_port": 22021,
       "pubkey_ed25519": "85c9cc92777fbd46f44dee65939e75d50eb2fdf2ff236e701327dc9ac8328c35",
@@ -12206,7 +8258,21 @@
         11,
         3
       ],
-      "swarm": "317fffffffffffff"
+      "swarm": "83ffffffffffffff"
+    },
+    {
+      "public_ip": "151.244.85.96",
+      "storage_port": 22128,
+      "pubkey_ed25519": "85eba218daf8c897090e2b0535d4e8646678fdeedb4f308c695ed80ab969b91b",
+      "pubkey_x25519": "74b5cd9b2c646f6e8760622cd58a04e27ce3edb868bbbf350cda816eef21c515",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20228,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "104.237.154.110",
@@ -12234,7 +8300,7 @@
         11,
         2
       ],
-      "swarm": "8cffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "89.58.25.106",
@@ -12251,62 +8317,6 @@
       "swarm": "51ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.22",
-      "storage_port": 22021,
-      "pubkey_ed25519": "877eb2c2313b0b964386cbf26a9370612350c0d5eb9db58e05d4e21cce24e0ff",
-      "pubkey_x25519": "887f53006d088118ad3cac971d19295a0ecfbd31207f021ed6af541587a29f56",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "fdffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22101,
-      "pubkey_ed25519": "87cd28e535ccdb096b5e807788c741dde96f9884c117b1cc2ddb1e54b59eea4b",
-      "pubkey_x25519": "a162525f611b9e269173cd42fab6477efaa6459361225b3be9ee281766a5c665",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "adffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22112,
-      "pubkey_ed25519": "87d62cff1e5ac4004c10fbd0d166773e77ccd5cb2690f5090ddb4a058911591f",
-      "pubkey_x25519": "015a5b87664bccb6674cc7b5fb3d434de4f2ca89a89743921528dab2f45b8942",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22113,
-      "pubkey_ed25519": "8848539cc1354bdc9abd29e6ab0b073208d699071b4c66a5622f16996b411539",
-      "pubkey_x25519": "a38519528620afb3797e71cb8ca6e0bf2e9ac76b57f8b3f98c40af02e1c2ac65",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5effffffffffffff"
-    },
-    {
       "public_ip": "2.59.133.234",
       "storage_port": 22021,
       "pubkey_ed25519": "887e42dd8254412253ad32a24264a23f8e4049d94c0cc320e394c9c3588a73dd",
@@ -12318,7 +8328,7 @@
         11,
         1
       ],
-      "swarm": "407fffffffffffff"
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "209.141.41.159",
@@ -12332,21 +8342,7 @@
         11,
         3
       ],
-      "swarm": "f0ffffffffffffff"
-    },
-    {
-      "public_ip": "66.94.111.202",
-      "storage_port": 22021,
-      "pubkey_ed25519": "88f41f5e71cb0cc4f8fcac9b7c53c1141df1381616c24b8a9a840ad744b2c073",
-      "pubkey_x25519": "34e881c254b368ad620fd1e2c8ead2348e116b68db992dfba8ccdcc6f284612f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "54ffffffffffffff"
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "51.81.83.232",
@@ -12360,35 +8356,21 @@
         11,
         2
       ],
-      "swarm": "daffffffffffffff"
+      "swarm": "e3ffffffffffffff"
     },
     {
-      "public_ip": "107.175.49.159",
-      "storage_port": 22021,
-      "pubkey_ed25519": "892c05f37dd8eb29be1cb658cb7cf9819441e2a91929adae23cf620dc4538310",
-      "pubkey_x25519": "581309c8b807846f1f71e9d428bf2e7d9f3d0ea02e766546596f75fae118f361",
-      "requested_unlock_height": 2085166,
-      "storage_lmq_port": 22020,
+      "public_ip": "151.244.85.190",
+      "storage_port": 22146,
+      "pubkey_ed25519": "890e167d37b1bd201ed47c697200813124bb3fde94da2d1fa7b51c63cd5ed3dc",
+      "pubkey_x25519": "b7018d122e3986b0a4f1f3ca2bc17b03b0355da76cd39b435464d6cdf9d08d70",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20246,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "c4ffffffffffffff"
-    },
-    {
-      "public_ip": "64.235.61.16",
-      "storage_port": 22021,
-      "pubkey_ed25519": "895360bde86788dd31453217e7bf338cfb7b4d4200d33d276600da38c8a6ab30",
-      "pubkey_x25519": "f296b3f9bf58c028744df86371c0daacf02a0a75480adf678ba2a9f10818000d",
-      "requested_unlock_height": 2086491,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "abffffffffffffff"
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "51.79.161.47",
@@ -12402,21 +8384,7 @@
         11,
         0
       ],
-      "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22138,
-      "pubkey_ed25519": "89e12490290fc846e0f94d8394cfea6f0d0a39e6bfec2b8fec271e0fd0461ccd",
-      "pubkey_x25519": "098203db37ab1c046a6a2c851c46f654dd81cf48bb53471e0944865951cd485f",
-      "requested_unlock_height": 2088776,
-      "storage_lmq_port": 20238,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "50ffffffffffffff"
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "205.185.122.57",
@@ -12444,7 +8412,7 @@
         11,
         3
       ],
-      "swarm": "37ffffffffffffff"
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "146.59.16.179",
@@ -12458,21 +8426,7 @@
         11,
         2
       ],
-      "swarm": "a9ffffffffffffff"
-    },
-    {
-      "public_ip": "94.72.102.238",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8abebf54a1a3ad76c57c42c612c0861b7aaef73437e3490df9545d86d6fa009b",
-      "pubkey_x25519": "eac540a4779d218acb5aa91552e603ac65c6d500ad90d638c572231977f1b178",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "beffffffffffffff"
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
@@ -12486,35 +8440,7 @@
         11,
         3
       ],
-      "swarm": "1c7fffffffffffff"
-    },
-    {
-      "public_ip": "64.227.69.108",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8ae307d9d796f59b6c37bda86101d65a3d062a083cd134d7c1918404325534b3",
-      "pubkey_x25519": "21da188c49abd3ba9d63025922ef49474e6d46b009b79e4115ac67ef1cb0d10b",
-      "requested_unlock_height": 2094234,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "5fffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22118,
-      "pubkey_ed25519": "8af0d990c8fac42829db9e2b7fa434c417a095c064d8098a7a21a7a991231fc3",
-      "pubkey_x25519": "ea11eac805e1e1dd87239a5075278b0bdd6668fd2194704c7eb5d4c3921eaa2e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20218,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "77ffffffffffffff"
+      "swarm": "ceffffffffffffff"
     },
     {
       "public_ip": "107.189.28.108",
@@ -12531,20 +8457,6 @@
       "swarm": "c4ffffffffffffff"
     },
     {
-      "public_ip": "45.84.59.88",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8c1fdeef2ba20c5d94ccf6e482640672812be0792c08800f0514e49e97e9cc97",
-      "pubkey_x25519": "cccf66b7e0d34feb8d8690c96897ec7decad4165f249dcad0ab181c4ac9e561f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "24ffffffffffffff"
-    },
-    {
       "public_ip": "129.213.162.17",
       "storage_port": 22021,
       "pubkey_ed25519": "8c1ffae994bee3613ad03438fb8248406f87ae70949b3593969c1be3ae1fa0fe",
@@ -12556,7 +8468,7 @@
         11,
         2
       ],
-      "swarm": "30ffffffffffffff"
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
@@ -12570,77 +8482,21 @@
         11,
         3
       ],
-      "swarm": "437fffffffffffff"
+      "swarm": "88ffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
       "storage_port": 22106,
       "pubkey_ed25519": "8c58a4acd16066dc5fc2d390cd35d99aa69a86f531132a92d832df47d0301077",
       "pubkey_x25519": "ab17239582b0f6756f5eed927f53b8058c0fb245c16ca07e5d6cd2a477a03339",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161188,
       "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "48ffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22103,
-      "pubkey_ed25519": "8c673b74801ba27a2c23596d681ddfe77fbe17ff852a922f93de410b23721eaa",
-      "pubkey_x25519": "52958f5feacc4243466a9074815d1780fecbfff363f7463367982727921ed464",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "deffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22103,
-      "pubkey_ed25519": "8ca92dee3f500c6205ee3f7f09f8c045238aef52b40e48c3aea6f49a6ac3f1d4",
-      "pubkey_x25519": "7ce8696968132be698b755e2bfd60362f7f89f41304cfbc92fb359940b89386a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d6ffffffffffffff"
-    },
-    {
-      "public_ip": "89.58.2.184",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8cd885c7bec503b32a21da48e568aca72b6f83b8769557cd23a754c37304645e",
-      "pubkey_x25519": "4061b4e84cb446866091bf0469b917d3c2bd0096e500b338de55152c078bb36c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3f7fffffffffffff"
-    },
-    {
-      "public_ip": "88.99.195.142",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8ce3bd6adf8bf5d5fe68f19ac26de2befe5e1b75358cd965860d13c25f28aea3",
-      "pubkey_x25519": "9cda29c9ce7582fdc73d1f95ce8bdc9ebc873f75b632f8f9b3b641f666ea642b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "93ffffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "89.58.10.191",
@@ -12668,49 +8524,7 @@
         11,
         1
       ],
-      "swarm": "ddffffffffffffff"
-    },
-    {
-      "public_ip": "147.182.176.227",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8df8d50108a84d417708c084688471cc4f81c0ea397f67fdf424d99199b74422",
-      "pubkey_x25519": "b470250ca09a551f08699108a5b249817816757b7c6e494a143c6c2a60cdf322",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3d7fffffffffffff"
-    },
-    {
-      "public_ip": "104.233.210.15",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8e07acd1a2708c865b6c86907b6327f42c153b8ad8affd87c08f03203a8f9444",
-      "pubkey_x25519": "cc2710acd79fc1ae1cd0cbb124977109f6d74d1d3ca554efb7e044e03825e27c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2f7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22112,
-      "pubkey_ed25519": "8e26e4cc3140a318d01b0b3944e3adb8866e59e0ba596854028d27a34341731d",
-      "pubkey_x25519": "ddfa1da8321e0919784e2ea0c16a766868030879e2472443e142abab32affc30",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "26ffffffffffffff"
+      "swarm": "9ffffffffffffff"
     },
     {
       "public_ip": "51.222.106.156",
@@ -12724,7 +8538,7 @@
         11,
         3
       ],
-      "swarm": "2affffffffffffff"
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "5.255.102.187",
@@ -12738,7 +8552,7 @@
         11,
         3
       ],
-      "swarm": "baffffffffffffff"
+      "swarm": "73ffffffffffffff"
     },
     {
       "public_ip": "135.125.129.15",
@@ -12752,7 +8566,7 @@
         11,
         2
       ],
-      "swarm": "5dffffffffffffff"
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "51.68.138.95",
@@ -12766,7 +8580,7 @@
         11,
         2
       ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "198.98.48.151",
@@ -12783,32 +8597,18 @@
       "swarm": "357fffffffffffff"
     },
     {
-      "public_ip": "217.216.35.231",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8ef6849155b1a12ecddbe488802b722b835d9521b90d637a5451c84b3a560d30",
-      "pubkey_x25519": "8aa3bd4f3e1ccd061a3a874bb45adaa8ab687802ad4c084ef6b988817e95772c",
+      "public_ip": "89.167.117.100",
+      "storage_port": 22102,
+      "pubkey_ed25519": "8edcd48e5e479ac831b8fb506e6b26947486815f5dae457dea8539d19588ddc7",
+      "pubkey_x25519": "c1fa98b9907b061b47d18c55bf0e225ed05ba6b7bf15faed1467c62145460824",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "76ffffffffffffff"
-    },
-    {
-      "public_ip": "209.126.85.21",
-      "storage_port": 22021,
-      "pubkey_ed25519": "8f7de0bf397565eeffcacb1e04cf53007ba2ce7ca4ae4c9bb77542d95fecb7af",
-      "pubkey_x25519": "6482660ce17aed4867c7252eaa55eeee3ce42d60d34e252208b4e641c36c2935",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e3ffffffffffffff"
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "15.204.236.128",
@@ -12822,7 +8622,7 @@
         11,
         3
       ],
-      "swarm": "93ffffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.33",
@@ -12836,7 +8636,7 @@
         11,
         3
       ],
-      "swarm": "33ffffffffffffff"
+      "swarm": "d9ffffffffffffff"
     },
     {
       "public_ip": "45.33.56.54",
@@ -12853,32 +8653,18 @@
       "swarm": "72ffffffffffffff"
     },
     {
-      "public_ip": "142.248.28.45",
-      "storage_port": 22021,
-      "pubkey_ed25519": "909b82b2a7212c1810027fadc912054d7fc6ed2ec2575ab0773383d280c3f207",
-      "pubkey_x25519": "641d90b6d9bbb5a2d596390158d6e01cf75c767f34bd1910273ea297ee483624",
-      "requested_unlock_height": 2084493,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "cbffffffffffffff"
-    },
-    {
       "public_ip": "65.21.240.249",
       "storage_port": 22101,
       "pubkey_ed25519": "90a74727ec61674fc013228927276187fb9fc42c8e7bc4012192dfd7bf00dee7",
       "pubkey_x25519": "5a4ccbeaae8ba04273c67d1a3be82ce275356d7f21853f0b5e6f283ca286ed41",
-      "requested_unlock_height": 2094670,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22401,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "a9ffffffffffffff"
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "198.98.55.4",
@@ -12892,7 +8678,7 @@
         11,
         3
       ],
-      "swarm": "2f7fffffffffffff"
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "107.189.1.61",
@@ -12906,21 +8692,21 @@
         11,
         2
       ],
-      "swarm": "63ffffffffffffff"
+      "swarm": "c3ffffffffffffff"
     },
     {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22112,
-      "pubkey_ed25519": "9147c04478c28527f5b4a54479c6f139d803646767cf0190b3bd2cb62aff2fd6",
-      "pubkey_x25519": "68eca17af350821424b42f14d9247728ee2cdbeaec988f9352fdc620ddf8bd3e",
+      "public_ip": "158.180.27.184",
+      "storage_port": 22103,
+      "pubkey_ed25519": "91417e61af52ee194fe38ec02a55f70b6e505deea068c8efe6695b08d4ffc9cd",
+      "pubkey_x25519": "3e6707344c8cc77baaf3c670d118a43cc12eecaf52740926b1ca39edbffc5e0a",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
+      "storage_lmq_port": 20203,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "7affffffffffffff"
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -12948,7 +8734,7 @@
         11,
         3
       ],
-      "swarm": "287fffffffffffff"
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "2.59.133.53",
@@ -12962,21 +8748,21 @@
         11,
         1
       ],
-      "swarm": "14ffffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.123",
-      "storage_port": 22021,
-      "pubkey_ed25519": "91f3bc97d4b0e7ed309d977060f5b0d1f55fb7e559010eb0ca2f737360e86c5a",
-      "pubkey_x25519": "990ed567bcc45d327588fbfda92c967ccca93cd93177d16616d152526138cd0b",
+      "public_ip": "128.140.94.83",
+      "storage_port": 22101,
+      "pubkey_ed25519": "91f7d418b0b298451f7ce61e1387477a4bb70e998e9da686fa7594bd22274005",
+      "pubkey_x25519": "714d3e02b23e0afa7cd65eceb23c88cc65047b2514b893de826c3ecaf97eda68",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 22401,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "68ffffffffffffff"
+      "swarm": "e8ffffffffffffff"
     },
     {
       "public_ip": "51.79.160.111",
@@ -12993,20 +8779,6 @@
       "swarm": "7effffffffffffff"
     },
     {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22101,
-      "pubkey_ed25519": "920c04438ce3aff3837f7dea462fd70994809582a24f01d6a425678079a14596",
-      "pubkey_x25519": "ecf4755b80e807975321ba24c0ccf80b59b6bd0785647296b055ea86d0253150",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c0ffffffffffffff"
-    },
-    {
       "public_ip": "164.92.211.163",
       "storage_port": 22021,
       "pubkey_ed25519": "925b7c0e7a5ed7109dce7a116398fb3b7ec81ac218674bf760523ea521aca80f",
@@ -13021,48 +8793,6 @@
       "swarm": "1affffffffffffff"
     },
     {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22106,
-      "pubkey_ed25519": "92c4e00b8a69a749c575075be0353e7f9f53eeab0748ee8050467ae688917efb",
-      "pubkey_x25519": "da7562d40b916ede47ca7874387e061dafd9323e6c597293756c35d3aae40f24",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "5bffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.67.208",
-      "storage_port": 22021,
-      "pubkey_ed25519": "92f6d3fc8b83eaab3ada73e1119fcf647eeb8fe419e1103eb2fcae290ef348a0",
-      "pubkey_x25519": "af4ecc945c802cd8ec5b243b0f00073c2cb6e0db1ec6240954bad05ad594e010",
-      "requested_unlock_height": 2090347,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "30ffffffffffffff"
-    },
-    {
-      "public_ip": "50.114.206.217",
-      "storage_port": 22021,
-      "pubkey_ed25519": "931fed63fef8fc81f768c25b317bd57afa361724ea7fc8a90ae5cf01b6029ee1",
-      "pubkey_x25519": "d0817807d701124875ee85ee65cb6e610653f6c08beebed7a030a9a9b259a464",
-      "requested_unlock_height": 2091682,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "89ffffffffffffff"
-    },
-    {
       "public_ip": "130.162.50.158",
       "storage_port": 22103,
       "pubkey_ed25519": "933a81bbdc8ec6ddbf512654027dcebe3d4bcde2b072b0d8a292cd0865be1622",
@@ -13074,7 +8804,7 @@
         11,
         3
       ],
-      "swarm": "4effffffffffffff"
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "154.53.40.109",
@@ -13091,20 +8821,6 @@
       "swarm": "2bffffffffffffff"
     },
     {
-      "public_ip": "164.68.98.105",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9353d7d130edcf285b08845e1edd45dcfb9e70c80d1ecc2f1ac575cec7f5f535",
-      "pubkey_x25519": "92f4ac9d8482af346c0bb27d63b3f5e218f816bcbae3937948cac8386060174f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b4ffffffffffffff"
-    },
-    {
       "public_ip": "45.136.28.239",
       "storage_port": 22021,
       "pubkey_ed25519": "937af3c2767bf9608919dc1954d6e18a60efded35d0e032138ae8fac8a3d0b2c",
@@ -13117,20 +8833,6 @@
         2
       ],
       "swarm": "2a7fffffffffffff"
-    },
-    {
-      "public_ip": "5.189.152.176",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9381e658bab25a7b52371b0966dc9ab8e493bee98780fdb2e6fdd2074661064b",
-      "pubkey_x25519": "0b5e8c9df69c9c7191b86fdebcf54c4bfa1984ae91c0b85a7d3199ce080ec972",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "47fffffffffffff"
     },
     {
       "public_ip": "107.189.7.179",
@@ -13147,18 +8849,18 @@
       "swarm": "377fffffffffffff"
     },
     {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22109,
-      "pubkey_ed25519": "93bd41c0e972696d86bb66e6962263bffb8a81c67d0983ef2425a1e78a7eb2bb",
-      "pubkey_x25519": "5d48ea8b4c4ac1ca369f82b6fab5bbd9b01f676a2e78719b322a173feb44104a",
+      "public_ip": "212.105.90.36",
+      "storage_port": 22115,
+      "pubkey_ed25519": "93b07f57b3dd2dccf767e37a4c2d29b051b6a065cbf6d55197448c0517dd069d",
+      "pubkey_x25519": "0c9d5012d3ddf2d27a94f76ac8562ba3c205011c636092bd269e4a292d366d74",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
+      "storage_lmq_port": 20215,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "eeffffffffffffff"
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -13175,34 +8877,6 @@
       "swarm": "377fffffffffffff"
     },
     {
-      "public_ip": "159.195.22.171",
-      "storage_port": 22021,
-      "pubkey_ed25519": "93c38a6c95dece07ebebf5cc50c357910915274fe0326911380bcfb2e734ef78",
-      "pubkey_x25519": "222f14a21fadfc5cc4baec8a8319e15e99603f0da67d2b7fc8da2804991d396e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "75ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22113,
-      "pubkey_ed25519": "93c97c3f1c531a5a1c2464dab191de3197e409f33aa6628707f438fc4d203342",
-      "pubkey_x25519": "085fba2eb1426b4f32ac57372396872732c2bff6c77c45f7f45725a00355575a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ddffffffffffffff"
-    },
-    {
       "public_ip": "178.157.91.16",
       "storage_port": 22021,
       "pubkey_ed25519": "940bf0393cc2cf181719ef4e9b423bcd62d093a8579a8d44851ee30e490da693",
@@ -13214,35 +8888,7 @@
         11,
         2
       ],
-      "swarm": "3f7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.160",
-      "storage_port": 22021,
-      "pubkey_ed25519": "94543f863a76ba6160524bc02ba2c788cbaf230f4deab2e5f6599211f6f3a7f8",
-      "pubkey_x25519": "86c8a9de9ae483898c4a5513447827d11fd8fdd22f1fd1b8862a3be8b9bede49",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "42ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22108,
-      "pubkey_ed25519": "94b567dbfd83312790a76b95c45f0835f7f531cca2b054588157d5e64d149d8a",
-      "pubkey_x25519": "18f27411ae6ca6cd4ea91c44ab7d246192cb5872ec34b9b9f159a707110dba0a",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "18ffffffffffffff"
+      "swarm": "47ffffffffffffff"
     },
     {
       "public_ip": "5.196.114.122",
@@ -13270,7 +8916,21 @@
         11,
         2
       ],
-      "swarm": "4cffffffffffffff"
+      "swarm": "66ffffffffffffff"
+    },
+    {
+      "public_ip": "216.22.27.30",
+      "storage_port": 22106,
+      "pubkey_ed25519": "95e2259a3825c86782528bbae43ee1c5800cc3b83aaaa9b271fe5d2623bc686c",
+      "pubkey_x25519": "a903cf9f7c2cadde16ac007cc4b572914334d6c66b5801741ca2c487ce9dc471",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20206,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "209.141.33.235",
@@ -13284,21 +8944,35 @@
         11,
         3
       ],
-      "swarm": "7ffffffffffffff"
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
       "storage_port": 22100,
       "pubkey_ed25519": "960a62165cfee99f128b4997a804ae792292125f7fec98b2b2821230ce2b0d32",
       "pubkey_x25519": "03f6a50e8df03540a39a160fa16885bf9cc961789305b535e7012f54bf754c57",
-      "requested_unlock_height": 2090029,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "baffffffffffffff"
+      "swarm": "9effffffffffffff"
+    },
+    {
+      "public_ip": "212.105.90.36",
+      "storage_port": 22113,
+      "pubkey_ed25519": "962d4135dfc039d360d8835576f1b098c8912f62948b3b120c76edd23dc440f2",
+      "pubkey_x25519": "c622fc3dc0e3a60a1bb7b1be6c77db39f936d183fa04e95d89cdb52e896a7558",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20213,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "3f7fffffffffffff"
     },
     {
       "public_ip": "198.71.58.236",
@@ -13312,10 +8986,10 @@
         11,
         3
       ],
-      "swarm": "deffffffffffffff"
+      "swarm": "47fffffffffffff"
     },
     {
-      "public_ip": "5.255.118.220",
+      "public_ip": "74.50.118.192",
       "storage_port": 22021,
       "pubkey_ed25519": "96ad275ae0a89cf0f665cd8426ed5ca6c1ecf983c6a879bdd070d7db91973cab",
       "pubkey_x25519": "f72ce7632973cece16cf4a8b97bea55c505f24d4f1f378330884796b4b810243",
@@ -13333,14 +9007,28 @@
       "storage_port": 22021,
       "pubkey_ed25519": "96c051516c0dac60022fd5f9163e131025dcfaa519a1d8fe9728545c43618d0f",
       "pubkey_x25519": "44f8347f0741923d505be9eea51f3b320d6b8783b723e7a6b41acf8cc67a6f37",
-      "requested_unlock_height": 2085167,
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "9ffffffffffffff"
+    },
+    {
+      "public_ip": "138.201.195.125",
+      "storage_port": 22021,
+      "pubkey_ed25519": "96cf88ba2af65271ef961c0a27b6989da7de5db29ffba302f91f4faf657369d0",
+      "pubkey_x25519": "cff982262aab95302e886dbbe5e9bf29789d3a0159b3b4e706e46e6790eb1226",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "dfffffffffffffff"
+      "swarm": "9effffffffffffff"
     },
     {
       "public_ip": "46.62.169.159",
@@ -13354,7 +9042,7 @@
         11,
         2
       ],
-      "swarm": "14ffffffffffffff"
+      "swarm": "34ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -13368,49 +9056,7 @@
         11,
         0
       ],
-      "swarm": "33ffffffffffffff"
-    },
-    {
-      "public_ip": "159.65.196.229",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9801c7dbabfeea5675b2b6f8bcbccbaeb653fbd07177d575adb73ec7aa260f3b",
-      "pubkey_x25519": "26153c6eb0af127dee7bbaec4a40ec5b9aa1b702fdb256d71ff82ff79f357e58",
-      "requested_unlock_height": 2094229,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "14ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22120,
-      "pubkey_ed25519": "982f54b09c8a817489c0b9a68a023182415a4d0a14a4beeabae54be8b10c8d80",
-      "pubkey_x25519": "3faeac009e0cb1f85b1633b7fff298fa608958e07dea6029eb6947ffe999fe2d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20220,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "15ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22103,
-      "pubkey_ed25519": "9867e3c0c319062a1fe5bc6aa25ae8ae0e0a78e1c11e7ecd9826cb9fba159dbc",
-      "pubkey_x25519": "be3c64b6cc9a34f9e10d421cc468e1e5938d9af340217a7eb2158a2f802dca7f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a9ffffffffffffff"
+      "swarm": "bdffffffffffffff"
     },
     {
       "public_ip": "159.69.19.204",
@@ -13424,63 +9070,21 @@
         11,
         2
       ],
-      "swarm": "efffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.65.60",
-      "storage_port": 22021,
-      "pubkey_ed25519": "98b1932491c42797481dcd9068d3dbf53de2b3cf61ae85a33d29c3b0c9843485",
-      "pubkey_x25519": "ab802c2f10f2ffb3d016505ef2577eb512203c06c836c15da9d5886521bbc16d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "7fffffffffffffff"
-    },
-    {
-      "public_ip": "217.217.250.41",
-      "storage_port": 22021,
-      "pubkey_ed25519": "98c838df51a2e5599f675f38448bba83e627d8b471db857ef7755bca2700b9d5",
-      "pubkey_x25519": "c37e030f79e901712ce18d89b7eaad094ddbaa26d343c7c90b42a84186301f02",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e5ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22113,
-      "pubkey_ed25519": "98ce73b325859a16b906d7d1a0d568b4fed2b1def950ffa07d07f037455ebd79",
-      "pubkey_x25519": "1399501c0e94bd1f8dc7f7a1e13bb031437b646fdf9271a42d3502fe74ce593d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d2ffffffffffffff"
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "31.25.10.140",
       "storage_port": 22021,
       "pubkey_ed25519": "9905f753f4a98e4c1cf2b538d71fcb6bef04f4c84e803df5cd86f2e46277009b",
       "pubkey_x25519": "4f88cf463abd1791d97ce4ef16af540829c3bb2ee77dde32ddc3c372eafa254f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161747,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "abffffffffffffff"
+      "swarm": "437fffffffffffff"
     },
     {
       "public_ip": "45.85.147.254",
@@ -13494,7 +9098,7 @@
         11,
         3
       ],
-      "swarm": "67fffffffffffff"
+      "swarm": "3a7fffffffffffff"
     },
     {
       "public_ip": "91.231.182.121",
@@ -13511,7 +9115,7 @@
       "swarm": "b2ffffffffffffff"
     },
     {
-      "public_ip": "64.235.39.22",
+      "public_ip": "107.175.49.159",
       "storage_port": 22021,
       "pubkey_ed25519": "99ae8886e286c1ff38e6d367acb71127e9336e9a8864c9a19e2ec659545bc58b",
       "pubkey_x25519": "96a2e9460a337245a06b019c38f778ec2ed55f939dd0a29ff2985ba26d29966c",
@@ -13522,35 +9126,7 @@
         11,
         3
       ],
-      "swarm": "8fffffffffffffff"
-    },
-    {
-      "public_ip": "157.173.192.73",
-      "storage_port": 22021,
-      "pubkey_ed25519": "99ce8d112edfe8059f44be61d5cab23f4962fd65d38fee3bb90b8e7d2d7972a0",
-      "pubkey_x25519": "2f143aae388ed5fbd5d67736f5679fcf5769204d3741579a5768d780ae4fbb08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "437fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22105,
-      "pubkey_ed25519": "9a198051fa7159a4574bc5972573dc1459310a0ef4b268d958eaafb30d47c5f1",
-      "pubkey_x25519": "278e525b2227e651b970c345de0e03e7657088bbc628fe2705b5723e60204771",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9cffffffffffffff"
+      "swarm": "a5ffffffffffffff"
     },
     {
       "public_ip": "198.98.55.38",
@@ -13564,21 +9140,7 @@
         11,
         3
       ],
-      "swarm": "19ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22106,
-      "pubkey_ed25519": "9a2cedc085daf9fd7657d697296c3f9f16c69546b33c572d9d3bdb123e599bf4",
-      "pubkey_x25519": "956006352fb70f90a56055002b5ec98817390dca32556ddc462424ff83d8dd4b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "51ffffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -13609,34 +9171,6 @@
       "swarm": "3a7fffffffffffff"
     },
     {
-      "public_ip": "89.168.69.126",
-      "storage_port": 22102,
-      "pubkey_ed25519": "9ac8055c3f1196c3fab2364b0a4b0c287ab24aadd69dd446b7950cfe3c9dc5f8",
-      "pubkey_x25519": "3d8a3bd2000bad419028b94cec12505395ce931c6907c43571960586b1e4c028",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e0ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22113,
-      "pubkey_ed25519": "9ae0be5d75076b694e8b5463ee586b3321fbc176bf67b9bb6efb0215eeb37e18",
-      "pubkey_x25519": "ae7429e21e57f5a57a9509e11892b02737cfa0a604ccda3ff57ac8190294bd2e",
-      "requested_unlock_height": 2093821,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "22ffffffffffffff"
-    },
-    {
       "public_ip": "23.88.103.210",
       "storage_port": 22021,
       "pubkey_ed25519": "9aeab67aa26c531e6ee877273dc043f4a53fc7c9346b4b2d3f2531f44668e07f",
@@ -13648,7 +9182,7 @@
         11,
         3
       ],
-      "swarm": "5affffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "157.90.226.160",
@@ -13662,21 +9196,7 @@
         11,
         0
       ],
-      "swarm": "affffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22104,
-      "pubkey_ed25519": "9b088fc6da3fd916830f885f20500fc9e40cee5b625ea2765fa4bed590e7151e",
-      "pubkey_x25519": "6e0f96b8087f8d03605314f7c37cdec13b86b314921754b147d0d23f9ced2d17",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "97fffffffffffff"
+      "swarm": "14ffffffffffffff"
     },
     {
       "public_ip": "51.68.71.134",
@@ -13690,7 +9210,7 @@
         11,
         2
       ],
-      "swarm": "72ffffffffffffff"
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "192.99.169.55",
@@ -13704,7 +9224,7 @@
         11,
         2
       ],
-      "swarm": "bbffffffffffffff"
+      "swarm": "94ffffffffffffff"
     },
     {
       "public_ip": "192.155.81.197",
@@ -13718,35 +9238,7 @@
         11,
         0
       ],
-      "swarm": "5bffffffffffffff"
-    },
-    {
-      "public_ip": "46.250.252.180",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9bbf350a687311f15f20f2e7bf4e79f62b9542b565ed865a8c3166211cbeab1c",
-      "pubkey_x25519": "d7439f534d2fc9d509caf072db7c5347507f9a64784bfb8615cb10419095984d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "ccffffffffffffff"
-    },
-    {
-      "public_ip": "135.181.90.158",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9bd0d0249150dd2b3d9982e75359b5dde4777692cd0d3136b3f5207a4c484fff",
-      "pubkey_x25519": "436bb0c8aadeeac4e64dd4623bd3257c7c9c26575a37bec3178848d604a75e6a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3fffffffffffffff"
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "51.81.202.49",
@@ -13760,7 +9252,21 @@
         11,
         2
       ],
-      "swarm": "6dffffffffffffff"
+      "swarm": "b4ffffffffffffff"
+    },
+    {
+      "public_ip": "135.181.86.150",
+      "storage_port": 22021,
+      "pubkey_ed25519": "9c0be50af77b658b92f872de9e06fa119d9e77af1eaa9668bd12962a82e51381",
+      "pubkey_x25519": "33f37db20a2fc56733e6adbb012d32a9dffa6a117c171c9a98604d2e41e13775",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "3dffffffffffffff"
     },
     {
       "public_ip": "108.171.193.114",
@@ -13774,21 +9280,7 @@
         11,
         3
       ],
-      "swarm": "33ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22110,
-      "pubkey_ed25519": "9c29514b20632df0afbabcdef88b1bf0befd8946d99e51bb13e8b8754b48dd58",
-      "pubkey_x25519": "baa4685cdce3f5812deba90fb384d2bd7c2ae1710fdbe38dc15131fbe6bbb655",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f8ffffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "107.173.166.139",
@@ -13802,7 +9294,7 @@
         11,
         0
       ],
-      "swarm": "407fffffffffffff"
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "217.182.206.34",
@@ -13816,7 +9308,7 @@
         11,
         2
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "26ffffffffffffff"
     },
     {
       "public_ip": "62.171.174.143",
@@ -13830,35 +9322,7 @@
         11,
         2
       ],
-      "swarm": "76ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22110,
-      "pubkey_ed25519": "9e5f61296a2ee627efe30b17a580c1709b2844f7f47294cb898e11d767707253",
-      "pubkey_x25519": "c43d387695d4a8d6051ee42e97b3ded6733f938180a9c28c1121d917b160b83a",
-      "requested_unlock_height": 2093820,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "fbffffffffffffff"
-    },
-    {
-      "public_ip": "193.22.147.70",
-      "storage_port": 22021,
-      "pubkey_ed25519": "9e932ffcc0018054ece1f65f8de756cd30c540d9ba06aec8d9ca41bc59022dbe",
-      "pubkey_x25519": "b781a29667fe8054691e8b585471a61bb18a96e4ced9d7cc494227eaa4d99b7d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "50ffffffffffffff"
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "139.162.25.130",
@@ -13872,7 +9336,7 @@
         11,
         2
       ],
-      "swarm": "aaffffffffffffff"
+      "swarm": "dcffffffffffffff"
     },
     {
       "public_ip": "138.197.173.72",
@@ -13900,7 +9364,7 @@
         11,
         0
       ],
-      "swarm": "67ffffffffffffff"
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "192.53.126.238",
@@ -13917,20 +9381,6 @@
       "swarm": "d3ffffffffffffff"
     },
     {
-      "public_ip": "94.237.81.75",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a03ab4097997be3a3a99c5b47561c1fae5a9c6c475c4af70ab143058a72eea03",
-      "pubkey_x25519": "973f95080b142eafccc4eee21de5f2210578a2ea937803c196a2fdb14229216b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "56ffffffffffffff"
-    },
-    {
       "public_ip": "140.238.126.154",
       "storage_port": 22102,
       "pubkey_ed25519": "a058fd0fb97a297fbfc80c42836537df8f09a59a0232673adef1e5047762e9ac",
@@ -13942,21 +9392,35 @@
         11,
         3
       ],
-      "swarm": "77fffffffffffff"
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "107.182.173.89",
       "storage_port": 22021,
       "pubkey_ed25519": "a0696c69aecba4f43bf1723a5f5e2412c9ee2f2baa82ee749af8b418df4c6b6c",
       "pubkey_x25519": "2cf859417fd7065fa47031e672bd19c00d0d365f6e5a24a293348d623f87b14e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161217,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "f6ffffffffffffff"
+      "swarm": "c3ffffffffffffff"
+    },
+    {
+      "public_ip": "212.105.90.36",
+      "storage_port": 22114,
+      "pubkey_ed25519": "a06dd42cc85705873ace1ff65de441410d20b4ba0d8a9c4b3c50d0c0a2eed628",
+      "pubkey_x25519": "879bcecaa5a1f7615985eba20d3d1340b713ac9454e0ad0682a24a375225fa5d",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "dffffffffffffff"
     },
     {
       "public_ip": "193.42.11.100",
@@ -13970,35 +9434,7 @@
         11,
         1
       ],
-      "swarm": "f4ffffffffffffff"
-    },
-    {
-      "public_ip": "173.249.18.34",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a0cbe49dbbda77d81e6f3972a0714bf62cbf09035d1c1113529a1d7904004b89",
-      "pubkey_x25519": "8beaf910738a79aa16233489ee44591dbb4aebc6bcd55d3ad70c810438cb8657",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "51ffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22102,
-      "pubkey_ed25519": "a0de8baa2406d7f52e133e0fce76ef7f802955d313145431c72cb6a30e729eec",
-      "pubkey_x25519": "8389159f413d38fde834764250daae62380ac2fb415abbe6acf9c05309067d33",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f6ffffffffffffff"
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "5.75.229.75",
@@ -14015,35 +9451,7 @@
       "swarm": "a7ffffffffffffff"
     },
     {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22101,
-      "pubkey_ed25519": "a113fb884ec0cd7f7cb44d4a09749e823b1bc7042fb9d487c4de113d57563f2e",
-      "pubkey_x25519": "9d1f58fe0839d2da5ed4e3662e275d1837582093c8e5ca32b4f2fd70927e4c73",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "69ffffffffffffff"
-    },
-    {
-      "public_ip": "193.70.87.174",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a117e74e36eabf2753425bcdf614125cef972a346759ee2c2c03f1e3852c1b3f",
-      "pubkey_x25519": "7ac195cd854a1ceccc08dfb91e61218168f9dbccfa6654fdd7911bee6c820777",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "87ffffffffffffff"
-    },
-    {
-      "public_ip": "146.71.85.210",
+      "public_ip": "185.173.235.108",
       "storage_port": 22021,
       "pubkey_ed25519": "a135bc2e3926a5106f0d53c88440fa7e7e02ce9857538eaf1e8ba5d921867a5a",
       "pubkey_x25519": "395671df134817717e75423cac4eeda971b3666b80c04ec0b6a5a52ce53dc933",
@@ -14052,9 +9460,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "447fffffffffffff"
+      "swarm": "ecffffffffffffff"
     },
     {
       "public_ip": "176.96.136.161",
@@ -14068,7 +9476,7 @@
         11,
         1
       ],
-      "swarm": "e3ffffffffffffff"
+      "swarm": "f8ffffffffffffff"
     },
     {
       "public_ip": "74.207.241.190",
@@ -14096,21 +9504,7 @@
         11,
         2
       ],
-      "swarm": "2bffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22142,
-      "pubkey_ed25519": "a1662109e074e4b4d4526386856bb4ee1e01f7680a3ae652c84479c5f4ec5273",
-      "pubkey_x25519": "5c207a04021f1703bf491c5ef53378aba0e2272a1f8b7c4ca726b099130a4a4f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20242,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "67ffffffffffffff"
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "164.90.166.150",
@@ -14124,49 +9518,7 @@
         11,
         0
       ],
-      "swarm": "b5ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22104,
-      "pubkey_ed25519": "a173901071dbec2acd419589c91cf0b82e9a10f4c3516391c314fa733ca8a8f6",
-      "pubkey_x25519": "063214661aabd097871dd23832f9d364755e0b9bcf8e6b5cf43ec8691cd1c211",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b8ffffffffffffff"
-    },
-    {
-      "public_ip": "104.234.124.143",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a1ba2f493993eeb93ceec6676fa6c530f24ca468c6c2ee8387a4667a5ceea511",
-      "pubkey_x25519": "05579b15cb9582bee032be9d2a5c419c1d3b173603772dab994d18056c117503",
-      "requested_unlock_height": 2094541,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "57fffffffffffff"
-    },
-    {
-      "public_ip": "5.189.160.68",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a1f0fffd63e19d5b0b21d2a8176f0911aa2a7c4c5ff85cb1d3fd6e063710c002",
-      "pubkey_x25519": "9b544525bf1d540f0f7e2e4147d5b3c12c10aff80f7fa4f5e0521c5192af3b57",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "75ffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "104.244.77.81",
@@ -14183,20 +9535,6 @@
       "swarm": "8effffffffffffff"
     },
     {
-      "public_ip": "158.220.112.165",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a256674e78d92c71f65c0cbae976798b7e37228bed8a9781a8fc8b62e194b436",
-      "pubkey_x25519": "6a839f80ca0b738afce7df2d08e0760f0d44a888bd963ba0135fe59109501c62",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "307fffffffffffff"
-    },
-    {
       "public_ip": "89.168.35.61",
       "storage_port": 22021,
       "pubkey_ed25519": "a26fbddd391c0d1a66ad89739086ca7a8de345b4bb3e8c8a57224ea9528d9bec",
@@ -14208,49 +9546,21 @@
         11,
         2
       ],
-      "swarm": "6dffffffffffffff"
+      "swarm": "baffffffffffffff"
     },
     {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22112,
-      "pubkey_ed25519": "a2713ecb57a9865f7111c1c0cb4562888c7ed964b2d7a72a8317fbb019328c4a",
-      "pubkey_x25519": "f77b1c4508888b2d26912b6d350ab0aae292c8e86dbb43f3c2b9d9073407587f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "52ffffffffffffff"
-    },
-    {
-      "public_ip": "141.105.130.149",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.111",
+      "storage_port": 22146,
       "pubkey_ed25519": "a2d22f886dc60fdccc562d0137a02f4e874790cecb39a08dc59a7182a8024bc4",
       "pubkey_x25519": "6d99fe604195b663b42522a7db2d21d7503310db672382f8b2f292b94e2fea2e",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20246,
       "storage_server_version": [
         2,
         11,
         3
       ],
       "swarm": "24ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22105,
-      "pubkey_ed25519": "a306100cda33b27fe3788b2bc8f069d2d127d9ff377b1fb6ddfe9460d608a39e",
-      "pubkey_x25519": "d41bb113a7936f2ee26f4abffcd6aca357aed42831c695429535f7fa7ed39052",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "18ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -14267,7 +9577,7 @@
       "swarm": "22ffffffffffffff"
     },
     {
-      "public_ip": "31.22.111.219",
+      "public_ip": "185.45.113.185",
       "storage_port": 22021,
       "pubkey_ed25519": "a35131b118b211189601e75b0bfcdf5ab58dcbfb35110ae56dafce0d98762dd4",
       "pubkey_x25519": "827d45024600e6b0d45617660bfbff1661ff07095f6ab5b11374f9352cb70c3b",
@@ -14292,7 +9602,7 @@
         11,
         0
       ],
-      "swarm": "8affffffffffffff"
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "198.98.62.178",
@@ -14306,38 +9616,24 @@
         11,
         3
       ],
-      "swarm": "257fffffffffffff"
+      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "64.44.157.112",
       "storage_port": 22021,
       "pubkey_ed25519": "a3c15e3b893a334eec8e9d8a9326c31387aeffc5562991353ed0d67f8a3afe31",
       "pubkey_x25519": "bf7581c9d6f2717fad5b275b787aa6d35502d18fcc9f2369398056b2ec18320f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161744,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "32ffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22119,
-      "pubkey_ed25519": "a3e416ccc22bf0a5ded68095db8e7b7abaf71c05cc3d1557ccb5d165200e32bb",
-      "pubkey_x25519": "547ba473d0e78e64ffba98b9c3f207357285ff1444b9783452217d9d352ad669",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9affffffffffffff"
-    },
-    {
-      "public_ip": "104.233.210.18",
+      "public_ip": "185.13.148.8",
       "storage_port": 22021,
       "pubkey_ed25519": "a43531db111ccb300d5608bfba41a182b13c6400008997b29343d326a64d9bae",
       "pubkey_x25519": "f9502184266881042c0c2d67d071c0ff53cd4fd4e90e67e28ba563762b442c18",
@@ -14348,7 +9644,7 @@
         11,
         3
       ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "205.185.123.189",
@@ -14362,7 +9658,7 @@
         11,
         3
       ],
-      "swarm": "47fffffffffffff"
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "161.97.98.151",
@@ -14376,7 +9672,7 @@
         11,
         3
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -14390,7 +9686,7 @@
         11,
         0
       ],
-      "swarm": "ecffffffffffffff"
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "176.96.138.191",
@@ -14404,7 +9700,7 @@
         11,
         3
       ],
-      "swarm": "2effffffffffffff"
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "128.140.124.48",
@@ -14418,57 +9714,15 @@
         11,
         3
       ],
-      "swarm": "5fffffffffffffff"
+      "swarm": "1affffffffffffff"
     },
     {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22115,
-      "pubkey_ed25519": "a59e7863c73a751d002ecc5765a6e65b267e439953b659c789ebc369500461d0",
-      "pubkey_x25519": "a6cb9c536dceeea17dea11b84abd057990000a9df02a77e882937ae15ccd7b4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b7fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22102,
-      "pubkey_ed25519": "a5abd1603e0ee1a110f5ac0c03a7a1a501b7743227c815353ae1526ebc2781c2",
-      "pubkey_x25519": "234e9d1f4b2c69a2c80f776954dbae102e335dfd9f738c6ea6aed8f7a826e925",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22111,
-      "pubkey_ed25519": "a64f4e45218281c8a0e3c910b0d503ea2af1ca5277e0ec34915be060d4bb3f64",
-      "pubkey_x25519": "c0d3b72355ec40ea2768de422fcc92c49ecc8bea96588fe9e465706c0ddbae11",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e4ffffffffffffff"
-    },
-    {
-      "public_ip": "141.105.130.166",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.1",
+      "storage_port": 22176,
       "pubkey_ed25519": "a67bce0a3e3a2fc109f5390b03269280c6b53fb08a514e70497dcfd67efae738",
       "pubkey_x25519": "0d34ba88c4e9353e270dead2a4d9d78cd43bc31972efcae672046109ffebe05b",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20276,
       "storage_server_version": [
         2,
         11,
@@ -14488,21 +9742,7 @@
         11,
         0
       ],
-      "swarm": "397fffffffffffff"
-    },
-    {
-      "public_ip": "216.230.232.35",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a714443c233bb87090215ab3efa7d72a9f29eaba6b5796e4422cf05fcb4e070d",
-      "pubkey_x25519": "543c4afe5b063e423cc674f0e6563130d7a140251a06296442545e03b6420225",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "477fffffffffffff"
+      "swarm": "b9ffffffffffffff"
     },
     {
       "public_ip": "57.129.102.67",
@@ -14517,20 +9757,6 @@
         2
       ],
       "swarm": "75ffffffffffffff"
-    },
-    {
-      "public_ip": "216.108.230.145",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a74e0c7ec31d8ad0f1d5a55282180e4e9a63196d8ea1ab0ddec6e32e1c0cfc96",
-      "pubkey_x25519": "e5a883e76e9f76eaad819755cb724e39c03efb5fadf4b2a87c2bbe92ba3e6668",
-      "requested_unlock_height": 2086492,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "45.79.76.51",
@@ -14558,21 +9784,7 @@
         11,
         0
       ],
-      "swarm": "227fffffffffffff"
-    },
-    {
-      "public_ip": "96.9.215.215",
-      "storage_port": 22104,
-      "pubkey_ed25519": "a8473cd0789ebb7cfdca48a6c3ba5bddb6fd42a02da910a64d6b9393bb19f327",
-      "pubkey_x25519": "b2bafab8939686446c1fd96b3835ea54d1a7d0fbfffd38b64ad1bb0f48f8743b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "12ffffffffffffff"
+      "swarm": "63ffffffffffffff"
     },
     {
       "public_ip": "95.216.199.207",
@@ -14584,9 +9796,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "68ffffffffffffff"
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "107.172.5.239",
@@ -14600,49 +9812,7 @@
         11,
         0
       ],
-      "swarm": "2bffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22113,
-      "pubkey_ed25519": "a8a8704d891837210b675e863181baa10190068007758aedce9e49547a5eb500",
-      "pubkey_x25519": "743f24f6274144de5fe9d5024846ceaa857090d59a01de8769159d5def3c9660",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "96ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.218",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a8af759b0b6ce0beed24823dad981dc7811b7d19744d83c19c57459187cb5fd0",
-      "pubkey_x25519": "7c52b44f4d7dec431efe982ba6b71222e3a3091bee94a714804844cd0879ec1c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "39ffffffffffffff"
-    },
-    {
-      "public_ip": "46.102.157.155",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a90d2f6041457941c6a34605562207938a9db89f875e4588fa2f23429d3096bb",
-      "pubkey_x25519": "0945149c5be833dc158d882a7df2e769fec407f9c5ac0e0172dd1a4796ac8c7a",
-      "requested_unlock_height": 2091002,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "eaffffffffffffff"
+      "swarm": "c3ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -14654,23 +9824,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "31ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.72",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a93d5bcb6f337c3dca6545ebfc3894d2f16b4ce93081f5c3b6d70ddfe905ceeb",
-      "pubkey_x25519": "d888b92823ae8d13f75389a30473375ec7d6b7314e484e30dd1d23a8d2734a15",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "477fffffffffffff"
     },
     {
       "public_ip": "107.189.2.69",
@@ -14684,7 +9840,7 @@
         11,
         2
       ],
-      "swarm": "3e7fffffffffffff"
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "162.55.32.78",
@@ -14698,63 +9854,7 @@
         11,
         2
       ],
-      "swarm": "bcffffffffffffff"
-    },
-    {
-      "public_ip": "100.42.181.126",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a972f3e8b4068120ce7225cb3bf0715c182444872f00f878160e35c01d404480",
-      "pubkey_x25519": "c16fba1c7311a6ae102caebf41c5ad3184bf23a72a63dbd88994aec542474f45",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "31ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.19",
-      "storage_port": 22021,
-      "pubkey_ed25519": "a983cd3c0b2699e4729516a3b5c63be01f1b134c22fdf0eb1011a43e5cb75198",
-      "pubkey_x25519": "17aed0ecb10ebfdc0752150990e189d66be4bf9253bed7a0deba48f44b0a4345",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7affffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22109,
-      "pubkey_ed25519": "a98d15aa25e203c0dae5cdc9faf44639fb9d1fdc5ea2d8b2d32406e3c8009334",
-      "pubkey_x25519": "9711263eef37308459bb002848a6a41c3b934aa429d8aec01ae2cc470df15355",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "477fffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22104,
-      "pubkey_ed25519": "a9b141da8cacf58a835263cb753aed3abcdac463275b7ecd21f22b7e1e077cd6",
-      "pubkey_x25519": "b5a9f10c0d1f2f12f9719075be7c4bf146dee320abe70d83aa5f87c11ca9267f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "59ffffffffffffff"
+      "swarm": "7dffffffffffffff"
     },
     {
       "public_ip": "89.117.60.23",
@@ -14768,7 +9868,7 @@
         11,
         2
       ],
-      "swarm": "73ffffffffffffff"
+      "swarm": "b7fffffffffffff"
     },
     {
       "public_ip": "72.11.152.205",
@@ -14782,35 +9882,21 @@
         11,
         3
       ],
-      "swarm": "d7fffffffffffff"
+      "swarm": "83ffffffffffffff"
     },
     {
-      "public_ip": "141.105.130.183",
-      "storage_port": 22021,
+      "public_ip": "151.244.85.80",
+      "storage_port": 22163,
       "pubkey_ed25519": "aaafcc3306e862b2f4ab6b49d21ce057d9672544da4c2410c8189d16c9980764",
       "pubkey_x25519": "081296e42315ee5ef3018f2394df201031ea228d8db7c8af9798cd066e2d9d0d",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20263,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "f7ffffffffffffff"
-    },
-    {
-      "public_ip": "64.235.61.138",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ab154c8cdaf5afcc0e590a860319ef2868426743d1b82a2c9f3db2b9c53fe3a6",
-      "pubkey_x25519": "ee5d921f06dd14107a9698ab910d2513a5263e5d2fd2ba7ee6512525ee72e44d",
-      "requested_unlock_height": 2092383,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "bbffffffffffffff"
+      "swarm": "19ffffffffffffff"
     },
     {
       "public_ip": "62.171.160.88",
@@ -14824,7 +9910,7 @@
         11,
         3
       ],
-      "swarm": "1bffffffffffffff"
+      "swarm": "7fffffffffffffff"
     },
     {
       "public_ip": "107.189.12.37",
@@ -14855,32 +9941,18 @@
       "swarm": "1d7fffffffffffff"
     },
     {
-      "public_ip": "45.92.156.210",
-      "storage_port": 22021,
+      "public_ip": "62.171.172.43",
+      "storage_port": 22100,
       "pubkey_ed25519": "abe75df72d88c5e43b3312c0aefaf1202bb98c23a1efba72248edff6cf5cce09",
       "pubkey_x25519": "fc5c1b3e4f2469637c5dcad88f77a5aba0849ec58496bf3ca3d66c2ecc7bc242",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f1ffffffffffffff"
-    },
-    {
-      "public_ip": "64.227.78.106",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ac339bdd44da77dd39086d04b7c1235b81b4323943f38cfffa4a4940aaca4998",
-      "pubkey_x25519": "7e22ad688876979b5be5a8310a4420a769fc3c6ee5bfaeca41a8cc9512eb930b",
-      "requested_unlock_height": 2094230,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20200,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "407fffffffffffff"
+      "swarm": "99ffffffffffffff"
     },
     {
       "public_ip": "209.141.43.224",
@@ -14894,21 +9966,7 @@
         11,
         3
       ],
-      "swarm": "d2ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.112.212",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ac6d0d3cb63303c13ecfcbfafa64ccbbec25242d45a5b97973f167dd52c3dda9",
-      "pubkey_x25519": "33ac95be69b8220e78c86417ea0fd14079b5263f900e5883cf329b9f09b0b932",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7effffffffffffff"
+      "swarm": "67fffffffffffff"
     },
     {
       "public_ip": "95.216.159.12",
@@ -14922,7 +9980,7 @@
         11,
         3
       ],
-      "swarm": "32ffffffffffffff"
+      "swarm": "56ffffffffffffff"
     },
     {
       "public_ip": "57.129.14.232",
@@ -14957,14 +10015,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "ad4913564aa31495c6cc416c6e246b8d10e7ac6329669965436fd76e972db632",
       "pubkey_x25519": "494de8a3e097911a28bb2de07fb69838b9d8df9988ab24fe1fe81b8ad8570978",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2170130,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "d1ffffffffffffff"
+      "swarm": "9fffffffffffffff"
     },
     {
       "public_ip": "107.189.4.249",
@@ -14978,7 +10036,7 @@
         11,
         2
       ],
-      "swarm": "b5ffffffffffffff"
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "198.98.57.68",
@@ -14992,7 +10050,7 @@
         11,
         3
       ],
-      "swarm": "5dffffffffffffff"
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "207.148.87.230",
@@ -15004,37 +10062,23 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22103,
-      "pubkey_ed25519": "adadd4af9b84573fa51a6ca2ead44877d7d3afd4ae83c4aa0965ec7950f59ad7",
-      "pubkey_x25519": "2a7b3f7504b3ae9146b524321f919ceb17377767a2cf1683c8fb479838184d33",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "2f7fffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "107.182.173.136",
       "storage_port": 22021,
       "pubkey_ed25519": "adb9165e771688a045cbf5f881b7595ac75579f30e4d6c4c9ec26eb82153ee00",
       "pubkey_x25519": "89a157d2eca357506638838378cb48df2f2837f0a64240b05daf5d2bbcc0161e",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161745,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "a0ffffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "152.89.29.65",
@@ -15060,9 +10104,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "d9ffffffffffffff"
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "84.247.184.139",
@@ -15076,7 +10120,7 @@
         11,
         2
       ],
-      "swarm": "aaffffffffffffff"
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "107.189.5.113",
@@ -15090,77 +10134,7 @@
         11,
         2
       ],
-      "swarm": "15ffffffffffffff"
-    },
-    {
-      "public_ip": "135.181.32.244",
-      "storage_port": 22100,
-      "pubkey_ed25519": "ae12111d89f309f3482b0c23ac0c96e8a1dbecbffa11184aaeb2c8bf856c1cf0",
-      "pubkey_x25519": "816849189c7de6ec7f63b45efd40a3727ecea2108838a670f7ef8667394ccb1a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "bdffffffffffffff"
-    },
-    {
-      "public_ip": "157.180.112.36",
-      "storage_port": 22101,
-      "pubkey_ed25519": "ae121155a7461f1f522a82d30856f45da876a9090e2ec0e8c914311cac1ddd01",
-      "pubkey_x25519": "e2a789a65866e895c5e9afc818d44a0ede075c3914b9f9eb090c3f9e1b35a543",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c7ffffffffffffff"
-    },
-    {
-      "public_ip": "157.180.112.36",
-      "storage_port": 22102,
-      "pubkey_ed25519": "ae1211baa79c310efca25265cef34a19ca59da382d98e17f041535c36b283702",
-      "pubkey_x25519": "0591e4c305981ff6a06f754380277c54d79f1660a8da5d247bda125e52ab8410",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "1effffffffffffff"
-    },
-    {
-      "public_ip": "157.180.112.36",
-      "storage_port": 22100,
-      "pubkey_ed25519": "ae1211bcfe9c09bc717a5b7e1fcacd23795a39e53569cf77a1883e6a0a609d00",
-      "pubkey_x25519": "6372e0b3d519dc6cdd38be9d6c92bdd1c5876f72932d1ba892f5cc1615d0f35d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e9ffffffffffffff"
-    },
-    {
-      "public_ip": "135.181.32.244",
-      "storage_port": 22101,
-      "pubkey_ed25519": "ae1211ff0d67937b6ce1df9276150a564e324bca7940fbb8b3f9f1a34a6cdbf1",
-      "pubkey_x25519": "4adba1fc5a9ede742bd60b91a79d283bdd17f219b8279d3c985c27d21028654d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "afffffffffffffff"
+      "swarm": "f4ffffffffffffff"
     },
     {
       "public_ip": "209.141.42.34",
@@ -15174,63 +10148,21 @@
         11,
         3
       ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "9effffffffffffff"
     },
     {
-      "public_ip": "77.74.199.107",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ae3cec0036d407af9a78a2e001183ef5a9adc0fc03d4a84141886300802be0f0",
-      "pubkey_x25519": "b1b160b9c0eb62c0f85bfa9e476e92f63455f53fd832f661ba429fef66f8ec50",
+      "public_ip": "151.244.85.190",
+      "storage_port": 22169,
+      "pubkey_ed25519": "af19e2e50efd016b916ed0e3d0d5ba67a9f90385cb1bb5ecf66312868d8c3591",
+      "pubkey_x25519": "59ff168fdce06e1ab9e9c70a006b3efe36121814ee29f088bdfeaf0eeb100b2a",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "38ffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.112",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ae8274ddd194c42c13ff541fd0d4b7956810a2103915f86db980ccd4492e815d",
-      "pubkey_x25519": "a0e4eaf20f8268d1dddc8c6e799f4bd2ec9b764b9e8958b83d567ae46cc87224",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.57",
-      "storage_port": 22021,
-      "pubkey_ed25519": "af58e0466038d918d95b387e372474fcb4849e1fd23f3aa216b88fbbdb8ab632",
-      "pubkey_x25519": "d828cda380e6b5f5b1b9a6c9eaa5110403ef0d2a2ace9e651ea9ae17b6ba1617",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "dffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22114,
-      "pubkey_ed25519": "af9f27ff07b890a3496a93fd8dd9b5452f3c704c8697b0b5bb5e62cdb178ef8e",
-      "pubkey_x25519": "8f16164b8674bacd3ddb6e79dcda0dc9fc9fbf0e1cf0119f3c5b469bd62f710b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
+      "storage_lmq_port": 20269,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "3d7fffffffffffff"
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "168.138.102.244",
@@ -15244,7 +10176,7 @@
         11,
         3
       ],
-      "swarm": "aeffffffffffffff"
+      "swarm": "31ffffffffffffff"
     },
     {
       "public_ip": "89.58.29.122",
@@ -15275,20 +10207,6 @@
       "swarm": "21ffffffffffffff"
     },
     {
-      "public_ip": "45.149.204.19",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b008756229b91e1fa71a555a16eac4b9f863938113cc63cd9afebc26b94b2eae",
-      "pubkey_x25519": "a2297b850624131529052c0bbc7381b13d4fb2d47d0d51cef86ec7d6d937395f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "78ffffffffffffff"
-    },
-    {
       "public_ip": "205.185.114.108",
       "storage_port": 22021,
       "pubkey_ed25519": "b01fcc83aea88583647066c1e6529386375269e86f011299abfc5732092ac0fa",
@@ -15300,7 +10218,7 @@
         11,
         3
       ],
-      "swarm": "427fffffffffffff"
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "135.125.147.171",
@@ -15314,7 +10232,7 @@
         11,
         3
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "165.22.51.13",
@@ -15331,7 +10249,7 @@
       "swarm": "8affffffffffffff"
     },
     {
-      "public_ip": "31.22.111.15",
+      "public_ip": "80.83.124.173",
       "storage_port": 22021,
       "pubkey_ed25519": "b08c9549e3b546531f31849ccd9fd24833b83fd43a9995e6fe80e1e691a10df1",
       "pubkey_x25519": "92b79c4bfa5fde2a039a41ad2b89d98f876608734c2f6b0df2a7f838178eed19",
@@ -15342,7 +10260,7 @@
         11,
         3
       ],
-      "swarm": "b9ffffffffffffff"
+      "swarm": "97ffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -15370,7 +10288,7 @@
         11,
         3
       ],
-      "swarm": "73ffffffffffffff"
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15398,7 +10316,7 @@
         11,
         3
       ],
-      "swarm": "78ffffffffffffff"
+      "swarm": "65ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15440,7 +10358,7 @@
         11,
         3
       ],
-      "swarm": "e2ffffffffffffff"
+      "swarm": "42ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15454,7 +10372,7 @@
         11,
         3
       ],
-      "swarm": "397fffffffffffff"
+      "swarm": "237fffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15468,7 +10386,7 @@
         11,
         3
       ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "caffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15482,7 +10400,7 @@
         11,
         3
       ],
-      "swarm": "207fffffffffffff"
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15538,7 +10456,7 @@
         11,
         3
       ],
-      "swarm": "2a7fffffffffffff"
+      "swarm": "e3ffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15566,7 +10484,7 @@
         11,
         3
       ],
-      "swarm": "3bffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "95.217.37.13",
@@ -15608,21 +10526,7 @@
         11,
         3
       ],
-      "swarm": "1cffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22107,
-      "pubkey_ed25519": "b171c788f264c7cc2997171d4c2e6a23d7767e995311c564d70aa6fd9d646edd",
-      "pubkey_x25519": "2b283f912898dc87e89c93b003d4b5c3a0eb74adf3aad8ca2649971e8aa1d36c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "70ffffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "198.98.49.76",
@@ -15643,42 +10547,14 @@
       "storage_port": 22021,
       "pubkey_ed25519": "b1d0dc87a9e8ed9bd17ad6f87a98780a50e8e41badbdb3f0b609ebd4378a51e4",
       "pubkey_x25519": "9887aa615c073f6d43926596f37f102062779157987f8404208b3a6cc305832f",
-      "requested_unlock_height": 2091004,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "f7ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.60",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b289716dd31f39d23838993fda6ed9dadc3d70d02a85029cac36343206a7cd36",
-      "pubkey_x25519": "5ff3953b26f0c23b594447ea598e457435211294da84cb8cbb15cccbca0e6364",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "317fffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22118,
-      "pubkey_ed25519": "b2d0b5665d0cee2685a640cafea6e69c9ccf15817a491c524bf4777cd7c9760e",
-      "pubkey_x25519": "91e36f89b8e8695edee590c2d548a4fbeea3654830b7f030c371a96ae56b1813",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20218,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "47fffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "185.207.250.197",
@@ -15692,13 +10568,13 @@
         11,
         2
       ],
-      "swarm": "187fffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
-      "public_ip": "46.250.251.176",
+      "public_ip": "194.163.179.98",
       "storage_port": 22021,
-      "pubkey_ed25519": "b3fdffae324dfe229a2a718a405234a1ee0fca9efa38d6bce6e8f9adbaed412a",
-      "pubkey_x25519": "79457873e63e5589aa35c29763579de214b5806f80e37db5f5b5fb2b18a2e96b",
+      "pubkey_ed25519": "b4ae2f297db9009b220cb316ef027c90457fee1f21f34af3fb15faf768268133",
+      "pubkey_x25519": "bc02d09d85963df9b9bf41f849f6ed813443ef88f608c5994ee5b50963a87735",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
@@ -15706,63 +10582,7 @@
         11,
         3
       ],
-      "swarm": "66ffffffffffffff"
-    },
-    {
-      "public_ip": "46.62.139.87",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b4037e7c04677f810ec97ac9854ef49ba8de56a2c663ca21d7487aa091b5532f",
-      "pubkey_x25519": "b7a34b1e6a4b096806e9a01a899fa999ef6bb01b68f3ac8aefe212ef28be6c31",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d1ffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.116",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b41a90d471ddf71b07c8d02e05ec4b32a841ef6269c2277ba6a2567be0ec7421",
-      "pubkey_x25519": "3846de12d20294e051f83ffec53b3aa6c219893f9607998f402974a8b872ed27",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "caffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.95",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b451a384d75d106917e610b532605d96e7812a0324d6664be3e7024167c397f0",
-      "pubkey_x25519": "ac17bce8453412a9e6575902460137dc8a0db61c54c3caf053d14a0dc65e9726",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "24ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22102,
-      "pubkey_ed25519": "b4ac6b5cf39d01552e0c7a732e3ee87783d79c745efacbe4ecca363e06605755",
-      "pubkey_x25519": "63ef259c2ba48b9744b9595d4699eac7854822becead01b90ca37388adabbe16",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "40ffffffffffffff"
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "51.81.174.80",
@@ -15776,7 +10596,7 @@
         11,
         3
       ],
-      "swarm": "2f7fffffffffffff"
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -15793,76 +10613,6 @@
       "swarm": "93ffffffffffffff"
     },
     {
-      "public_ip": "172.93.167.59",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b52ee4fe875702d5a83c280aeaf32fdbcfff4922a6c2e8cf1243d4921043005a",
-      "pubkey_x25519": "78702bf131bba499786fa2d149ff3654864301d3b1bf068ddc1c513af5a8b35c",
-      "requested_unlock_height": 2091681,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "edffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22106,
-      "pubkey_ed25519": "b5715524948bb0bc31baa2fa5f7aa98ee5f0b26142ce0b4cb6ffa5dc4056ef43",
-      "pubkey_x25519": "1c8f28766ee72df57f12e5204882a57e139db16910d33af52c0fe6d49e2b7674",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "89ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22112,
-      "pubkey_ed25519": "b5a913e190292b47560f00ed3f21e3f4873315da3e1c09406f5e57ea2881063c",
-      "pubkey_x25519": "e6249dfdcbecbe0f0c8526793546fc66570184086afbd74e8a41990e4156b24b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1ffffffffffffff"
-    },
-    {
-      "public_ip": "65.108.159.68",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5b3bb394826976ee1a95fe7601adf5d07f8ced78263643619b6542bed491945",
-      "pubkey_x25519": "6f09accaf672cae6c0fa602d55b7b04b3e9181ff8e49381b1ca27ef30cb5597b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "2fffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.127.19",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5ea3b383ae4218d1a7bb796a73ee2265a03224154db0c133a8dfb9a4f30a28e",
-      "pubkey_x25519": "d99b8fdb95b0923b2a47548ea813cf392673f33a28d0551157f61daac6255b6f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "97ffffffffffffff"
-    },
-    {
       "public_ip": "135.125.112.188",
       "storage_port": 22021,
       "pubkey_ed25519": "b5ed0932695034ccbe24d1460dca11ef657057a66a3a847439ddf28994345393",
@@ -15877,20 +10627,6 @@
       "swarm": "abffffffffffffff"
     },
     {
-      "public_ip": "77.74.199.80",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5f299e59f51b84f9c2e443ea5a73d5b51f127b0c9070a384345f2f330ebff77",
-      "pubkey_x25519": "918be7aa7af2811edabebdff1ffffbe8588a030ee3974115f99931442abb767b",
-      "requested_unlock_height": 2093347,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "76ffffffffffffff"
-    },
-    {
       "public_ip": "45.79.94.226",
       "storage_port": 22021,
       "pubkey_ed25519": "b5f35c99b058f6a53c2d91b0dca7196fcb3641528d882b4bb0cae203b1e10103",
@@ -15902,21 +10638,7 @@
         11,
         0
       ],
-      "swarm": "bfffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.85",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b5fc4d8a5c25f9947aae0aabecc953f368c90c1d413ad6f35e434d38da9ee8a5",
-      "pubkey_x25519": "072f91ef34b730e5b488036bc8371458f8081f48598f708db48801a7d7512441",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f7ffffffffffffff"
+      "swarm": "377fffffffffffff"
     },
     {
       "public_ip": "95.217.21.148",
@@ -15930,63 +10652,21 @@
         11,
         0
       ],
-      "swarm": "9affffffffffffff"
+      "swarm": "80ffffffffffffff"
     },
     {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22109,
-      "pubkey_ed25519": "b68ec51f664c35ae81280d5c7fd3d3bbc419bee63db0921a7c504fec7c10c39a",
-      "pubkey_x25519": "275473d18bcaf4fae6aecfb9e7c2c70aaae83c13f2f454aa35de542bd2e9043f",
+      "public_ip": "207.180.199.143",
+      "storage_port": 22021,
+      "pubkey_ed25519": "b6e2a54aa68c2008569e7e670d482acb7ebb1c8082996b4af619c164fc2844a1",
+      "pubkey_x25519": "fbef1758a1e385f2339120593ff9eb2ac55d59a8adec6af9e91052d5a2eb7143",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "1c7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.114.77",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b6cb4b5c8e9be7a3dda05a18f004612350eba3debddc1940f143bb6174a1df61",
-      "pubkey_x25519": "52d2142f98d8fd53efbca863c5f8e1fac59408e4cc4d64af3faf84a013853a04",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "c3ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.214",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b6ed86d800f829b314fb49fe81a920c7459e6b02426e78159f0ab354e7e10370",
-      "pubkey_x25519": "2465c4603f54976a92e458d727a7cd693f448f61a9acdd88c14656d39d711e54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22102,
-      "pubkey_ed25519": "b72142bf9a847fb9de1f97845bfa69f146d9aea2bcdc433137d8d089a31b00e7",
-      "pubkey_x25519": "f7965297353736dd8a892683408445930a64ac379ae4077fb4d51a2060243225",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "33ffffffffffffff"
+      "swarm": "8effffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -16003,6 +10683,20 @@
       "swarm": "34ffffffffffffff"
     },
     {
+      "public_ip": "13.140.135.95",
+      "storage_port": 22021,
+      "pubkey_ed25519": "b8419ead063d1dadef19297f859bfb4e25e5432c7581a0a67b59bb95e2c2a9c8",
+      "pubkey_x25519": "b599acd93a15f75f0e30e0105aed78b380025c46104f58cb248c239e6e767e44",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "e7fffffffffffff"
+    },
+    {
       "public_ip": "51.81.87.72",
       "storage_port": 22021,
       "pubkey_ed25519": "b8538d3b3cc95259ac9064fa2069e2798d278c3ff026793962d7587c5fc28a64",
@@ -16012,7 +10706,7 @@
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
       "swarm": "3f7fffffffffffff"
     },
@@ -16042,7 +10736,7 @@
         11,
         2
       ],
-      "swarm": "27ffffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "178.157.82.104",
@@ -16056,21 +10750,21 @@
         11,
         2
       ],
-      "swarm": "caffffffffffffff"
+      "swarm": "72ffffffffffffff"
     },
     {
-      "public_ip": "176.126.86.31",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b8fc7b2fa596392a6b17bca28d00c034ceba696510cbacd4d3923bcceb4288c5",
-      "pubkey_x25519": "51551a38a1941e39f59e0dc3e2d957441907629d0ebd0bc4394061a7bfcfbf03",
-      "requested_unlock_height": 2090219,
-      "storage_lmq_port": 22020,
+      "public_ip": "212.105.90.36",
+      "storage_port": 22112,
+      "pubkey_ed25519": "b94c7301fdad018b4eb9d069882b526c8565ee98406d15251735a5f92f2eac25",
+      "pubkey_x25519": "f09fc7fe649bb3b85b51fc7606ccadabc7523c46542e918a37140eea3f427501",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20212,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "197fffffffffffff"
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "152.89.29.20",
@@ -16084,35 +10778,7 @@
         11,
         3
       ],
-      "swarm": "1effffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22114,
-      "pubkey_ed25519": "b9c8b5c2f4fd418a82300673352e911e7e4bc035441cb2ea932d69211b3cd536",
-      "pubkey_x25519": "a401d0837838f6ab54d0be6420cb67129b9bb05d2bf86c6fe40dac76e8e18e5e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "7effffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22106,
-      "pubkey_ed25519": "b9ce05d9a464a0b276c480d6ebac2439dde75c308897b4e7b70179edd39b7c1a",
-      "pubkey_x25519": "bcac23e1c2edefb4855d0a9efede77ce6815cd918d7d51d0c151b0f8d44bae0c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4bffffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
       "public_ip": "178.156.181.213",
@@ -16126,7 +10792,7 @@
         11,
         1
       ],
-      "swarm": "8fffffffffffffff"
+      "swarm": "71ffffffffffffff"
     },
     {
       "public_ip": "89.58.28.248",
@@ -16140,21 +10806,7 @@
         11,
         2
       ],
-      "swarm": "187fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.71",
-      "storage_port": 22021,
-      "pubkey_ed25519": "b9f9a8336ee4e6a91d6fcfe264e2535fd38e7f7d2d7abb3a36aaefed92903cc8",
-      "pubkey_x25519": "89682badaa2b505633ee9a1fba40078ee76248a590527ccf986b3a314ca0d435",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6bffffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "157.90.226.160",
@@ -16168,21 +10820,7 @@
         11,
         0
       ],
-      "swarm": "94ffffffffffffff"
-    },
-    {
-      "public_ip": "150.136.106.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ba48da83f74406dc617cfcfba58bad515c5566d63d39ad8a3d86f6f336a9a088",
-      "pubkey_x25519": "903e42089c9973a7d5c0cb4f5c55cee68b9f88bfeea8897ae6fc8da1d4208c5e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "54ffffffffffffff"
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "141.105.130.20",
@@ -16195,34 +10833,6 @@
         2,
         11,
         3
-      ],
-      "swarm": "70ffffffffffffff"
-    },
-    {
-      "public_ip": "82.180.147.179",
-      "storage_port": 22021,
-      "pubkey_ed25519": "baaae4945a020e35dbe8f63af9fd3c8b84b1b557a595e721f97c7abb77a716f6",
-      "pubkey_x25519": "93ccb45037755204b63a8fb64b55eef74eff194d1f82cbe8429a5bd5f0ab3b22",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "93ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.66",
-      "storage_port": 22021,
-      "pubkey_ed25519": "bad52b8338107d4f4181cf0d9f353b83df41f91d3eaeb29b56ff4b6fc66c45ed",
-      "pubkey_x25519": "680bc30efa3c5cc076bfa123c72df96390c13723c02ea6c16e06c7ef6ed59211",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
       ],
       "swarm": "b6ffffffffffffff"
     },
@@ -16238,35 +10848,7 @@
         11,
         0
       ],
-      "swarm": "9bffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22113,
-      "pubkey_ed25519": "bb581b7ee8b6a2a1869fcc6c877e45d5d0952fee2a1a76d99e939743e21e9376",
-      "pubkey_x25519": "368faa6fc52f32e774bd724d7a1aced1eaa1d32683355bda0a9f73f0c542f61a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "23ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22114,
-      "pubkey_ed25519": "bb5c2c2509213f30e1c155ece0b58bc0c704b7a2f11a63e00b71859647608817",
-      "pubkey_x25519": "864a9868885391a15695172b9e1d88767c6671c35e2d7e993ab56872cda3c243",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "40ffffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -16280,7 +10862,7 @@
         11,
         1
       ],
-      "swarm": "adffffffffffffff"
+      "swarm": "6dffffffffffffff"
     },
     {
       "public_ip": "23.239.23.208",
@@ -16294,21 +10876,7 @@
         11,
         0
       ],
-      "swarm": "affffffffffffff"
-    },
-    {
-      "public_ip": "144.91.74.95",
-      "storage_port": 22021,
-      "pubkey_ed25519": "bbe12b70327f94e9b408ff1c10a43aa9424ac888369aff07a16c394c9d8139cc",
-      "pubkey_x25519": "7a436ac1f6120677eedb26d95c610894dec9ab9368d214458a6aed715d245e16",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "20ffffffffffffff"
+      "swarm": "bcffffffffffffff"
     },
     {
       "public_ip": "185.135.137.82",
@@ -16320,9 +10888,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "eeffffffffffffff"
+      "swarm": "69ffffffffffffff"
     },
     {
       "public_ip": "162.19.227.254",
@@ -16336,38 +10904,10 @@
         11,
         2
       ],
-      "swarm": "197fffffffffffff"
+      "swarm": "227fffffffffffff"
     },
     {
-      "public_ip": "46.225.90.28",
-      "storage_port": 22021,
-      "pubkey_ed25519": "bc67c993dbf95c416bf65cf7ad8e1ef28e6c93e9a09b58132b0333b8ef1a26d1",
-      "pubkey_x25519": "a3393a557fd9bdfe96a92eb42a19390053278bfe8329440b44c1a4166c340845",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4bffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22105,
-      "pubkey_ed25519": "bc6b8368a98cc93db5ce5586ef8429f274d5ccab15029c4ca52885a9139ffd21",
-      "pubkey_x25519": "332ddc0250754558b97682a78ddf6a6a79fd82144181615db100118600acde64",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d0ffffffffffffff"
-    },
-    {
-      "public_ip": "193.219.97.159",
+      "public_ip": "167.233.71.110",
       "storage_port": 22021,
       "pubkey_ed25519": "bcc88c24c4860843dd84500da78c339895748e62983a79793ef07c37fb61fbdb",
       "pubkey_x25519": "feab77098134c200f08941192a58ba9555574bcf692879e435ea9428aa89c045",
@@ -16378,7 +10918,7 @@
         11,
         3
       ],
-      "swarm": "c7fffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -16392,7 +10932,7 @@
         11,
         0
       ],
-      "swarm": "4cffffffffffffff"
+      "swarm": "5bffffffffffffff"
     },
     {
       "public_ip": "104.244.79.249",
@@ -16409,25 +10949,11 @@
       "swarm": "65ffffffffffffff"
     },
     {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22101,
-      "pubkey_ed25519": "bd5025557aa3f96670a4f460e2d75d8d24e013ab0e4eb612d9403aaef8fa08c1",
-      "pubkey_x25519": "542be3c0f51ae7e3b9680bd424106b987d8fd83f62a58e6252c60105a3cf147e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "287fffffffffffff"
-    },
-    {
       "public_ip": "51.81.202.55",
       "storage_port": 22021,
       "pubkey_ed25519": "bd82fc5d7c8d1bef807ffcb7a4c1ce19854216a27f646f1c420a5330228b9547",
       "pubkey_x25519": "e337643ec09e5268b3a215a298ae7c8dbd6a3a9cffea828b44e8dd4e11866e25",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2166449,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
@@ -16448,21 +10974,21 @@
         11,
         2
       ],
-      "swarm": "3c7fffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22106,
-      "pubkey_ed25519": "bdba90f4e827c8879c67f3a8e3c0d8d4777eae4820454acccdd6dfa014513eed",
-      "pubkey_x25519": "d288715f92382308b288d8c366af17c80dccabbc25011f14574309e6dc20c014",
+      "public_ip": "51.222.26.201",
+      "storage_port": 22021,
+      "pubkey_ed25519": "be2049e870ed5d864a67ba34385914cbf738fe9e531b30fe1a987d14856d71d9",
+      "pubkey_x25519": "82e3cc06ab2ebbad1562ffa7a637ae6012425971faf118368f8e18bd0f776a21",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "65.108.251.24",
@@ -16476,21 +11002,7 @@
         11,
         1
       ],
-      "swarm": "cdffffffffffffff"
-    },
-    {
-      "public_ip": "89.167.53.13",
-      "storage_port": 22021,
-      "pubkey_ed25519": "be7ca0d6c1f18c5be6e998055a7b05d5870fb3a13b4521226b422340eb69f95b",
-      "pubkey_x25519": "6d835cc87db7ce2dea2b6224bebeb9ac7969c1c67ba767e2f2b81258cb239f1f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f3ffffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "209.141.49.92",
@@ -16504,21 +11016,7 @@
         11,
         3
       ],
-      "swarm": "83ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.116.136",
-      "storage_port": 22021,
-      "pubkey_ed25519": "becac7961948a24d271554ffb0b4b5f736498d3da05caf769aa49f55ae41f03b",
-      "pubkey_x25519": "3d49b1cdf0cb13e28bbacac7c9bd46532c82fa6ab8610791ff8281050b35ea1f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6fffffffffffffff"
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "107.189.4.161",
@@ -16539,7 +11037,7 @@
       "storage_port": 22105,
       "pubkey_ed25519": "beda0d207020c02aa9f4dc1c1920231e9ea6115f122acd15ceb462dc19b1a567",
       "pubkey_x25519": "fb4590a8a993b4cf2ccc41c3721186700f1adac213e6e850c3ac2564c6efc57d",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161187,
       "storage_lmq_port": 22405,
       "storage_server_version": [
         2,
@@ -16560,21 +11058,7 @@
         11,
         2
       ],
-      "swarm": "d4ffffffffffffff"
-    },
-    {
-      "public_ip": "5.189.177.246",
-      "storage_port": 22021,
-      "pubkey_ed25519": "bf24341da879a379589a663444a59a2e82df8cfbe306c719fe27ed5ea46575da",
-      "pubkey_x25519": "a57dafaecc1d55542b889274a836a4287bc499aa526cec04dfa593146d3f4671",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "41ffffffffffffff"
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "23.82.99.99",
@@ -16586,7 +11070,7 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
       "swarm": "6effffffffffffff"
     },
@@ -16616,35 +11100,21 @@
         11,
         3
       ],
-      "swarm": "92ffffffffffffff"
+      "swarm": "ddffffffffffffff"
     },
     {
       "public_ip": "46.225.102.55",
       "storage_port": 22100,
       "pubkey_ed25519": "bfbb58bf0f34e2dada5916aaf412fa3bb1d131b0328cb9f3824da8c3c7f16659",
       "pubkey_x25519": "55b61203d0625de9e5c2c19a84fd721b80c2aa08059f4e6a8184429c8784ed2f",
-      "requested_unlock_height": 2086613,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "227fffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22113,
-      "pubkey_ed25519": "c00fd8646dbbf567d3d9fc112b0d2e03de96e63c84bcc0ea0f07c3666c408bd3",
-      "pubkey_x25519": "b923ac01533daf5067342817437e07e1d27a39be3faeaf76b8439fb4e6501a2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1d7fffffffffffff"
+      "swarm": "2bffffffffffffff"
     },
     {
       "public_ip": "37.27.212.116",
@@ -16658,7 +11128,7 @@
         11,
         3
       ],
-      "swarm": "fffffffffffffff"
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "158.220.105.1",
@@ -16670,9 +11140,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "d4ffffffffffffff"
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "172.236.51.205",
@@ -16686,7 +11156,7 @@
         11,
         2
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "172.236.52.223",
@@ -16700,19 +11170,19 @@
         11,
         3
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "1d7fffffffffffff"
     },
     {
-      "public_ip": "139.162.158.65",
-      "storage_port": 22021,
+      "public_ip": "167.160.188.203",
+      "storage_port": 22102,
       "pubkey_ed25519": "c0ffee02fbe6be89047f605843d9f4b701186d8f9b9494791f22947da421ff31",
       "pubkey_x25519": "25d03ba669a00697462755004132f348ff27fb4d0de361347c3bfc216e9d7f7c",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
         11,
-        1
+        3
       ],
       "swarm": "69ffffffffffffff"
     },
@@ -16726,9 +11196,9 @@
       "storage_server_version": [
         2,
         11,
-        1
+        3
       ],
-      "swarm": "4ffffffffffffff"
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "167.160.188.203",
@@ -16740,9 +11210,9 @@
       "storage_server_version": [
         2,
         11,
-        1
+        3
       ],
-      "swarm": "3ffffffffffffff"
+      "swarm": "a9ffffffffffffff"
     },
     {
       "public_ip": "167.160.188.203",
@@ -16754,7 +11224,7 @@
       "storage_server_version": [
         2,
         11,
-        1
+        3
       ],
       "swarm": "fcffffffffffffff"
     },
@@ -16784,7 +11254,7 @@
         11,
         2
       ],
-      "swarm": "acffffffffffffff"
+      "swarm": "93ffffffffffffff"
     },
     {
       "public_ip": "116.203.182.145",
@@ -16798,63 +11268,7 @@
         11,
         2
       ],
-      "swarm": "3e7fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22111,
-      "pubkey_ed25519": "c1c0ac40fa13c5ba50050ee635f6394854781e88a31a7cd9705fe150f81ef116",
-      "pubkey_x25519": "26c328d5cf40b534b109253b139782d7fcc29aad2614d20598ea46ef2fae1229",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "93ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22106,
-      "pubkey_ed25519": "c1d102cbe8f04074520e7274e46d70b68dda493d12d20bc08aff83b96e7c855f",
-      "pubkey_x25519": "6252fd0be1fc9a115a8259730554091b7cb49499b86f50881e4a0878fd4d233a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "427fffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22103,
-      "pubkey_ed25519": "c1d2dc1bba8f2b75bd9cddc68020ee6b359484aa2cc87a3e3043a6830e4178f6",
-      "pubkey_x25519": "215e26d995c448b7ab66043369397f943a693ab2cf9a7e54f638654595e09d47",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1f7fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.78",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c23b705f48a639efcb3a9b3c3688e0c8936f8a29236272ba42a384b3820aac5a",
-      "pubkey_x25519": "89540e88d985a1316beb575390a9afefe4c0222674e5649218359bc9e784856a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "15ffffffffffffff"
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "205.185.122.236",
@@ -16871,24 +11285,10 @@
       "swarm": "457fffffffffffff"
     },
     {
-      "public_ip": "209.145.63.121",
+      "public_ip": "198.23.229.176",
       "storage_port": 22021,
-      "pubkey_ed25519": "c273254c2a9bfb3cb2adc9d616400fd792b366810a468e3fa4c3adba766c0acf",
-      "pubkey_x25519": "c6fafbd98f03790eb8b9d8b4c2c852ab5d015c2dae1fe2714033c10586dfcd18",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2affffffffffffff"
-    },
-    {
-      "public_ip": "164.68.125.96",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c27f243185b5a2bf8eea91efcdcad478d94fb5bec74ee585584bdf0fd4696f7a",
-      "pubkey_x25519": "f1f70270cbae3193af90699d6ca275821182eca9f261f135a08be18e4f5c9f07",
+      "pubkey_ed25519": "c27507fe99e5bfe964d9cb2cc4f354b7a220d37d7231443f1551a32cbfb05ca3",
+      "pubkey_x25519": "851043a093ebfc6d39ea4a085b23fd18e09a2b7300bf57ac150ed3778698b46a",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
@@ -16896,7 +11296,7 @@
         11,
         0
       ],
-      "swarm": "dfffffffffffffff"
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "94.130.15.33",
@@ -16910,7 +11310,7 @@
         11,
         2
       ],
-      "swarm": "2ffffffffffffff"
+      "swarm": "fcffffffffffffff"
     },
     {
       "public_ip": "209.141.42.27",
@@ -16924,7 +11324,7 @@
         11,
         3
       ],
-      "swarm": "59ffffffffffffff"
+      "swarm": "baffffffffffffff"
     },
     {
       "public_ip": "158.69.223.104",
@@ -16938,7 +11338,7 @@
         11,
         2
       ],
-      "swarm": "297fffffffffffff"
+      "swarm": "2a7fffffffffffff"
     },
     {
       "public_ip": "5.83.150.60",
@@ -16950,26 +11350,12 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "5fffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22109,
-      "pubkey_ed25519": "c40b7ec10811d354f1ad1dba205116aab268534c9d4c7d42f6ea29e454ad7693",
-      "pubkey_x25519": "a6f15ac6e9bde178fa6e46bd6d0d451c2bb592219672c66f3dc24275d902c131",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "7affffffffffffff"
+      "swarm": "e8ffffffffffffff"
     },
     {
-      "public_ip": "212.105.90.36",
+      "public_ip": "212.105.90.34",
       "storage_port": 22101,
       "pubkey_ed25519": "c451e5ac41e4f6d5324b1bfb5c72888ffee66fd3efca833986b6a394b81603cf",
       "pubkey_x25519": "04a78d98779e69a12809543f86ef7763b22835c994cc3aedd333ef29022ab179",
@@ -16980,35 +11366,7 @@
         11,
         3
       ],
-      "swarm": "d0ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.40",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c46e4bddf47dc6616c88633bf57ae5afb126f25e36541fce95b504f6eb4abea3",
-      "pubkey_x25519": "e3c0a8628bd82aa0318630978e3421ff51525eb8f8f12293c613d7c30245402a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3e7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22114,
-      "pubkey_ed25519": "c47e06207a9c0753fa47f08432aa4ca61f55445631d44cca9058381761e13f10",
-      "pubkey_x25519": "b87bedb31b1a2882e78533ca2c0ebfd7464f55b0c5fc30d3f1417f5368e9b124",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2dffffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "188.245.98.109",
@@ -17022,7 +11380,7 @@
         11,
         2
       ],
-      "swarm": "30ffffffffffffff"
+      "swarm": "8bffffffffffffff"
     },
     {
       "public_ip": "100.42.181.71",
@@ -17036,21 +11394,7 @@
         11,
         2
       ],
-      "swarm": "3b7fffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22111,
-      "pubkey_ed25519": "c5475090d21281693c55f19ea4eec1d537f79918226f42b38217c753977b3a38",
-      "pubkey_x25519": "3dea491458c6cee76dd86aac02110e1836991fe7020601afb3898ed9949d630c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "407fffffffffffff"
+      "swarm": "cffffffffffffff"
     },
     {
       "public_ip": "51.79.86.65",
@@ -17067,20 +11411,6 @@
       "swarm": "c7ffffffffffffff"
     },
     {
-      "public_ip": "49.12.101.226",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c55d772ba96dd1a81f64910eb74c597167c0342c227c012b8b5a83c4585093fc",
-      "pubkey_x25519": "e58371d2c0efb7c38abcbc831fa1845d4535b3960907db78b4c58af3981ab35a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7cffffffffffffff"
-    },
-    {
       "public_ip": "198.98.61.172",
       "storage_port": 22021,
       "pubkey_ed25519": "c5694ae105999d24a31ac6137c0c065c2a9a1390966ebf5caaa282d4ee0649e5",
@@ -17092,7 +11422,7 @@
         11,
         3
       ],
-      "swarm": "17ffffffffffffff"
+      "swarm": "66ffffffffffffff"
     },
     {
       "public_ip": "199.195.252.173",
@@ -17109,34 +11439,6 @@
       "swarm": "c7fffffffffffff"
     },
     {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22107,
-      "pubkey_ed25519": "c5af14d1fb6ca9f782269a64cafaa98df0ddcd13c924c1fe65178c2eddb2e422",
-      "pubkey_x25519": "051eaac03053d9becde10fc14b4cd51c246906ab6c879d0ef71f46b4f036cf02",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "77ffffffffffffff"
-    },
-    {
-      "public_ip": "45.130.104.239",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c5c3365df3e71f72fe37cd02e0fff7a07b475deab4e87ab15ce51ea816adeec0",
-      "pubkey_x25519": "47c82fec270dcf6ac2c26345036eb1482235121248af2d4efe702920b0027f10",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d7fffffffffffff"
-    },
-    {
       "public_ip": "91.231.182.106",
       "storage_port": 22021,
       "pubkey_ed25519": "c5c42bbbca36ed6e1e41b6de05629cb2c834b900d869839d338d466e6d308a57",
@@ -17148,7 +11450,7 @@
         11,
         3
       ],
-      "swarm": "48ffffffffffffff"
+      "swarm": "e1ffffffffffffff"
     },
     {
       "public_ip": "185.2.101.84",
@@ -17160,9 +11462,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "18ffffffffffffff"
+      "swarm": "ccffffffffffffff"
     },
     {
       "public_ip": "144.91.114.18",
@@ -17176,7 +11478,7 @@
         11,
         2
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "89.58.31.158",
@@ -17190,24 +11492,10 @@
         11,
         2
       ],
-      "swarm": "97fffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22109,
-      "pubkey_ed25519": "c655f6fe189779bd9992eb845722549da4b1d033f86846f964f1649ee8091023",
-      "pubkey_x25519": "b37daed7f471f9e37fcfc25477d938cf0f0d1f6ce54b5aecfd316d336125ee5d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "0"
-    },
-    {
-      "public_ip": "172.245.228.217",
+      "public_ip": "23.94.75.12",
       "storage_port": 22021,
       "pubkey_ed25519": "c66d8b775b69a7b71676aa7b0236e101daecb134de1ccb4d80f677ad2c1c2b86",
       "pubkey_x25519": "2226448c868c289a2bcb724db2cb15a26af135388f477f5afb02327d1ccb7616",
@@ -17216,23 +11504,9 @@
       "storage_server_version": [
         2,
         11,
-        0
-      ],
-      "swarm": "22ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22103,
-      "pubkey_ed25519": "c6714dfc45fe1ebeb3bb0f0568b6f6a9578caa6d4acd14275aaf1e4204ebac16",
-      "pubkey_x25519": "87e29c19828f6699ed8e7cd4afe1974fd9bbe21d9406397e620cf1b939354e00",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "76ffffffffffffff"
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "141.144.243.51",
@@ -17246,7 +11520,7 @@
         11,
         3
       ],
-      "swarm": "6fffffffffffffff"
+      "swarm": "d3ffffffffffffff"
     },
     {
       "public_ip": "178.157.91.231",
@@ -17260,7 +11534,7 @@
         11,
         2
       ],
-      "swarm": "1ffffffffffffff"
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "167.114.156.20",
@@ -17277,21 +11551,7 @@
       "swarm": "b4ffffffffffffff"
     },
     {
-      "public_ip": "164.68.113.32",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c6c6c819fb205253864a971feb163e95ae8ab19b847316f4ac0e9ef58d0d083b",
-      "pubkey_x25519": "d34478dfd8bfe6a47692f8973a46324837b0f6f5f955eb39497e256fafe16142",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "427fffffffffffff"
-    },
-    {
-      "public_ip": "193.160.96.235",
+      "public_ip": "50.114.206.131",
       "storage_port": 22021,
       "pubkey_ed25519": "c73c3090e37f8f39b16ddbb25b18ad7fea25909ef915f82c24c62a03ac971e55",
       "pubkey_x25519": "16e15ae0f31a6009c7f9fb4e28fffcceb2da8b70e90794697e350cd129f0c60c",
@@ -17300,23 +11560,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "87ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22106,
-      "pubkey_ed25519": "c82527362073f38b2fff247dfeb1170d0f143874f2f0d776816fc77030483609",
-      "pubkey_x25519": "cda4994e5d04a08f2ab0cbc2d50bfa9a077b2aa9ca3116c401978757e6aa960b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "d5ffffffffffffff"
+      "swarm": "8cffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -17330,7 +11576,7 @@
         11,
         0
       ],
-      "swarm": "13ffffffffffffff"
+      "swarm": "3cffffffffffffff"
     },
     {
       "public_ip": "164.68.107.76",
@@ -17347,34 +11593,6 @@
       "swarm": "b7fffffffffffff"
     },
     {
-      "public_ip": "164.68.125.174",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c9375215b4e119fc5ffc86744e605262f7910e2d2256a8e502cdb8ff51b39eb3",
-      "pubkey_x25519": "a4157863fba1578b2fad5842c0768566941f6a79e67610ef6ee4dccf8b486874",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "63ffffffffffffff"
-    },
-    {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22111,
-      "pubkey_ed25519": "c9673a2677ab5423ff575b8943fbad20bc7ac56e5a7f079a2f1c137fd092e8e9",
-      "pubkey_x25519": "d673a1fbe533546ae0cb2cd32f892bb233c66276cbe9d601c8ed901851589433",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "dbffffffffffffff"
-    },
-    {
       "public_ip": "192.99.237.162",
       "storage_port": 22021,
       "pubkey_ed25519": "c989930b59fb14d7bde39227c1b5c61f37d94f8d985bf049c725eb8f937aecc9",
@@ -17386,24 +11604,38 @@
         11,
         3
       ],
-      "swarm": "2a7fffffffffffff"
+      "swarm": "cbffffffffffffff"
     },
     {
-      "public_ip": "141.105.130.162",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c9b8ef3151b1438f90c13fdfe3230e7b9fa70f7df21a8eac665c8dd3bfd5cd69",
-      "pubkey_x25519": "44f78904eee98c5d677338796fb239d0d62a6141e65f979f474779dbc4e94a3f",
+      "public_ip": "212.105.90.36",
+      "storage_port": 22110,
+      "pubkey_ed25519": "c9b1bea89ded2ef9334e448988fcd310713795844eee8d37fea1312c0151bc56",
+      "pubkey_x25519": "35b07ac7e2921e81cc05c73c6534d7ecfb0ba3f516bb96ce004809bdd0e5cb64",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
+      "storage_lmq_port": 20210,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "6effffffffffffff"
     },
     {
-      "public_ip": "38.45.71.55",
+      "public_ip": "151.244.85.111",
+      "storage_port": 22103,
+      "pubkey_ed25519": "c9b8ef3151b1438f90c13fdfe3230e7b9fa70f7df21a8eac665c8dd3bfd5cd69",
+      "pubkey_x25519": "44f78904eee98c5d677338796fb239d0d62a6141e65f979f474779dbc4e94a3f",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20203,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "8dffffffffffffff"
+    },
+    {
+      "public_ip": "172.93.167.59",
       "storage_port": 22021,
       "pubkey_ed25519": "c9cfb8a5d5064fd35c8c7faccdb0280705a70b19e3249be7ea1d852317de5d19",
       "pubkey_x25519": "2d99b6e337aecb3ef970923eaa48d98220f96be146dbcb9427a37ffa65983e5f",
@@ -17412,65 +11644,9 @@
       "storage_server_version": [
         2,
         11,
-        2
-      ],
-      "swarm": "3b7fffffffffffff"
-    },
-    {
-      "public_ip": "65.109.132.81",
-      "storage_port": 22021,
-      "pubkey_ed25519": "c9f426ee9cb8b983727e9c14e44aeafb48ab930c97e0a9160c5b58cc87dbe162",
-      "pubkey_x25519": "13c29e3f7880c421457e6f7c5687f863e54afd2fbd0f20e179c62465c51c4d08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "137fffffffffffff"
-    },
-    {
-      "public_ip": "193.160.96.225",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ca77d19915bd905b06d769892bddfa930c6be9cfb93941c80924495963af867b",
-      "pubkey_x25519": "f323421f8c690ec4c8cb2206d5bf0b5b4523b728faca4c2e3671c1ff0ec33434",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c5ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.235",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ca92601b37b881bd3c653bf45d9b222143fa10de9cc84a44c1afec38dc65ad00",
-      "pubkey_x25519": "14f96f9d7665c39105ae12b237f0742e5f03cfc23d743839017351d644a00b48",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "74ffffffffffffff"
-    },
-    {
-      "public_ip": "23.95.134.153",
-      "storage_port": 22021,
-      "pubkey_ed25519": "caab86dd10e727964594fb93838c5a31fd0e0eb9e7ddc201d69330f4e62a6fe4",
-      "pubkey_x25519": "f68116b735cf343ab2ba4ed5ece91471a7a60853127354e714d55fff93769c3c",
-      "requested_unlock_height": 2091652,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "21ffffffffffffff"
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "5.189.129.195",
@@ -17485,6 +11661,20 @@
         2
       ],
       "swarm": "c4ffffffffffffff"
+    },
+    {
+      "public_ip": "151.244.85.1",
+      "storage_port": 22114,
+      "pubkey_ed25519": "cae5d85ee7f9e80e1f4524f8ba97172a2904ed847ab8fb22b20977a2da550f6e",
+      "pubkey_x25519": "090e5eb28b851a72f8a09c5c2fdd12b39f9520a3a5c9f5fcdd4e99ddd939ef07",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20214,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
@@ -17512,7 +11702,7 @@
         11,
         2
       ],
-      "swarm": "42ffffffffffffff"
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
@@ -17582,7 +11772,7 @@
         11,
         2
       ],
-      "swarm": "dbffffffffffffff"
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.191",
@@ -17638,7 +11828,7 @@
         11,
         2
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17652,7 +11842,7 @@
         11,
         2
       ],
-      "swarm": "4dffffffffffffff"
+      "swarm": "fbffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17666,7 +11856,7 @@
         11,
         2
       ],
-      "swarm": "407fffffffffffff"
+      "swarm": "3d7fffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17680,7 +11870,7 @@
         11,
         2
       ],
-      "swarm": "88ffffffffffffff"
+      "swarm": "e6ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17708,7 +11898,7 @@
         11,
         2
       ],
-      "swarm": "50ffffffffffffff"
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17722,7 +11912,7 @@
         11,
         2
       ],
-      "swarm": "e5ffffffffffffff"
+      "swarm": "eaffffffffffffff"
     },
     {
       "public_ip": "206.221.176.9",
@@ -17792,7 +11982,7 @@
         11,
         3
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "74ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17820,7 +12010,7 @@
         11,
         3
       ],
-      "swarm": "f7ffffffffffffff"
+      "swarm": "3ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17834,7 +12024,7 @@
         11,
         3
       ],
-      "swarm": "77fffffffffffff"
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17848,7 +12038,7 @@
         11,
         3
       ],
-      "swarm": "467fffffffffffff"
+      "swarm": "bffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17862,7 +12052,7 @@
         11,
         3
       ],
-      "swarm": "74ffffffffffffff"
+      "swarm": "daffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17876,7 +12066,7 @@
         11,
         3
       ],
-      "swarm": "387fffffffffffff"
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17890,7 +12080,7 @@
         11,
         3
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17904,7 +12094,7 @@
         11,
         3
       ],
-      "swarm": "dcffffffffffffff"
+      "swarm": "f3ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17918,7 +12108,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17932,7 +12122,7 @@
         11,
         3
       ],
-      "swarm": "9effffffffffffff"
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "185.150.191.51",
@@ -17946,21 +12136,7 @@
         11,
         3
       ],
-      "swarm": "467fffffffffffff"
-    },
-    {
-      "public_ip": "135.181.149.114",
-      "storage_port": 22021,
-      "pubkey_ed25519": "cb8387c41ef37d550947836202a1da21d92509681b5d58b3d822f858da4ba2e9",
-      "pubkey_x25519": "33985f5e3b04a3eee6801a1a10bfb24f083fd6a27e1f1f883c62f75cb38bc304",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "fcffffffffffffff"
+      "swarm": "d5ffffffffffffff"
     },
     {
       "public_ip": "128.199.238.28",
@@ -17977,32 +12153,32 @@
       "swarm": "e0ffffffffffffff"
     },
     {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22104,
-      "pubkey_ed25519": "cbb86e70216308f23ee06be7311cf17a0ff61405ddadcf7dcbe1e1926400d31d",
-      "pubkey_x25519": "033407504cd198ac9829d06998c44ce581f5e2657f1a55b5c637dd814e72982a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "caffffffffffffff"
-    },
-    {
-      "public_ip": "161.97.137.219",
+      "public_ip": "95.216.89.34",
       "storage_port": 22021,
-      "pubkey_ed25519": "cbeaa9f1115254c2ce225018908c2166d4f4b3f3f624ff5750c65387f4ce98b6",
-      "pubkey_x25519": "6636e95eb46e39c7d44bcfcf39c95dbf6e3cffc1c387bc13d88d68b8cc6ecd4c",
+      "pubkey_ed25519": "cbfeff6d6c63ded2608651b5e779795583c167dd77924fd3f1d2da571b3b6e6d",
+      "pubkey_x25519": "dd7d6602bc42aa7fed9b563c5ef13af89c98210ca51b80580cbfd7ded648f318",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "b5ffffffffffffff"
+      "swarm": "73ffffffffffffff"
+    },
+    {
+      "public_ip": "46.250.251.176",
+      "storage_port": 22021,
+      "pubkey_ed25519": "cc0caf9f73f280d8d903087b5223bf5b7b000a6b404a2f8597d377a76575b4bc",
+      "pubkey_x25519": "b729ec8d593a463721b728e37dc0d9c2a675af14ded56227fae493c5a3d70467",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "3bffffffffffffff"
     },
     {
       "public_ip": "91.229.245.243",
@@ -18016,7 +12192,7 @@
         11,
         2
       ],
-      "swarm": "3d7fffffffffffff"
+      "swarm": "297fffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -18030,7 +12206,7 @@
         11,
         0
       ],
-      "swarm": "377fffffffffffff"
+      "swarm": "fffffffffffffff"
     },
     {
       "public_ip": "185.209.228.134",
@@ -18044,49 +12220,7 @@
         11,
         2
       ],
-      "swarm": "a7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22125,
-      "pubkey_ed25519": "cc70f6135c51a9bfa365580cf2ce94076174c728a0ada570627a2c62abae4b62",
-      "pubkey_x25519": "da17610e7de606e87c27313b894228e28913b623a7e751bae2d1dd3ba398f579",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20225,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "4bffffffffffffff"
-    },
-    {
-      "public_ip": "94.72.125.80",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ccba88dc9c24db706f961de688265791f7ed4650acc1c180983a32bc8726574e",
-      "pubkey_x25519": "0cb4874794725a8d75259fa41850e68d1de3369673dd3476e7a275f7145d6e16",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "9ffffffffffffff"
-    },
-    {
-      "public_ip": "31.22.111.5",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ccbef169a13b207bbe4ba6b26ef137fbed788f670a7d1913d19beb60a43d5e35",
-      "pubkey_x25519": "945aa11c17cff249da87efeccd2c0e8d8fb4405fd3ec8cdfb2348d6610bda46f",
-      "requested_unlock_height": 2085897,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "a4ffffffffffffff"
+      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "5.189.189.215",
@@ -18100,7 +12234,7 @@
         11,
         3
       ],
-      "swarm": "d8ffffffffffffff"
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "135.125.140.64",
@@ -18117,88 +12251,18 @@
       "swarm": "2bffffffffffffff"
     },
     {
-      "public_ip": "95.216.137.153",
-      "storage_port": 22021,
-      "pubkey_ed25519": "cd6d8a7336f01a062ab14bd27218b1843fd45e5f99e4d48a1922806ff1e3faa3",
-      "pubkey_x25519": "2b5f67544af22bb681b65262e85d127215499fbc96155e460718f8adb1cd4779",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "15ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22115,
-      "pubkey_ed25519": "cd88528e1bdf2a49228c6101fde62a099367d315464127eaecb531575ab0c6cd",
-      "pubkey_x25519": "0b2d9e4d421efdcdd5318978f302eb2d40a5f12e140555cf1f5b70e0b5272c3c",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "1c7fffffffffffff"
-    },
-    {
-      "public_ip": "185.198.27.134",
-      "storage_port": 22021,
-      "pubkey_ed25519": "cdb274d473fa5bf03edb1f24b9c12b6d0ef768d9644571b5c567f0de6ae4a467",
-      "pubkey_x25519": "1b1d36fec1f04b67222a623605c56484a7c4082f001f0567a5c58a6c57a03133",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "6dffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22108,
-      "pubkey_ed25519": "cddbed1373b83dc946bcc944b97db03a8b67c8cc126f66147b828184e46e564e",
-      "pubkey_x25519": "85996e11c35261b3852ce7c304a1959dafc09a0ee866df6c496bdff2ca633d63",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8affffffffffffff"
-    },
-    {
       "public_ip": "207.58.175.90",
       "storage_port": 22021,
       "pubkey_ed25519": "cdfbcdae2de00da6058312a88e05249840168e8725847a0a12e4b3818d6ae037",
       "pubkey_x25519": "97f72b77d9cab72ed659244c1a1968e30555955ad898534322c48b44a1139940",
-      "requested_unlock_height": 2090245,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "91ffffffffffffff"
-    },
-    {
-      "public_ip": "144.24.179.149",
-      "storage_port": 22102,
-      "pubkey_ed25519": "ce0e9dff3877faa6011cb3aa89bd2a58a568a667fc33295f012d45fc246dbf40",
-      "pubkey_x25519": "5339b037e574cf03a16faa737251cd65e251388dc0c444392960c426d1999f41",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "47ffffffffffffff"
+      "swarm": "447fffffffffffff"
     },
     {
       "public_ip": "138.199.168.156",
@@ -18212,49 +12276,21 @@
         11,
         2
       ],
-      "swarm": "adffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22115,
-      "pubkey_ed25519": "cf0e87e03b7621f4c9f439c69601e708557f353f0608bda2578e9f0907f9b185",
-      "pubkey_x25519": "4ab4d5b030018fd5e98f484851da433e722f61c416cb13366a31f72a444eac64",
+      "public_ip": "51.222.24.183",
+      "storage_port": 22021,
+      "pubkey_ed25519": "cf57a9216af2062b40915159b5b14131914cf7d365ff3d175912980a0e1b38ae",
+      "pubkey_x25519": "e91d3eb4beb9d1e455faf0756b84757229cbe3469043f3f87d6d96e54f626d38",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d3ffffffffffffff"
-    },
-    {
-      "public_ip": "102.219.85.93",
-      "storage_port": 22100,
-      "pubkey_ed25519": "cf446948060ecd12fe12b5fbc28e67d1251d0ec33d522a8c9ac31121724a8588",
-      "pubkey_x25519": "e9add909986d043a326469f3b5941160e75a7886aca724f8409b6f0d34312e42",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d3ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22114,
-      "pubkey_ed25519": "cfdec08d375d6cef24d4797a104b5840b79799397d96d9e19583f2e36372dd40",
-      "pubkey_x25519": "010507b33aa6370e2d9ffeff797692bf66e44d750d231f33964e0c3e9c01e01f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "49ffffffffffffff"
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "23.88.58.63",
@@ -18268,7 +12304,7 @@
         11,
         3
       ],
-      "swarm": "91ffffffffffffff"
+      "swarm": "a6ffffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -18282,80 +12318,10 @@
         11,
         0
       ],
-      "swarm": "94ffffffffffffff"
+      "swarm": "97ffffffffffffff"
     },
     {
-      "public_ip": "164.68.125.136",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d0358a902f237f44f6c75948783e69c98b8092f76c6d5e20f16e5ba4c17b4cb7",
-      "pubkey_x25519": "960dd6bc935c3a6a4c086afb0e06f10a5660009ecd35baa9e8b1fa4efd6c6970",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
-      "public_ip": "208.87.129.102",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d03738f8a4d3e49a45e104d14775e8fab9e3e81927a81178e550dbda41e31b9a",
-      "pubkey_x25519": "e90c345863dc50cff06cdaf6d68c9c3cfa2e3933491609b9cb7de480c47d3a7e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6bffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22106,
-      "pubkey_ed25519": "d079d0acfb611764675e770b79a41d4c6fb930ac65b0ab02d5904e65128b4bd7",
-      "pubkey_x25519": "392d2d3cf18ef2c454970430987881d18cbd98703ee62c41c6daf80580e38e30",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "387fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22112,
-      "pubkey_ed25519": "d0989e60ec38e6447d97410b87eaaf8843367419a978e7d5b222d561ffe159d0",
-      "pubkey_x25519": "f9b33a6c72e6b26a2f3b4774323fe33e24cd3e86a56b42075896061988d50b36",
-      "requested_unlock_height": 2084500,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3fffffffffffffff"
-    },
-    {
-      "public_ip": "109.234.36.164",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d0aa3ac5b984174a4ef640da93adaae57ad8e4eecc97d2a338e58e511db757cd",
-      "pubkey_x25519": "96f5d5ddfad37e48e757e3d92f23a89748c1a57f6b2b65f45717c1005fab095c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f9ffffffffffffff"
-    },
-    {
-      "public_ip": "212.105.90.36",
+      "public_ip": "212.105.90.34",
       "storage_port": 22102,
       "pubkey_ed25519": "d0b22df940dd22bbb16759b24f11799125a442aa7187f2d1ae47eddec98ad572",
       "pubkey_x25519": "47c28eb0a738de028dda603d85f8262be6a3468b66b2918c492d7c0f8d0b6613",
@@ -18366,49 +12332,7 @@
         11,
         3
       ],
-      "swarm": "327fffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22119,
-      "pubkey_ed25519": "d0df95dcbefb72135577b5d34920164a5ab057c503470f2633e62add344fc905",
-      "pubkey_x25519": "4e4779bf1c25443c6d03adb7727e286bb6b528ec2f05d8fb8d281fa597377414",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "21ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22121,
-      "pubkey_ed25519": "d10097cdd26e57bc6162d75b231f449d6cb31dc798261ba9d592acddd42e78c8",
-      "pubkey_x25519": "b568d529dae3ca9f820334d409806a214ce252d99746f744ddcf49c5be612b24",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20221,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ecffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.104.98",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d103b5ccd3aef4283e0ef4780d7db44090694f13feb7fec830d5b2d8b1865590",
-      "pubkey_x25519": "5d603a1fae0a6304e11131bb0554b4f3c132891e7d03be49cce5ec335bf5c006",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7affffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "104.248.163.43",
@@ -18422,35 +12346,7 @@
         11,
         0
       ],
-      "swarm": "c6ffffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22104,
-      "pubkey_ed25519": "d16d3afb45792f9e795bb7f4826c1d189fb5076755b1c6c68ddee15987909529",
-      "pubkey_x25519": "d21b992f8af9292d16b13180d747e40bf5e440367d03637a1c9667c3b6b1f022",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "7dffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.76.191",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d19783f75bc0e87cad4b8a9d63696ffb0122edf495da6d5c3a627512e485bc85",
-      "pubkey_x25519": "777aa868c8315a23ff15ed6053f9d4172c0ca4f4ae77468b8d835c266f44e74a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a6ffffffffffffff"
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "135.181.109.199",
@@ -18464,7 +12360,7 @@
         11,
         0
       ],
-      "swarm": "3ffffffffffffff"
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "199.195.251.55",
@@ -18481,60 +12377,18 @@
       "swarm": "e8ffffffffffffff"
     },
     {
-      "public_ip": "188.227.250.41",
+      "public_ip": "87.106.25.143",
       "storage_port": 22021,
-      "pubkey_ed25519": "d273bd93e04d8fbcbf1cb5adee0cab008ed241828ca726fd44cefc2db6aae5de",
-      "pubkey_x25519": "bb60d6aafd2992131eb2c87b48b25ed1e307255c15b87c3967569739761ce302",
+      "pubkey_ed25519": "d22edbec0f11fd1dd30de5802df4958554dfe4d51dc54f2607b43ea5ff638a40",
+      "pubkey_x25519": "7806036af8b1b7c9461a3ecd1897e6dee26b3f1c5c5453a5535e6a99b23e073f",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "69ffffffffffffff"
-    },
-    {
-      "public_ip": "192.3.63.197",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d29251a5ee2c8f7022b47488e3defc6b6184117c9e455ed800ac60f9c1388fb3",
-      "pubkey_x25519": "6c68ff631e64f09c48170b9e5d576531b4a5fa8ea4580d583eccda989eb1e973",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "7dffffffffffffff"
-    },
-    {
-      "public_ip": "85.239.247.57",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d299056394d9e52a9c3c8633cd801a42f5ab0ba72d9d44d296388f0ccb216ed2",
-      "pubkey_x25519": "38c990454cb3d31c1ac1ea06dac989601e9e26a37b9f182c27575a2dad2b8066",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "477fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22102,
-      "pubkey_ed25519": "d2a5ef4f952b15f4562b44d024a6bc8b0058513a8f782b2dd76a68c4e97cc459",
-      "pubkey_x25519": "2979d41330544b72f61f1240e3c2ea5838b28cdb8b2d46529d2b87c5f9dda41a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "cdffffffffffffff"
+      "swarm": "54ffffffffffffff"
     },
     {
       "public_ip": "212.105.90.36",
@@ -18546,9 +12400,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "a5ffffffffffffff"
+      "swarm": "acffffffffffffff"
     },
     {
       "public_ip": "185.153.55.236",
@@ -18562,35 +12416,7 @@
         11,
         3
       ],
-      "swarm": "3dffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22104,
-      "pubkey_ed25519": "d2ccf087c84ad6dfd15f1f175c434b7fa8b8addf2cfc979c6410f59b0fb25b97",
-      "pubkey_x25519": "4867852c3dfcd268843830daa5c7b57bb3cfb29f62c28c1fd25221bc631ea968",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "18ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22109,
-      "pubkey_ed25519": "d2db0142725c139d494207619ac348c72eaaedf6383bd0a10df5ec1a52bb3bb2",
-      "pubkey_x25519": "5f0e4398604c06f02869dd96abc9a2b98b3def2ee65796cf33ae1bedd2ec8b42",
-      "requested_unlock_height": 2086578,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "4bffffffffffffff"
     },
     {
       "public_ip": "135.181.105.205",
@@ -18618,7 +12444,7 @@
         11,
         0
       ],
-      "swarm": "3a7fffffffffffff"
+      "swarm": "76ffffffffffffff"
     },
     {
       "public_ip": "141.94.206.162",
@@ -18633,20 +12459,6 @@
         2
       ],
       "swarm": "a9ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22119,
-      "pubkey_ed25519": "d3a1b5cb29572409d479e21f0fd3c3ecab56f0910488f73e17c6703485a38d49",
-      "pubkey_x25519": "502de7e4551d6b8ac3315638d201a933be27a0d3fae901aa3f32e6581e169f04",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20219,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3c7fffffffffffff"
     },
     {
       "public_ip": "149.56.128.86",
@@ -18674,21 +12486,7 @@
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.123.162",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d4b1e879d9ad4c8e5278cbfc8711d4e739b499cb2ced29c0065439d7f45b4757",
-      "pubkey_x25519": "69f922608ac561e2991be8f3162e3ad20919563e73e63d4b5d7ea5586710e815",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "7ffffffffffffff"
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "198.98.53.254",
@@ -18716,7 +12514,7 @@
         11,
         0
       ],
-      "swarm": "70ffffffffffffff"
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "147.135.115.55",
@@ -18733,20 +12531,6 @@
       "swarm": "d6ffffffffffffff"
     },
     {
-      "public_ip": "31.22.111.227",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d53130ee19018c7f2223675cd5d7c9f7a6a7b3694cc0cc37a2b34ae03f7e2a9b",
-      "pubkey_x25519": "d85b379bcba84278504410a2c70884b86e52d84b7e7179c50e0a7bf25337000a",
-      "requested_unlock_height": 2088816,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e7fffffffffffff"
-    },
-    {
       "public_ip": "139.99.135.156",
       "storage_port": 22021,
       "pubkey_ed25519": "d624df8573ffd69e45949223657df772df29dcac2e9c675804be1cf099a071e4",
@@ -18758,77 +12542,7 @@
         11,
         2
       ],
-      "swarm": "bfffffffffffffff"
-    },
-    {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22113,
-      "pubkey_ed25519": "d627de06cc2d4820cbf4df5b7ade2392b684dcf470e9ca9cd7a198032e1f8ee3",
-      "pubkey_x25519": "7d426e94ac42f00ffb47c5f1d0c324b253bb8d2867cc2202e011d2dad718df2b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "247fffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.68",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d65a221b38bb7f1285bcdb64d4b03490c36487e54a1331b430256a7643914247",
-      "pubkey_x25519": "a066b671eb6cffee0709632d9326727fb1434a12d1e7d46232b6a998b8cd554b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "aeffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22112,
-      "pubkey_ed25519": "d69d45b83cd34ebd394e761561d4feb0ad7a47daa8f198d0997cbea3a7622858",
-      "pubkey_x25519": "41548b2d0c9774e8682412d3207f3379807a128a200f74e9c87572885aecae08",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "e5ffffffffffffff"
-    },
-    {
-      "public_ip": "64.235.37.175",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d6eeb243a84c55190514188084a69da2393213921aa169c11e8e5424256a5915",
-      "pubkey_x25519": "d8a04a6821ab35f790a23dfbc95b93c709bc2a13964023930a9ad114c472a013",
-      "requested_unlock_height": 2084583,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "8ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.220",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d72ea1a6d387d9242a47b21839ae81c99e3569dae96196661ae2ee2c2f654c43",
-      "pubkey_x25519": "b73a9771fee04c99b91f09d853833eccf072cff4a220452ccc58a2c2e1c7ef52",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "15.204.87.227",
@@ -18840,9 +12554,9 @@
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "98ffffffffffffff"
+      "swarm": "beffffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -18870,10 +12584,10 @@
         11,
         2
       ],
-      "swarm": "bffffffffffffff"
+      "swarm": "d0ffffffffffffff"
     },
     {
-      "public_ip": "212.105.90.36",
+      "public_ip": "212.105.90.34",
       "storage_port": 22103,
       "pubkey_ed25519": "d77069c7366db2ed67a88e802a973b9f3daa78deaf4785854e726447e68dba70",
       "pubkey_x25519": "2d673cfe96e44012c2049a7852d45e573c91b5bfd3321c5426f62a0f914d846c",
@@ -18884,21 +12598,7 @@
         11,
         3
       ],
-      "swarm": "baffffffffffffff"
-    },
-    {
-      "public_ip": "45.159.220.22",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d778e23c36a5568dfaa042c9b25542bdddee7931678ae5defa960ce3a001355a",
-      "pubkey_x25519": "546a3cf81f54d5ebaffd9d1bf4c0e2a175095700b9882e2c30ed5fa21602da06",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "abffffffffffffff"
+      "swarm": "a4ffffffffffffff"
     },
     {
       "public_ip": "38.60.229.76",
@@ -18912,7 +12612,21 @@
         11,
         2
       ],
-      "swarm": "60ffffffffffffff"
+      "swarm": "7dffffffffffffff"
+    },
+    {
+      "public_ip": "46.225.102.55",
+      "storage_port": 22101,
+      "pubkey_ed25519": "d7e89afa5ab929aa94699632c93645f6a08b9197e058b9b11b9348e64b014370",
+      "pubkey_x25519": "3418506e70b0b1b9bf89828de3de94e0e4989342eabb0aa77d3ffe902f51c85c",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22401,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "95.111.229.181",
@@ -18926,21 +12640,21 @@
         11,
         2
       ],
-      "swarm": "fffffffffffffff"
+      "swarm": "88ffffffffffffff"
     },
     {
-      "public_ip": "169.197.86.232",
+      "public_ip": "62.171.172.43",
       "storage_port": 22021,
-      "pubkey_ed25519": "d8081e0f5c1ee1687b0dbb7de7b12d38f778046e35cb75142122a7309e200220",
-      "pubkey_x25519": "cdaa0515139b54ebfc3313a30206d5e04eef5a12777446af179daad05354e869",
-      "requested_unlock_height": 2090338,
+      "pubkey_ed25519": "d7fc9b124e0e46e18dd6df94448f122210e2a6e3ad990a8045ad99d6c1912a75",
+      "pubkey_x25519": "416cc1f3239c592dd7e0b85080ca4ed45f16b2aa62ed5849b0cb6432f83a546b",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "2a7fffffffffffff"
+      "swarm": "3e7fffffffffffff"
     },
     {
       "public_ip": "193.123.76.22",
@@ -18954,21 +12668,7 @@
         11,
         3
       ],
-      "swarm": "3dffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22106,
-      "pubkey_ed25519": "d8af8c1f0af2bd69a12f0a1cad98bce41814f1295635a1db73771e7615811d4f",
-      "pubkey_x25519": "8b68b322b6774771e1aecd6e1bfb12349456b20641db6a514219d10b80cbc672",
-      "requested_unlock_height": 2094708,
-      "storage_lmq_port": 20206,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "88ffffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
       "public_ip": "89.58.0.228",
@@ -18982,7 +12682,7 @@
         11,
         2
       ],
-      "swarm": "40ffffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "104.234.231.219",
@@ -18994,9 +12694,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "d6ffffffffffffff"
     },
     {
       "public_ip": "185.173.235.101",
@@ -19013,60 +12713,18 @@
       "swarm": "b2ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22115,
-      "pubkey_ed25519": "d99a17fc9eaf71457bd23f77d8fa1ab77be0788af7a0d988c8b23dcda6845ed3",
-      "pubkey_x25519": "fd49ec101dd3c253c96f5d567d2af059103ec6772917a4511fd106e29daa0059",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "26ffffffffffffff"
-    },
-    {
       "public_ip": "107.182.173.71",
       "storage_port": 22021,
       "pubkey_ed25519": "d9b65d97d5c4b474b13883e6a1ce5f7b6b140fd99f736eae508d3fcb8c92a30a",
       "pubkey_x25519": "67199ec9d1bcaab8808c096b3370aea4e2c9a2d91341cba68730bb1949891b7f",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2161745,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "187fffffffffffff"
-    },
-    {
-      "public_ip": "158.220.126.109",
-      "storage_port": 22021,
-      "pubkey_ed25519": "d9ef91ebd50315ebe2cee7ed3add941b44aa83629f932e0d0768d7e526628e18",
-      "pubkey_x25519": "5dc8bbc77d5a57d3b11e8bac2161d5b4bb203247e3455df76a3ba79e4dd5be1d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d1ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.16",
-      "storage_port": 22021,
-      "pubkey_ed25519": "da280f677391f00244d5e7b13859a56e5347cee5f2fc0d9bb5e7e78d6ca8270a",
-      "pubkey_x25519": "c11ece75669e5284f2f977d3258e247acfe42e20c11afccd756ba06567caae73",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "b5ffffffffffffff"
+      "swarm": "eeffffffffffffff"
     },
     {
       "public_ip": "149.56.12.216",
@@ -19080,7 +12738,21 @@
         11,
         2
       ],
-      "swarm": "d1ffffffffffffff"
+      "swarm": "ddffffffffffffff"
+    },
+    {
+      "public_ip": "155.103.66.138",
+      "storage_port": 22021,
+      "pubkey_ed25519": "da5c2b2cfc541987093c589abc0c736531dcfe1cae5b276cd95f3ba4770e3f59",
+      "pubkey_x25519": "40160a04eb710525a283a9359d4b39a4bdcb5d7c81779d850430d7b69d75f039",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22020,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "3b7fffffffffffff"
     },
     {
       "public_ip": "135.148.27.21",
@@ -19125,20 +12797,6 @@
       "swarm": "337fffffffffffff"
     },
     {
-      "public_ip": "93.95.231.60",
-      "storage_port": 22108,
-      "pubkey_ed25519": "db4e72005254ef0ace19567d8734802458d9af895953fbadc7e904225394f29f",
-      "pubkey_x25519": "e953c575ddee59a6653a79fac31a732a7d00fb89589a79ef1dbfedec52cb6849",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "14ffffffffffffff"
-    },
-    {
       "public_ip": "65.21.244.24",
       "storage_port": 22021,
       "pubkey_ed25519": "db9ad0f417a0b79e2dd2923be8cc5289a3d552bdc5f7bad51574d98d7e584e5a",
@@ -19153,48 +12811,6 @@
       "swarm": "60ffffffffffffff"
     },
     {
-      "public_ip": "144.24.183.0",
-      "storage_port": 22102,
-      "pubkey_ed25519": "dbd97e7d6abcd38917ebb60f9d9ba697185ac67617c357276c2c403fa64fc4da",
-      "pubkey_x25519": "75b509dbd4832f3a911d24016bb2964ded2a444179cb76121e42653f12ddc22c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "cffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.126.233",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dbea94b570ea06818323067a618b1a88ac24b18a16cd9aeacd97b132e3cf2f00",
-      "pubkey_x25519": "eb05d0fe7260907db89e1bc3398f5d2628e113b0de1379e2586c65bd9aa44822",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "67ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22105,
-      "pubkey_ed25519": "dc548201343c40baf0d5017891359606c3cc936be64143bb1b1bc59046230514",
-      "pubkey_x25519": "40e0ee30d7ceab7fe93598c4bf95a6332d3f5ab704bf50a0ed8dce09163f3f23",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "287fffffffffffff"
-    },
-    {
       "public_ip": "65.21.240.249",
       "storage_port": 22108,
       "pubkey_ed25519": "dc621c55dcb90d7f2134c82d6c8923a500bba480d3fb394fb08a2294721ebf3a",
@@ -19206,21 +12822,7 @@
         11,
         0
       ],
-      "swarm": "f7ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22100,
-      "pubkey_ed25519": "dce98cc2602f0673c365dc41e3df099bb44c9d3fa8ca393d1c25a6aa1c7a59c3",
-      "pubkey_x25519": "245312f764acb5c7f8573a7b0ae4b864a1c075f3b839345b3284f55828785256",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "e2ffffffffffffff"
+      "swarm": "6bffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -19237,62 +12839,6 @@
       "swarm": "e7fffffffffffff"
     },
     {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22109,
-      "pubkey_ed25519": "dd75931ac08255af80ade2c1e56d3924f8f4edc368b660796c6165dad7c7fa9d",
-      "pubkey_x25519": "05b9c22bcfb2131e5003b69feb3381c96510c391eac07fea2bd2f839826d9b54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3d7fffffffffffff"
-    },
-    {
-      "public_ip": "142.248.29.61",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dd7a27c830745d8f304f8e2f505cc1d9bf6255ca48bb70c7867bd8992035d7bb",
-      "pubkey_x25519": "a015243bb21c72e1b1c18903da5002d1dc0de1846cb4fa9c6fc78d07c5021952",
-      "requested_unlock_height": 2085149,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "beffffffffffffff"
-    },
-    {
-      "public_ip": "37.27.38.161",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ddb6e0665652287203c1d4108ca13c5a31ba8411a911244b734afb8a4ed4d5e0",
-      "pubkey_x25519": "4fb63510efdd0a6f4e34dac6bb5f6de9b917664c65b7bbf65bf10daae19abf2d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "72ffffffffffffff"
-    },
-    {
-      "public_ip": "85.9.211.140",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dec60e8c3af5e7383f5cc8749988e2a0d105fd9c6ca54811ae1a790bbfe06267",
-      "pubkey_x25519": "2186678eb2df1aae2b148ba40eebf27a13c28f5728118d8fcf5f9eaf0e5b797f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c8ffffffffffffff"
-    },
-    {
       "public_ip": "152.53.230.229",
       "storage_port": 22021,
       "pubkey_ed25519": "df060d570f99a32bfd74af6814483134fc049d9ea76aa8a08c4ad6f4dad469fa",
@@ -19307,20 +12853,6 @@
       "swarm": "dbffffffffffffff"
     },
     {
-      "public_ip": "164.68.104.155",
-      "storage_port": 22021,
-      "pubkey_ed25519": "df3b644169a37f816519a87d8858efa636da5483a25b2a62abd02f9ff24adb59",
-      "pubkey_x25519": "b80f35bba920e7715ab924928bf0a23a01eec1e7fe32480acae629a04e585832",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "f1ffffffffffffff"
-    },
-    {
       "public_ip": "95.216.32.189",
       "storage_port": 22106,
       "pubkey_ed25519": "df5f041f59b9b01f12d3e325cde945fb64e3366e80fb99212478a9f943798aba",
@@ -19332,10 +12864,10 @@
         11,
         3
       ],
-      "swarm": "52ffffffffffffff"
+      "swarm": "2dffffffffffffff"
     },
     {
-      "public_ip": "167.17.40.236",
+      "public_ip": "91.109.118.103",
       "storage_port": 22021,
       "pubkey_ed25519": "df65f3baee7170efbc3ff263cc034b1f18c71cc52be0bcbfedd2acac266c6a0d",
       "pubkey_x25519": "86afa90c299b209f358b30764de2f2ad9a0d9d8c9b958c2765d8ae431795260e",
@@ -19346,133 +12878,7 @@
         11,
         3
       ],
-      "swarm": "34ffffffffffffff"
-    },
-    {
-      "public_ip": "89.147.110.157",
-      "storage_port": 22115,
-      "pubkey_ed25519": "df7907cf6d967bcef4374424b9326308086acb5044899e01e39f41eb2590c592",
-      "pubkey_x25519": "18e920b93119f1e658a859619d6a62af56068db1ded7e6ee82484ce3bab9116d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "d2ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22107,
-      "pubkey_ed25519": "df9f53af152380b80f6879d998994cb8547700aaad3576d71bf270cd960b0f3f",
-      "pubkey_x25519": "483c47185e72ec489049670a4ff784b1ebf5548e1eb30c75d6d41f7276205e75",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a8ffffffffffffff"
-    },
-    {
-      "public_ip": "158.220.127.207",
-      "storage_port": 22021,
-      "pubkey_ed25519": "dfb4d131046af3b03ed213ea360e5f7fdab240d0de692cbb735220cd85ae3f3f",
-      "pubkey_x25519": "f9f8f9c209f9ac93559b0697859745bc459abbff685f2c2b043820a951087e21",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "47fffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22101,
-      "pubkey_ed25519": "dfe854814ace9c1a8eaac9bc8b47f747548db973c737d6be5655e157cbb6b73a",
-      "pubkey_x25519": "6b61ee276e8f781867b269aa7a99ac4fce65486156a7f604c8954347fab2bf61",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "fbffffffffffffff"
-    },
-    {
-      "public_ip": "194.5.248.48",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e01a3e9479ba1fb35f31d107981fc74ae1e8674160d950f89ad5e87fcfeca050",
-      "pubkey_x25519": "ff55e7893e8252100affd8a192dcc7a24289ab122a5f870b94fc2de0d940c353",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "e3ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22102,
-      "pubkey_ed25519": "e094b5473f5c4e0ae0f284ed6c356f7ffcb5fbdff863783f4231f7ff078c8f4b",
-      "pubkey_x25519": "a7ef551c46770acaa9783025896d4c3cc27ee4116db04c0eb659fbc1d5a5cd47",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20202,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ffffffffffffff"
-    },
-    {
-      "public_ip": "209.126.7.133",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e0be1a63c30f6dcff9c3c2fec4c643dd19dce30da5d97b1ba9de6a16850aef74",
-      "pubkey_x25519": "c16707c8ef5f28121e91d15ef59bb5d66fd287b4ee4dbf1316930b8e5443e158",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4bffffffffffffff"
-    },
-    {
-      "public_ip": "77.74.199.82",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e0f259d5620e7c6d16bcbe470d53f8e900c06eb5c00ab021c6f0e8d3028ef7d6",
-      "pubkey_x25519": "570718d983f4fb66303c690abe2e57481e90f7ca7d800a68f9d5b0bd0f6e9574",
-      "requested_unlock_height": 2091685,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "1cffffffffffffff"
-    },
-    {
-      "public_ip": "85.209.48.151",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e0f6eaba6ba08e32befea4b0bc6a74216630a97fed944eb38c52946a6545d494",
-      "pubkey_x25519": "174cfc72aa9405732305ce53f61102565deda3d004d5e19d49f668b264730633",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "3fffffffffffffff"
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "91.99.144.21",
@@ -19486,7 +12892,7 @@
         11,
         2
       ],
-      "swarm": "6cffffffffffffff"
+      "swarm": "12ffffffffffffff"
     },
     {
       "public_ip": "209.141.57.149",
@@ -19500,21 +12906,7 @@
         11,
         3
       ],
-      "swarm": "23ffffffffffffff"
-    },
-    {
-      "public_ip": "193.26.157.116",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e1af541c255ccfa56f63185e9aab06e8afd7b3c385bea4f21dd2b3f6bdd3a8ff",
-      "pubkey_x25519": "af04e07bf6237645122961dd91170fa595446db9e55d195c53f3eb27f63c723f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "dfffffffffffffff"
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "158.69.201.96",
@@ -19528,7 +12920,7 @@
         11,
         2
       ],
-      "swarm": "83ffffffffffffff"
+      "swarm": "78ffffffffffffff"
     },
     {
       "public_ip": "45.145.42.82",
@@ -19542,7 +12934,7 @@
         11,
         2
       ],
-      "swarm": "36ffffffffffffff"
+      "swarm": "bbffffffffffffff"
     },
     {
       "public_ip": "144.76.74.2",
@@ -19556,21 +12948,21 @@
         11,
         2
       ],
-      "swarm": "a7ffffffffffffff"
+      "swarm": "b6ffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
       "storage_port": 22106,
       "pubkey_ed25519": "e29106d27e4c43de76e66a38d743761afc89ec2af04756e6db637cf080d6c505",
       "pubkey_x25519": "8510e9e535d020b1ea06e9b4d55a0a10c1f5be98e8efabf80dae207dd25a045d",
-      "requested_unlock_height": 2086864,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "c3ffffffffffffff"
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "45.153.186.74",
@@ -19584,49 +12976,7 @@
         11,
         2
       ],
-      "swarm": "89ffffffffffffff"
-    },
-    {
-      "public_ip": "46.62.134.250",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e2dc0b7dbef83bb23a1c7b24930b957ddc9f94f7fae6eb6ff9a4fe8fe845cdb3",
-      "pubkey_x25519": "79b7310f6a2bea1399c92843979f0cd4db540d6f54239bc8fba1f9261adbc526",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "daffffffffffffff"
-    },
-    {
-      "public_ip": "141.140.12.182",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e34245544f2dd7b0ad4c9e2b3fe31a2d614b4342f7af02218644bd193bbfbfe2",
-      "pubkey_x25519": "4afed8fee0a65934ce5be75ba7cd32af78158d901adbe04be4870e9f0c032f6e",
-      "requested_unlock_height": 2085162,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "0"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22111,
-      "pubkey_ed25519": "e34523ad6345484e40a9349639f484d62dea707c703f8f122e7c417a5c50697f",
-      "pubkey_x25519": "1fbd23f0304f27cb7c601b43fc74f2a1d274b47f7170f36b9fda0e1753c21954",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "ffffffffffffff"
+      "swarm": "dbffffffffffffff"
     },
     {
       "public_ip": "51.79.251.59",
@@ -19640,49 +12990,21 @@
         11,
         2
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "b3ffffffffffffff"
     },
     {
-      "public_ip": "158.220.89.153",
+      "public_ip": "178.238.230.131",
       "storage_port": 22021,
-      "pubkey_ed25519": "e38db659c2df17d64fd8a6a35fd6d2d8e769de82b1bc0adde227ff3da0023557",
-      "pubkey_x25519": "9e85e80573f31e5f80fb2729fb9faa53231fa5b7699dce8b3de27d83bb0ea85f",
+      "pubkey_ed25519": "e40618531d44226f6eff51596b0151aa94fc185298c5a5a35a538eae72408df6",
+      "pubkey_x25519": "2712801a2570a8a88d0b28dbcb82799d429ca109d3b932c2863f71ea15f40f28",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "39ffffffffffffff"
-    },
-    {
-      "public_ip": "154.53.37.42",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e422704615c072e6ce5e59bd21013e6b74952e218be04e6eae9e196dd9695692",
-      "pubkey_x25519": "f57ab48ed683078396be57100f7ec3723159cdfb655d80b059050194c6823447",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "457fffffffffffff"
-    },
-    {
-      "public_ip": "173.212.204.166",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e42e1d5ddac8f002be1584f902ca59251fe08e05f1280bd62427cc419fafa23c",
-      "pubkey_x25519": "c999d3b15d67a548ad1692e707e77cffc9ce346aa41f627576303f733da2e856",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "acffffffffffffff"
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "72.60.178.74",
@@ -19696,35 +13018,7 @@
         11,
         3
       ],
-      "swarm": "17ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.213",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e468e032835ff7b08b100efca8b1231fe3340d266e7f968a62504c7e1177edee",
-      "pubkey_x25519": "d1eb2475fbf3446cc3ffe367a7c9646025cba86cf392986ca3e333b245974132",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "50ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22113,
-      "pubkey_ed25519": "e4bba8db5e9fd5e891872c47b19e3b6278efe49d69367967512b1170c5da6a8f",
-      "pubkey_x25519": "767dd9c91b8540e703bdf7be827a73b3399b6300c96928b1b0a77d681a9a3b17",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20213,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "feffffffffffffff"
+      "swarm": "9bffffffffffffff"
     },
     {
       "public_ip": "45.33.105.193",
@@ -19752,21 +13046,7 @@
         11,
         3
       ],
-      "swarm": "12ffffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22112,
-      "pubkey_ed25519": "e53edbe54fa6a3f6b701d356c444d6772475dec15ee0a353c1c7351187d11f5c",
-      "pubkey_x25519": "15d69ae50e61b90e6b79c3b645e109841b2cc052b952851d2c4afd09d4225024",
-      "requested_unlock_height": 2086578,
-      "storage_lmq_port": 20212,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "ccffffffffffffff"
+      "swarm": "1ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -19780,7 +13060,7 @@
         11,
         3
       ],
-      "swarm": "c8ffffffffffffff"
+      "swarm": "a7fffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
@@ -19794,7 +13074,7 @@
         11,
         0
       ],
-      "swarm": "377fffffffffffff"
+      "swarm": "357fffffffffffff"
     },
     {
       "public_ip": "170.64.144.131",
@@ -19806,37 +13086,37 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "70ffffffffffffff"
+      "swarm": "cbffffffffffffff"
+    },
+    {
+      "public_ip": "128.140.94.83",
+      "storage_port": 22100,
+      "pubkey_ed25519": "e5ae2de3ea7ae8e26aa6f0fd4a7e9662c707b8a3612f8511e43e20e380cc3099",
+      "pubkey_x25519": "9d9e5f015307e14e26d87c7f9634e9c60e1aa5662d157d897fdb4968ed895e4a",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22400,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "d0ffffffffffffff"
     },
     {
       "public_ip": "51.81.210.5",
       "storage_port": 22021,
       "pubkey_ed25519": "e5b8a3014e2ffc44aecfcbe7f6aefb4bc818c2112510d23b9276bb64931d21a9",
       "pubkey_x25519": "9fe0999bd430a5b229444ce6b2dd7e2a86870dba240bddec0e8e3722503e9a33",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2166449,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
         2
       ],
-      "swarm": "1cffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22117,
-      "pubkey_ed25519": "e5d40f69ef158bb4a5e76019f72a374d959fc10d6e37bda0794ef6e48466bdb6",
-      "pubkey_x25519": "3ab79651a1da64306c1de4d94de046c4a9b2480b92dda666117fd82b8504630d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20217,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3f7fffffffffffff"
+      "swarm": "1d7fffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
@@ -19850,49 +13130,35 @@
         11,
         0
       ],
-      "swarm": "c8ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.190.48",
-      "storage_port": 22110,
-      "pubkey_ed25519": "e64be5fe56b600eff129ac3335e96ad3a4278c542ce722c392bff69e828501a6",
-      "pubkey_x25519": "b17ba2b4117d383d59da158fd26e2cd15085089dbb5bd09c13ef44a855be3e45",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "79ffffffffffffff"
+      "swarm": "1effffffffffffff"
     },
     {
       "public_ip": "95.216.223.93",
       "storage_port": 22105,
       "pubkey_ed25519": "e6562fb8845232c190130c5b2698ea0c868c7b8b28972dfd3bba900b82db5198",
       "pubkey_x25519": "2e58a08d45b5f060b3b24ea33e351eeac432736ce6ae720745697e7c45cb9b29",
-      "requested_unlock_height": 2084751,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22405,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "ccffffffffffffff"
+      "swarm": "94ffffffffffffff"
     },
     {
-      "public_ip": "158.220.127.144",
+      "public_ip": "13.140.148.2",
       "storage_port": 22021,
-      "pubkey_ed25519": "e6655f0d8f58c8d8994132dad121d04a1d309566b775914c1dd4bc99625e1219",
-      "pubkey_x25519": "d19c93fc49858a8c018866cc21ae3f51c9d9fa19cf35006638720a52732b4a62",
+      "pubkey_ed25519": "e6df3b0e1f1278b92e6870ff51b2d9b63c6dd62f4cb10d00da6364aef9b9b77a",
+      "pubkey_x25519": "6282507d28d0180aac156e76567e8ade1545b4c4b2c9e9d68e57acff70fe6d39",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "68ffffffffffffff"
+      "swarm": "feffffffffffffff"
     },
     {
       "public_ip": "209.141.52.233",
@@ -19909,20 +13175,6 @@
       "swarm": "3f7fffffffffffff"
     },
     {
-      "public_ip": "54.38.52.251",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e714c94f45032159fe2872999483dbdb89509a3e027f06ecffbcdd41230e46e8",
-      "pubkey_x25519": "b46b6d8a1f42128bf69f6d0176c128a075084e6c0ccf65f9d67a05502e5de75b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "c9ffffffffffffff"
-    },
-    {
       "public_ip": "185.216.178.30",
       "storage_port": 22021,
       "pubkey_ed25519": "e749ccef94f39284252bf96a7465cadeb5551355b37a82ec10ba5eba70192376",
@@ -19937,32 +13189,18 @@
       "swarm": "a1ffffffffffffff"
     },
     {
-      "public_ip": "195.246.230.27",
-      "storage_port": 22117,
-      "pubkey_ed25519": "e78edb02540e1130c57ead0a1e8603549c9e23c507740131b61b153e7c722970",
-      "pubkey_x25519": "5f7f70229b98af0e2a66b4044d0be5dce4df255b927304c589ebecaa15683c7f",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20217,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "c0ffffffffffffff"
-    },
-    {
-      "public_ip": "193.160.96.229",
+      "public_ip": "212.47.79.56",
       "storage_port": 22021,
-      "pubkey_ed25519": "e7bbb6f54a2b7f61589ab4eb1832d2ba8461eba9b537256bbe5b55c027a25cc9",
-      "pubkey_x25519": "1bb216470bbccada8145d63f50563f2098c57b01e43b28ecd79c994d71c0fa40",
+      "pubkey_ed25519": "e772a84107c8d810dfad6258572bcecff3610151cecaee2122d2a46b9a4aa1c1",
+      "pubkey_x25519": "c729a8bac709cda82ba6c7fb686cd7ff630a341ac35d0d656d8595109af70203",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "66ffffffffffffff"
+      "swarm": "75ffffffffffffff"
     },
     {
       "public_ip": "173.249.207.148",
@@ -19974,9 +13212,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "71ffffffffffffff"
+      "swarm": "e0ffffffffffffff"
     },
     {
       "public_ip": "129.213.211.207",
@@ -19990,7 +13228,7 @@
         11,
         3
       ],
-      "swarm": "6cffffffffffffff"
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "209.141.51.234",
@@ -20004,77 +13242,35 @@
         11,
         3
       ],
-      "swarm": "387fffffffffffff"
+      "swarm": "87ffffffffffffff"
     },
     {
-      "public_ip": "46.254.214.27",
-      "storage_port": 22150,
+      "public_ip": "46.254.214.39",
+      "storage_port": 22130,
       "pubkey_ed25519": "e873fd9b8259dc297f962124cb16e367d82394b974fb1f6e90d9c6473d1c5494",
       "pubkey_x25519": "26ec3afa773d7d46aaddd99e919732d957f7e19d901f1c9b0a663d04f82eb236",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20250,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "dbffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22104,
-      "pubkey_ed25519": "e88c6085304d07610d4e7cb70f4d5ff4241c5363d62fc316c64ba01aae063bbd",
-      "pubkey_x25519": "a3db808b57f022a30fca992cb021599c8ac81dd6ee1fa7155cb65007f551fc56",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
+      "storage_lmq_port": 20230,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "77fffffffffffff"
     },
     {
-      "public_ip": "164.68.113.145",
+      "public_ip": "161.97.98.159",
       "storage_port": 22021,
-      "pubkey_ed25519": "e89ecaceb83c158ce2f962024c6eaeeb26ea5f97c6a09f65eb33828c19e13b45",
-      "pubkey_x25519": "6cea696149fc8d54f5068bf8c3bcb9d2f6064b19015e846d7657e44e994f0277",
-      "requested_unlock_height": 0,
+      "pubkey_ed25519": "e89f36f4da67024366d7a0d1ff7122cbb1d08af442e8a6122dae91c6289ebdd2",
+      "pubkey_x25519": "c053849af98f4e1c5ea3659112b62ee4ed4a2ade39cafa6a63766f08b0863e43",
+      "requested_unlock_height": 2161744,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
-      ],
-      "swarm": "6effffffffffffff"
-    },
-    {
-      "public_ip": "172.93.167.217",
-      "storage_port": 22100,
-      "pubkey_ed25519": "e89f36f4da67024366d7a0d1ff7122cbb1d08af442e8a6122dae91c6289ebdd2",
-      "pubkey_x25519": "c053849af98f4e1c5ea3659112b62ee4ed4a2ade39cafa6a63766f08b0863e43",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "207fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22105,
-      "pubkey_ed25519": "e8c7889976e8dfc1106fa672a28cec6fcb08ad5edc3391c63edfc6da45d11794",
-      "pubkey_x25519": "093b607580be6071205c021daaa92fae2e960b5bf9da2a6cf1ea79f6b7fd1c55",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
         3
       ],
-      "swarm": "3bffffffffffffff"
+      "swarm": "aeffffffffffffff"
     },
     {
       "public_ip": "167.99.32.79",
@@ -20088,21 +13284,7 @@
         11,
         0
       ],
-      "swarm": "98ffffffffffffff"
-    },
-    {
-      "public_ip": "107.175.74.23",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e95eada37853f449a448fde3d190422c8401108c51477000a692b91821df5c0c",
-      "pubkey_x25519": "a136e8e9d3580863f4eb4fd3468e7d89059cb51ea396f3444abbf6dcc273a528",
-      "requested_unlock_height": 2084488,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2dffffffffffffff"
+      "swarm": "50ffffffffffffff"
     },
     {
       "public_ip": "199.195.250.36",
@@ -20116,35 +13298,7 @@
         11,
         3
       ],
-      "swarm": "37ffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22115,
-      "pubkey_ed25519": "e9742d07c92944862499d8d7a9f863e5804f8cf557213686cc3f9ac24996fa3e",
-      "pubkey_x25519": "1a2f590c9a075b63a21e35720f04010216d141dee5936c9645502c71e99bc478",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "deffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.170",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e9a65df172ef366752bd6ba29dcfbcbc35bed13feb1ebe070917f68c0f3604ef",
-      "pubkey_x25519": "3eb04ee15b3001025951efddc25211a2f7817827624e3c587505e8f44f73f434",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "6effffffffffffff"
+      "swarm": "ffffffffffffff"
     },
     {
       "public_ip": "198.98.51.211",
@@ -20158,21 +13312,7 @@
         11,
         3
       ],
-      "swarm": "97ffffffffffffff"
-    },
-    {
-      "public_ip": "67.217.247.11",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e9bbe9fecb2366287b68b10df9f447b9cfbae48fa8182e45ed7116d59a6c7113",
-      "pubkey_x25519": "21d5b1b0280726e1c27db2d2eeb10a7e91cc0a7a7fc9b0ad2b3236236af97474",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "51ffffffffffffff"
+      "swarm": "dfffffffffffffff"
     },
     {
       "public_ip": "51.81.209.45",
@@ -20186,21 +13326,7 @@
         11,
         3
       ],
-      "swarm": "2effffffffffffff"
-    },
-    {
-      "public_ip": "103.146.222.77",
-      "storage_port": 22021,
-      "pubkey_ed25519": "e9ea4c8afcbe0157ebf2a46fae481788f2f990b35737971fca8ddae6bec2bae8",
-      "pubkey_x25519": "a29630c1ae8b26c24f90785bc968145ae583825d677e0e01bcd1586a055b3e51",
-      "requested_unlock_height": 2085135,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "5fffffffffffffff"
+      "swarm": "e4ffffffffffffff"
     },
     {
       "public_ip": "45.33.57.47",
@@ -20215,20 +13341,6 @@
         0
       ],
       "swarm": "f1ffffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22111,
-      "pubkey_ed25519": "eb078d0159c73da11df1548a9e6bb067f4b5789e74c56e0e2815635253431e95",
-      "pubkey_x25519": "79845e419ce208c23a8c64ec3c37584e93b87ed52be262f7a99c68309bea927e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "f0ffffffffffffff"
     },
     {
       "public_ip": "107.189.28.98",
@@ -20256,7 +13368,21 @@
         11,
         0
       ],
-      "swarm": "8ffffffffffffff"
+      "swarm": "9effffffffffffff"
+    },
+    {
+      "public_ip": "95.217.218.66",
+      "storage_port": 22104,
+      "pubkey_ed25519": "eb6f9608fbfb113d86af148521b31fb7f1189da26be18da590d072075623e9e3",
+      "pubkey_x25519": "71df8e957fd88b1b08991c604888b632e059661a9fd0b5ddac848cffdc080071",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22404,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "45ffffffffffffff"
     },
     {
       "public_ip": "198.98.55.67",
@@ -20284,7 +13410,7 @@
         11,
         3
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "a1ffffffffffffff"
     },
     {
       "public_ip": "89.58.27.224",
@@ -20298,7 +13424,7 @@
         11,
         2
       ],
-      "swarm": "cbffffffffffffff"
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "209.97.175.53",
@@ -20310,9 +13436,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "ccffffffffffffff"
+      "swarm": "37ffffffffffffff"
     },
     {
       "public_ip": "209.141.52.82",
@@ -20326,21 +13452,7 @@
         11,
         3
       ],
-      "swarm": "a7fffffffffffff"
-    },
-    {
-      "public_ip": "154.26.159.141",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ec47ee2e60a73fe0b13db04c507f0e28799f2c9ace808790444cded77514c79e",
-      "pubkey_x25519": "91e253463d918fac8c93be935863525bd936a36e4031a066d30e1afe5641a066",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "fbffffffffffffff"
+      "swarm": "c7fffffffffffff"
     },
     {
       "public_ip": "172.93.167.229",
@@ -20357,116 +13469,18 @@
       "swarm": "d0ffffffffffffff"
     },
     {
-      "public_ip": "154.38.188.206",
+      "public_ip": "173.249.30.74",
       "storage_port": 22021,
-      "pubkey_ed25519": "ec6a4b84ba3fb62e35a5dd2df8383f77b03e0cc862afba6031b2fa97c72c6e3c",
-      "pubkey_x25519": "be80932a4df14e16a38b7375786ef520a1cb54cf5a6b879761f8f49476398b26",
+      "pubkey_ed25519": "ed1998622eab7d3dd70c98199396fcc93b4ab40590ec0fa661b8e28d2fa6e3d7",
+      "pubkey_x25519": "81cd52c954c59bb8e562072eb70cd07df140ea5e4f130a3921d91d2cfeeb551e",
       "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "4effffffffffffff"
-    },
-    {
-      "public_ip": "209.222.98.114",
-      "storage_port": 22100,
-      "pubkey_ed25519": "ec6e2c3e74ce5d95d2697923641adfb71faae5bfce79416021a4d43c6091c426",
-      "pubkey_x25519": "88792b56a861aa71e0cb2b2b159224603454d9f7a4407006f3a60451f9e42b24",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "13ffffffffffffff"
-    },
-    {
-      "public_ip": "206.221.184.74",
-      "storage_port": 22109,
-      "pubkey_ed25519": "ec86eab297c04a232a7e8a30341e60151dcee5ec4f3f8489250476b8a660bfa2",
-      "pubkey_x25519": "770182d8d1e9284fe50daa2bce3258cb0bc0b976eae9fa7a2d3aef0d6451c204",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20209,
       "storage_server_version": [
         2,
         11,
         3
-      ],
-      "swarm": "197fffffffffffff"
-    },
-    {
-      "public_ip": "194.61.28.228",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ec89e10c5888fbc3e09711f2b04db9a4f76c14f98a48406c3c794d86879b95a9",
-      "pubkey_x25519": "de256b8ebf75f92756ef6a37bb8f0e8283098fe255c9eb9cfeb4c426fbb0115a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "7fffffffffffffff"
-    },
-    {
-      "public_ip": "95.217.21.148",
-      "storage_port": 22101,
-      "pubkey_ed25519": "ed8a93c9516ecfcc1986616adf91eacb33e36239dcbe779b2ed2de75575aca8d",
-      "pubkey_x25519": "34e1fbde971a442bb4e7d117c236ba9c29b3cfe3b51ddc790677367c8803450a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22401,
-      "storage_server_version": [
-        2,
-        11,
-        0
       ],
       "swarm": "e7ffffffffffffff"
-    },
-    {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22114,
-      "pubkey_ed25519": "ed96f9db026ca5cdad31e1c21607bbc4d88e43c6e8da95645444bea6fa73df11",
-      "pubkey_x25519": "e64cd6cd78fc14870b6626a12d6b14c16dc7280a23840bb8e2094ed6d7491d71",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "477fffffffffffff"
-    },
-    {
-      "public_ip": "104.248.87.76",
-      "storage_port": 22021,
-      "pubkey_ed25519": "edf3cecaef192da0e0c4360b81fe1a16b55be3ca7e9ac37112950b9d26753e5d",
-      "pubkey_x25519": "ff0381d5510485bac05d560d739665f84b63dbb64e6f0200eeee7ccefb577275",
-      "requested_unlock_height": 2094233,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "99ffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.98.135",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ee2b833abf4edae2112a124087e7b269f7e8f741d6e3920a2f1bb969f45dcf7f",
-      "pubkey_x25519": "010c45545333eef36cf74320f84bcafa87bbb04f8d6f7037d91e845155f72b4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "287fffffffffffff"
     },
     {
       "public_ip": "107.189.1.148",
@@ -20480,7 +13494,21 @@
         11,
         2
       ],
-      "swarm": "387fffffffffffff"
+      "swarm": "b2ffffffffffffff"
+    },
+    {
+      "public_ip": "46.254.214.39",
+      "storage_port": 22170,
+      "pubkey_ed25519": "ee7cf7e36c271732eb612a94483b8e9c83d02b0193e5c2ba3264daa8a5179d8e",
+      "pubkey_x25519": "171b3b67b53f7495fd9cfc0b93e9b22c0778b3189251171b8647b821cc973029",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20270,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "bfffffffffffffff"
     },
     {
       "public_ip": "205.185.120.200",
@@ -20494,21 +13522,21 @@
         11,
         3
       ],
-      "swarm": "86ffffffffffffff"
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "23.19.230.174",
       "storage_port": 22021,
       "pubkey_ed25519": "eebf79d43b94a520fdb58de202ab41ccc76b48eac7a9b3347d4a4f47d0287177",
       "pubkey_x25519": "c5a3ff2e53f18e1fb33713488b44b85f9f2e3d597dafb8ca64ec365f0bec4236",
-      "requested_unlock_height": 2084498,
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "13ffffffffffffff"
+      "swarm": "abffffffffffffff"
     },
     {
       "public_ip": "209.141.50.48",
@@ -20522,7 +13550,7 @@
         11,
         3
       ],
-      "swarm": "deffffffffffffff"
+      "swarm": "80ffffffffffffff"
     },
     {
       "public_ip": "209.141.54.13",
@@ -20536,21 +13564,7 @@
         11,
         3
       ],
-      "swarm": "4bffffffffffffff"
-    },
-    {
-      "public_ip": "199.127.62.234",
-      "storage_port": 22118,
-      "pubkey_ed25519": "ef23b6e3b6fd78b1a2952c812d34ff47268b57121b4a697f03824234ea4fa649",
-      "pubkey_x25519": "a76945ea78acc6c11f9489f33a5d3954a6a6e86e1149237fbab853dd36994703",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20218,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "c4ffffffffffffff"
     },
     {
       "public_ip": "217.216.86.165",
@@ -20567,6 +13581,20 @@
       "swarm": "65ffffffffffffff"
     },
     {
+      "public_ip": "129.159.125.192",
+      "storage_port": 22102,
+      "pubkey_ed25519": "ef46e7e0a0dfee041feebc00cc84f650ae5cd57c8a1230b5f122134f0d68513c",
+      "pubkey_x25519": "1248f654dd17d5f4dd10db8005a273f727042c3564a608d7799cc793875d7d19",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 20202,
+      "storage_server_version": [
+        2,
+        11,
+        3
+      ],
+      "swarm": "477fffffffffffff"
+    },
+    {
       "public_ip": "109.123.240.83",
       "storage_port": 22021,
       "pubkey_ed25519": "ef51d4a475670a4e71e125fa4d7315c51925356395eca529f3193119d6c7d4cd",
@@ -20576,23 +13604,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "1d7fffffffffffff"
-    },
-    {
-      "public_ip": "193.160.96.238",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ef79ee74a68130282865be957158ab54b602508045ce9120af43262d168bff62",
-      "pubkey_x25519": "964e2d9a901319f47398cdf2dcf8f0b127f0ba2ba09aa29ad4495d649e90a851",
-      "requested_unlock_height": 2085896,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "e9ffffffffffffff"
+      "swarm": "8affffffffffffff"
     },
     {
       "public_ip": "57.129.102.67",
@@ -20605,48 +13619,6 @@
         2,
         11,
         2
-      ],
-      "swarm": "e7fffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.112",
-      "storage_port": 22107,
-      "pubkey_ed25519": "efbf1a56df9f7aec0bb411285f2ce1f927079d38033d775694a9039bed9924dd",
-      "pubkey_x25519": "8316322d124d69757968107110ee807d2819c7c411d8f829672b3521be752c24",
-      "requested_unlock_height": 2090303,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2a7fffffffffffff"
-    },
-    {
-      "public_ip": "144.91.77.9",
-      "storage_port": 22021,
-      "pubkey_ed25519": "efc8d1c0cc2ef97bafc210dc2bdc6bed4cbe0435cbf365ce8f3083c4b0b87dd7",
-      "pubkey_x25519": "6036c72b6ab909b83bad43c80cbb6cbab9a43edaaf29256340a5fd07573b1a4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "13ffffffffffffff"
-    },
-    {
-      "public_ip": "144.91.76.126",
-      "storage_port": 22021,
-      "pubkey_ed25519": "efd13cd61671588c11841414563cd2d467888543047b6e2d893211ec96ad96ea",
-      "pubkey_x25519": "ae300831d1cc08700797be71ffc65eab92ce13f9a9ef29386a78895599980d4e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
       ],
       "swarm": "e7fffffffffffff"
     },
@@ -20676,21 +13648,7 @@
         11,
         2
       ],
-      "swarm": "1bffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.101.217",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f112e19a5b0d77cbd3b33a682fea3aac5c446a209423ec0c6d794e61bc616cd6",
-      "pubkey_x25519": "ce818b001c840e0c3bd06506dc945bca4db701a2d5d3368f774c93568b3a2028",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a5ffffffffffffff"
+      "swarm": "79ffffffffffffff"
     },
     {
       "public_ip": "205.185.113.44",
@@ -20718,21 +13676,7 @@
         11,
         3
       ],
-      "swarm": "f6ffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22114,
-      "pubkey_ed25519": "f18373cba32a1e33b569623f94161d7f9a9c666ad6723fa59aab8a72d5b5d0e8",
-      "pubkey_x25519": "27b9c26f37094b3f8ef4ed81afd72143bb77b4d8ebf0bd3d86bfffe15f81396e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "39ffffffffffffff"
+      "swarm": "22ffffffffffffff"
     },
     {
       "public_ip": "91.99.120.185",
@@ -20746,21 +13690,7 @@
         11,
         3
       ],
-      "swarm": "a6ffffffffffffff"
-    },
-    {
-      "public_ip": "152.53.139.17",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f1f9bee0ade678cdbe8f969e8a44c0d9f6677d172f0e4aaf1d73718c25d88136",
-      "pubkey_x25519": "cf094e210af7afb114ecff72c89aeefd95d271d7ca97c512057bb4d4e51ebb54",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "45ffffffffffffff"
+      "swarm": "c5ffffffffffffff"
     },
     {
       "public_ip": "202.61.195.129",
@@ -20774,7 +13704,7 @@
         11,
         3
       ],
-      "swarm": "207fffffffffffff"
+      "swarm": "83ffffffffffffff"
     },
     {
       "public_ip": "65.109.140.246",
@@ -20788,21 +13718,7 @@
         11,
         0
       ],
-      "swarm": "42ffffffffffffff"
-    },
-    {
-      "public_ip": "46.101.15.115",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f24c36650f5d182e81353898611cfb78fb3ae5e4d52b095dce3a07205ddc7134",
-      "pubkey_x25519": "e1630d4bf173be5a6da803cc66ad94eb0b5704e5692e45f65649b8fae8902762",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "a2ffffffffffffff"
+      "swarm": "87ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -20816,21 +13732,21 @@
         11,
         3
       ],
-      "swarm": "73ffffffffffffff"
+      "swarm": "e6ffffffffffffff"
     },
     {
-      "public_ip": "46.254.214.27",
-      "storage_port": 22180,
+      "public_ip": "46.254.214.39",
+      "storage_port": 22140,
       "pubkey_ed25519": "f2f0c7ad98ad892ce804b9ad60605a207d412f18871a1729e76a3c208c0ce02e",
       "pubkey_x25519": "0e1cd648c9481ba0d88e381841fef6eb18c589a63878fd2df2bf9b2d75b9de6b",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20280,
+      "storage_lmq_port": 20240,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "19ffffffffffffff"
+      "swarm": "81ffffffffffffff"
     },
     {
       "public_ip": "95.216.32.189",
@@ -20844,21 +13760,7 @@
         11,
         3
       ],
-      "swarm": "3bffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.41.194",
-      "storage_port": 22111,
-      "pubkey_ed25519": "f32faf3217dcadc052d395461ac24dd5e45c1d605b2daedfc0023d49fa5033f6",
-      "pubkey_x25519": "64b293e2ac3d0b38863efd45b807c5ee454de15dd55aacce03ce8b00665ade5b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "3c7fffffffffffff"
+      "swarm": "90ffffffffffffff"
     },
     {
       "public_ip": "65.21.240.249",
@@ -20872,21 +13774,21 @@
         11,
         0
       ],
-      "swarm": "5dffffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22132,
-      "pubkey_ed25519": "f3809b208bdeb5eb0addb556451ede8b79aabbd675875341033e3d3378dd2f59",
-      "pubkey_x25519": "c31fa66744aae36a5a1c3d43df26bbb94efc1936a49f5f1b268faef87b8e5514",
+      "public_ip": "37.221.93.45",
+      "storage_port": 22021,
+      "pubkey_ed25519": "f373004c083f3e9cc99226e17f50e32719bcf8aa9cd96c6357c7a9148735d77f",
+      "pubkey_x25519": "d11880bef4afb92e72d0c17f63fb5e1961883a6110794aec7286436a5ad6a918",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20232,
+      "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        0
+        3
       ],
-      "swarm": "24ffffffffffffff"
+      "swarm": "51ffffffffffffff"
     },
     {
       "public_ip": "209.141.40.229",
@@ -20900,24 +13802,10 @@
         11,
         3
       ],
-      "swarm": "6cffffffffffffff"
+      "swarm": "edffffffffffffff"
     },
     {
-      "public_ip": "164.68.126.243",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f43964325ae9452b6ca6f01a6be6d344adc5cf82deb2ac1045e28d00b6366fba",
-      "pubkey_x25519": "ad052ed8c0f890f8b6dfa58091cdb251d2650dda5492b2b872e5cfaa63483e5b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "207fffffffffffff"
-    },
-    {
-      "public_ip": "173.249.205.185",
+      "public_ip": "64.44.168.82",
       "storage_port": 22021,
       "pubkey_ed25519": "f4468e7b89d772cca2648f0fe3dd7b38aa9cd08850911f2b4ae053533bebbf58",
       "pubkey_x25519": "a794b64cf4b1f31cdaf5536e63173ecd1f454e896b93ffa4b1b3880a95120a2e",
@@ -20928,7 +13816,7 @@
         11,
         2
       ],
-      "swarm": "22ffffffffffffff"
+      "swarm": "2ffffffffffffff"
     },
     {
       "public_ip": "209.141.42.160",
@@ -20945,20 +13833,6 @@
       "swarm": "b4ffffffffffffff"
     },
     {
-      "public_ip": "157.173.201.190",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f542d10f3f21a3d22b371574e1c430bd939bbd35d198cb76adb1ca838bd1ac07",
-      "pubkey_x25519": "f334f5d620be66ec447c29d98a811689a94f13fd338aa022f92b675eace2a127",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "2d7fffffffffffff"
-    },
-    {
       "public_ip": "5.189.146.159",
       "storage_port": 22021,
       "pubkey_ed25519": "f5de277a6aa7f52dd7d87edcb99b0b4e38c7c7b03a441e84c067f38d89bdba9b",
@@ -20970,7 +13844,7 @@
         11,
         2
       ],
-      "swarm": "f4ffffffffffffff"
+      "swarm": "1bffffffffffffff"
     },
     {
       "public_ip": "152.53.225.64",
@@ -20998,7 +13872,7 @@
         11,
         3
       ],
-      "swarm": "7ffffffffffffff"
+      "swarm": "5dffffffffffffff"
     },
     {
       "public_ip": "116.203.146.221",
@@ -21012,7 +13886,7 @@
         11,
         0
       ],
-      "swarm": "9fffffffffffffff"
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "89.58.39.31",
@@ -21024,9 +13898,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "2dffffffffffffff"
+      "swarm": "7effffffffffffff"
     },
     {
       "public_ip": "51.81.84.242",
@@ -21040,21 +13914,7 @@
         11,
         2
       ],
-      "swarm": "8fffffffffffffff"
-    },
-    {
-      "public_ip": "164.68.113.43",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f6e2f1ec801b0d39cfc61acd43dc3314024ae1837c00fad2c899ea64be5c0363",
-      "pubkey_x25519": "f25f5732437af35f363a6b08faa9fa45b96f999c8566505158176723cc998777",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "3fffffffffffffff"
+      "swarm": "13ffffffffffffff"
     },
     {
       "public_ip": "104.244.76.155",
@@ -21089,14 +13949,14 @@
       "storage_port": 22106,
       "pubkey_ed25519": "f70b16935cce36a78a3db75ba6656666e9ba48adc5fa39d1c01e7e0943f5ae31",
       "pubkey_x25519": "186bc491a4d3847ea1c863d3940c60e44968d5a13be21c6a925a38272f820515",
-      "requested_unlock_height": 0,
+      "requested_unlock_height": 2169393,
       "storage_lmq_port": 22406,
       "storage_server_version": [
         2,
         11,
         0
       ],
-      "swarm": "ddffffffffffffff"
+      "swarm": "b8ffffffffffffff"
     },
     {
       "public_ip": "91.98.69.235",
@@ -21124,35 +13984,7 @@
         11,
         2
       ],
-      "swarm": "e4ffffffffffffff"
-    },
-    {
-      "public_ip": "95.217.21.148",
-      "storage_port": 22108,
-      "pubkey_ed25519": "f7a2c41bc399f82202bd37b18345e579a9c2c5757329b6d97db4ccf58e7ae005",
-      "pubkey_x25519": "adde02e31973bd81d4539886f40a92a99a3af74157159728e4c51221d4729860",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22408,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "cbffffffffffffff"
-    },
-    {
-      "public_ip": "167.114.156.20",
-      "storage_port": 22107,
-      "pubkey_ed25519": "f7b08bcdb32bd77e004e63786c208fbf5c10676d372b3b41e02a5395fdb2dca5",
-      "pubkey_x25519": "fda7556dc5fe0ac59bfa9ba737557fc8aae717061878bcddec55f4b5c1fc271b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "22ffffffffffffff"
+      "swarm": "24ffffffffffffff"
     },
     {
       "public_ip": "107.189.12.72",
@@ -21180,7 +14012,7 @@
         11,
         3
       ],
-      "swarm": "f2ffffffffffffff"
+      "swarm": "fdffffffffffffff"
     },
     {
       "public_ip": "51.81.241.138",
@@ -21194,7 +14026,7 @@
         11,
         3
       ],
-      "swarm": "ccffffffffffffff"
+      "swarm": "187fffffffffffff"
     },
     {
       "public_ip": "157.180.33.180",
@@ -21208,7 +14040,7 @@
         11,
         3
       ],
-      "swarm": "54ffffffffffffff"
+      "swarm": "5affffffffffffff"
     },
     {
       "public_ip": "45.79.84.176",
@@ -21222,7 +14054,7 @@
         11,
         0
       ],
-      "swarm": "37fffffffffffff"
+      "swarm": "e2ffffffffffffff"
     },
     {
       "public_ip": "83.136.209.69",
@@ -21239,20 +14071,6 @@
       "swarm": "19ffffffffffffff"
     },
     {
-      "public_ip": "193.22.147.69",
-      "storage_port": 22021,
-      "pubkey_ed25519": "f8f02a167d3b291fbcf8ec72b9a98dca06973009be0f0fc1caa5ea8f07b7560e",
-      "pubkey_x25519": "bc54576d3b968a0812f4555423b16b71abd4ab37e849206ba03dc885d821b11a",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        0
-      ],
-      "swarm": "d7fffffffffffff"
-    },
-    {
       "public_ip": "107.189.3.58",
       "storage_port": 22021,
       "pubkey_ed25519": "f92c938fd525c1950dc89e6949327b96fcbcfc5eca265d38a9881d850d4fb98f",
@@ -21264,7 +14082,7 @@
         11,
         2
       ],
-      "swarm": "fdffffffffffffff"
+      "swarm": "6fffffffffffffff"
     },
     {
       "public_ip": "216.22.27.30",
@@ -21278,21 +14096,21 @@
         11,
         3
       ],
-      "swarm": "c9ffffffffffffff"
+      "swarm": "67fffffffffffff"
     },
     {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22114,
-      "pubkey_ed25519": "f9c5b2fb1e5684bef1e46ff03df49a67fde22ad2e1dd8fde4f510c000c34559f",
-      "pubkey_x25519": "308b9b6747021a066427476ea38866696849f13658dfaf8ce936665cb2404c2d",
+      "public_ip": "95.217.218.66",
+      "storage_port": 22100,
+      "pubkey_ed25519": "f9c54678a4320c972a6e0be862d0c6be88809b44b427d3b21d19fe57d2efed33",
+      "pubkey_x25519": "cd3674c0e0b91c882caf2a0ec552f7a397bfac523f8257483a2c3c50ab98372f",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
+      "storage_lmq_port": 22400,
       "storage_server_version": [
         2,
         11,
-        2
+        0
       ],
-      "swarm": "73ffffffffffffff"
+      "swarm": "48ffffffffffffff"
     },
     {
       "public_ip": "45.153.187.108",
@@ -21306,35 +14124,21 @@
         11,
         2
       ],
-      "swarm": "c8ffffffffffffff"
+      "swarm": "c9ffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.68",
-      "storage_port": 22111,
-      "pubkey_ed25519": "fa3e6151f161e88f711e695df4f5929572767459961a6c5f83fa0d0cc6110435",
-      "pubkey_x25519": "e1740fa7781dfa75894d7267b909b95aa753493ac1497f8bc3728235f2b06e26",
-      "requested_unlock_height": 2093820,
-      "storage_lmq_port": 20211,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "81ffffffffffffff"
-    },
-    {
-      "public_ip": "107.182.173.179",
-      "storage_port": 22100,
+      "public_ip": "161.97.98.159",
+      "storage_port": 22101,
       "pubkey_ed25519": "fa7eab86baaad11f5dca206ee19c78e265650d1eb1bc0d815eacc07728f20990",
       "pubkey_x25519": "eb0cb8fa7ab2272c3572146ab5215d4eaf647afecb40f1a3d8a81bf7092c523e",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
+      "requested_unlock_height": 2161745,
+      "storage_lmq_port": 20201,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "9ffffffffffffff"
+      "swarm": "27ffffffffffffff"
     },
     {
       "public_ip": "23.80.81.187",
@@ -21348,7 +14152,7 @@
         11,
         3
       ],
-      "swarm": "a8ffffffffffffff"
+      "swarm": "efffffffffffffff"
     },
     {
       "public_ip": "88.198.244.201",
@@ -21365,6 +14169,20 @@
       "swarm": "d4ffffffffffffff"
     },
     {
+      "public_ip": "135.181.105.205",
+      "storage_port": 22109,
+      "pubkey_ed25519": "fad64d97bddfabb1c21d72f003a8267e5f11a55637499bb6245caeede0b896f3",
+      "pubkey_x25519": "3d3657fbd31c29681f99780ca9dee810f65203b0992e953667dabcdad0dce803",
+      "requested_unlock_height": 0,
+      "storage_lmq_port": 22409,
+      "storage_server_version": [
+        2,
+        11,
+        0
+      ],
+      "swarm": "c9ffffffffffffff"
+    },
+    {
       "public_ip": "152.53.162.123",
       "storage_port": 22021,
       "pubkey_ed25519": "faf7e163435709ced1aeb57066c8d8a178a18ebdf55ca5d76a78e846befa2365",
@@ -21374,65 +14192,37 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "48ffffffffffffff"
+      "swarm": "e7fffffffffffff"
     },
     {
-      "public_ip": "46.254.214.27",
-      "storage_port": 22110,
+      "public_ip": "46.254.214.39",
+      "storage_port": 22120,
       "pubkey_ed25519": "fb27c6fc9188b02fa99e0dd46e98905e91933e2b04b394fae75c8cb83a851477",
       "pubkey_x25519": "4bca85fbacc7424223a0cb5a62d247a2c5ca0aea6f9f1c6e12bb7927726a1904",
       "requested_unlock_height": 0,
-      "storage_lmq_port": 20210,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "247fffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22101,
-      "pubkey_ed25519": "fbb9ec83a4770b847926f532b131fdd4ab364ecf2f0784c3e0e43a9fdf0f09d5",
-      "pubkey_x25519": "e937804d651602dbc7d4d5b1307e15f91b138b2390eec9b20eb1f9c3e90be649",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20201,
+      "storage_lmq_port": 20220,
       "storage_server_version": [
         2,
         11,
         3
       ],
-      "swarm": "8fffffffffffffff"
+      "swarm": "3dffffffffffffff"
     },
     {
-      "public_ip": "64.44.157.64",
+      "public_ip": "37.60.226.177",
       "storage_port": 22021,
-      "pubkey_ed25519": "fc1890b2602949d9d2587688a05aa435ff8f65ebb118f903be95fb326c67659d",
-      "pubkey_x25519": "17b5dc154af3584019128ad27f9db00161efa411f01cd827f82a31567fd6c145",
-      "requested_unlock_height": 2085236,
+      "pubkey_ed25519": "fc3b21a8430a30a51a22755977ac4544a82e10a7344f3d0828784d13527a7492",
+      "pubkey_x25519": "4c9badb5d90370da87c8d3c55e4fa22e33c2a5cff25dbe430b280f5683925b06",
+      "requested_unlock_height": 0,
       "storage_lmq_port": 22020,
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "d8ffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.34.25",
-      "storage_port": 22107,
-      "pubkey_ed25519": "fc3043fed6350b2c2da2e70243eb6a08a0cd1a61ec97b31707b7216e9da65bc8",
-      "pubkey_x25519": "f15f1535739b035618b3d53c563ab1d312a51c818906dc51286a2052743a3411",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20207,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "ecffffffffffffff"
+      "swarm": "36ffffffffffffff"
     },
     {
       "public_ip": "142.91.105.130",
@@ -21463,34 +14253,6 @@
       "swarm": "1bffffffffffffff"
     },
     {
-      "public_ip": "185.150.191.47",
-      "storage_port": 22115,
-      "pubkey_ed25519": "fc9f51ffa5c70885049c278805339c44dc164bfda5301e5de33c9cb7215d94ff",
-      "pubkey_x25519": "139d3c3424086919ae809f567acd5fd8aa9fb9c14150054e94d4269605a96119",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20215,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "b9ffffffffffffff"
-    },
-    {
-      "public_ip": "38.45.65.93",
-      "storage_port": 22021,
-      "pubkey_ed25519": "fcbcd7644525b776d34ea295ca48927431ac3e07edb4c3e969af4f1bf1a0dc18",
-      "pubkey_x25519": "703727ccf46b1025793bbd9a93415dc406c0778270572c1bdb51a39113f8ef5e",
-      "requested_unlock_height": 2085136,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "337fffffffffffff"
-    },
-    {
       "public_ip": "45.33.32.101",
       "storage_port": 22021,
       "pubkey_ed25519": "fd3754c38a7b291de9d1210bc74480149548deec8109e4860cc60a98b53c60a5",
@@ -21502,52 +14264,10 @@
         11,
         0
       ],
-      "swarm": "387fffffffffffff"
+      "swarm": "acffffffffffffff"
     },
     {
-      "public_ip": "102.208.228.249",
-      "storage_port": 22100,
-      "pubkey_ed25519": "fe5abebdb75955b38348b62b444e6782f6e47a8352c17eb02c736e6029703479",
-      "pubkey_x25519": "6fe061c926d995b251b86a4f9df7e7f5c677b49915f57c1c5f81d0d907ff810d",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20200,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d9ffffffffffffff"
-    },
-    {
-      "public_ip": "104.233.210.13",
-      "storage_port": 22021,
-      "pubkey_ed25519": "fe67e78ae24cb6cccbaa1e5b1282ca95d2a7447bf61a3e97cb4ad974d60c6631",
-      "pubkey_x25519": "c2fbade0f4d54c6a216a2b0a9bbb167471e61a150dbfebe281ed451260010a0c",
-      "requested_unlock_height": 2088902,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "2dffffffffffffff"
-    },
-    {
-      "public_ip": "104.243.32.47",
-      "storage_port": 22114,
-      "pubkey_ed25519": "fe90be150c2af2db6dd8242f20014b09d622018960ad77f860c65ed6e733b947",
-      "pubkey_x25519": "37e3eaf94a8860a232fcc604c6fe3e1719e64e1a33dc62372e035761d96f1d4b",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20214,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "30ffffffffffffff"
-    },
-    {
-      "public_ip": "46.254.214.27",
+      "public_ip": "46.254.214.39",
       "storage_port": 22160,
       "pubkey_ed25519": "fee1bf596b651f08b61f3ace292fc8a371f17ec61e87c5ab5e1a1715546a1e6e",
       "pubkey_x25519": "6dc54d864e1d6972dc9b6c00f8656a3c65eb11224faa0c95171a26ddb7d4a35a",
@@ -21556,23 +14276,9 @@
       "storage_server_version": [
         2,
         11,
-        2
+        3
       ],
-      "swarm": "8bffffffffffffff"
-    },
-    {
-      "public_ip": "57.129.77.227",
-      "storage_port": 22021,
-      "pubkey_ed25519": "fef9ff4ba7b61d26749c8421442edd0d7c44bc16985449af3206c177d0001b83",
-      "pubkey_x25519": "c13f4da96bb375bebf2c5a253def6996ae98305144bdaf6504ebd5614f082d3c",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "d7fffffffffffff"
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "141.105.130.210",
@@ -21586,7 +14292,7 @@
         11,
         3
       ],
-      "swarm": "90ffffffffffffff"
+      "swarm": "7cffffffffffffff"
     },
     {
       "public_ip": "45.145.43.202",
@@ -21600,7 +14306,7 @@
         11,
         2
       ],
-      "swarm": "97ffffffffffffff"
+      "swarm": "32ffffffffffffff"
     },
     {
       "public_ip": "154.12.246.164",
@@ -21614,7 +14320,7 @@
         11,
         3
       ],
-      "swarm": "63ffffffffffffff"
+      "swarm": "aaffffffffffffff"
     },
     {
       "public_ip": "146.71.85.145",
@@ -21631,34 +14337,6 @@
       "swarm": "257fffffffffffff"
     },
     {
-      "public_ip": "185.187.170.128",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ffa2f50dc5f741f9a53cf4677faee365a02110152f01dec20a3747c188a69bc6",
-      "pubkey_x25519": "8900619c8fad516966341d949b93ef687e4b7205c82f7302572b17f4216efd77",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        1
-      ],
-      "swarm": "437fffffffffffff"
-    },
-    {
-      "public_ip": "31.22.111.20",
-      "storage_port": 22021,
-      "pubkey_ed25519": "ffafecd0441a56f7e0f2b6c0771bb10c8c0aa2fbe4b03c9850b19bed2b0b262f",
-      "pubkey_x25519": "c14d53836199af7f96257f005881e4ee4f9b4f0e3af78a976007317ada88be5b",
-      "requested_unlock_height": 2085155,
-      "storage_lmq_port": 22020,
-      "storage_server_version": [
-        2,
-        11,
-        2
-      ],
-      "swarm": "68ffffffffffffff"
-    },
-    {
       "public_ip": "159.223.228.183",
       "storage_port": 22021,
       "pubkey_ed25519": "ffb0cda81436b75ae414f1e18d1ce9f0c324d347f851f7b4b8e1210abf555c71",
@@ -21670,21 +14348,7 @@
         11,
         0
       ],
-      "swarm": "8effffffffffffff"
-    },
-    {
-      "public_ip": "185.150.189.71",
-      "storage_port": 22108,
-      "pubkey_ed25519": "ffea0e92981b38c84d299e543f1de59a7608312383798e09120c6a944a633b80",
-      "pubkey_x25519": "da1ff5f78329166ac5d887ea9274dac4de5b20aba769727c4668794c4bd60974",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20208,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "eeffffffffffffff"
+      "swarm": "faffffffffffffff"
     },
     {
       "public_ip": "57.128.22.91",
@@ -21698,50 +14362,8 @@
         11,
         1
       ],
-      "swarm": "76ffffffffffffff"
-    },
-    {
-      "public_ip": "157.180.47.65",
-      "storage_port": 22103,
-      "pubkey_ed25519": "ffffff35508bc999ae402872804528ec4754314717851723207ab99dfa0f9003",
-      "pubkey_x25519": "584341c05e52efa57b6273277262197df09d4acdcf0bebf993389ab0de494169",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20203,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "327fffffffffffff"
-    },
-    {
-      "public_ip": "157.180.47.65",
-      "storage_port": 22105,
-      "pubkey_ed25519": "ffffffb52245fb47b3a286db09db28d3e75bdf2d18e3418b9fbaa8c71ea73005",
-      "pubkey_x25519": "67b03f1dcd5d0515532d08eeec0c11eb54a262c41f3db4439ce2b45f9eba0013",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20205,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "6bffffffffffffff"
-    },
-    {
-      "public_ip": "157.180.47.65",
-      "storage_port": 22104,
-      "pubkey_ed25519": "fffffff2e7dc9e1560794ae34f2b93f5f258be196338ad63b008542107ea6604",
-      "pubkey_x25519": "8836d27806e54a8b45b3f2710d9ae2638e1c99408ee65ebd35aa433d636e4279",
-      "requested_unlock_height": 0,
-      "storage_lmq_port": 20204,
-      "storage_server_version": [
-        2,
-        11,
-        3
-      ],
-      "swarm": "a7fffffffffffff"
+      "swarm": "3bffffffffffffff"
     }
   ],
-  "height": 2084231
+  "height": 2159841
 }


### PR DESCRIPTION
[Automated]
This PR updates the static service node list which is used as a fallback when a new client is unable to contact the seed nodes