### PR TITLE
Fix an issue where some group notification messages could get dropped when they shouldn't

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		7BFA8AE32831D0D4001876F3 /* ContextMenuVC+EmojiReactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFA8AE22831D0D4001876F3 /* ContextMenuVC+EmojiReactsView.swift */; };
 		7BFD1A8A2745C4F000FB91B9 /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD1A892745C4F000FB91B9 /* Permissions.swift */; };
 		7BFD1A972747689000FB91B9 /* Session-Turn-Server in Resources */ = {isa = PBXBuildFile; fileRef = 7BFD1A962747689000FB91B9 /* Session-Turn-Server */; };
+		7C2B214EABA6A0389BF40373 /* SwarmPollerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D980B840B604F5BBABCA02D /* SwarmPollerSpec.swift */; };
 		855B33086CFBDD499937E6A4 /* ProErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C82C950DB036AA43AE94F2C /* ProErrorMessage.swift */; };
 		9409433E2C7EB81800D9D2E0 /* WebRTCSession+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9409433D2C7EB81800D9D2E0 /* WebRTCSession+Constants.swift */; };
 		940943402C7ED62300D9D2E0 /* StartupError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9409433F2C7ED62300D9D2E0 /* StartupError.swift */; };
@@ -1004,6 +1005,7 @@
 		FDAA36CA2EB476090040603E /* SessionProProfileFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA36C92EB476060040603E /* SessionProProfileFeatures.swift */; };
 		FDAA36CE2EB4844F0040603E /* SessionProDecodedProForMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA36CD2EB484450040603E /* SessionProDecodedProForMessage.swift */; };
 		FDAA36D02EB485F20040603E /* SessionProDecodedStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA36CF2EB485EF0040603E /* SessionProDecodedStatus.swift */; };
+		FDAA7A1E0001000000000002 /* MainThreadUITripwire.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA7A1E0001000000000001 /* MainThreadUITripwire.swift */; };
 		FDAB8A832EB2A4CB000A6C65 /* MentionSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C302093D25DCBF07001F572D /* MentionSelectionView.swift */; };
 		FDAB8A852EB2BC37000A6C65 /* MentionSelectionView+SessionMessagingKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAB8A842EB2BC2F000A6C65 /* MentionSelectionView+SessionMessagingKit.swift */; };
 		FDAE2DB62F5A5B9B00E6FB80 /* Crypto+OpenGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A02C9A60A6002A2623 /* Crypto+OpenGroup.swift */; };
@@ -1102,7 +1104,6 @@
 		FDDF074429C3E3D000E5E8B5 /* FetchRequest+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDF074329C3E3D000E5E8B5 /* FetchRequest+Utilities.swift */; };
 		FDDF074A29DAB36900E5E8B5 /* JobRunnerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDF074929DAB36900E5E8B5 /* JobRunnerSpec.swift */; };
 		FDE125232A837E4E002DA685 /* MainAppContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE125222A837E4E002DA685 /* MainAppContext.swift */; };
-		FDAA7A1E0001000000000002 /* MainThreadUITripwire.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAA7A1E0001000000000001 /* MainThreadUITripwire.swift */; };
 		FDE287532E94C5CB00442E03 /* Update.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE287522E94C5C900442E03 /* Update.swift */; };
 		FDE287552E94CFDB00442E03 /* URL+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE287542E94CFD400442E03 /* URL+Utilities.swift */; };
 		FDE287572E94D7B800442E03 /* DeveloperSettingsFileServerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE287562E94D7B200442E03 /* DeveloperSettingsFileServerViewModel.swift */; };
@@ -2020,6 +2021,7 @@
 		94D716812E8FA19D008294EE /* AttributedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedLabel.swift; sourceTree = "<group>"; };
 		94D716852E93394B008294EE /* SessionProBadge+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionProBadge+Utilities.swift"; sourceTree = "<group>"; };
 		94E9BC0C2C7BFBDA006984EA /* Localization+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Localization+Style.swift"; sourceTree = "<group>"; };
+		9D980B840B604F5BBABCA02D /* SwarmPollerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwarmPollerSpec.swift; sourceTree = "<group>"; };
 		A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		A163E8AA16F3F6A90094D68B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		A1C32D4D17A0652C000A904E /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
@@ -2646,6 +2648,7 @@
 		FDAA36C92EB476060040603E /* SessionProProfileFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionProProfileFeatures.swift; sourceTree = "<group>"; };
 		FDAA36CD2EB484450040603E /* SessionProDecodedProForMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionProDecodedProForMessage.swift; sourceTree = "<group>"; };
 		FDAA36CF2EB485EF0040603E /* SessionProDecodedStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionProDecodedStatus.swift; sourceTree = "<group>"; };
+		FDAA7A1E0001000000000001 /* MainThreadUITripwire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadUITripwire.swift; sourceTree = "<group>"; };
 		FDAB8A842EB2BC2F000A6C65 /* MentionSelectionView+SessionMessagingKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MentionSelectionView+SessionMessagingKit.swift"; sourceTree = "<group>"; };
 		FDAE2DC22F5F818A00E6FB80 /* Animation+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Animation+Utilities.swift"; sourceTree = "<group>"; };
 		FDB11A4B2DCC527900BEF49F /* NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContent.swift; sourceTree = "<group>"; };
@@ -2751,7 +2754,6 @@
 		FDDF074329C3E3D000E5E8B5 /* FetchRequest+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FetchRequest+Utilities.swift"; sourceTree = "<group>"; };
 		FDDF074929DAB36900E5E8B5 /* JobRunnerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobRunnerSpec.swift; sourceTree = "<group>"; };
 		FDE125222A837E4E002DA685 /* MainAppContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAppContext.swift; sourceTree = "<group>"; };
-		FDAA7A1E0001000000000001 /* MainThreadUITripwire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadUITripwire.swift; sourceTree = "<group>"; };
 		FDE287522E94C5C900442E03 /* Update.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update.swift; sourceTree = "<group>"; };
 		FDE287542E94CFD400442E03 /* URL+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Utilities.swift"; sourceTree = "<group>"; };
 		FDE287562E94D7B200442E03 /* DeveloperSettingsFileServerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSettingsFileServerViewModel.swift; sourceTree = "<group>"; };
@@ -4889,6 +4891,7 @@
 			isa = PBXGroup;
 			children = (
 				FD336F6B2CAA29C200C0B51B /* CommunityPollerManagerSpec.swift */,
