### PR TITLE
Bind Apple Pro payments to the master key via appAccountToken

### DIFF
--- a/SessionMessagingKit/Crypto/Crypto+LibSession.swift
+++ b/SessionMessagingKit/Crypto/Crypto+LibSession.swift
@@ -413,9 +413,55 @@ public extension Crypto.Generator {
             }
             
             let seed: Data = try dependencies[singleton: .crypto].tryGenerate(.ed25519Seed(ed25519SecretKey: cMasterSecretKey))
-            
+
             return try dependencies[singleton: .crypto].tryGenerate(.ed25519KeyPair(seed: seed))
         }
+    }
+
+    /// Derives the deterministic `appAccountToken` (a `UUID`) to attach to an Apple StoreKit purchase from the
+    /// Session Pro master public key.
+    ///
+    /// See `UUID(sessionProMasterPublicKey:)` for why this exists and how it's constructed. The Pro backend
+    /// performs the identical derivation from the master public key it receives in the redemption request and
+    /// compares it against the `appAccountToken` Apple reported in the payment notification, cryptographically
+    /// binding the payment to the master key rather than relying on the (guessable/observable) transaction id.
+    static func sessionProAppleAccountToken() -> Crypto.Generator<UUID> {
+        return Crypto.Generator(
+            id: "sessionProAppleAccountToken",
+            args: []
+        ) { dependencies in
+            let masterKeyPair: KeyPair = try dependencies[singleton: .crypto]
+                .tryGenerate(.sessionProMasterKeyPair())
+
+            return try UUID(sessionProMasterPublicKey: masterKeyPair.publicKey)
+        }
+    }
+}
+
+public extension UUID {
+    /// Builds a deterministic `UUID` from a Session Pro master public key, for use as Apple's `appAccountToken`.
+    ///
+    /// Apple only lets us attach a single opaque `UUID` to a StoreKit purchase, and that value is the only
+    /// piece of client-controlled data the Pro backend receives from Apple's payment notification. To bind a
+    /// payment to a specific master key (rather than trusting that the Apple transaction id stays secret) we
+    /// stuff the first 16 bytes of the master public key into the UUID, overwriting only the 6 bits that the
+    /// version-4 UUID format reserves for the version/variant. That leaves 122 bits of the master public key
+    /// intact — enough that forging a matching payment within the window before the real client redeems it is
+    /// impractical.
+    ///
+    /// This is the exact equivalent of Python's `uuid.UUID(bytes=master_pkey[:16], version=4)`; the backend
+    /// must derive the token the same way for the comparison to succeed.
+    init(sessionProMasterPublicKey publicKey: [UInt8]) throws {
+        guard publicKey.count >= 16 else { throw CryptoError.invalidPublicKey }
+
+        var bytes: [UInt8] = Array(publicKey.prefix(16))
+        bytes[6] = (bytes[6] & 0x0F) | 0x40     /// Version 4
+        bytes[8] = (bytes[8] & 0x3F) | 0x80     /// Variant (RFC 4122)
+
+        self = UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 }
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -37,7 +37,6 @@ public actor SessionProManager: SessionProManagerType {
     
     private var isRefreshingState: Bool = false
     private var rotatingKeyPair: KeyPair?
-    private var accountToken: String?
     
     nonisolated private let stateStream: CurrentValueAsyncStream<SessionPro.State> = CurrentValueAsyncStream(.invalid)
     nonisolated private let hasCompletedInitialization: CurrentValueAsyncStream<Bool> = CurrentValueAsyncStream(false)
@@ -68,8 +67,7 @@ public actor SessionProManager: SessionProManagerType {
     public init(using dependencies: Dependencies) {
         self.dependencies = dependencies
         self.syncState = SessionProManagerSyncState(using: dependencies)
-        self.accountToken = (try? dependencies[singleton: .crypto].tryGenerate(.sessionProMasterKeyPair()))?.publicKey.toHexString()
-        
+
         Task.detached(priority: .medium) { [weak self] in
             await self?.startProMockingObservations()
             
@@ -435,10 +433,13 @@ public actor SessionProManager: SessionProManagerType {
             throw SessionProError.productNotFound
         }
         
-        var options: Set<Product.PurchaseOption> = []
-        if let accountTokenString: String = self.accountToken, let accountToken: UUID = UUID(uuidString: accountTokenString) {
-            options = [ .appAccountToken(accountToken) ]
-        }
+        /// Attach a deterministic `appAccountToken` derived from the Pro master public key so the Pro backend can
+        /// cryptographically bind this Apple payment to the master key (rather than trusting the transaction id to
+        /// stay secret). This is mandatory — proceeding without it would leave the payment claimable by anyone who
+        /// learns the transaction id.
+        let appleAccountToken: UUID = try dependencies[singleton: .crypto]
+            .tryGenerate(.sessionProAppleAccountToken())
+        let options: Set<Product.PurchaseOption> = [ .appAccountToken(appleAccountToken) ]
         let result: Product.PurchaseResult = try await product.purchase(options: options)
         
         guard case .success(let verificationResult) = result else {

--- a/SessionMessagingKitTests/Crypto/CryptoSMKSpec.swift
+++ b/SessionMessagingKitTests/Crypto/CryptoSMKSpec.swift
@@ -183,6 +183,65 @@ class CryptoSMKSpec: AsyncSpec {
                     .to(throwError(MessageError.decodingFailed))
                 }
             }
+
+            // MARK: -- when deriving the Session Pro Apple account token
+            describe("when deriving the Session Pro Apple account token") {
+                // MARK: ---- derives a deterministic UUID from a known master public key
+                it("derives a deterministic UUID from a known master public key") {
+                    let publicKey: [UInt8] = Array(0..<32).map { UInt8($0) }
+
+                    expect(try UUID(sessionProMasterPublicKey: publicKey).uuidString)
+                        .to(equal("00010203-0405-4607-8809-0A0B0C0D0E0F"))
+                }
+
+                // MARK: ---- overwrites only the version and variant bits
+                it("overwrites only the version and variant bits") {
+                    let publicKey: [UInt8] = [
+                        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88,
+                        0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                    ]
+
+                    /// The 6th byte's high nibble becomes `4` (version) and the 8th byte's top two bits become
+                    /// `10` (variant → `b`), every other bit of the first 16 bytes is preserved verbatim
+                    expect(try UUID(sessionProMasterPublicKey: publicKey).uuidString)
+                        .to(equal("FFEEDDCC-BBAA-4988-B766-554433221100"))
+                }
+
+                // MARK: ---- uses only the first 16 bytes of the master public key
+                it("uses only the first 16 bytes of the master public key") {
+                    let first16: [UInt8] = Array(0..<16).map { UInt8($0) }
+                    let differentTail: [UInt8] = first16 + Array(repeating: 0xAB, count: 16)
+
+                    expect(try UUID(sessionProMasterPublicKey: differentTail))
+                        .to(equal(try UUID(sessionProMasterPublicKey: first16 + Array(repeating: 0, count: 16))))
+                }
+
+                // MARK: ---- throws if the public key is too short
+                it("throws if the public key is too short") {
+                    expect { try UUID(sessionProMasterPublicKey: Array(0..<15).map { UInt8($0) }) }
+                        .to(throwError(CryptoError.invalidPublicKey))
+                }
+
+                // MARK: ---- produces a valid version 4 UUID via the crypto generator
+                it("produces a valid version 4 UUID via the crypto generator") {
+                    let result: UUID? = crypto.generate(.sessionProAppleAccountToken())
+                    try require(result).toNot(beNil())
+
+                    let chars: [Character] = Array(result!.uuidString)
+
+                    /// 15th character (start of the 3rd group) is the version and must be `4`
+                    expect(chars[14]).to(equal(Character("4")))
+
+                    /// 20th character (start of the 4th group) is the variant and must be one of `8`, `9`, `a`, `b`
+                    expect([Character("8"), Character("9"), Character("A"), Character("B")])
+                        .to(contain(chars[19]))
+
+                    /// The derivation is deterministic for a given identity seed
+                    expect(crypto.generate(.sessionProAppleAccountToken())).to(equal(result))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Previously an Apple Pro payment could be claimed by anyone who learned its transaction id: the client submitted no appAccountToken (the master pubkey was stored as a 64-char hex string and run through UUID(uuidString:), which always returned nil), so nothing bound the payment to the buyer beyond the non-secret txid.

Derive a deterministic appAccountToken UUID from the Pro master public key and attach it to the StoreKit purchase, so the backend can verify it against the master pubkey in the redemption request. The first 16 bytes of the master pubkey are stuffed into a v4 UUID, overwriting only the 6 version/variant bits (equivalent to Python's uuid.UUID(bytes=master_pkey[:16], version=4)), preserving 122 bits.
- Add UUID(sessionProMasterPublicKey:) and the .sessionProAppleAccountToken() crypto generator
- Attach the token as a mandatory purchase option (throw rather than silently purchase without it) and drop the dead accountToken field
- Add unit tests for the derivation (known vectors, version/variant masking, first-16-bytes-only, determinism) Backend must implement the matching derivation (currently a stub) for the check to take effect.