### PR TITLE
Add TestFlight release script suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ DerivedData
 *.xcuserstate
 Index/
 
+# Release credentials (never commit)
+.env
+*.p8
+*.p12
+
 # CocoaPods
 Pods
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,163 @@
+# Releasing Session iOS
+
+A small suite of scripts under `Scripts/` builds a distribution IPA and submits it to
+TestFlight without opening Xcode. They run locally (a maintainer just runs them) and are
+CI-ready (all credentials come from environment variables). No Fastlane.
+
+## Prerequisites
+
+- Xcode + command-line tools, `xcbeautify`, and the GitHub CLI (`gh`, authenticated).
+- An **App Store Connect API key** (`.p8`) — see below. For cloud signing it must be an
+  **Admin Team Key** (an Individual key, or an App Manager key, will not work).
+
+Signing uses **cloud-managed certificates** (the default when a team sets signing up through
+Xcode — Apple holds the distribution private key). With the Admin API key and
+`-allowProvisioningUpdates`, `xcodebuild` cloud-signs the distribution build without any
+local certificate. **You do not need to create or export a `.p12`.** Providing one is only a
+fallback for teams not using cloud-managed signing (see the last section).
+
+## Obtaining credentials
+
+### App Store Connect API key
+Create it in App Store Connect → **Users and Access → Integrations**. Two requirements,
+both confirmed necessary in practice for the cloud-signed release:
+
+- It must be a **Team Key** (the "Team Keys" tab), **not an Individual Key**. An Individual
+  key — even one owned by an Admin user — was rejected for cloud signing (export failed with
+  `Cloud signing permission error` and xcodebuild fell back to a local Apple ID account).
+- The key must have the **Admin** role. App Manager is not sufficient for cloud signing /
+  distribution-certificate operations (same `Cloud signing permission error`). App Manager is
+  only enough if you sign with a local `.p12` (see the fallback section).
+
+Then **Download** the `.p8` (only downloadable once). Note the **Key ID** (10 chars) and the
+**Issuer ID** (UUID) shown on that page.
+- Apple: [Creating API keys for the App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api)
+- Apple: [App Store Connect API — Get started](https://developer.apple.com/help/app-store-connect/get-started/app-store-connect-api/)
+
+### Cloud-managed signing certificate
+Nothing to export — it is managed remotely by Apple and used automatically during the
+cloud-signed archive/export. Background:
+- Apple: [Cloud-managed certificates](https://developer.apple.com/help/account/certificates/cloud-managed-certificates/)
+- WWDC21: [Distribute apps in Xcode with cloud signing](https://developer.apple.com/videos/play/wwdc2021/10204/)
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `ASC_KEY_ID` | 10-char App Store Connect API key ID |
+| `ASC_ISSUER_ID` | App Store Connect issuer UUID |
+| `ASC_KEY_P8_BASE64` | base64 of the `.p8` private key |
+| `SKIP_KEYCHAIN=1` | **use cloud-managed signing** — no local certificate/keychain. This is the normal path for this project. |
+| `ASC_DIST_CERT_P12_BASE64` | *(fallback only)* base64 of an Apple Distribution `.p12` (incl. private key) |
+| `ASC_DIST_CERT_PASSWORD` | *(fallback only)* the `.p12` export password |
+| `KEYCHAIN_PASSWORD` | *(fallback only, optional)* temp-keychain password (generated if unset) |
+
+To base64-encode the key:
+
+```sh
+base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy   # -> ASC_KEY_P8_BASE64
+```
+
+All secrets are written to restricted temp locations and deleted on exit (success,
+failure, or Ctrl-C) by a trap in `Scripts/release_env.sh`.
+
+## How versioning fits the branch model
+
+Version numbers live at the **project level** in `project.pbxproj` (inherited by the app +
+extension targets). A version bump is a normal change that lands on **`dev`** and reaches
+**`master`** through the reviewed `dev → master` merge — the release scripts **never** change
+the version. Bumping is a separate step (`bump_version.sh`), and a release just reads whatever
+version is already on `master` and tags it.
+
+### Bumping the version (on dev)
+
+```sh
+Scripts/bump_version.sh 2.15.4        # optional 2nd arg sets the build number (default +1)
+```
+
+This branches off `dev`, bumps the project-level `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`,
+pushes, and opens a PR into `dev` for review. Once merged and promoted to `master`, release it.
+
+## Quick start (one command)
+
+```sh
+Scripts/release.sh          # reads the version already on master; add a version to sanity-check
+```
+
+`release.sh` orchestrates the release: it loads credentials from `.env` if present, prompts
+for anything missing (offering to save them), reads the version on `master`, checks the tag,
+prints a plan, and pauses before each outward-facing step. It runs:
+
+1. `prepare_github_release.sh` — create the tag + GitHub draft release on `master` (no version change)
+2. `build_release.sh --attach` — build, sign, export `session-<version>.ipa`, attach to the draft
+3. `testflight_upload.sh` — upload the IPA to TestFlight
+
+**Tag gating:** if `master`'s version has **no** tag yet, it creates the tag + draft and
+proceeds. If a tag for that version **already exists** (i.e. the version hasn't been bumped
+since the last release), it pauses so you can (1) re-check after merging a bump, (2) build and
+submit with the current version anyway, or (3) abort.
+
+Then it prints (and offers to open) the GitHub releases page and App Store Connect for the two
+remaining manual actions: publishing the GitHub release and managing/submitting in TestFlight.
+
+Useful flags: `-y/--yes` (no prompts, for CI), `--allow-existing-version` (build even if the
+tag exists), `--skip-upload`, `--skip-draft`. Env: `RELEASE_REMOTE` (default `origin`),
+`RELEASE_BRANCH` (default `master`). Run `Scripts/release.sh --help` for details.
+
+### Using a `.env`
+
+Put credentials in a `.env` at the repo root (git-ignored — never committed) so you don't
+re-enter them each time. First interactive run offers to create it for you. Format:
+
+```sh
+ASC_KEY_ID="XXXXXXXXXX"
+ASC_ISSUER_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+ASC_KEY_P8_BASE64="<base64 of AuthKey_XXXXXXXXXX.p8>"
+SKIP_KEYCHAIN=1
+```
+
+## Running the steps individually
+
+The orchestrator just calls these; run them directly if you need finer control. Credentials
+come from the environment or `.env` (`build_release.sh` and `testflight_upload.sh` auto-load
+`.env` via `release_env.sh`; set them explicitly if you're not using a `.env`):
+
+```sh
+export ASC_KEY_ID="XXXXXXXXXX"
+export ASC_ISSUER_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export ASC_KEY_P8_BASE64="$(base64 -i AuthKey_XXXXXXXXXX.p8)"
+export SKIP_KEYCHAIN=1
+
+Scripts/prepare_github_release.sh 2.15.4     # create tag + draft release on master
+Scripts/build_release.sh 2.15.4 --attach     # version defaults to the project's if omitted
+Scripts/testflight_upload.sh 2.15.4
+gh release edit 2.15.4 --draft=false          # publish the GitHub release when ready
+```
+
+Outputs:
+- `build/Session.xcarchive` — the archive, including `dSYMs/` for crash symbolication.
+- `build/export/session-<version>.ipa` — the signed, App-Store-ready IPA (naming matches
+  the historical builds in `~/Projects/Builds`).
+
+## Notes
+
+- **Version numbers** are set at the project level in `project.pbxproj` and inherited by
+  the app + extension targets. `bump_version.sh` changes only those project-level values (on
+  `dev`); the release scripts never modify them.
+- **dSYMs**: `App_Store_Release` defaults to `DEBUG_INFORMATION_FORMAT = dwarf`; the device
+  archive (`build_ci.sh archive-device`) overrides this to `dwarf-with-dsym` so symbols are
+  produced and uploaded (`uploadSymbols` in `exportOptions.plist`).
+- **CI**: there is intentionally no Drone deploy pipeline yet (matching Session Android).
+  The scripts already read everything from env vars, so wiring them into CI later is just a
+  matter of injecting the secrets above.
+- `Scripts/testflight_upload.sh` is decoupled so you can re-upload an existing IPA without
+  re-archiving. It uses `xcrun altool`; if Apple removes `altool`, switch it to
+  `exportOptions.plist` `destination=upload` (drops the local artifact) or Transporter.
+
+## Fallback: manual `.p12` signing (not needed for this project)
+
+If a team is *not* using cloud-managed signing, provide an Apple Distribution certificate
+instead of setting `SKIP_KEYCHAIN=1`: export the identity from Keychain Access as a `.p12`
+(with its private key), then set `ASC_DIST_CERT_P12_BASE64` (=`base64 -i cert.p12`) and
+`ASC_DIST_CERT_PASSWORD`. `release_env.sh` imports it into a temporary keychain for the build
+and deletes it on exit. This project uses cloud signing, so this path should not be required.

--- a/Scripts/build_ci.sh
+++ b/Scripts/build_ci.sh
@@ -5,7 +5,7 @@ IFS=$' \t\n'
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
-    echo "Error: Missing mode. Usage: $0 [test|archive] [unique_xcodebuild_args...]"
+    echo "Error: Missing mode. Usage: $0 [test|archive|archive-device] [unique_xcodebuild_args...]"
     exit 1
 fi
 
@@ -254,7 +254,40 @@ elif [[ "$MODE" == "archive" ]]; then
             "${UNIQUE_ARGS[@]}" 2>&1 | xcbeautify --is-ci
     fi
     
+elif [[ "$MODE" == "archive-device" ]]; then
+
+    echo "--- Running Device Archive Build for Distribution (App_Store_Release) ---"
+
+    # Distribution-signed device archive for App Store / TestFlight.
+    # Device archive for distribution. We rely on the project's existing automatic
+    # signing (CODE_SIGN_STYLE=Automatic, DEVELOPMENT_TEAM=SUQ8J2PCT7) plus
+    # -allowProvisioningUpdates + the App Store Connect API key (passed by
+    # build_release.sh as UNIQUE_ARGS). The distribution identity is resolved
+    # automatically at export time (method: app-store-connect) via the cloud-managed
+    # certificate — do NOT force CODE_SIGN_IDENTITY here: a global override is applied
+    # to every target, including the automatically-signed SPM packages, which then fail
+    # with "conflicting provisioning settings". We only override DEBUG_INFORMATION_FORMAT
+    # so the archive emits dSYMs (the App_Store_Release default is plain dwarf).
+    DEVICE_ARCHIVE_ARGS=(
+        -destination "generic/platform=iOS"
+        -sdk iphoneos
+        -allowProvisioningUpdates
+        DEBUG_INFORMATION_FORMAT=dwarf-with-dsym
+    )
+
+    if [[ "$USE_RAW_LOGS" -eq 1 ]]; then
+        NSUnbufferedIO=YES xcodebuild archive \
+            "${COMMON_ARGS[@]}" \
+            "${DEVICE_ARCHIVE_ARGS[@]}" \
+            "${UNIQUE_ARGS[@]}" 2>&1
+    else
+        NSUnbufferedIO=YES xcodebuild archive \
+            "${COMMON_ARGS[@]}" \
+            "${DEVICE_ARCHIVE_ARGS[@]}" \
+            "${UNIQUE_ARGS[@]}" 2>&1 | xcbeautify --is-ci
+    fi
+
 else
-    echo "Error: Invalid mode '$MODE' specified. Use 'test' or 'archive'."
+    echo "Error: Invalid mode '$MODE' specified. Use 'test', 'archive', or 'archive-device'."
     exit 1
 fi

--- a/Scripts/build_release.sh
+++ b/Scripts/build_release.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# build_release.sh — archive a distribution device build, export a signed IPA, and
+# (optionally) attach it to the GitHub draft release.
+#
+# Produces:
+#   build/Session.xcarchive              the archive (incl. dSYMs/)
+#   build/export/session-<version>.ipa   the signed, App-Store-ready IPA
+#
+# Usage:
+#   Scripts/build_release.sh [version] [--attach]
+#
+#   version    marketing version, e.g. 2.15.3 (defaults to the project's MARKETING_VERSION)
+#   --attach   upload the IPA to the GitHub draft release tagged <version> (needs `gh`)
+#
+# Credentials come from the environment — see Scripts/release_env.sh for the list.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+ATTACH=0
+VERSION=""
+for arg in "$@"; do
+    case "$arg" in
+        --attach) ATTACH=1 ;;
+        *)        VERSION="$arg" ;;
+    esac
+done
+
+# Fall back to the project's configured marketing version.
+if [ -z "$VERSION" ]; then
+    VERSION="$(xcodebuild -project Session.xcodeproj -scheme Session \
+        -configuration App_Store_Release -showBuildSettings 2>/dev/null \
+        | awk -F' = ' '/ MARKETING_VERSION / {print $2; exit}')"
+fi
+if [ -z "$VERSION" ]; then
+    echo "Error: could not determine version (pass it explicitly)." >&2
+    exit 1
+fi
+echo "--- Building release for version ${VERSION} ---"
+
+# Set up credentials + signing (installs its own cleanup trap in this shell).
+# shellcheck source=Scripts/release_env.sh
+source "$SCRIPT_DIR/release_env.sh"
+
+ARCHIVE_PATH="./build/Session.xcarchive"
+EXPORT_DIR="./build/export"
+IPA_PATH="${EXPORT_DIR}/session-${VERSION}.ipa"
+
+mkdir -p ./build
+
+# 1. Archive (distribution-signed device build; overrides live in build_ci.sh).
+"$SCRIPT_DIR/build_ci.sh" archive-device \
+    -archivePath "$ARCHIVE_PATH" \
+    -authenticationKeyPath "$ASC_KEY_PATH" \
+    -authenticationKeyID "$ASC_KEY_ID" \
+    -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+# 2. Export the IPA.
+rm -rf "$EXPORT_DIR"
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_DIR" \
+    -exportOptionsPlist "./exportOptions.plist" \
+    -allowProvisioningUpdates \
+    -authenticationKeyPath "$ASC_KEY_PATH" \
+    -authenticationKeyID "$ASC_KEY_ID" \
+    -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+# 3. Rename to the house convention (matches ~/Projects/Builds/session-<version>.ipa).
+EXPORTED_IPA="$(find "$EXPORT_DIR" -maxdepth 1 -name '*.ipa' | head -n1)"
+if [ -z "$EXPORTED_IPA" ]; then
+    echo "Error: no .ipa found in ${EXPORT_DIR} after export." >&2
+    exit 1
+fi
+if [ "$EXPORTED_IPA" != "$IPA_PATH" ]; then
+    mv "$EXPORTED_IPA" "$IPA_PATH"
+fi
+echo "--- Exported ${IPA_PATH} ---"
+echo "    dSYMs: ${ARCHIVE_PATH}/dSYMs/"
+
+# 4. Optionally attach to the GitHub draft release.
+if [ "$ATTACH" -eq 1 ]; then
+    echo "--- Attaching IPA to GitHub release ${VERSION} ---"
+    gh release upload "$VERSION" "$IPA_PATH" --clobber
+fi
+
+echo "--- Done. Upload to TestFlight with: Scripts/testflight_upload.sh ${VERSION} ---"

--- a/Scripts/bump_version.sh
+++ b/Scripts/bump_version.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# bump_version.sh — bump the app version on a dev branch and open a PR.
+#
+# Version changes belong on `dev` and reach `master` through the normal reviewed merge,
+# so this does NOT touch master and is separate from the release flow. It bumps the
+# project-level MARKETING_VERSION / CURRENT_PROJECT_VERSION (inherited by all targets),
+# pushes a branch, and opens a PR into dev for review.
+#
+# Usage:
+#   Scripts/bump_version.sh <version> [build]
+#
+#   version    new marketing version, e.g. 2.15.4
+#   build      new build number (defaults to current + 1)
+#
+# Env:
+#   RELEASE_REMOTE   git remote to branch from / push to (default: origin)
+#   DEV_BRANCH       branch to base + target the PR on (default: dev)
+#
+# Requires: git, gh.
+set -euo pipefail
+
+NEW_VERSION="${1:?Usage: bump_version.sh <version> [build]}"
+NEW_BUILD="${2:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+# shellcheck source=Scripts/lib_version.sh
+source "$SCRIPT_DIR/lib_version.sh"
+
+PBX="Session.xcodeproj/project.pbxproj"
+REMOTE="${RELEASE_REMOTE:-origin}"
+DEV_BRANCH="${DEV_BRANCH:-dev}"
+BR="bump/version-${NEW_VERSION}"
+
+# --- branch off the latest dev -------------------------------------------------
+git fetch "$REMOTE"
+git checkout -B "$BR" "$REMOTE/$DEV_BRANCH"
+
+# --- read current project-level values (from the tree we're editing) -----------
+OLD_VERSION="$(read_project_version "$PBX" MARKETING_VERSION)"
+OLD_BUILD="$(read_project_version "$PBX" CURRENT_PROJECT_VERSION)"
+: "${OLD_VERSION:?could not read current MARKETING_VERSION from ${PBX}}"
+: "${OLD_BUILD:?could not read current CURRENT_PROJECT_VERSION from ${PBX}}"
+[ -n "$NEW_BUILD" ] || NEW_BUILD=$((OLD_BUILD + 1))
+
+echo "--- Bumping version on ${BR} (off ${REMOTE}/${DEV_BRANCH}) ---"
+echo "    marketing version: ${OLD_VERSION} -> ${NEW_VERSION}"
+echo "    build number     : ${OLD_BUILD} -> ${NEW_BUILD}"
+
+if [ "$OLD_VERSION" = "$NEW_VERSION" ] && [ "$OLD_BUILD" = "$NEW_BUILD" ]; then
+    echo "Error: new version/build match the current values — nothing to bump." >&2
+    exit 1
+fi
+
+# --- bump (old-value-anchored; the old values live only in the project-level configs) ---
+mv_count=$(grep -c "MARKETING_VERSION = ${OLD_VERSION};" "$PBX" || true)
+cpv_count=$(grep -c "CURRENT_PROJECT_VERSION = ${OLD_BUILD};" "$PBX" || true)
+echo "    (updating ${mv_count} MARKETING_VERSION and ${cpv_count} CURRENT_PROJECT_VERSION lines)"
+if [ "$mv_count" -eq 0 ] || [ "$cpv_count" -eq 0 ]; then
+    echo "Error: could not find project-level version lines to bump. Aborting." >&2
+    exit 1
+fi
+
+sed -i '' \
+    -e "s/MARKETING_VERSION = ${OLD_VERSION};/MARKETING_VERSION = ${NEW_VERSION};/g" \
+    -e "s/CURRENT_PROJECT_VERSION = ${OLD_BUILD};/CURRENT_PROJECT_VERSION = ${NEW_BUILD};/g" \
+    "$PBX"
+
+echo "--- Diff ---"
+git --no-pager diff -- "$PBX" || true
+
+# --- commit, push, open PR -----------------------------------------------------
+git add "$PBX"
+git commit -m "Bump version to ${NEW_VERSION} (build ${NEW_BUILD})"
+git push -u "$REMOTE" "$BR"
+
+echo "--- Opening PR into ${DEV_BRANCH} ---"
+gh pr create \
+    --base "$DEV_BRANCH" \
+    --head "$BR" \
+    --title "Bump version to ${NEW_VERSION} (build ${NEW_BUILD})" \
+    --body "Bumps MARKETING_VERSION to ${NEW_VERSION} and CURRENT_PROJECT_VERSION to ${NEW_BUILD}."
+
+echo "--- Done. Once merged into ${DEV_BRANCH} and released to master, run Scripts/release.sh ---"

--- a/Scripts/lib_version.sh
+++ b/Scripts/lib_version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# lib_version.sh — shared helpers for reading the project-level (inherited) version
+# from project.pbxproj. Sourced by the release scripts; not executed directly.
+#
+# Version numbers are set on the PBXProject's App_Store_Release configuration and
+# inherited by the app + extension targets, so these read that one block. The config
+# list that identifies the project-level block appears *after* the block itself in the
+# file, so we resolve the GUID first (pass 1) then read the block (pass 2).
+
+# read_project_version <pbx-path> <setting-key>  ->  echoes the value (e.g. 2.15.3)
+read_project_version() {
+    local pbx="$1" key="$2" guid
+    guid=$(awk '
+        /Build configuration list for PBXProject .*= \{/ { inlist=1 }
+        inlist && /App_Store_Release \*\/,/ { match($0,/[A-F0-9]{24}/); print substr($0,RSTART,RLENGTH); exit }
+    ' "$pbx")
+    [ -n "$guid" ] || return 1
+    awk -v guid="$guid" -v key="$key" '
+        $0 ~ "^\t\t"guid" \\/\\* App_Store_Release \\*\\/ = \\{" { inblock=1 }
+        inblock && $0 ~ "[[:space:]]"key" = " { v=$0; sub(/.*= /,"",v); sub(/;.*/,"",v); print v; exit }
+        inblock && /^\t\t\};/ { exit }
+    ' "$pbx"
+}

--- a/Scripts/prepare_github_release.sh
+++ b/Scripts/prepare_github_release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# prepare_github_release.sh — create the GitHub tag + draft release for a version.
+#
+# Does NOT bump the version (that happens on dev via bump_version.sh and reaches master
+# through review). This just tags the release branch's current head and opens a draft
+# release. The version must already be committed on that branch.
+#
+# Usage:
+#   Scripts/prepare_github_release.sh <version>
+#
+# Env:
+#   RELEASE_REMOTE   git remote whose repo the release is created on (default: origin)
+#   RELEASE_BRANCH   branch/ref to tag (default: master)
+#
+# Requires: gh. Aborts if a tag for <version> already exists.
+set -euo pipefail
+
+VERSION="${1:?Usage: prepare_github_release.sh <version>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+REMOTE="${RELEASE_REMOTE:-origin}"
+BRANCH="${RELEASE_BRANCH:-master}"
+
+# Guard: never clobber an existing tag/release.
+if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null 2>&1 \
+   || git ls-remote --tags "$REMOTE" "refs/tags/${VERSION}" 2>/dev/null | grep -q .; then
+    echo "Error: tag '${VERSION}' already exists. Aborting (bump the version first)." >&2
+    exit 1
+fi
+
+echo "--- Creating draft release ${VERSION} (tagging ${BRANCH}) ---"
+gh release create "$VERSION" \
+    --draft \
+    --target "$BRANCH" \
+    --title "$VERSION" \
+    --generate-notes
+
+echo "--- Draft release ${VERSION} created. ---"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+#
+# release.sh — one-command release from master to TestFlight.
+#
+# Reads the version already committed on master (version bumps happen on dev via
+# bump_version.sh and reach master through review — this script never changes the
+# version). It then tags the release, builds + signs + exports the IPA, attaches it to a
+# GitHub draft release, and uploads to TestFlight.
+#
+# Tag gating:
+#   • If no tag exists for master's current version, it creates the tag + draft release
+#     and proceeds.
+#   • If a tag for that version already exists, a version bump probably still needs to be
+#     merged — it pauses and lets you re-check after merging, build with the current
+#     version anyway, or abort.
+#
+# Usage:
+#   Scripts/release.sh [version] [options]
+#
+#   version                     optional sanity check against master's version
+#
+# Options:
+#   -y, --yes                   don't pause for confirmations (non-interactive / CI)
+#   --allow-existing-version    build/submit even if a tag for the version already exists
+#   --skip-upload               stop after building + attaching (no TestFlight upload)
+#   --skip-draft                don't create a GitHub tag/draft release
+#   -h, --help                  show this help
+#
+# Env:
+#   RELEASE_REMOTE  git remote to release from (default: origin)
+#   RELEASE_BRANCH  branch to release (default: master)
+#   Credentials     ASC_KEY_ID, ASC_ISSUER_ID, ASC_KEY_P8_BASE64, SKIP_KEYCHAIN=1
+#                   (loaded from .env if present; see RELEASING.md)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+# shellcheck source=Scripts/lib_version.sh
+source "$SCRIPT_DIR/lib_version.sh"
+
+PBX="Session.xcodeproj/project.pbxproj"
+REMOTE="${RELEASE_REMOTE:-origin}"
+BRANCH="${RELEASE_BRANCH:-master}"
+ENV_FILE="$REPO_ROOT/.env"
+
+ASSUME_YES=0; SKIP_UPLOAD=0; SKIP_DRAFT=0; ALLOW_EXISTING=0; USER_VERSION=""
+usage() { sed -n '2,38p' "$SCRIPT_DIR/release.sh" | sed 's/^# \{0,1\}//'; }
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes)                 ASSUME_YES=1 ;;
+        --allow-existing-version) ALLOW_EXISTING=1 ;;
+        --skip-upload)            SKIP_UPLOAD=1 ;;
+        --skip-draft)             SKIP_DRAFT=1 ;;
+        -h|--help)                usage; exit 0 ;;
+        -*)                       echo "Unknown option: $arg" >&2; exit 1 ;;
+        *)                        USER_VERSION="$arg" ;;
+    esac
+done
+
+# --- helpers -------------------------------------------------------------------
+is_tty() { [ -t 0 ] && [ -t 1 ]; }
+confirm() {
+    [ "$ASSUME_YES" -eq 1 ] && return 0
+    if ! is_tty; then
+        echo "Refusing to continue without confirmation (not a TTY). Re-run with --yes." >&2
+        return 1
+    fi
+    local reply; read -r -p "$1 [y/N] " reply; [[ "$reply" =~ ^[Yy]$ ]]
+}
+tag_exists() {
+    git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1 && return 0
+    git ls-remote --tags "$REMOTE" "refs/tags/$1" 2>/dev/null | grep -q . && return 0
+    return 1
+}
+
+# --- load .env + resolve credentials -------------------------------------------
+if [ -f "$ENV_FILE" ]; then
+    echo "--- Loading credentials from .env ---"
+    set -a; # shellcheck disable=SC1090
+    source "$ENV_FILE"; set +a
+fi
+NEWLY_PROMPTED=0
+prompt_var() {
+    local var="$1" text="$2" val
+    [ -n "${!var:-}" ] && return 0
+    if ! is_tty; then echo "Error: $var is not set (no .env value and no TTY to prompt)." >&2; exit 1; fi
+    read -r -p "$text: " val
+    export "$var=$val"; NEWLY_PROMPTED=1
+}
+# Update-or-insert KEY="value" in .env, preserving every other line (so a dev's other
+# env vars aren't lost). Creates .env if absent.
+upsert_env() {
+    local key="$1" val="$2" tmp
+    tmp="$(mktemp)"
+    if [ -f "$ENV_FILE" ]; then grep -v "^${key}=" "$ENV_FILE" > "$tmp" 2>/dev/null || true; fi
+    printf '%s="%s"\n' "$key" "$val" >> "$tmp"
+    mv "$tmp" "$ENV_FILE"; chmod 600 "$ENV_FILE"
+}
+
+# Resolve each required credential; prompt for any that .env didn't provide.
+if [ -z "${ASC_KEY_P8_BASE64:-}" ]; then
+    if is_tty; then
+        read -r -p "Path to App Store Connect API key (.p8): " _p8
+        _p8="${_p8/#\~/$HOME}"
+        [ -f "$_p8" ] || { echo "Error: file not found: $_p8" >&2; exit 1; }
+        ASC_KEY_P8_BASE64="$(base64 -i "$_p8")"; export ASC_KEY_P8_BASE64; NEWLY_PROMPTED=1
+    else
+        echo "Error: ASC_KEY_P8_BASE64 is not set (no .env value and no TTY to prompt)." >&2; exit 1
+    fi
+fi
+prompt_var ASC_KEY_ID    "App Store Connect API Key ID"
+prompt_var ASC_ISSUER_ID "App Store Connect Issuer ID"
+if [ -z "${SKIP_KEYCHAIN:-}" ] && [ -z "${ASC_DIST_CERT_P12_BASE64:-}" ]; then
+    export SKIP_KEYCHAIN=1
+fi
+
+# Offer to persist anything newly entered, merging into any existing .env.
+if [ "$NEWLY_PROMPTED" -eq 1 ] && is_tty; then
+    if confirm "Save the entered credential(s) to .env for next time? (git-ignored; existing entries preserved)"; then
+        umask 077
+        upsert_env ASC_KEY_ID        "$ASC_KEY_ID"
+        upsert_env ASC_ISSUER_ID     "$ASC_ISSUER_ID"
+        upsert_env ASC_KEY_P8_BASE64 "$ASC_KEY_P8_BASE64"
+        [ "${SKIP_KEYCHAIN:-}" = "1" ] && upsert_env SKIP_KEYCHAIN 1
+        echo "Updated $ENV_FILE."
+    fi
+fi
+
+# --- confirm the ref we're releasing -------------------------------------------
+CUR_BRANCH="$(git branch --show-current 2>/dev/null || echo '')"
+if [ "$CUR_BRANCH" != "$BRANCH" ]; then
+    confirm "You are on '$CUR_BRANCH', not the release branch '$BRANCH'. Release from '$CUR_BRANCH' anyway?" \
+        || { echo "Aborted. Check out $BRANCH first."; exit 1; }
+fi
+git fetch "$REMOTE" --tags >/dev/null 2>&1 || true
+
+# --- read the version already on the branch (never modified here) --------------
+VERSION="$(read_project_version "$PBX" MARKETING_VERSION)"
+: "${VERSION:?could not read MARKETING_VERSION from ${PBX}}"
+if [ -n "$USER_VERSION" ] && [ "$USER_VERSION" != "$VERSION" ]; then
+    confirm "Version on ${CUR_BRANCH:-HEAD} is ${VERSION}, but you passed ${USER_VERSION}. Proceed with ${VERSION}?" \
+        || { echo "Aborted."; exit 1; }
+fi
+
+# --- tag gating ----------------------------------------------------------------
+REUSE_TAG=0
+while tag_exists "$VERSION"; do
+    echo ""
+    echo "A release tag '${VERSION}' already exists."
+    echo "This usually means the version on '${BRANCH}' hasn't been bumped since the last"
+    echo "release — a bump needs to be merged (Scripts/bump_version.sh opens that PR)."
+    if [ "$ALLOW_EXISTING" -eq 1 ]; then
+        echo "(--allow-existing-version) Building the current version anyway."
+        REUSE_TAG=1; break
+    fi
+    if [ "$ASSUME_YES" -eq 1 ] || ! is_tty; then
+        echo "Refusing to proceed. Re-run with --allow-existing-version to build the current" >&2
+        echo "version anyway, or merge a version bump first." >&2
+        exit 1
+    fi
+    echo "  1) I've merged the bump — re-check '${BRANCH}'"
+    echo "  2) Build & submit with the current version anyway (reuse existing tag)"
+    echo "  3) Abort"
+    read -r -p "Choose [1/2/3]: " choice
+    case "$choice" in
+        1|"") git fetch "$REMOTE" --tags >/dev/null 2>&1 || true
+              [ "$CUR_BRANCH" = "$BRANCH" ] && git merge --ff-only "$REMOTE/$BRANCH" >/dev/null 2>&1 || true
+              VERSION="$(read_project_version "$PBX" MARKETING_VERSION)"
+              : "${VERSION:?could not re-read MARKETING_VERSION}"
+              echo "Re-read version: ${VERSION}" ;;
+        2)    REUSE_TAG=1; break ;;
+        *)    echo "Aborted."; exit 1 ;;
+    esac
+done
+
+# --- plan summary --------------------------------------------------------------
+ORIGIN_URL="$(git remote get-url "$REMOTE" 2>/dev/null || echo '?')"
+if [ "${SKIP_KEYCHAIN:-0}" = "1" ]; then SIGNING_DESC="cloud-managed"; else SIGNING_DESC="manual .p12"; fi
+if [ "$REUSE_TAG" -eq 1 ]; then TAG_DESC="reuse existing tag ${VERSION}";
+elif [ "$SKIP_DRAFT" -eq 1 ]; then TAG_DESC="(skip draft/tag)";
+else TAG_DESC="create tag + draft ${VERSION}"; fi
+STEP_UPLOAD="testflight"; [ "$SKIP_UPLOAD" -eq 1 ] && STEP_UPLOAD="(skip upload)"
+echo ""
+echo "=================== Release plan ==================="
+echo "  Version   : $VERSION  (read from ${CUR_BRANCH:-HEAD})"
+echo "  Remote    : $REMOTE  ($ORIGIN_URL)"
+echo "  Tag/draft : $TAG_DESC"
+echo "  Steps     : build+attach -> $STEP_UPLOAD"
+echo "===================================================="
+confirm "Proceed?" || { echo "Aborted."; exit 1; }
+
+# --- 1. tag + draft release ----------------------------------------------------
+if [ "$REUSE_TAG" -eq 0 ] && [ "$SKIP_DRAFT" -eq 0 ]; then
+    if confirm "Create tag + draft release ${VERSION} on ${BRANCH}?"; then
+        RELEASE_REMOTE="$REMOTE" RELEASE_BRANCH="$BRANCH" "$SCRIPT_DIR/prepare_github_release.sh" "$VERSION"
+    else
+        echo "Skipped draft creation."
+    fi
+fi
+
+# --- 2. build + attach ---------------------------------------------------------
+echo "--- Building + exporting + attaching IPA ---"
+"$SCRIPT_DIR/build_release.sh" "$VERSION" --attach
+
+# --- 3. upload to TestFlight ---------------------------------------------------
+if [ "$SKIP_UPLOAD" -eq 0 ]; then
+    if confirm "Upload session-${VERSION}.ipa to TestFlight?"; then
+        "$SCRIPT_DIR/testflight_upload.sh" "$VERSION"
+    else
+        echo "Skipped TestFlight upload."
+    fi
+fi
+
+# --- next steps ----------------------------------------------------------------
+RELEASES_URL="$(printf '%s' "$ORIGIN_URL" | sed -E 's#git@github.com:#https://github.com/#; s#\.git$##')/releases"
+echo ""
+echo "=================== Done ==================="
+echo "Remaining manual steps:"
+echo "  • Publish the GitHub release when ready:  gh release edit ${VERSION} --draft=false"
+echo "  • App Store Connect → TestFlight: manage testers / submit for review."
+echo "  GitHub releases : $RELEASES_URL"
+echo "  App Store Connect: https://appstoreconnect.apple.com/apps"
+if is_tty && confirm "Open both in the browser now?"; then
+    open "$RELEASES_URL" "https://appstoreconnect.apple.com/apps" 2>/dev/null || true
+fi

