### PR TITLE
Expose pro env vars and resolve some issues found when testing

### DIFF
--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
@@ -3,9 +3,10 @@
 // stringlint:disable
 
 import UIKit
+import SessionUIKit
 import SessionNetworkingKit
+import SessionMessagingKit
 import SessionUtilitiesKit
-import SessionNetworkingKit
 
 // MARK: - Automated Test Convenience
 
@@ -146,7 +147,93 @@ extension DeveloperSettingsViewModel {
             /// Controls whether Session Pro should be enabled
             ///
             /// **Value:** `true`/`false` (default: `false`)
+            ///
+            /// **Note:** This is the master gate - the `mockCurrentUser…` values below are only reflected in the UI when this is `true`
             case sessionPro
+
+            /// Simulates the Session Pro status the backend reports for the current user
+            ///
+            /// **Value:** `"useActual"`/`"never"`/`"active"`/`"expired"` (default: `"useActual"`)
+            ///
+            /// **Note:** These match the canonical wire codes (`BackendUserProStatus.neverCode` and friends) rather than the
+            /// prettier `"neverBeenPro"`, so the test contract reads the same as what the backend actually sends
+            ///
+            /// **Note:** `unknown(code)` is intentionally not settable. It carries a free-form wire value for
+            /// unrecognised/future codes and the type deliberately excludes it from `allCases` as "a real-backend value, not a
+            /// dev-picker option" - and since it must never grant Pro (it fails closed, like `never`), a test wanting that
+            /// behaviour should use `"never"`
+            case mockCurrentUserSessionProBackendStatus
+
+            /// Simulates the loading state of the Session Pro status request, letting a test reach the loading and
+            /// backend-unavailable screens without having to take the backend down
+            ///
+            /// **Value:** `"useActual"`/`"loading"`/`"error"`/`"success"` (default: `"useActual"`)
+            case mockCurrentUserSessionProLoadingState
+
+            /// Simulates the platform the current user's subscription was originally purchased on
+            ///
+            /// **Value:** `"useActual"`/`"iOS"`/`"android"` (default: `"useActual"`)
+            case mockCurrentUserSessionProOriginatingPlatform
+
+            /// Simulates whether the current user's subscription was purchased on the account they're currently logged into, which is
+            /// what drives the "non-originating account" screens
+            ///
+            /// **Value:** `"useActual"`/`"originatingAccount"`/`"nonOriginatingAccount"` (default: `"useActual"`)
+            case mockCurrentUserOriginatingAccount
+
+            /// Simulates whether the current user's subscription has a refund pending
+            ///
+            /// **Value:** `"useActual"`/`"notRefunding"`/`"refunding"` (default: `"useActual"`)
+            case mockCurrentUserSessionProRefundingStatus
+
+            /// Simulates the build variant used by the Session Pro screens, which is what determines whether the app believes it has
+            /// billing access
+            ///
+            /// **Value:** `"useActual"`/`"appStore"`/`"development"`/`"testFlight"`/`"ipa"`/`"apk"`/`"fDroid"`/`"huawei"`
+            /// (default: `"useActual"`)
+            ///
+            /// **Note:** Only `appStore` and `testFlight` grant billing access, so any of the others are how a test reaches the
+            /// "no billing access" screens
+            case mockCurrentUserSessionProBuildVariant
+
+            /// Simulates the timestamp at which the current user's Session Pro access expires
+            ///
+            /// **Value:** Seconds since epoch (default: unset, meaning the actual value is used)
+            ///
+            /// **Note:** A timestamp in the past is how a test reaches the expired states; this is separate from
+            /// `mockCurrentUserSessionProBackendStatus`, which controls what the backend *reports*
+            ///
+            /// **Note:** As with `customDateTime`, the stored value loses some precision at present-day epoch values (observed
+            /// rounding of up to ~a minute), so assert that a date is before/after a boundary rather than exactly equal to what
+            /// was provided
+            case mockCurrentUserAccessExpiryTimestamp
+        }
+
+        /// Resolves a mockable Session Pro feature from an environment variable value, returning `nil` (having logged) when the
+        /// value isn't one of the documented options
+        ///
+        /// **Note:** The accepted strings are mapped explicitly rather than derived, because this is an **external contract** - the
+        /// Appium suite is written against these names, so they should stay readable and stable independently of anything internal.
+        /// Deriving them isn't viable either way: `MockableFeatureValue.rawValue` is an `Int`, so a derived contract would be numeric
+        /// (`…BackendStatus=2`) rather than readable (`=active`) and would shift meaning if a type is ever renumbered, and deriving
+        /// from `description` is worse still since some of these (eg. `SessionProUI.ClientPlatform`) return *display* text - which is
+        /// exactly the kind of localized-string lookup that previously deadlocked the splash screen during feature-store init.
+        func mockedProFeature<T: MockableFeatureValue>(
+            _ value: String,
+            for key: EnvironmentVariable,
+            options: KeyValuePairs<String, T>
+        ) -> MockableFeature<T>? {
+            guard value != "useActual" else { return .useActual }
+
+            guard let match: T = options.first(where: { $0.key == value })?.value else {
+                let accepted: String = (["useActual"] + options.map { $0.key })
+                    .map { "'\($0)'" }
+                    .joined(separator: ", ")
+                Log.error("Invalid '\(key.rawValue)' value '\(value)' provided, expected one of: \(accepted). Ignoring it rather than guessing.")
+                return nil
+            }
+
+            return .simulate(match)
         }
         
         let envVars: [EnvironmentVariable: String] = ProcessInfo.processInfo.environment
