### PR TITLE
Pro: allow the Session Pro backend to be overridden for QA/testing

### DIFF
--- a/Session/Settings/DeveloperSettings/DeveloperSettingsProViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsProViewModel.swift
@@ -22,6 +22,11 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
     /// This value is the current state of the view
     @MainActor @Published private(set) var internalState: State
     private var observationTask: Task<Void, Never>?
+
+    /// The values currently being typed into the custom Pro backend modals (the modal body only reports changes
+    /// via `onChange` so they need somewhere to live until the user confirms)
+    private var updatedProBackendUrl: String?
+    private var updatedProBackendPubkey: String?
     
     // MARK: - Initialization
     
@@ -48,6 +53,7 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
     public enum Section: SessionListScreenContent.ListSection {
         case general
         case subscriptions
+        case proBackendServer
         case proBackend
         case features
         
@@ -55,6 +61,7 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
             switch self {
                 case .general: return nil
                 case .subscriptions: return "Subscriptions"
+                case .proBackendServer: return "Pro Backend Server"
                 case .proBackend: return "Pro Backend"
                 case .features: return "Features"
             }
@@ -94,6 +101,9 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         case restoreProSubscription
         case requestRefund
         
+        case customProBackendUrl
+        case customProBackendPubkey
+
         case submitPurchaseToProBackend
         case refreshProState
         case resetRevocationListTicket
@@ -125,6 +135,9 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
                 case .restoreProSubscription: return "restoreProSubscription"
                 case .requestRefund: return "requestRefund"
                 
+                case .customProBackendUrl: return "customProBackendUrl"
+                case .customProBackendPubkey: return "customProBackendPubkey"
+
                 case .submitPurchaseToProBackend: return "submitPurchaseToProBackend"
                 case .refreshProState: return "refreshProState"
                 case .resetRevocationListTicket: return "resetRevocationListTicket"
@@ -159,6 +172,9 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
                 case .restoreProSubscription: result.append(.restoreProSubscription); fallthrough
                 case .requestRefund: result.append(.requestRefund); fallthrough
                 
+                case .customProBackendUrl: result.append(.customProBackendUrl); fallthrough
+                case .customProBackendPubkey: result.append(.customProBackendPubkey); fallthrough
+
                 case .submitPurchaseToProBackend: result.append(.submitPurchaseToProBackend); fallthrough
                 case .refreshProState: result.append(.refreshProState); fallthrough
                 case .resetRevocationListTicket: result.append(.resetRevocationListTicket); fallthrough
@@ -207,6 +223,7 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         let currentProStatus: String?
         let currentProStatusErrored: Bool
         let currentRevocationListTicket: Int64
+        let customProBackend: Network.SessionPro.Custom
         
         @MainActor public func sections(viewModel: DeveloperSettingsProViewModel, previousState: State) -> [SectionModel] {
             DeveloperSettingsProViewModel.sections(
@@ -229,6 +246,7 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
             .feature(.forceMessageFeatureProBadge),
             .feature(.forceMessageFeatureLongMessage),
             .feature(.forceMessageFeatureAnimatedAvatar),
+            .feature(.customProBackend),
             .updateScreen(DeveloperSettingsProViewModel.self),
             .proRevocationListUpdated
         ]
@@ -262,7 +280,8 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
                 
                 currentProStatus: nil,
                 currentProStatusErrored: false,
-                currentRevocationListTicket: 0
+                currentRevocationListTicket: 0,
+                customProBackend: dependencies[feature: .customProBackend]
             )
         }
     }
@@ -347,7 +366,8 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
             submittedTransactionErrored: submittedTransactionErrored,
             currentProStatus: currentProStatus,
             currentProStatusErrored: currentProStatusErrored,
-            currentRevocationListTicket: currentRevocationListTicket
+            currentRevocationListTicket: currentRevocationListTicket,
+            customProBackend: dependencies[feature: .customProBackend]
         )
     }
     
@@ -804,6 +824,48 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
             ]
         )
         
