### PR TITLE
Fix push notification reliability issues

### DIFF
--- a/Session/Notifications/SyncPushTokensJob.swift
+++ b/Session/Notifications/SyncPushTokensJob.swift
@@ -180,12 +180,17 @@ public enum SyncPushTokensJob: JobExecutor {
             do {
                 try await Network.PushNotification.subscribeAll(
                     token: Data(hex: pushToken),
-                    isForcedUpdate: true,
                     using: dependencies
                 )
                 Log.debug(.syncPushTokensJob, "Recording push tokens locally. pushToken: \(redact(pushToken)), voipToken: \(redact(voipToken))")
                 Log.info(.syncPushTokensJob, "Completed")
-                
+
+                /// Since `subscribeAll` only returns without throwing when the user swarm subscription succeeded we can now
+                /// cache the token data (recording this on a failed subscription would incorrectly suppress future attempts)
+                dependencies[defaults: .standard, key: .deviceToken] = pushToken
+                dependencies[defaults: .standard, key: .lastDeviceTokenUpload] = dependencies.dateNow.timeIntervalSince1970
+                dependencies[defaults: .standard, key: .isUsingFullAPNs] = true
+
                 try await dependencies[singleton: .storage].write { db in
                     db[.lastRecordedPushToken] = pushToken
                     db[.lastRecordedVoipToken] = voipToken

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI+SessionMessagingKit.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI+SessionMessagingKit.swift
@@ -9,18 +9,8 @@ import SessionUtilitiesKit
 public extension Network.PushNotification {
     static func subscribeAll(
         token: Data,
-        isForcedUpdate: Bool,
         using dependencies: Dependencies
     ) async throws {
-        let hexEncodedToken: String = token.toHexString()
-        let oldToken: String? = dependencies[defaults: .standard, key: .deviceToken]
-        let lastUploadTime: Double = dependencies[defaults: .standard, key: .lastDeviceTokenUpload]
-        let now: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-        
-        guard isForcedUpdate || hexEncodedToken != oldToken || now - lastUploadTime > tokenExpirationInterval else {
-            return Log.info(.pushNotificationAPI, "Device token hasn't changed or expired; no need to re-upload.")
-        }
-        
         let swarms: [SwarmInfo] = try await retrieveAllSwarms(
             retrievalReason: "subscribe", // stringlint:ignore
             using: dependencies
@@ -30,12 +20,17 @@ public extension Network.PushNotification {
             swarms: swarms,
             using: dependencies
         )
-        
-        /// Only cache the token data If we successfully subscribed for user PNs
-        if response.subResponses.first?.success == true {
-            dependencies[defaults: .standard, key: .deviceToken] = hexEncodedToken
-            dependencies[defaults: .standard, key: .lastDeviceTokenUpload] = now
-            dependencies[defaults: .standard, key: .isUsingFullAPNs] = true
+
+        /// The user's own swarm is always the first entry (see `retrieveAllSwarms`) so if it failed to subscribe then the device
+        /// won't receive push notifications for the user; throw so the caller can retry (and avoid caching state which would
+        /// otherwise incorrectly suppress future subscription attempts) rather than treating the subscription as successful
+        ///
+        /// **Note:** Individual group swarm failures are tolerated (they are logged within `subscribe`) as we don't want a
+        /// single bad group to prevent the user (and other groups) from receiving push notifications
+        if response.subResponses.first?.success != true {
+            throw NetworkError.explicit(
+                "Failed to subscribe the user swarm for push notifications (error: \(response.subResponses.first?.error ?? -1))."
+            )
         }
     }
     

--- a/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
@@ -241,14 +241,25 @@ public enum SwarmPoller {
                         )
                         hadValidHashUpdate = (message.info?.storeUpdatedLastHash(db) == true)
                         
-                        /// Insert the standard dedupe record ignoring dedupe files if needed
-                        try MessageDeduplication.insert(
-                            db,
-                            processedMessage: processedMessage,
-                            ignoreDedupeFiles: ignoreDedupeFiles,
-                            using: dependencies
-                        )
-                        
+                        /// Insert the deduplication record (ignoring dedupe files if needed)
+                        ///
+                        /// **Note:** For the synchronous notification extension import path (`forceSynchronousProcessing`, ie. loading
+                        /// messages saved by the notification extension) we defer this insert - for both standard **and** config messages -
+                        /// so it can be performed within the same savepoint as the message handling below. This ensures we never commit a
+                        /// dedupe record without successfully handling the message (which would otherwise permanently prevent it from being
+                        /// reprocessed on a future poll). Asynchronously-handled messages (which retry via a persistent job if they fail) and
+                        /// the normal synchronous poll handling still insert the record here
+                        let willHandleSynchronouslyInSavepoint: Bool = (shouldStoreMessages && forceSynchronousProcessing)
+
+                        if !willHandleSynchronouslyInSavepoint {
+                            try MessageDeduplication.insert(
+                                db,
+                                processedMessage: processedMessage,
+                                ignoreDedupeFiles: ignoreDedupeFiles,
+                                using: dependencies
+                            )
+                        }
+
                         return processedMessage
                     }
                     catch {
@@ -288,17 +299,58 @@ public enum SwarmPoller {
                 if namespace.isConfigNamespace {
                     do {
                         /// Process config messages all at once in case they are multi-part messages
-                        try dependencies.mutate(cache: .libSession) {
-                            try $0.handleConfigMessages(
-                                db,
-                                swarmPublicKey: swarmPublicKey,
-                                messages: ConfigMessageReceiveJob
-                                    .Details(messages: processedMessages)
-                                    .messages
-                            )
+                        ///
+                        /// For the synchronous notification extension import path (`forceSynchronousProcessing`) we perform the
+                        /// deferred deduplication inserts and the config handling within a savepoint so they are atomic - otherwise a
+                        /// failure would leave dedupe records behind without the config changes having been applied, permanently
+                        /// preventing them from being reprocessed. For all other paths the dedupe records were already inserted above
+                        /// so we just handle the messages
+                        try db.inSavepoint {
+                            if forceSynchronousProcessing {
+                                try processedMessages.forEach { processedMessage in
+                                    do {
+                                        try MessageDeduplication.insert(
+                                            db,
+                                            processedMessage: processedMessage,
+                                            ignoreDedupeFiles: ignoreDedupeFiles,
+                                            using: dependencies
+                                        )
+                                    }
+                                    catch {
+                                        /// Tolerate duplicates (the record already exists so there's nothing more to insert - just cancel
+                                        /// the pending file write) but let any other error roll the savepoint back
+                                        switch error {
+                                            case DatabaseError.SQLITE_CONSTRAINT_UNIQUE,
+                                                DatabaseError.SQLITE_CONSTRAINT,    /// Sometimes thrown for UNIQUE
+                                                MessageError.duplicateMessage,
+                                                MessageError.selfSend:
+                                                MessageDeduplication.removePendingWrite(processedMessage, using: dependencies)
+
+                                            default: throw error
+                                        }
+                                    }
+                                }
+                            }
+
+                            try dependencies.mutate(cache: .libSession) {
+                                try $0.handleConfigMessages(
+                                    db,
+                                    swarmPublicKey: swarmPublicKey,
+                                    messages: ConfigMessageReceiveJob
+                                        .Details(messages: processedMessages)
+                                        .messages
+                                )
+                            }
+
+                            return .commit
                         }
                     }
                     catch {
+                        /// If we deferred the dedupe inserts then the savepoint rolled them back so cancel their pending file writes too
+                        if forceSynchronousProcessing {
+                            processedMessages.forEach { MessageDeduplication.removePendingWrite($0, using: dependencies) }
+                        }
+
                         invalidMessageCount += 1
                         Log.error(cat, "Failed to handle processed config message in \(swarmPublicKey) due to error: \(error).")
                     }
@@ -309,24 +361,42 @@ public enum SwarmPoller {
                         guard case .standard(let threadId, let threadVariant, let messageInfo, _) = processedMessage else {
                             return
                         }
-                        
+
                         do {
-                            let info: MessageReceiver.InsertedInteractionInfo? = try MessageReceiver.handle(
-                                db,
-                                threadId: threadId,
-                                threadVariant: threadVariant,
-                                message: messageInfo.message,
-                                decodedMessage: messageInfo.decodedMessage,
-                                serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
-                                suppressNotifications: (source == .pushNotification),    /// Have already shown
-                                currentUserSessionIds: [currentUserSessionId.hexString], /// Swarm poller only has one
-                                using: dependencies
-                            )
-                            
-                            /// Notify about the received message
+                            var insertedInteractionInfo: MessageReceiver.InsertedInteractionInfo?
+
+                            /// Perform the deduplication insert and message handling within a savepoint so the two are atomic - if the
+                            /// handling fails we must **not** leave a dedupe record behind as that would permanently prevent the
+                            /// message from being reprocessed on a future poll (the dedupe insert was deferred above for exactly this
+                            /// reason)
+                            try db.inSavepoint {
+                                try MessageDeduplication.insert(
+                                    db,
+                                    processedMessage: processedMessage,
+                                    ignoreDedupeFiles: ignoreDedupeFiles,
+                                    using: dependencies
+                                )
+
+                                insertedInteractionInfo = try MessageReceiver.handle(
+                                    db,
+                                    threadId: threadId,
+                                    threadVariant: threadVariant,
+                                    message: messageInfo.message,
+                                    decodedMessage: messageInfo.decodedMessage,
+                                    serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
+                                    suppressNotifications: (source == .pushNotification),    /// Have already shown
+                                    currentUserSessionIds: [currentUserSessionId.hexString], /// Swarm poller only has one
+                                    using: dependencies
+                                )
+
+                                return .commit
+                            }
+
+                            /// Notify about the received message (performed outside the savepoint as a notification failure shouldn't
+                            /// roll back the successfully handled message)
                             MessageReceiver.prepareNotificationsForInsertedInteractions(
                                 db,
-                                insertedInteractionInfo: info,
+                                insertedInteractionInfo: insertedInteractionInfo,
                                 isMessageRequest: dependencies.mutate(cache: .libSession) { cache in
                                     cache.isMessageRequest(threadId: threadId, threadVariant: messageInfo.threadVariant)
                                 },
@@ -334,8 +404,23 @@ public enum SwarmPoller {
                             )
                         }
                         catch {
-                            invalidMessageCount += 1
-                            Log.error(cat, "Failed to handle processed message in \(threadId) due to error: \(error).")
+                            /// The savepoint rolled back the dedupe insert and any partial handling, but the pending dedupe file write is
+                            /// registered outside the transaction scope so cancel it explicitly to keep the two consistent
+                            MessageDeduplication.removePendingWrite(processedMessage, using: dependencies)
+
+                            switch error {
+                                /// Ignore duplicate & selfSend message errors (the message was already handled previously so there's
+                                /// nothing more to do)
+                                case DatabaseError.SQLITE_CONSTRAINT_UNIQUE,
+                                    DatabaseError.SQLITE_CONSTRAINT,    /// Sometimes thrown for UNIQUE
+                                    MessageError.duplicateMessage,
+                                    MessageError.selfSend:
+                                    break
+
+                                default:
+                                    invalidMessageCount += 1
+                                    Log.error(cat, "Failed to handle processed message in \(threadId) due to error: \(error).")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Two independent fixes for recurring iOS push notification problems.

Subscription state (SyncPushTokensJob, PushNotificationAPI):
- subscribeAll now throws when the user's own swarm fails to subscribe instead of returning as if it succeeded, so a failed subscription no longer records the push token as uploaded. Previously a failed subscribe (e.g. the PN server returning SERVICE_TIMEOUT) still advanced lastRecordedPushToken, which could leave the device silently unsubscribed for up to 12h after an APNs token rotation. This also revives the job's 3x retry loop, which was effectively dead for server-side failures.
- Moved the deviceToken / lastDeviceTokenUpload / isUsingFullAPNs writes out of subscribeAll and into SyncPushTokensJob's success branch, and removed the redundant throttle guard (the job already throttles) so subscribeAll is a side-effect-free bulk-API wrapper.

Message loss on the notification-extension import path (SwarmPoller):
- processPollResponse inserted the deduplication record before handling a message, with no savepoint, on the synchronous loadMessages path used to import messages saved by the notification extension. If handling failed (e.g. attachment persistence for an image/link message) the dedupe record was committed without the message and the disk file was deleted, so future polls dropped the message as a duplicate — permanent loss.
- Standard and config messages on this path now perform the dedupe insert and message handling within a db.inSavepoint (mirroring CommunityManager), cancelling the pending dedupe file on failure. A failed handle now rolls back both so the message can be reprocessed on a future poll. Normal swarm polling is unchanged.