@@ -343,6 +430,107 @@ extension DeveloperSettingsViewModel {
                     
                 case .sessionPro:
                     dependencies.set(feature: .sessionProEnabled, to: (value == "true"))
+
+                case .mockCurrentUserSessionProBackendStatus:
+                    guard
+                        let mock: MockableFeature<Network.SessionPro.BackendUserProStatus> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                /// **Note:** `unknown(code)` is deliberately absent - the type excludes it from `allCases` as a
+                                /// real-backend value rather than a dev-picker option, and it fails closed like `never` anyway
+                                "never": .never,
+                                "active": .active,
+                                "expired": .expired
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserSessionProBackendStatus, to: mock)
+
+                case .mockCurrentUserSessionProLoadingState:
+                    guard
+                        let mock: MockableFeature<SessionPro.LoadingState> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                "loading": .loading,
+                                "error": .error,
+                                "success": .success
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserSessionProLoadingState, to: mock)
+
+                case .mockCurrentUserSessionProOriginatingPlatform:
+                    guard
+                        let mock: MockableFeature<SessionProUI.ClientPlatform> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                "iOS": .iOS,
+                                "android": .android
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserSessionProOriginatingPlatform, to: mock)
+
+                case .mockCurrentUserOriginatingAccount:
+                    guard
+                        let mock: MockableFeature<SessionPro.OriginatingAccount> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                "originatingAccount": .originatingAccount,
+                                "nonOriginatingAccount": .nonOriginatingAccount
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserOriginatingAccount, to: mock)
+
+                case .mockCurrentUserSessionProRefundingStatus:
+                    guard
+                        let mock: MockableFeature<SessionPro.RefundingStatus> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                "notRefunding": .notRefunding,
+                                "refunding": .refunding
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserSessionProRefundingStatus, to: mock)
+
+                case .mockCurrentUserSessionProBuildVariant:
+                    guard
+                        let mock: MockableFeature<BuildVariant> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                "appStore": .appStore,
+                                "development": .development,
+                                "testFlight": .testFlight,
+                                "ipa": .ipa,
+                                "apk": .apk,
+                                "fDroid": .fDroid,
+                                "huawei": .huawei
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserSessionProBuildVariant, to: mock)
+
+                case .mockCurrentUserAccessExpiryTimestamp:
+                    guard let timestamp: TimeInterval = try? TimeInterval(value, format: .number) else {
+                        Log.error("Invalid 'mockCurrentUserAccessExpiryTimestamp' value '\(value)' provided, expected seconds since epoch. Ignoring it rather than guessing.")
+                        continue
+                    }
+
+                    dependencies.set(feature: .mockCurrentUserAccessExpiryTimestamp, to: timestamp)
             }
         }
 #endif