+        let proBackendServer: SectionModel = SectionModel(
+            model: .proBackendServer,
+            elements: [
+                SessionListScreenContent.ListItemInfo(
+                    id: .customProBackendUrl,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            title: SessionListScreenContent.TextInfo("Custom Pro Backend URL", font: .Body.largeBold),
+                            description: .htmlTagged("""
+                            The URL to use instead of the default Session Pro backend (the production backend has no way to grant an entitlement to a test account, so QA needs its own instance).
+
+                            <b>Current:</b> <span>\(Network.SessionPro.server(using: viewModel.dependencies))</span>
+                            """),
+                            trailingAccessory: .icon(.squarePen)
+                        )
+                    ),
+                    onTap: { [weak viewModel] in
+                        viewModel?.showProBackendUrlModal(current: state.customProBackend)
+                    }
+                ),
+                SessionListScreenContent.ListItemInfo(
+                    id: .customProBackendPubkey,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            title: SessionListScreenContent.TextInfo("Custom Pro Backend Public Key", font: .Body.largeBold),
+                            description: .htmlTagged("""
+                            The Ed25519 public key for the above backend (if empty then the default backend's key will be used).
+
+                            <b>Note:</b> this key is also what libSession verifies <b>other users'</b> pro proofs against, so every device in a test needs the same value - a device left on the default will read a custom-backend proof as invalid.
+
+                            <b>Current:</b> <span>\(state.customProBackend.pubkey.isEmpty ? "Default" : state.customProBackend.pubkey)</span>
+                            """),
+                            trailingAccessory: .icon(.squarePen)
+                        )
+                    ),
+                    onTap: { [weak viewModel] in
+                        viewModel?.showProBackendPubkeyModal(current: state.customProBackend)
+                    }
+                )
+            ]
+        )
+        
         let proBackend: SectionModel = SectionModel(
             model: .proBackend,
             elements: [
@@ -880,7 +942,7 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
             ]
         )
         
-        return [general, features, subscriptions, proBackend]
+        return [general, proBackendServer, features, subscriptions, proBackend]
     }
     
     // MARK: - Functions
@@ -924,6 +986,126 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         }
     }
     