--- a/Scripts/release_env.sh
+++ b/Scripts/release_env.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# release_env.sh — shared credential + keychain setup for the release scripts.
+#
+# This file is meant to be SOURCED, not executed:
+#
+#     source "$(dirname "$0")/release_env.sh"
+#
+# It validates the required environment variables, materialises the App Store
+# Connect API key and (optionally) a distribution certificate into a temporary
+# keychain, and installs a cleanup trap that removes all secrets when the calling
+# script exits (success, failure, or interrupt).
+#
+# See RELEASING.md for how to obtain these credentials.
+#
+# Required environment variables:
+#   ASC_KEY_ID              10-char App Store Connect API key ID
+#   ASC_ISSUER_ID           App Store Connect issuer UUID
+#   ASC_KEY_P8_BASE64       base64 of the .p8 private key
+#     NOTE: for distribution/cloud signing the key needs the *Admin* role.
+#
+# Signing mode:
+#   SKIP_KEYCHAIN=1         Cloud-managed signing (the normal path for this project): do not
+#                           create a keychain or import a cert — xcodebuild cloud-signs via
+#                           the API key + -allowProvisioningUpdates. Apple holds the private
+#                           key. Also covers "a distribution identity already exists in the
+#                           login keychain" for local runs.
+#
+# Fallback (only when NOT using cloud-managed signing — required unless SKIP_KEYCHAIN=1):
+#   ASC_DIST_CERT_P12_BASE64   base64 of the Apple Distribution cert (incl. private key)
+#   ASC_DIST_CERT_PASSWORD     the .p12 export password
+#   KEYCHAIN_PASSWORD          (optional) password for the temp keychain (generated if unset)
+#
+# On success it exports:
+#   ASC_KEY_PATH            absolute path to AuthKey_<ID>.p8 (for -authenticationKeyPath)
+
+# --- guard against direct execution --------------------------------------------
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    echo "release_env.sh must be sourced, not executed:  source ${BASH_SOURCE[0]}" >&2
+    exit 1
+fi
+
+# NOTE: we deliberately do not enable `set -x` anywhere that could echo secrets.
+
+# --- load .env (repo root) if present ------------------------------------------
+_RELEASE_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_ENV_FILE="$_RELEASE_ENV_DIR/../.env"
+if [ -f "$_ENV_FILE" ]; then
+    echo "[release_env] Loading credentials from .env"
+    set -a; # shellcheck disable=SC1090
+    source "$_ENV_FILE"; set +a
+fi
+
+# --- validate required env vars ------------------------------------------------
+: "${ASC_KEY_ID:?ASC_KEY_ID is required}"
+: "${ASC_ISSUER_ID:?ASC_ISSUER_ID is required}"
+: "${ASC_KEY_P8_BASE64:?ASC_KEY_P8_BASE64 is required}"
+
+_RELEASE_ENV_CLEANUP=()
+_release_env_cleanup() {
+    local item
+    for item in "${_RELEASE_ENV_CLEANUP[@]:-}"; do
+        [ -z "$item" ] && continue
+        case "$item" in
+            keychain:*) security delete-keychain "${item#keychain:}" 2>/dev/null || true ;;
+            *)          rm -f "$item" 2>/dev/null || true ;;
+        esac
+    done
+}
+trap _release_env_cleanup EXIT INT TERM
+
+# --- materialise the App Store Connect API key ---------------------------------
+# altool / iTMSTransporter locate the key by filename convention in one of a few
+# dirs; ~/.appstoreconnect/private_keys is one of them, so we can use the same file
+# for both `xcodebuild -authenticationKeyPath` and `altool --apiKey`.
+_ASC_KEY_DIR="$HOME/.appstoreconnect/private_keys"
+mkdir -p "$_ASC_KEY_DIR"
+chmod 700 "$_ASC_KEY_DIR"
+export ASC_KEY_PATH="$_ASC_KEY_DIR/AuthKey_${ASC_KEY_ID}.p8"
+printf '%s' "$ASC_KEY_P8_BASE64" | base64 --decode > "$ASC_KEY_PATH"
+chmod 600 "$ASC_KEY_PATH"
+_RELEASE_ENV_CLEANUP+=("$ASC_KEY_PATH")
+echo "[release_env] App Store Connect API key ready (key id: ${ASC_KEY_ID})."
+
+# --- distribution certificate / keychain ---------------------------------------
+if [ "${SKIP_KEYCHAIN:-0}" = "1" ]; then
+    echo "[release_env] SKIP_KEYCHAIN=1 — cloud-managed signing (no local cert imported)."
+else
+    : "${ASC_DIST_CERT_P12_BASE64:?ASC_DIST_CERT_P12_BASE64 is required (or set SKIP_KEYCHAIN=1)}"
+    : "${ASC_DIST_CERT_PASSWORD:?ASC_DIST_CERT_PASSWORD is required (or set SKIP_KEYCHAIN=1)}"
+
+    KEYCHAIN_PASSWORD="${KEYCHAIN_PASSWORD:-$(openssl rand -base64 24)}"
+    _KEYCHAIN_PATH="$HOME/Library/Keychains/session-release-$$.keychain-db"
+    _P12_PATH="$(mktemp -t session-dist-cert).p12"
+    _RELEASE_ENV_CLEANUP+=("keychain:$_KEYCHAIN_PATH" "$_P12_PATH")
+
+    printf '%s' "$ASC_DIST_CERT_P12_BASE64" | base64 --decode > "$_P12_PATH"
+
+    security create-keychain -p "$KEYCHAIN_PASSWORD" "$_KEYCHAIN_PATH"
+    security set-keychain-settings -lut 3600 "$_KEYCHAIN_PATH"
+    security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$_KEYCHAIN_PATH"
+    security import "$_P12_PATH" -k "$_KEYCHAIN_PATH" -P "$ASC_DIST_CERT_PASSWORD" \
+        -T /usr/bin/codesign -T /usr/bin/xcodebuild
+    # Allow codesign/xcodebuild to use the key without an interactive prompt.
+    security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$_KEYCHAIN_PATH" >/dev/null
+    # Prepend our keychain to the user search list (preserving the existing entries).
+    _EXISTING_KEYCHAINS="$(security list-keychains -d user | sed 's/[[:space:]]*"//;s/"[[:space:]]*$//')"
+    # shellcheck disable=SC2086
+    security list-keychains -d user -s "$_KEYCHAIN_PATH" $_EXISTING_KEYCHAINS
+    rm -f "$_P12_PATH"
+
+    echo "[release_env] Distribution certificate imported into temp keychain."
+fi
+
+echo "[release_env] Ready."