--- a/SessionTests/Conversations/Settings/ThreadDisappearingMessagesViewModelSpec.swift
+++ b/SessionTests/Conversations/Settings/ThreadDisappearingMessagesViewModelSpec.swift
@@ -43,19 +43,24 @@ class ThreadDisappearingMessagesSettingsViewModelSpec: AsyncSpec {
                 .when { await $0.jobsMatching(filters: .any) }
                 .thenReturn([:])
             
-            viewModel = await ThreadDisappearingMessagesSettingsViewModel(
+            /// **Note:** The sink captures this *instance* rather than the `viewModel` variable. Some examples below replace
+            /// `viewModel` with a second instance, and capturing the variable meant this subscription kept feeding whichever
+            /// instance was current - so the first view model's emissions were applied to the second one, letting a stale value
+            /// overwrite the state under test.
+            let initialViewModel: ThreadDisappearingMessagesSettingsViewModel = await ThreadDisappearingMessagesSettingsViewModel(
                 threadId: "TestId",
                 threadVariant: .contact,
                 currentUserRole: nil,
                 config: DisappearingMessagesConfiguration.defaultWith("TestId"),
                 using: dependencies
             )
+            viewModel = initialViewModel
             cancellables = [
-                viewModel.tableDataPublisher
+                initialViewModel.tableDataPublisher
                     .receive(on: ImmediateScheduler.shared)
                     .sink(
                         receiveCompletion: { _ in },
-                        receiveValue: { viewModel.updateTableData($0) }
+                        receiveValue: { initialViewModel.updateTableData($0) }
                     )
             ]
         }
@@ -145,19 +150,21 @@ class ThreadDisappearingMessagesSettingsViewModelSpec: AsyncSpec {
                 try await mockStorage.write { db in
                     try config.upserted(db)
                 }
-                viewModel = await ThreadDisappearingMessagesSettingsViewModel(
+                /// **Note:** Capture this *instance* in the sink rather than the `viewModel` variable - see the note in `beforeEach`
+                let updatedViewModel: ThreadDisappearingMessagesSettingsViewModel = await ThreadDisappearingMessagesSettingsViewModel(
                     threadId: "TestId",
                     threadVariant: .contact,
                     currentUserRole: nil,
                     config: config,
                     using: dependencies
                 )
+                viewModel = updatedViewModel
                 cancellables.append(
-                    viewModel.tableDataPublisher
+                    updatedViewModel.tableDataPublisher
                         .receive(on: ImmediateScheduler.shared)
                         .sink(
                             receiveCompletion: { _ in },
-                            receiveValue: { viewModel.updateTableData($0) }
+                            receiveValue: { updatedViewModel.updateTableData($0) }
                         )
                 )
                 
@@ -269,32 +276,50 @@ class ThreadDisappearingMessagesSettingsViewModelSpec: AsyncSpec {
                 try await mockStorage.write { db in
                     try config.upserted(db)
                 }
-                viewModel = await ThreadDisappearingMessagesSettingsViewModel(
+                /// **Note:** Capture this *instance* in the sink rather than the `viewModel` variable - see the note in `beforeEach`
+                let updatedViewModel: ThreadDisappearingMessagesSettingsViewModel = await ThreadDisappearingMessagesSettingsViewModel(
                     threadId: "TestId",
                     threadVariant: .contact,
                     currentUserRole: nil,
                     config: config,
                     using: dependencies
                 )
+                viewModel = updatedViewModel
                 cancellables.append(
-                    viewModel.tableDataPublisher
+                    updatedViewModel.tableDataPublisher
                         .receive(on: ImmediateScheduler.shared)
                         .sink(
                             receiveCompletion: { _ in },
-                            receiveValue: { viewModel.updateTableData($0) }
+                            receiveValue: { updatedViewModel.updateTableData($0) }
                         )
                 )
                 
                 await expect(viewModel.tableData)
                     .toEventually(haveCount(2), timeout: .milliseconds(100))
                 
-                // Change to Off, wait for 1 section with no footer button
-                await viewModel.tableData.first?.elements.first?.onTap?()
-                await expect { viewModel.tableData }
-                    .toEventually(haveCount(1), timeout: .milliseconds(100))
-                
-                // Change back, wait for 2 sections to confirm timer section is present
-                await viewModel.tableData.first?.elements.last?.onTap?()
+                /// Change to Off, wait for 1 section with no footer button
+                ///
+                /// **Note:** We wait until the tapped option is actually *selected* rather than just until the section count
+                /// changes. `haveCount` is satisfied by the first emission that happens to have the right number of sections,
+                /// and the test then reads and taps again immediately with no margin - so a subsequent emission can replace the
+                /// element between the check and the next read, leaving that tap to silently no-op through the optional chain
+                /// and stranding the following wait. Requiring the tap target makes that case fail loudly instead of as a
+                /// confusing timeout.
+                let offOption: SessionCell.Info<String> = try require(viewModel.tableData.first?.elements.first)
+                    .toNot(beNil())
+                let offTap: @MainActor () -> Void = try require(offOption.onTap).toNot(beNil())
+                await offTap()
+                await expect { viewModel.tableData.first?.elements.first?.isRadioSelected }
+                    .toEventually(beTrue(), timeout: .milliseconds(100))
+                expect(viewModel.tableData).to(haveCount(1))
+
+                /// Change back, wait for 2 sections to confirm timer section is present
+                let sendOption: SessionCell.Info<String> = try require(viewModel.tableData.first?.elements.last)
+                    .toNot(beNil())
+                let sendTap: @MainActor () -> Void = try require(sendOption.onTap).toNot(beNil())
+                await sendTap()
+                await expect { viewModel.tableData.first?.elements.last?.isRadioSelected }
+                    .toEventually(beTrue(), timeout: .milliseconds(100))
                 await expect { viewModel.tableData }
                     .toEventually(haveCount(2), timeout: .milliseconds(100))
                 
@@ -379,7 +404,10 @@ class ThreadDisappearingMessagesSettingsViewModelSpec: AsyncSpec {
                             )
                     )
                     
-                    await viewModel.tableData.first?.elements.last?.onTap?()
+                    let tapTarget: SessionCell.Info<String> = try require(viewModel.tableData.first?.elements.last)
+                        .toNot(beNil())
+                    let tapAction: @MainActor () -> Void = try require(tapTarget.onTap).toNot(beNil())
+                    await tapAction()
                     await expect { viewModel.tableData }
                         .toEventually(haveCount(2), timeout: .milliseconds(100))
                 }
@@ -443,5 +471,18 @@ class ThreadDisappearingMessagesSettingsViewModelSpec: AsyncSpec {
                 }
             }
         }
+    }
+}
+
+// MARK: - Convenience
+
+private extension SessionCell.Info {
+    /// Whether this cell's trailing radio is currently selected
+    ///
+    /// **Note:** Test-only helper. It lets a spec wait on the *settled* selection state rather than on a section count -
+    /// `haveCount` is satisfied by the first emission with the expected number of sections, which isn't necessarily the final
+    /// one, so tapping straight after a count check can race a later emission.
+    var isRadioSelected: Bool {
+        return ((trailingAccessory as? SessionCell.AccessoryConfig.Radio)?.isSelected == true)
     }
 }