+				9D980B840B604F5BBABCA02D /* SwarmPollerSpec.swift */,
 			);
 			path = Pollers;
 			sourceTree = "<group>";
@@ -7008,8 +7011,8 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH",
-				"$TARGET_BUILD_DIR/$INFOPLIST_PATH",
+				$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH,
+				$TARGET_BUILD_DIR/$INFOPLIST_PATH,
 			);
 			name = "Add Commit Hash To Build Info Plist";
 			outputFileListPaths = (
@@ -7030,8 +7033,8 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH",
-				"$TARGET_BUILD_DIR/$INFOPLIST_PATH",
+				$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH,
+				$TARGET_BUILD_DIR/$INFOPLIST_PATH,
 			);
 			name = "Add Commit Hash To Build Info Plist";
 			outputFileListPaths = (
@@ -7133,8 +7136,8 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH",
-				"$TARGET_BUILD_DIR/$INFOPLIST_PATH",
+				$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH,
+				$TARGET_BUILD_DIR/$INFOPLIST_PATH,
 			);
 			name = "Add Commit Hash To Build Info Plist";
 			outputFileListPaths = (
@@ -8379,6 +8382,7 @@
 				FD3C906727E416AF00CD579F /* BlindedIdLookupSpec.swift in Sources */,
 				FDEF309D2F29742E0004C5BD /* MockLogger.swift in Sources */,
 				FD78E9F22DDA9EA200D55B50 /* MockImageDataManager.swift in Sources */,
+				7C2B214EABA6A0389BF40373 /* SwarmPollerSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Session/Meta/Translations/InfoPlist.xcstrings
+++ b/Session/Meta/Translations/InfoPlist.xcstrings
@@ -76,7 +76,7 @@
         "bg" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session трябва да използва Apple Music, за да възпроизвежда медийни прикачени файлове."
+            "value" : "Session се нуждае от Apple Music, за да възпроизведе конкретните прикачени файлове."
           }
         },
         "bn" : {
@@ -214,7 +214,7 @@
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session-nak szüksége van az Apple Music használatára a média mellékletek lejátszásához."
+            "value" : "A(z) Session alkalmazásnak szüksége van az Apple Music használatára a médiafájlok lejátszásához."
           }
         },
         "hy-AM" : {
@@ -543,7 +543,7 @@
         "az" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session foto və video çəkmək və ya QR kodlarını skan etmək üçün kameraya müraciət etməlidir."
+            "value" : "Session foto və video çəkmək və ya QR kodlarını skan etmək üçün kameraya erişməlidir."
           }
         },
         "bal" : {
@@ -561,7 +561,7 @@
         "bg" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session се нуждае от достъп до камерата, за да прави снимки и видеота, или да сканира QR кодове."
+            "value" : "Session се нуждае от достъп до камерата, за да заснема снимки и видео, и да сканира QR кодове."
           }
         },
         "bn" : {
@@ -591,7 +591,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session kræver tilladelse til at tilgå dit kamera, for at kunne tage billeder eller scanne QR-koder."
+            "value" : "Session skal bruge kameraadgang, for at kunne tage billeder eller scanne QR-koder."
           }
         },
         "de" : {
@@ -699,7 +699,7 @@
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session alkalmazásnak kamera-hozzáférésre van szüksége fotók és videók készítéséhez, illetve QR-kódok beolvasásához."
+            "value" : "A(z) Session alkalmazásnak hozzáférésre van szüksége a kamerához, hogy fényképeket és videókat készítsen, vagy QR-kódokat olvasson be."
           }
         },
         "hy-AM" : {
@@ -1286,7 +1286,7 @@
         "my" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session တွင် အမ်ကာ မျက်နှာ မြင်စနစ် लॉग इन ၏ လုံခြုံစေသည်။"
+            "value" : "Session ရှိ မျက်နှာပြင်ခတ် သော့သည် Face ID ကို အသုံးပြုပါသည်။"
           }
         },
         "nb" : {
@@ -1564,6 +1564,12 @@
             "value" : "Session necesita acceso a la red local para realizar llamadas de voz y video."
           }
         },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session برای برقراری تماس‌های صوتی و تصویری به دسترسی شبکهٔ محلی نیاز دارد."
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1604,6 +1610,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Session이 음성 및 영상 통화를 하기 위해 로컬 네트워크에 접근해야 합니다."
+          }
+        },
+        "my" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "အသံခေါ်ဆိုမှုနှင့် ဗီဒီယိုခေါ်ဆိုမှုများ ပြုလုပ်ရန် Session သည် လိုကယ်ကွန်ရက်သို့ ဝင်ရောက်ခွင့် လိုအပ်ပါသည်။"
           }
         },
         "nb" : {
@@ -1716,7 +1728,7 @@
         "az" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session zəng etmək və səsli mesajlar yazmaq üçün mikrofona müraciət etməlidir."
+            "value" : "Session zəng etmək və səsli mesajlar yazmaq üçün mikrofona erişməlidir."
           }
         },
         "bal" : {
@@ -1734,7 +1746,7 @@
         "bg" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session се нуждае от достъп до микрофона, за да осъществява обаждания и записва аудио съобщения."
+            "value" : "С цел да осъществява обаждания и да записва звукови съобщения Session се нуждае от достъп до микрофона на вашето устройство."
           }
         },
         "bn" : {
@@ -1764,7 +1776,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session kræver mikrofonadgang for at foretage opkald og optage lydmeddelelser."
+            "value" : "Session skal bruge mikrofonadgang for at foretage opkald og optage lydmeddelelser."
           }
         },
         "de" : {
@@ -1872,7 +1884,7 @@
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session alkalmazásnak mikrofon-hozzáférésre van szüksége hívások bonyolítására és hangüzeneteket rögzítésére."
+            "value" : "A(z) Session alkalmazásnak hozzáférésre van szüksége a mikrofonhoz, hogy hívásokat kezdeményezzen és hangüzeneteket rögzítsen."
           }
         },
         "hy-AM" : {
@@ -2219,7 +2231,7 @@
         "bg" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session се нуждае от достъп до хранилището, за да запазва прикачени файлове и медия."
+            "value" : "Session се нуждае от достъп до постоянната памет на вашето устройство, за да запазва прикачени файлове, снимки и звукови файлове."
           }
         },
         "bn" : {
@@ -2249,7 +2261,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session skal have lageradgang for at gemme vedhæftninger og mediefiler."
+            "value" : "Session skal bruge lageradgang for at gemme vedhæftninger og mediefiler."
           }
         },
         "de" : {
@@ -2357,7 +2369,7 @@
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session alkalmazásnak tárhely-hozzáférésre van szüksége a mellékletek és médiák mentéséhez."
+            "value" : "A(z) Session alkalmazásnak hozzáférésre van szüksége a tárhelyhez, hogy mellékleteket és médiafájlokat menthessen."
           }
         },
         "hy-AM" : {
@@ -2465,7 +2477,7 @@
         "my" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session သည် ပူးတွဲချက်များနှင့် မီဒီယာကို သိမ်းဆည်းရန် သိုလှောင်မှုခွင့်ပြုချက်လိုအပ်ပါသည်။"
+            "value" : "Session သည် ပူးတွဲချက်များနှင့် မီဒီယာကို သိမ်းဆည်းရန် သိုလှောင်မှုခွင့်ပြုချက် လိုအပ်ပါသည်။"
           }
         },
         "nb" : {
@@ -2531,7 +2543,7 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session precisa de acesso ao armazenamento para salvar anexos e mídia."
+            "value" : "Session precisa de acesso ao armazenamento para salvar anexos e multimédia."
           }
         },
         "ro" : {
@@ -2686,7 +2698,7 @@
         "az" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session foto və videoları göndərmək üçün anbara müraciət etməlidir."
+            "value" : "Session foto və videoları göndərmək üçün anbara erişməlidir."
           }
         },
         "bal" : {
@@ -2704,7 +2716,7 @@
         "bg" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session се нуждае от достъп до хранилището, за да изпраща снимки и видеота."
+            "value" : "За да може да изпраща снимки и видео файлове Session се нуждае от достъп до постоянната памет (диска) на вашето устройство."
           }
         },
         "bn" : {
@@ -2734,7 +2746,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session har brug for lageradgang for at sende billeder og videoer."
+            "value" : "Session skal bruge lageradgang for at sende billeder og videoer."
           }
         },
         "de" : {
@@ -2842,7 +2854,7 @@
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session alkalmazásnak tárhely-hozzáférésre van szüksége a fotók és videók elküldéséhez."
+            "value" : "A(z) Session alkalmazásnak hozzáférésre van szüksége a tárhelyhez, hogy fényképeket és videókat küldhessen."
           }
         },
         "hy-AM" : {
@@ -2950,7 +2962,7 @@
         "my" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session သည် ဓာတ်ပုံများနှင့် ဗွီဒီယိုများ ပို့ရန် သိမ်းဆည်းမှုပုံစံခွင့်လိုအပ်သည်။"
+            "value" : "Session သည် ဓာတ်ပုံများနှင့် ဗွီဒီယိုများ ပို့ရန် သိမ်းဆည်းမှုပုံစံခွင့် လိုအပ်သည်။"
           }
         },
         "nb" : {

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+SharedGroup.swift
@@ -298,10 +298,18 @@ internal extension LibSession {
         dependencies.mutate(cache: .libSession) { cache in
             cache.removeConfigs(for: groupSessionId)
         }
-        
+
         _ = try? ConfigDump
             .filter(ConfigDump.Columns.sessionId == groupSessionId.hexString)
             .deleteAll(db)
+
+        /// Also remove the replicated config dumps from the extension cache so the notification extension can't keep
+        /// loading (and decrypting with) group config state that the main app has just removed - if it did the two would
+        /// diverge and the extension could decrypt/notify for messages the main app can no longer read (a root cause of
+        /// group messages appearing in a notification but being lost from the conversation)
+        db.afterCommit { [extensionHelper = dependencies[singleton: .extensionHelper]] in
+            extensionHelper.removeConfigDumps(for: groupSessionId)
+        }
     }
     
     static func saveCreatedGroup(

--- a/SessionMessagingKit/Messages/LibSessionMessage.swift
+++ b/SessionMessagingKit/Messages/LibSessionMessage.swift
@@ -6,9 +6,15 @@ import SessionUtilitiesKit
 public final class LibSessionMessage: Message, NotProtoConvertible {
     private enum CodingKeys: String, CodingKey {
         case ciphertext
+        case serverTimestampMs
     }
-    
+
     public var ciphertext: Data
+
+    /// The timestamp (ms) at which the message was stored on the swarm. Used to reject stale/replayed control messages
+    /// (eg. a `groupKicked` message which predates the user's current group membership). Optional as it's only populated
+    /// for messages received from a swarm origin - when `nil` any freshness check fails-safe (ie. proceeds as if fresh)
+    public var serverTimestampMs: Int64?
     
     // MARK: - Validation
     
@@ -32,7 +38,8 @@ public final class LibSessionMessage: Message, NotProtoConvertible {
         let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
         
         ciphertext = try container.decode(Data.self, forKey: .ciphertext)
-        
+        serverTimestampMs = try container.decodeIfPresent(Int64.self, forKey: .serverTimestampMs)
+
         try super.init(from: decoder)
     }
     
@@ -42,6 +49,7 @@ public final class LibSessionMessage: Message, NotProtoConvertible {
         var container: KeyedEncodingContainer<CodingKeys> = encoder.container(keyedBy: CodingKeys.self)
         
         try container.encode(ciphertext, forKey: .ciphertext)
+        try container.encodeIfPresent(serverTimestampMs, forKey: .serverTimestampMs)
     }
 }
 
@@ -79,6 +87,7 @@ public extension LibSessionMessage {
         plaintext: Data,
         userSessionId: SessionId,
         groupSessionId: SessionId,
+        serverTimestampMs: Int64?,
         using dependencies: Dependencies
     ) throws {
         /// Ignore the message if the `memberSessionIds` doesn't contain the current users session id,
@@ -86,7 +95,7 @@ public extension LibSessionMessage {
         guard let (memberId, keysGen): (SessionId, Int) = try? LibSessionMessage.groupKicked(plaintext: plaintext) else {
             throw MessageError.invalidMessage("Could not process as group kicked message")
         }
-        
+
         guard
             let currentKeysGen: Int = try? LibSession.currentGeneration(
                 groupSessionId: groupSessionId,
@@ -95,5 +104,33 @@ public extension LibSessionMessage {
             memberId == userSessionId,
             keysGen >= currentKeysGen
         else { throw MessageError.ignorableMessage }
+
+        /// Reject stale/replayed kick messages which predate the user's _current_ membership of the group
+        ///
+        /// The `keysGen >= currentKeysGen` check above is only a generation _floor_ and isn't sufficient on its own: after a
+        /// kick+re-invite a non-admin member's `groupKeys` starts empty at generation 0 until a poll merges the real keys, so
+        /// during that window a replayed old "kicked at gen N" message would satisfy `N >= 0` and wrongly wipe the group
+        /// state again. The kick is delivered via the admin-only `revokedRetrievableGroupMessages` namespace so its swarm
+        /// `serverTimestampMs` is trustworthy, and a genuine _current_ kick is always sent after the member's most recent
+        /// (re-)join - so we can safely ignore any kick whose swarm timestamp predates the stored `joinedAt`.
+        ///
+        /// **Note:** We only reject when we _positively_ know the message is stale (both timestamps present and the message is
+        /// strictly older). If either value is missing we fall through and apply the kick, since failing to apply a genuine kick
+        /// (leaving an ex-member with group access) is far worse than a rare failure to reject a replay
+        let joinedAtMs: Int64? = dependencies
+            .mutate(cache: .libSession) { cache in
+                cache.groupInfo(for: [groupSessionId.hexString]).first.flatMap { $0 }?.joinedAt
+            }
+            .map { Int64($0 * 1000) }
+
+        if
+            let joinedAtMs: Int64 = joinedAtMs,
+            let serverTimestampMs: Int64 = serverTimestampMs,
+            joinedAtMs > 0,
+            serverTimestampMs > 0,
+            serverTimestampMs < joinedAtMs
+        {
+            throw MessageError.ignorableMessage
+        }
     }
 }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Groups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Groups.swift
@@ -793,15 +793,17 @@ extension MessageReceiver {
         _ db: ObservingDatabase,
         groupSessionId: SessionId,
         plaintext: Data,
+        serverTimestampMs: Int64?,
         using dependencies: Dependencies
     ) throws {
         let userSessionId: SessionId = dependencies[cache: .general].sessionId
-        
+
         /// Ensure the `groupKicked` message was valid before continuing
         try LibSessionMessage.validateGroupKickedMessage(
             plaintext: plaintext,
             userSessionId: userSessionId,
             groupSessionId: groupSessionId,
+            serverTimestampMs: serverTimestampMs,
             using: dependencies
         )
         

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+LibSession.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+LibSession.swift
@@ -65,6 +65,7 @@ extension MessageReceiver {
                         db,
                         groupSessionId: senderSessionId,
                         plaintext: plaintext,
+                        serverTimestampMs: message.serverTimestampMs,
                         using: dependencies
                     )
                     

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -40,12 +40,15 @@ public enum MessageReceiver {
         
         /// The group "revoked retrievable" namespace uses custom encryption so we need to custom handle it
         guard !origin.isRevokedRetrievableNamespace else {
-            guard case .swarm(let publicKey, _, let serverHash, _, let serverExpirationTimestamp) = origin else {
+            guard case .swarm(let publicKey, _, let serverHash, let serverTimestampMs, let serverExpirationTimestamp) = origin else {
                 throw MessageError.invalidRevokedRetrievalMessageHandling
             }
-            
+
             let message: LibSessionMessage = LibSessionMessage(ciphertext: data)
             message.serverHash = serverHash
+            /// Retain the swarm timestamp so a stale/replayed `groupKicked` control message can be rejected downstream
+            /// (see `validateGroupKickedMessage`)
+            message.serverTimestampMs = serverTimestampMs
             
             return .standard(
                 threadId: publicKey,

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI+SessionMessagingKit.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI+SessionMessagingKit.swift
@@ -29,7 +29,7 @@ public extension Network.PushNotification {
         /// single bad group to prevent the user (and other groups) from receiving push notifications
         if response.subResponses.first?.success != true {
             throw NetworkError.explicit(
-                "Failed to subscribe the user swarm for push notifications (error: \(response.subResponses.first?.error ?? -1))."
+                "Failed to subscribe the user swarm for push notifications (error: \(response.subResponses.first?.error ?? -1))." // stringlint:ignore
             )
         }
     }

--- a/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
@@ -283,8 +283,23 @@ public enum SwarmPoller {
                             default:
                                 invalidMessageCount += 1
                                 Log.error(cat, "Failed to deserialize envelope due to error: \(error).")
+
+                                /// On the synchronous notification extension import path the message (and a dedupe file) will have
+                                /// been saved by the extension; since we failed to process it here (eg. `CryptoError.invalidKey` when
+                                /// the group keys haven't synced into the main app yet) we need to remove that dedupe record so a
+                                /// subsequent poll can genuinely reprocess the message once it becomes decryptable - otherwise the
+                                /// surviving dedupe file would make the poll drop it as a duplicate and the message would be lost
+                                ///
+                                /// **Note:** For groups the `threadId` matches the `swarmPublicKey`; for other conversations the
+                                /// computed path won't exist so this is a harmless no-op (hence `try?`)
+                                if forceSynchronousProcessing {
+                                    try? dependencies[singleton: .extensionHelper].removeDedupeRecord(
+                                        threadId: swarmPublicKey,
+                                        uniqueIdentifier: message.hash
+                                    )
+                                }
                         }
-                        
+
                         return nil
                     }
                 }
@@ -420,6 +435,16 @@ public enum SwarmPoller {
                                 default:
                                     invalidMessageCount += 1
                                     Log.error(cat, "Failed to handle processed message in \(threadId) due to error: \(error).")
+
+                                    /// The savepoint rolled back the message handling (and its deferred dedupe insert) but the extension
+                                    /// may have saved a dedupe file for this message; remove it so a subsequent poll can reprocess the
+                                    /// message rather than dropping it as a duplicate
+                                    if forceSynchronousProcessing {
+                                        try? dependencies[singleton: .extensionHelper].removeDedupeRecord(
+                                            threadId: threadId,
+                                            uniqueIdentifier: processedMessage.uniqueIdentifier
+                                        )
+                                    }
                             }
                         }
                     }

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -373,6 +373,20 @@ public class ExtensionHelper: ExtensionHelperType {
         catch { Log.error(.cat, "Failed to replicate \(dump.variant) dump for \(dump.sessionId.hexString) due to error: \(error).") }
     }
     
+    // stringlint:ignore_contents
+    public func removeConfigDumps(for sessionId: SessionId) {
+        guard let conversationPath: String = conversationPath(sessionId.hexString) else { return }
+
+        /// Remove the replicated config dumps for the conversation so the notification extension can't keep loading
+        /// config state (eg. group keys) that the main app has removed - if it did the two would diverge and the
+        /// extension could decrypt/notify for messages the main app can no longer read
+        let dumpsPath: String = URL(fileURLWithPath: conversationPath)
+            .appendingPathComponent("dumps")
+            .path
+
+        try? dependencies[singleton: .fileManager].removeItem(atPath: dumpsPath)
+    }
+
     public func replicateAllConfigDumpsIfNeeded(
         userSessionId: SessionId,
         allDumpSessionIds: Set<SessionId>
@@ -1147,6 +1161,7 @@ public protocol ExtensionHelperType {
     func lastUpdatedTimestamp(for sessionId: SessionId, variant: ConfigDump.Variant) -> TimeInterval
     func replicate(dump: ConfigDump?, replaceExisting: Bool)
     func replicateAllConfigDumpsIfNeeded(userSessionId: SessionId, allDumpSessionIds: Set<SessionId>) async
+    func removeConfigDumps(for sessionId: SessionId)
     func refreshDumpModifiedDate(sessionId: SessionId, variant: ConfigDump.Variant)
     func loadUserConfigState(
         into cache: LibSessionCacheType,

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -2917,6 +2917,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                             db,
                             groupSessionId: fixture.groupId,
                             plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
                             using: fixture.dependencies
                         )
                     }
@@ -2932,6 +2933,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                             db,
                             groupSessionId: fixture.groupId,
                             plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
                             using: fixture.dependencies
                         )
                     }
@@ -2959,6 +2961,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                             db,
                             groupSessionId: fixture.groupId,
                             plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
                             using: fixture.dependencies
                         )
                     }
@@ -2974,6 +2977,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                             db,
                             groupSessionId: fixture.groupId,
                             plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
                             using: fixture.dependencies
                         )
                     }
@@ -2990,6 +2994,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                             db,
                             groupSessionId: fixture.groupId,
                             plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
                             using: fixture.dependencies
                         )
                     }
@@ -3020,6 +3025,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                             db,
                             groupSessionId: fixture.groupId,
                             plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
                             using: fixture.dependencies
                         )
                     }
@@ -3074,6 +3080,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3089,6 +3096,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3104,6 +3112,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3120,6 +3129,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3145,6 +3155,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3160,6 +3171,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3176,6 +3188,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3199,6 +3212,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3219,6 +3233,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3238,6 +3253,7 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
@@ -3257,13 +3273,94 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                                 db,
                                 groupSessionId: fixture.groupId,
                                 plaintext: fixture.deleteMessage,
+                                serverTimestampMs: nil,
                                 using: fixture.dependencies
                             )
                         }
                     }.to(throwError(MessageError.ignorableMessage))
                 }
+
+                // MARK: ---- ignores a stale kick message which predates the current membership
+                it("ignores a stale kick message which predates the current membership") {
+                    /// A valid-looking kick (passes the generation floor) but with a swarm timestamp earlier than the group's
+                    /// `joinedAt` - ie. a replayed kick from before the user's current membership (see #700)
+                    fixture.deleteMessage = try! LibSessionMessage.groupKicked(
+                        memberId: "05\(TestConstants.publicKey)",
+                        groupKeysGen: 1
+                    ).1
+                    let stubbedGroupInfo: LibSession.GroupInfo? = LibSession.GroupInfo(
+                        groupSessionId: fixture.groupId.hexString,
+                        groupIdentityPrivateKey: nil,
+                        name: "TestGroup",
+                        authData: Data([1, 2, 3]),
+                        priority: 0,
+                        joinedAt: 2000,
+                        invited: false,
+                        wasKickedFromGroup: false,
+                        wasGroupDestroyed: false
+                    )
+                    try await fixture.mockLibSessionCache
+                        .when { $0.groupInfo(for: .any) }
+                        .thenReturn([stubbedGroupInfo])
+
+                    await expect {
+                        try await fixture.mockStorage.write { db in
+                            try MessageReceiver.handleGroupDelete(
+                                db,
+                                groupSessionId: fixture.groupId,
+                                plaintext: fixture.deleteMessage,
+                                serverTimestampMs: 1_000_000,   /// 1,000s - earlier than joinedAt (2,000s)
+                                using: fixture.dependencies
+                            )
+                        }
+                    }.to(throwError(MessageError.ignorableMessage))
+
+                    /// The stale kick must NOT wipe the group state
+                    await fixture.mockLibSessionCache
+                        .verify { try $0.markAsKicked(groupSessionIds: [fixture.groupId.hexString]) }
+                        .wasNotCalled(timeout: .milliseconds(100))
+                    await fixture.mockLibSessionCache
+                        .verify { $0.removeConfigs(for: fixture.groupId) }
+                        .wasNotCalled(timeout: .milliseconds(100))
+                }
+
+                // MARK: ---- still applies a genuine kick which is newer than the current membership
+                it("still applies a genuine kick which is newer than the current membership") {
+                    fixture.deleteMessage = try! LibSessionMessage.groupKicked(
+                        memberId: "05\(TestConstants.publicKey)",
+                        groupKeysGen: 1
+                    ).1
+                    let stubbedGroupInfo: LibSession.GroupInfo? = LibSession.GroupInfo(
+                        groupSessionId: fixture.groupId.hexString,
+                        groupIdentityPrivateKey: nil,
+                        name: "TestGroup",
+                        authData: Data([1, 2, 3]),
+                        priority: 0,
+                        joinedAt: 2000,
+                        invited: false,
+                        wasKickedFromGroup: false,
+                        wasGroupDestroyed: false
+                    )
+                    try await fixture.mockLibSessionCache
+                        .when { $0.groupInfo(for: .any) }
+                        .thenReturn([stubbedGroupInfo])
+
+                    try await fixture.mockStorage.write { db in
+                        try MessageReceiver.handleGroupDelete(
+                            db,
+                            groupSessionId: fixture.groupId,
+                            plaintext: fixture.deleteMessage,
+                            serverTimestampMs: 3_000_000,   /// 3,000s - later than joinedAt (2,000s)
+                            using: fixture.dependencies
+                        )
+                    }
+
+                    await fixture.mockLibSessionCache
+                        .verify { try $0.markAsKicked(groupSessionIds: [fixture.groupId.hexString]) }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
+                }
             }
-            
+
             // MARK: -- when receiving a visible message from a member that is not accepted and the current user is a group admin
             context("when receiving a visible message from a member that is not accepted and the current user is a group admin") {
                 beforeEach {

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -3010,7 +3010,24 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                     }
                     expect(dumps).to(beEmpty())
                 }
-                
+
+                // MARK: ---- removes the replicated config dumps from the extension cache
+                it("removes the replicated config dumps from the extension cache") {
+                    try await fixture.mockStorage.write { db in
+                        try MessageReceiver.handleGroupDelete(
+                            db,
+                            groupSessionId: fixture.groupId,
+                            plaintext: fixture.deleteMessage,
+                            serverTimestampMs: nil,
+                            using: fixture.dependencies
+                        )
+                    }
+
+                    await fixture.mockExtensionHelper
+                        .verify { $0.removeConfigDumps(for: fixture.groupId) }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
+                }
+
                 // MARK: ------ unsubscribes from push notifications
                 it("unsubscribes from push notifications") {
                     try await fixture.mockUserDefaults
@@ -3975,6 +3992,9 @@ private class MessageReceiverGroupsTestFixture: FixtureBase {
             .thenReturn(())
         try await mockExtensionHelper
             .when { try $0.upsertLastClearedRecord(threadId: .any) }
+            .thenReturn(())
+        try await mockExtensionHelper
+            .when { $0.removeConfigDumps(for: .any) }
             .thenReturn(())
     }
     

--- a/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
@@ -1,0 +1,166 @@
+// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import GRDB
+import Quick
+import Nimble
+import SessionUtil
+import SessionUtilitiesKit
+import TestUtilities
+
+@testable import SessionNetworkingKit
+@testable import SessionMessagingKit
+
+class SwarmPollerSpec: AsyncSpec {
+    override class func spec() {
+        @TestState var fixture: SwarmPollerTestFixture!
+
+        beforeEach {
+            fixture = try await SwarmPollerTestFixture.create()
+        }
+
+        // MARK: - a SwarmPoller processing a poll response
+        describe("a SwarmPoller processing a poll response") {
+            // MARK: -- when a message fails to process on the notification extension import path
+            context("when a message fails to process on the notification extension import path") {
+                // MARK: ---- removes the orphan dedupe record so the message can be reprocessed by a later poll
+                it("removes the orphan dedupe record so the message can be reprocessed by a later poll") {
+                    _ = try await fixture.mockStorage.write { db in
+                        SwarmPoller.processPollResponse(
+                            db,
+                            cat: .poller,
+                            source: .pushNotification,
+                            swarmPublicKey: fixture.groupId.hexString,
+                            shouldStoreMessages: true,
+                            ignoreDedupeFiles: true,
+                            forceSynchronousProcessing: true,
+                            sortedMessages: [(
+                                namespace: .groupMessages,
+                                messages: [fixture.message(hash: "TestHash")],
+                                lastHash: nil
+                            )],
+                            using: fixture.dependencies
+                        )
+                    }
+
+                    await fixture.mockExtensionHelper
+                        .verify {
+                            try $0.removeDedupeRecord(
+                                threadId: fixture.groupId.hexString,
+                                uniqueIdentifier: "TestHash"
+                            )
+                        }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
+                }
+            }
+
+            // MARK: -- when a message fails to process on the normal (non-synchronous) poll path
+            context("when a message fails to process on the normal (non-synchronous) poll path") {
+                // MARK: ---- does not remove the dedupe record
+                it("does not remove the dedupe record") {
+                    _ = try await fixture.mockStorage.write { db in
+                        SwarmPoller.processPollResponse(
+                            db,
+                            cat: .poller,
+                            source: .pushNotification,
+                            swarmPublicKey: fixture.groupId.hexString,
+                            shouldStoreMessages: true,
+                            ignoreDedupeFiles: false,
+                            forceSynchronousProcessing: false,
+                            sortedMessages: [(
+                                namespace: .groupMessages,
+                                messages: [fixture.message(hash: "TestHash")],
+                                lastHash: nil
+                            )],
+                            using: fixture.dependencies
+                        )
+                    }
+
+                    await fixture.mockExtensionHelper
+                        .verify { try $0.removeDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
+                        .wasNotCalled(timeout: .milliseconds(100))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - SwarmPollerTestFixture
+
+private class SwarmPollerTestFixture: FixtureBase {
+    var mockStorage: Storage {
+        mock(for: .storage) { dependencies in
+            try! Storage.createForTesting(using: dependencies)
+        }
+    }
+    var mockCrypto: MockCrypto { mock(for: .crypto) }
+    var mockExtensionHelper: MockExtensionHelper { mock(for: .extensionHelper) }
+    var mockGeneralCache: MockGeneralCache { mock(cache: .general) }
+
+    let groupId: SessionId = SessionId(
+        .group,
+        hex: "03cbd569f56fb13ea95a3f0c05c331cc24139c0090feb412069dc49fab34406ece"
+    )
+
+    static func create() async throws -> SwarmPollerTestFixture {
+        let fixture: SwarmPollerTestFixture = SwarmPollerTestFixture()
+        try await fixture.applyBaselineStubs()
+
+        return fixture
+    }
+
+    // MARK: - Convenience
+
+    func message(hash: String) -> Network.StorageServer.Message {
+        return Network.StorageServer.Message(
+            snode: nil,
+            publicKey: groupId.hexString,
+            namespace: .groupMessages,
+            rawMessage: Network.StorageServer.GetMessagesResponse.RawMessage(
+                base64EncodedDataString: Data([1, 2, 3]).base64EncodedString(),
+                expirationMs: nil,
+                hash: hash,
+                timestampMs: 1234567890
+            )
+        )!
+    }
+
+    // MARK: - Setup
+
+    private func applyBaselineStubs() async throws {
+        try await mockStorage.perform(migrations: SNMessagingKit.migrations)
+        try await mockStorage.write { db in
+            try Identity(variant: .x25519PublicKey, data: Data(hex: TestConstants.publicKey)).insert(db)
+            try Identity(variant: .ed25519SecretKey, data: Data(hex: TestConstants.edSecretKey)).insert(db)
+        }
+
+        try await mockGeneralCache
+            .when { $0.sessionId }
+            .thenReturn(SessionId(.standard, hex: TestConstants.publicKey))
+        try await mockGeneralCache
+            .when { $0.ed25519SecretKey }
+            .thenReturn(Array(Data(hex: TestConstants.edSecretKey)))
+
+        /// Force message parsing to fail (as it would when the group keys haven't synced into the main app yet)
+        try await mockCrypto
+            .when {
+                try $0.tryGenerate(
+                    .decodedMessage(
+                        encodedMessage: Data.any,
+                        origin: .swarm(
+                            publicKey: .any,
+                            namespace: .groupMessages,
+                            serverHash: .any,
+                            serverTimestampMs: .any,
+                            serverExpirationTimestamp: .any
+                        )
+                    )
+                )
+            }
+            .thenThrow(CryptoError.invalidKey)
+
+        try await mockExtensionHelper
+            .when { try $0.removeDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
+            .thenReturn(())
+    }
+}

--- a/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
@@ -71,7 +71,11 @@ class MockExtensionHelper: ExtensionHelperType, Mockable {
     func replicateAllConfigDumpsIfNeeded(userSessionId: SessionId, allDumpSessionIds: Set<SessionId>) async {
         handler.mockNoReturn(args: [userSessionId, allDumpSessionIds])
     }
-    
+
+    func removeConfigDumps(for sessionId: SessionId) {
+        handler.mockNoReturn(args: [sessionId])
+    }
+
     func refreshDumpModifiedDate(sessionId: SessionId, variant: ConfigDump.Variant) {
         handler.mockNoReturn(args: [sessionId, variant])
     }

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -496,6 +496,7 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
                                 plaintext: plaintext,
                                 userSessionId: userSessionId,
                                 groupSessionId: senderSessionId,
+                                serverTimestampMs: libSessionMessage.serverTimestampMs,
                                 using: dependencies
                             )
                             


### PR DESCRIPTION
Group messages could be permanently lost after their push notification. The notification extension decrypts and saves the message (using its on-disk group config), but if the main app's group keys config is momentarily empty (seqno 0) the import fails to decrypt (CryptoError: Invalid key), discards the message, and leaves the extension's dedupe file behind — which then makes the later (post-key-sync) poll drop the refetched message as a "duplicate", losing it.

Recover the message (SwarmPoller):
- When processPollResponse fails to process a message on the synchronous notification-extension import path, remove the corresponding dedupe record so a later poll can genuinely reprocess the message once the keys sync, rather than it being permanently masked as a duplicate. Payload files are still deleted (garbage collection preserved) and the normal poll path is unchanged.

Stop the erroneous key wipe (validateGroupKickedMessage):
- A stale or replayed `groupKicked` message could wipe an active member's group state. Validation was a generation floor (keysGen >= currentKeysGen) with no freshness check, so after a kick+re-invite — when the member's current key generation is momentarily 0 — a replayed old "kicked at gen N" message would pass and delete the group config again. Reject a kick whose swarm serverTimestampMs predates the group's joinedAt, keeping the generation floor. A genuine current kick is always sent after the most recent (re-)join, and if either timestamp is missing we fall through and apply the kick, so a real kick is never missed. Plumbs the previously-discarded swarm timestamp through to the validator and adds a Codable serverTimestampMs to LibSessionMessage.

`removeGroupStateIfNeeded` deleted the group's GRDB `ConfigDump` and unloaded the in-memory libSession config, but left the replicated dump on disk in the extension cache untouched. That left the main app and the notification extension diverged: the extension kept decrypting group messages with keys the main app had removed, so a message could appear in a notification and then be dropped when the main app failed to decrypt it (a root cause of group messages lost after a push notification).

Add `ExtensionHelper.removeConfigDumps(for:)`, which deletes the conversation's `dumps` directory, and call it from `removeGroupStateIfNeeded` via `afterCommit` so that every legitimate group-config removal (kick / leave / delete / config-sync removal) also clears the extension replica and keeps the two stores in sync.

Adds SwarmPollerSpec and stale-kick regression tests to MessageReceiverGroupsSpec.
