### PR TITLE
Removed synchronous log flush from scene lifecycle callbacks

### DIFF
--- a/Session/Meta/SceneDelegate.swift
+++ b/Session/Meta/SceneDelegate.swift
@@ -69,7 +69,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let appDelegate else { return }
         if !appDelegate.hasInitialRootViewController { Log.info(.cat, "Entered background before startup was completed") }
         Log.info(.cat, "sceneDidEnterBackground.")
-        Log.flush()
         appDelegate.dependencies.notifyAsync(key: .sceneLifecycle(.didEnterBackground))
         
         // NOTE: Fix an edge case where user taps on the callkit notification
@@ -189,8 +188,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         Log.info(.cat, "Setting 'lastSeenHasMicrophonePermission'.")
         appDelegate?.dependencies[defaults: .appGroup, key: .lastSeenHasMicrophonePermission] = (Permissions.microphone == .granted)
         appDelegate?.clearAllNotificationsAndRestoreBadgeCount()
-
-        Log.flush()
     }
     
     public func scheduleLoadMessages() {


### PR DESCRIPTION
SceneDelegate.sceneWillResignActive and sceneDidEnterBackground each called Log.flush() synchronously on the main thread. Log.flush() maps to DDLog.flushLog(), a barrier that dispatch_syncs onto the logging queue and blocks until it drains, then fsyncs the log file. Its duration is unbounded (it depends on the queued backlog and disk speed), so a stalled file-logger write() blocks the main thread indefinitely.

During an Appium regression run — Debug build (verbose logging), rapid foreground/background transitions, and disk contention from parallel simulators — a log-file write() stalled past the 10s scene-update watchdog, which killed the app with 0x8BADF00D (app CPU time 0.017s, i.e. blocked, not busy).

These flushes were not buying durability: DDFileLogger (3.9.0) writes every message immediately via write() into the kernel page cache, which survives the app being suspended or jettisoned. flush() only adds an fsync (guards kernel panic / power loss) and a queue drain (only matters when the process dies without letting GCD run). Neither applies to a backgrounded app, so the calls were pure watchdog risk plus a recurring fsync on a hot path.

Removed both. The queue-drain-before-termination cases (applicationWillTerminate, exit(0)), the export-logs paths, and the extension flushes are unchanged.