--- a/SessionUtilitiesKit/Observations/DebounceTaskManager.swift
+++ b/SessionUtilitiesKit/Observations/DebounceTaskManager.swift
@@ -10,12 +10,24 @@ public actor DebounceTaskManager<Event: Sendable> {
     /// The interval needs to be long enough to be able to group different events that could be triggered by an action (db write, async
     /// tasks, actor hopping, etc.) but not so long that the user might perceive some lag after performing an action that should trigger a
     /// UI update.
-    private let debounceInterval: DispatchTimeInterval = .milliseconds(25)
-    
+    public static var defaultInterval: DispatchTimeInterval { .milliseconds(25) }
+
+    private let debounceInterval: DispatchTimeInterval
     private var debounceTask: Task<Void, Never>? = nil
     private var pendingEvents: [Event] = []
     private var pendingEventSet: Set<AnyHashable> = []
     private var action: (@Sendable ([Event]) async -> Void)?
+
+    // MARK: - Initialization
+
+    /// Create a debouncer
+    ///
+    /// **Note:** The interval is injectable so tests can drive it to zero. The debounce is a real `Task.sleep`, so it adds wall-clock
+    /// latency that the schedulers injected via `Dependencies` cannot control - leaving it at the production value makes any spec
+    /// which asserts on an observation timing-dependent (see `QueryRunner`).
+    public init(interval: DispatchTimeInterval = DebounceTaskManager.defaultInterval) {
+        self.debounceInterval = interval
+    }
 
     public func setAction(_ newAction: @Sendable @escaping ([Event]) async -> Void) {
         self.action = newAction

--- a/SessionUtilitiesKit/Observations/ObservationBuilder.swift
+++ b/SessionUtilitiesKit/Observations/ObservationBuilder.swift
@@ -153,7 +153,7 @@ public struct ConfiguredObservationBuilder<Output: ObservableKeyProvider> {
 private actor QueryRunner<Output: ObservableKeyProvider> {
     private let dependencies: Dependencies
     private let observationManager: ObservationManager
-    private let debouncer: DebounceTaskManager<ObservedEvent> = DebounceTaskManager()
+    private let debouncer: DebounceTaskManager<ObservedEvent>
     private let continuation: AsyncStream<Output>.Continuation
     private let query: (_ previousValue: Output, _ events: [ObservedEvent], _ isInitialFetch: Bool, _ dependencies: Dependencies) async -> Output
     
@@ -178,6 +178,19 @@ private actor QueryRunner<Output: ObservableKeyProvider> {
         self.observationManager = observationManager
         self.continuation = continuation
         self.lastValue = initialValue
+
+        /// Drop the debounce entirely when running synchronously (ie. in tests)
+        ///
+        /// The debounce is a real `Task.sleep`, so unlike the schedulers/queues it isn't neutralised by `forceSynchronous` - leaving it
+        /// at the production interval means every observation-driven assertion has to out-wait it, which quietly makes those specs
+        /// wall-clock dependent and intermittently slower than whatever deadline they picked
+        self.debouncer = DebounceTaskManager(
+            interval: (
+                dependencies.forceSynchronous ?
+                    .milliseconds(0) :
+                    DebounceTaskManager<ObservedEvent>.defaultInterval
+            )
+        )
     }
     
     // MARK: - Functions
@@ -223,6 +236,12 @@ private actor QueryRunner<Output: ObservableKeyProvider> {
         isRunningQuery = true
         
         /// Capture the updated data and new keys to observe
+        ///
+        /// **Note:** We record when the query started so that any key it turns out we need to observe can replay events emitted
+        /// while it was running - we can't subscribe any earlier than this because the query is what tells us which keys to observe.
+        /// This uses the wall clock rather than `dependencies.dateNow` deliberately, as it's compared against the manager's own
+        /// buffer timestamps and must not be affected by a test freezing time.
+        let queryStartedAt: Date = Date()
         let newResult: Output = await self.query(previousValueForQuery, eventsToProcess, isInitialQuery, dependencies)
         let newKeys: Set<ObservableKey> = newResult.observedKeys(using: dependencies)
 
@@ -234,7 +253,7 @@ private actor QueryRunner<Output: ObservableKeyProvider> {
             
             /// Start observing new keys **before** cancelling anything
             for addedKey in addedKeys {
-                keyListenerTasks[addedKey] = observe(key: addedKey)
+                keyListenerTasks[addedKey] = await observe(key: addedKey, since: queryStartedAt)
             }
             
             /// Cancel tasks for and keys that were removed
@@ -259,29 +278,45 @@ private actor QueryRunner<Output: ObservableKeyProvider> {
         }
     }
     
-    private func observe(key: ObservableKey) -> Task<Void, Never> {
-        return Task(priority: .utility) { [weak self] in
-            guard let self = self else { return }
-            
-            do {
-                if let source = key.streamSource {
-                    if let stream = await source.makeStream() {
-                        for await value in stream {
-                            try Task.checkCancellation()
-                            
-                            let event = ObservedEvent(key: key, value: value)
-                            await self.debouncer.signal(event: event)
-                        }
+    /// Start observing a key
+    ///
+    /// **Note:** The stream is acquired **before** this returns, so the continuation is registered as part of the key becoming active
+    /// rather than whenever a spawned task happens to get scheduled. Previously the subscription happened inside the task, which
+    /// meant a key could be active but unobserved for an unbounded period - any event emitted in that gap was recoverable only from
+    /// the replay buffer, and if the task was starved for longer than that the event was silently lost. Only the *consumption* loop
+    /// needs to be a task.
+    ///
+    /// - Parameter since: When this observation logically began, so the manager can replay anything emitted while the query that
+    /// produced this key was still running (the keys aren't known until it finishes, so that window is unavoidable).
+    private func observe(key: ObservableKey, since: Date) async -> Task<Void, Never> {
+        /// An external source yields raw values rather than events, so it has to be wrapped separately
+        if let source = key.streamSource {
+            guard let stream = await source.makeStream() else { return Task {} }
+
+            return Task(priority: .userInitiated) { [weak self] in
+                do {
+                    for await value in stream {
+                        try Task.checkCancellation()
+
+                        await self?.debouncer.signal(event: ObservedEvent(key: key, value: value))
                     }
                 }
-                else {
-                    let stream = await self.observationManager.observe(key)
-                    
-                    for await event in stream {
-                        try Task.checkCancellation()
-                        
-                        await self.debouncer.signal(event: event)
-                    }
+                catch {
+                    // A CancellationError could be thrown here but we just ignore it because
+                    // it'll generally just be the result of observing a new set of keys while
+                    // there are pending changes in the debouncer
+                }
+            }
+        }
+
+        let stream: AsyncStream<ObservedEvent> = await observationManager.observe(key, since: since)
+
+        return Task(priority: .userInitiated) { [weak self] in
+            do {
+                for await event in stream {
+                    try Task.checkCancellation()
+
+                    await self?.debouncer.signal(event: event)
                 }
             }
             catch {

--- a/SessionUtilitiesKit/Observations/ObservationManager.swift
+++ b/SessionUtilitiesKit/Observations/ObservationManager.swift
@@ -24,6 +24,14 @@ public actor ObservationManager {
     /// observer - we need the window to be large enough to account for the worst case actor-hop, but not so large to have an excessive
     /// buffer size
     private let bufferWindow: TimeInterval = 0.1
+
+    /// How long buffered events are retained for
+    ///
+    /// This is deliberately longer than `bufferWindow`: that window is the *default* replay reach for a caller which doesn't know
+    /// when it started observing, whereas a caller which passes an explicit `since` can only replay what's still retained here. Keeping
+    /// these separate means an unusually slow query can't silently cost us an event, and the extra retention is cheap (events are
+    /// small and this is a rolling buffer).
+    private let bufferRetention: TimeInterval = 1
     private let lifecycleObservations: [any NSObjectProtocol]
     private var eventBuffer: [ObservableKey: [BufferedEvent]] = [:]
     private var store: [ObservableKey: [UUID: AsyncStream<ObservedEvent>.Continuation]] = [:]
@@ -60,16 +68,22 @@ public actor ObservationManager {
     
     // MARK: - Functions
     
-    public func observe(_ key: ObservableKey) -> AsyncStream<ObservedEvent> {
+    /// Observe a key, replaying any buffered events the observer would otherwise have missed
+    ///
+    /// - Parameter since: The instant from which the caller considers itself to be observing. Pass this when there is a known gap
+    /// between *deciding* to observe a key and this subscription actually being registered (eg. a query has to run first to work out
+    /// which keys to observe) - everything buffered from that instant is replayed, so the caller doesn't depend on how long the gap
+    /// happened to take. When omitted the `bufferWindow` is used, which only covers a gap shorter than that window.
+    public func observe(_ key: ObservableKey, since: Date? = nil) -> AsyncStream<ObservedEvent> {
         let id: UUID = UUID()
-        
+
         return AsyncStream { continuation in
             self.addContinuation(continuation, for: key, id: id)
-            
-            /// Replay any buffered events within the window
-            let now: Date = Date()
+
+            /// Replay any buffered events the observer missed
+            let cutoff: Date = (since ?? Date().addingTimeInterval(-bufferWindow))
             eventBuffer[key]?
-                .filter { now.timeIntervalSince($0.timestamp) < bufferWindow }
+                .filter { $0.timestamp >= cutoff }
                 .forEach { continuation.yield($0.event) }
             
             continuation.onTermination = { _ in
@@ -86,7 +100,7 @@ public actor ObservationManager {
             store[event.key]?.values.forEach { $0.yield(event) }
         }
         
-        pruneBuffer(before: now.addingTimeInterval(-bufferWindow))
+        pruneBuffer(before: now.addingTimeInterval(-bufferRetention))
     }
     
     // MARK: - Internal Functions


### PR DESCRIPTION
- Expose the Session Pro mock features as launch-arg environment variables
- Close a subscription gap in the observation pipeline, and make the debounce injectable
- Fix cross-talk between view models in the disappearing messages spec