### PR TITLE
Pro redemption reflow, part 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ for harness setup and the run commands.
   extract/reuse it rather than copy-pasting. Pull shared logic into the appropriate
   lower-level module rather than repeating it across call sites.
 - **File header** (top of every new Swift file):
-  `// Copyright © <year> Rangeproof Pty Ltd. All rights reserved.`
+  `// Copyright © <year> Session Technology Foundation. All rights reserved.`
 - **C++** is formatted with `.clang-format` (WebKit base, 120-column, no tabs).
 - A `.swiftlint.yml` exists but SwiftLint is **not actually run** on this project — don't
   rely on it as a lint gate or spend effort satisfying it.

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -6591,7 +6591,7 @@
 				LastSwiftUpdateCheck = 2610;
 				LastTestingUpgradeCheck = 0600;
 				LastUpgradeCheck = 2610;
-				ORGANIZATIONNAME = "Rangeproof Pty Ltd";
+				ORGANIZATIONNAME = "Session Technology Foundation";
 				TargetAttributes = {
 					453518671FC635DD00210559 = {
 						CreatedOnToolsVersion = 9.2;

--- a/Session/Meta/MainThreadUITripwire.swift
+++ b/Session/Meta/MainThreadUITripwire.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 // stringlint:disable
 
 #if DEBUG

--- a/SessionMessagingKit/Database/Migrations/_052_RecoverBrokenCommunityAttachments.swift
+++ b/SessionMessagingKit/Database/Migrations/_052_RecoverBrokenCommunityAttachments.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 //
 // stringlint:disable
 

--- a/SessionMessagingKit/Database/Migrations/_053_RenameProColumnsForWireFormat.swift
+++ b/SessionMessagingKit/Database/Migrations/_053_RenameProColumnsForWireFormat.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import GRDB

--- a/SessionMessagingKit/SessionPro/ProErrorMessage.swift
+++ b/SessionMessagingKit/SessionPro/ProErrorMessage.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2025 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import SessionNetworkingKit

--- a/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import GRDB

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2025 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import SessionUtil

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -11,7 +11,6 @@ public extension Network.SessionPro {
     struct GetProStatusResponse: Equatable {
         public let header: ResponseHeader
         public let status: BackendUserProStatus
-        public let errorReport: ErrorReport
         public let autoRenewing: Bool
         public let expiryTimestampSeconds: UInt64
         public let gracePeriodDurationSeconds: UInt64
@@ -34,35 +33,14 @@ public extension Network.SessionPro {
             self.header = ResponseHeader(result.header)
             /// `status` (the account user-status) is an opaque NUL-terminated `const char*` code.
             self.status = BackendUserProStatus(code: result.get(\.status))
-            self.errorReport = ErrorReport(result.error_report)
+            /// `error_report` is being dropped from the response (buggy-by-design: e.g. on Apple it can
+            /// never clear once set, and a set value carries no actionable signal) — we stop reading it.
             self.autoRenewing = result.auto_renewing
             /// Whole unix seconds on the wire and in our domain — direct assigns, no conversion.
             self.expiryTimestampSeconds = UInt64(max(0, result.expiry_ts))
             self.gracePeriodDurationSeconds = UInt64(max(0, result.grace_period_duration))
             /// `refund_requested_ts` is gone from the response — refund-pending is config-synced state now.
             self.latestPaymentItem = (result.has_latest_payment ? PaymentItem(result.latest_payment) : nil)
-        }
-    }
-}
-
-public extension Network.SessionPro.GetProStatusResponse {
-    enum ErrorReport: CaseIterable {
-        case success
-        case genericError
-
-        var libSessionValue: SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT {
-            switch self {
-                case .success: return SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_SUCCESS
-                case .genericError: return SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR
-            }
-        }
-
-        init(_ libSessionValue: SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT) {
-            switch libSessionValue {
-                case SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_SUCCESS: self = .success
-                case SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR: self = .genericError
-                default: self = .genericError
-            }
         }
     }
 }

--- a/SessionNetworkingKit/SessionPro/Types/ProRequest.swift
+++ b/SessionNetworkingKit/SessionPro/Types/ProRequest.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2025 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import SessionUtil

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProPaymentScreen+Purchase.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProPaymentScreen+Purchase.swift
@@ -91,7 +91,7 @@ struct  SessionProPlanPurchaseContent: View {
                     "proTosDescription"
                         .put(key: "action_type", value: actionType)
                         .put(key: "activation_type", value: activationType)
-                        .put(key: "entity", value: Constants.entity_rangeproof)
+                        .put(key: "entity", value: Constants.entity_stf)
                         .localizedFormatted(Fonts.Body.smallRegular)
                 )
                 .font(.Body.smallRegular)

--- a/SessionUIKit/Style Guide/Constants.swift
+++ b/SessionUIKit/Style Guide/Constants.swift
@@ -17,7 +17,6 @@ public enum Constants {
     public static let app_pro: String = "Session Pro"
     public static let session_foundation: String = "Session Foundation"
     public static let pro: String = "Pro"
-    public static let entity_rangeproof: String = "Rangeproof PTY LTD"
     public static let entity_stf: String = "The Session Technology Foundation"
     public static let donate_appeal_name: String = "Cofounder of Session Chris McCabe"
     public static let entity_stf_short: String = "Session Technology Foundation (STF)"


### PR DESCRIPTION
Misc small commits that were meant to be included in #723 but weren't pushed to the branch yet.

- Renames the Rangeproof provider to STF, reflecting the same change in the pro-backend
- Updates the project settings to Session Technology Foundation as it now develops, rather than Rangeproof.
- `error_report` inside backend pro status was broken by design and is now removed.