+    // MARK: - Custom Pro Backend
+
+    private func showProBackendUrlModal(current: Network.SessionPro.Custom) {
+        updatedProBackendUrl = current.url
+
+        self.transitionToScreen(
+            ConfirmationModal(
+                info: ConfirmationModal.Info(
+                    title: "Custom Pro Backend URL",
+                    body: .input(
+                        explanation: ThemedAttributedString(
+                            string: "The url for the custom Session Pro backend."
+                        ),
+                        info: ConfirmationModal.Info.Body.InputInfo(
+                            placeholder: "Enter URL",
+                            initialValue: current.url,
+                            inputChecker: { text in
+                                guard URL(string: text) != nil else {
+                                    return "Value must be a valid url (with HTTP or HTTPS)."
+                                }
+
+                                return nil
+                            }
+                        ),
+                        onChange: { [weak self] value in
+                            self?.updatedProBackendUrl = value.lowercased()
+                        }
+                    ),
+                    confirmTitle: "save".localized(),
+                    confirmEnabled: .afterChange { [weak self] _ in
+                        guard
+                            let value: String = self?.updatedProBackendUrl,
+                            let url: URL = URL(string: value)
+                        else { return false }
+
+                        return (url.scheme != nil && url.host != nil)
+                    },
+                    cancelTitle: (current.url.isEmpty ? "cancel".localized() : "remove".localized()),
+                    cancelStyle: (current.url.isEmpty ? .alert_text : .danger),
+                    hasCloseButton: !current.url.isEmpty,
+                    onConfirm: { [weak self, dependencies] _ in
+                        guard
+                            let value: String = self?.updatedProBackendUrl,
+                            URL(string: value) != nil
+                        else { return }
+
+                        dependencies.set(feature: .customProBackend, to: current.with(url: value))
+                    },
+                    onCancel: { [dependencies] modal in
+                        modal.dismiss(animated: true)
+
+                        /// The cancel button doubles as "remove" once a custom url has been set
+                        guard !current.url.isEmpty else { return }
+
+                        dependencies.set(feature: .customProBackend, to: current.with(url: ""))
+                    }
+                )
+            ),
+            transitionType: .present
+        )
+    }
+
+    private func showProBackendPubkeyModal(current: Network.SessionPro.Custom) {
+        updatedProBackendPubkey = current.pubkey
+
+        self.transitionToScreen(
+            ConfirmationModal(
+                info: ConfirmationModal.Info(
+                    title: "Custom Pro Backend Public Key",
+                    body: .input(
+                        explanation: ThemedAttributedString(
+                            string: "The Ed25519 public key for the custom Session Pro backend (also used to verify other users' pro proofs)."
+                        ),
+                        info: ConfirmationModal.Info.Body.InputInfo(
+                            placeholder: "Enter public key",
+                            initialValue: current.pubkey,
+                            inputChecker: { text in
+                                guard Hex.isValid(text), text.count == 64 else {
+                                    return "Value must be a 64 character hex encoded public key."
+                                }
+
+                                return nil
+                            }
+                        ),
+                        onChange: { [weak self] value in
+                            self?.updatedProBackendPubkey = value.lowercased()
+                        }
+                    ),
+                    confirmTitle: "save".localized(),
+                    confirmEnabled: .afterChange { [weak self] _ in
+                        guard let value: String = self?.updatedProBackendPubkey else { return false }
+
+                        return (Hex.isValid(value) && value.count == 64)
+                    },
+                    cancelTitle: (current.pubkey.isEmpty ? "cancel".localized() : "remove".localized()),
+                    cancelStyle: (current.pubkey.isEmpty ? .alert_text : .danger),
+                    hasCloseButton: !current.pubkey.isEmpty,
+                    onConfirm: { [weak self, dependencies] _ in
+                        guard
+                            let value: String = self?.updatedProBackendPubkey,
+                            Hex.isValid(value),
+                            value.count == 64
+                        else { return }
+
+                        dependencies.set(feature: .customProBackend, to: current.with(pubkey: value))
+                    },
+                    onCancel: { [dependencies] modal in
+                        modal.dismiss(animated: true)
+
+                        /// The cancel button doubles as "remove" once a custom pubkey has been set
+                        guard !current.pubkey.isEmpty else { return }
+
+                        dependencies.set(feature: .customProBackend, to: current.with(pubkey: ""))
+                    }
+                )
+            ),
+            transitionType: .present
+        )
+    }
+
     // MARK: - Pro Requests
     
     private func purchaseSubscription(currentProduct: Product?) async {

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
@@ -151,6 +151,23 @@ extension DeveloperSettingsViewModel {
             /// **Note:** This is the master gate - the `mockCurrentUser…` values below are only reflected in the UI when this is `true`
             case sessionPro
 
+            /// Controls the url which is used for the Session Pro backend
+            ///
+            /// **Value:** Valid url string
+            ///
+            /// **Note:** If `customProBackendPubkey` isn't also provided then the default Pro backend pubkey will be used
+            case customProBackendUrl
+
+            /// Controls the pubkey which is used for the Session Pro backend
+            ///
+            /// **Value:** 64 character hex encoded Ed25519 public key
+            ///
+            /// **Note:** Only used if `customProBackendUrl` is valid
+            ///
+            /// **Note:** This key is also what `libSession` verifies **other users'** pro proofs against, so every device in a
+            /// test needs the same value - a device left on the default will read a custom-backend proof as invalid
+            case customProBackendPubkey
+
             /// Simulates the Session Pro status the backend reports for the current user
             ///
             /// **Value:** `"useActual"`/`"never"`/`"active"`/`"expired"` (default: `"useActual"`)
@@ -405,7 +422,28 @@ extension DeveloperSettingsViewModel {
                     
                 /// This is handled in the `customFileServerUrl` case
                 case .customFileServerPubkey: continue
-                    
+
+                case .customProBackendUrl:
+                    /// Ensure values were provided first
+                    guard let url: String = envVars[.customProBackendUrl], !url.isEmpty else {
+                        Log.warn("An empty 'customProBackendUrl' was provided")
+                        continue
+                    }
+                    let proPubkey: String = (envVars[.customProBackendPubkey] ?? "")
+                    let proBackend: Network.SessionPro.Custom = Network.SessionPro.Custom(
+                        url: url,
+                        pubkey: proPubkey
+                    )
+
+                    guard proBackend.isValid else {
+                        Log.warn("The custom Pro backend info provided was not valid: (url: '\(url)', pubkey: '\(proPubkey)'")
+                        continue
+                    }
+                    dependencies.set(feature: .customProBackend, to: proBackend)
+
+                /// This is handled in the `customProBackendUrl` case
+                case .customProBackendPubkey: continue
+
                 case .customDateTime:
                     guard
                         let valueString: String = envVars[.customDateTime],

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -401,6 +401,7 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
 
                             <b>Session Pro:</b> <span>\(sessionProStatus)</span>
                             <b>Mock Pro Status:</b> \(mockedProStatus)
+                            <b>Session Pro Server:</b> <span>\(Network.SessionPro.server(using: dependencies))</span>
                             """),
                             trailingAccessory: .icon(.chevronRight)
                         )

--- a/SessionMessagingKit/Crypto/Crypto+LibSession.swift
+++ b/SessionMessagingKit/Crypto/Crypto+LibSession.swift
@@ -141,7 +141,9 @@ public extension Crypto.Generator {
             args: []
         ) { dependencies in
             let cEncodedMessage: [UInt8] = Array(encodedMessage)
-            let cBackendPubkey: [UInt8] = Array(Data(hex: Network.SessionPro.serverEdPublicKey))
+            /// **Note:** This is the key `libSession` verifies the sender's pro proof against, so it has to be the
+            /// same backend the sender got their proof from (see `Network.SessionPro.edPublicKey(using:)`)
+            let cBackendPubkey: [UInt8] = Array(Data(hex: Network.SessionPro.edPublicKey(using: dependencies)))
             var error: [CChar] = [CChar](repeating: 0, count: 256)
             
             switch origin {

--- a/SessionNetworkingKit/SessionPro/SessionPro.swift
+++ b/SessionNetworkingKit/SessionPro/SessionPro.swift
@@ -10,19 +10,143 @@ public extension Network {
     enum SessionPro {
         public static let apiVersion: UInt8 = 0
 
-        /// The backend base URL + Ed25519 signing pubkey now come from libsession (single source of
-        /// truth), replacing the previously hard-coded — and stale — client copies. libsession owns the
-        /// prod/default values; a dev/test override, if needed, still lives client-side.
-        static let server: String = (SESSION_PRO_BACKEND_URL.map { String(cString: $0) } ?? "")
-        public static let serverEdPublicKey: String =
+        /// The production backend base URL + Ed25519 signing pubkey, which come from libsession (the single
+        /// source of truth), replacing the previously hard-coded — and stale — client copies
+        ///
+        /// **Note:** These are only the defaults — use `server(using:)` and `edPublicKey(using:)` so the
+        /// `customProBackend` dev override is honoured (reading these directly bypasses it)
+        static let defaultServer: String = (SESSION_PRO_BACKEND_URL.map { String(cString: $0) } ?? "")
+        public static let defaultEdPublicKey: String =
             (SESSION_PRO_BACKEND_PUBKEY.map { Data(bytes: $0, count: 32).toHexString() } ?? "")
+
+        /// The backend to talk to, which is the libsession-provided production URL unless a custom backend
+        /// has been configured in the developer settings
+        public static func server(using dependencies: Dependencies) -> String {
+            let customUrl: String = dependencies[feature: .customProBackend].url
+
+            guard
+                dependencies[feature: .customProBackend].isValid,
+                !customUrl.isEmpty  /// An empty `url` means the default should be used
+            else { return defaultServer }
+
+            return customUrl
+        }
+
+        /// The Ed25519 key the Session Pro backend signs with
+        ///
+        /// **Warning:** This key does double duty — it authenticates the backend for our own requests **and**
+        /// it's the key `libSession` verifies other users' proofs against when decoding their messages (see
+        /// `session_protocol_decode_envelope`). A device pointed at a custom backend therefore can't validate
+        /// a proof signed by the production backend, and vice versa, so every device in a test needs the
+        /// same override or their proofs will read as `invalidProBackendSig` to each other.
+        public static func edPublicKey(using dependencies: Dependencies) -> String {
+            let customPubkey: String = dependencies[feature: .customProBackend].pubkey
+
+            guard
+                dependencies[feature: .customProBackend].isValid,
+                !customPubkey.isEmpty   /// An empty `pubkey` means the default should be used
+            else { return defaultEdPublicKey }
+
+            return customPubkey
+        }
 
         internal static func x25519PublicKey(using dependencies: Dependencies) throws -> String {
             let x25519Pubkey: [UInt8] = try dependencies[singleton: .crypto].tryGenerate(
-                .x25519(ed25519Pubkey: Array(Data(hex: serverEdPublicKey)))
+                .x25519(ed25519Pubkey: Array(Data(hex: edPublicKey(using: dependencies))))
             )
 
             return x25519Pubkey.toHexString()
+        }
+    }
+}
+
+// MARK: - Dev Settings
+
+public extension FeatureStorage {
+    static let customProBackend: FeatureConfig<Network.SessionPro.Custom> = Dependencies.create(
+        identifier: "customProBackend"
+    )
+}
+
+public extension Network.SessionPro {
+    /// A custom Session Pro backend to use instead of the libsession-provided production one
+    ///
+    /// **Note:** This mirrors `Network.FileServer.Custom` — the production Pro backend has no way to grant an
+    /// entitlement to a test account (it has no `/dev` routes, by design), so the automated tests need to be
+    /// able to point at a QA instance, which brings its own signing key with it
+    struct Custom: Sendable, Equatable, Codable, FeatureOption {
+        public typealias RawValue = String
+
+        private struct Values: Equatable, Codable {
+            public let url: String
+            public let pubkey: String
+        }
+
+        public static let defaultOption: Custom = Custom(
+            url: "",
+            pubkey: ""
+        )
+
+        public let title: String = "Custom Pro Backend"
+        public let subtitle: String? = nil
+        private let values: Values
+
+        public var url: String { values.url }
+        public var pubkey: String { values.pubkey }
+        public var isEmpty: Bool {
+            values.url.isEmpty &&
+            values.pubkey.isEmpty
+        }
+        public var isValid: Bool {
+            let pubkeyValid: Bool = (
+                Hex.isValid(values.pubkey) &&
+                values.pubkey.count == 64
+            )
+
+            return (
+                URL(string: url) != nil && (
+                    values.pubkey.isEmpty ||    /// Default pubkey would be used if empty
+                    pubkeyValid
+                )
+            )
+        }
+
+        /// This is needed to conform to `FeatureOption` so it can be saved to `UserDefaults`
+        public var rawValue: String {
+            (try? JSONEncoder().encode(values)).map { String(data: $0, encoding: .utf8) } ?? ""
+        }
+
+        // MARK: - Initialization
+
+        public init(url: String, pubkey: String) {
+            self.values = Values(url: url, pubkey: pubkey)
+        }
+
+        public init?(rawValue: String) {
+            guard
+                let data: Data = rawValue.data(using: .utf8),
+                let decodedValues: Values = try? JSONDecoder().decode(Values.self, from: data)
+            else { return nil }
+
+            self.values = decodedValues
+        }
+
+        // MARK: - Functions
+
+        public func with(
+            url: String? = nil,
+            pubkey: String? = nil
+        ) -> Custom {
+            return Custom(
+                url: (url ?? self.values.url),
+                pubkey: (pubkey ?? self.values.pubkey)
+            )
+        }
+
+        // MARK: - Equality
+
+        public static func == (lhs: Custom, rhs: Custom) -> Bool {
+            return (lhs.values == rhs.values)
         }
     }
 }

--- a/SessionNetworkingKit/SessionPro/Types/Request+SessionProAPI.swift
+++ b/SessionNetworkingKit/SessionPro/Types/Request+SessionProAPI.swift
@@ -17,7 +17,7 @@ public extension Request where Endpoint == Network.SessionPro.Endpoint {
             endpoint: endpoint,
             destination: .server(
                 method: method,
-                server: Network.SessionPro.server,
+                server: Network.SessionPro.server(using: dependencies),
                 queryParameters: queryParameters,
                 headers: headers,
                 x25519PublicKey: Network.SessionPro.x25519PublicKey(using: dependencies)


### PR DESCRIPTION
The production Pro backend has no way to grant an entitlement to a test account (it ships no `/dev` routes, by design), so the cross-platform Appium rows that need a *real* proof - one a peer will actually validate - can't run against it. Mocks are display-level and can't produce one.

Adds a `customProBackend` feature mirroring `customFileServer`: a url + Ed25519 pubkey pair, settable per-run via the `customProBackendUrl` / `customProBackendPubkey` launch-arg env vars, or by hand from a new "Pro Backend Server" section on the Developer Pro Settings screen. `Network.SessionPro`'s two `static let`s become `server(using:)` / `edPublicKey(using:)` so the override is actually reachable - both call sites already had a `Dependencies` to hand.

The pubkey override matters as much as the url: the same key authenticates our own requests *and* is what libSession verifies other users' proofs against when decoding their messages, so overriding only the url would leave the client checking a QA-signed proof against the production key. By the same token every device in a test needs the same value, which is called out on `edPublicKey(using:)` and on the env var.

Also drops the comment claiming a client-side override already existed - it described an intention, not a facility, and had already sent two people looking for code that wasn't there.

**Note:** This is based on #724