--- a/Scripts/testflight_upload.sh
+++ b/Scripts/testflight_upload.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# testflight_upload.sh — upload an already-exported IPA to TestFlight / App Store
+# Connect using the App Store Connect API key.
+#
+# Decoupled from build_release.sh so a maintainer can re-upload an existing build
+# without re-archiving.
+#
+# Usage:
+#   Scripts/testflight_upload.sh [version|ipa-path]
+#
+#   With no argument it uploads build/export/session-<MARKETING_VERSION>.ipa.
+#   You may pass a version (e.g. 2.15.3) or a direct path to a .ipa.
+#
+# Credentials come from the environment — see Scripts/release_env.sh. Signing/keychain
+# are not needed here, so SKIP_KEYCHAIN is forced on (only the API key is required).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+ARG="${1:-}"
+if [ -n "$ARG" ] && [ -f "$ARG" ]; then
+    IPA_PATH="$ARG"
+else
+    VERSION="$ARG"
+    if [ -z "$VERSION" ]; then
+        VERSION="$(xcodebuild -project Session.xcodeproj -scheme Session \
+            -configuration App_Store_Release -showBuildSettings 2>/dev/null \
+            | awk -F' = ' '/ MARKETING_VERSION / {print $2; exit}')"
+    fi
+    IPA_PATH="./build/export/session-${VERSION}.ipa"
+fi
+
+if [ ! -f "$IPA_PATH" ]; then
+    echo "Error: IPA not found: ${IPA_PATH} (run Scripts/build_release.sh first)." >&2
+    exit 1
+fi
+
+# Only the API key is needed for upload — skip the signing keychain entirely.
+export SKIP_KEYCHAIN=1
+# shellcheck source=Scripts/release_env.sh
+source "$SCRIPT_DIR/release_env.sh"
+
+echo "--- Uploading ${IPA_PATH} to TestFlight ---"
+xcrun altool --upload-app \
+    -f "$IPA_PATH" \
+    --type ios \
+    --apiKey "$ASC_KEY_ID" \
+    --apiIssuer "$ASC_ISSUER_ID"
+
+echo "--- Upload submitted. The build will appear in App Store Connect → TestFlight"
+echo "    once Apple finishes processing it. ---"

--- a/exportOptions.plist
+++ b/exportOptions.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    Export options for App Store / TestFlight distribution.
+
+    method = app-store-connect is the Xcode 15.3+ name for the old "app-store"
+    value. If this ever runs under Xcode < 15.3, change it back to "app-store".
+
+    destination = export produces a local .ipa (which we rename to
+    session-<version>.ipa, attach to the GitHub release, and upload to TestFlight).
+    Set to "upload" if you want -exportArchive to submit directly instead.
+
+    manageAppVersionAndBuildNumber = false so the tooling does NOT silently bump the
+    build number — versions are controlled explicitly by prepare_release.sh.
+-->
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>destination</key>
+    <string>export</string>
+    <key>teamID</key>
+    <string>SUQ8J2PCT7</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
Add a self-contained set of scripts to build, sign, and submit Session iOS to TestFlight without opening Xcode — runnable locally and CI-ready (all credentials via environment variables / .env).
- release.sh: one-command orchestrator (reads master's version, tag-gates, builds, attaches to a GitHub draft, uploads to TestFlight)
- bump_version.sh: bumps the project-level version on dev and opens a PR
- prepare_github_release.sh: creates the tag + GitHub draft release
- build_release.sh: distribution device archive + IPA export (session-<v>.ipa)
- testflight_upload.sh: uploads the IPA via the App Store Connect API key
- release_env.sh / lib_version.sh: shared credential/keychain + version helpers
- build_ci.sh: new archive-device mode (Apple Distribution + dwarf-with-dsym)
- exportOptions.plist, RELEASING.md, and .gitignore entries for credentials

Signing uses cloud-managed certificates via an App Store Connect API key and -allowProvisioningUpdates, so no .p12 is required.