### PR TITLE
Pro: fully remove the pre-launch Pro-availability gate

### DIFF
--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -2384,7 +2384,7 @@ class ThreadSettingsViewModel: SessionListScreenContent.ViewModelType, Navigatio
             .state
             .first(defaultValue: .invalid)
         
-        if sessionProState.sessionProEnabled && !isCurrentlyPinned && sessionProState.status != .active {
+        if !isCurrentlyPinned && sessionProState.status != .active {
             // TODO: [Database Relocation] Retrieve the full conversation list from lib session and check the pinnedPriority that way instead of using the database
             do {
                 let numPinnedConversations: Int = try await dependencies[singleton: .storage].write { [dependencies] db in

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsProViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsProViewModel.swift
@@ -81,8 +81,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
     }
     
     public enum ListItem: Hashable, Differentiable, CaseIterable {
-        case enableSessionPro
-        
         case mockCurrentUserSessionProBuildVariant
         case mockCurrentUserSessionProBackendStatus
         case mockCurrentUserSessionProLoadingState
@@ -115,8 +113,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         
         public var differenceIdentifier: String {
             switch self {
-                case .enableSessionPro: return "enableSessionPro"
-                    
                 case .mockCurrentUserSessionProBuildVariant: return "mockCurrentUserSessionProBuildVariant"
                 case .mockCurrentUserSessionProBackendStatus: return "mockCurrentUserSessionProBackendStatus"
                 case .mockCurrentUserSessionProLoadingState: return "mockCurrentUserSessionProLoadingState"
@@ -151,9 +147,7 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         
         public static var allCases: [ListItem] {
             var result: [ListItem] = []
-            switch ListItem.enableSessionPro {
-                case .enableSessionPro: result.append(.enableSessionPro); fallthrough
-                
+            switch ListItem.mockCurrentUserSessionProBuildVariant {
                 case .mockCurrentUserSessionProBuildVariant: result.append(.mockCurrentUserSessionProBuildVariant); fallthrough
                 case .mockCurrentUserSessionProBackendStatus: result.append(.mockCurrentUserSessionProBackendStatus); fallthrough
                 case .mockCurrentUserSessionProLoadingState: result.append(.mockCurrentUserSessionProLoadingState); fallthrough
@@ -195,8 +189,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
     // MARK: - Content
     
     public struct State: Equatable, ObservableKeyProvider {
-        let sessionProEnabled: Bool
-        
         let mockCurrentUserSessionProBuildVariant: MockableFeature<BuildVariant>
         let mockCurrentUserSessionProBackendStatus: MockableFeature<Network.SessionPro.BackendUserProStatus>
         let mockCurrentUserSessionProLoadingState: MockableFeature<SessionPro.LoadingState>
@@ -234,7 +226,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         }
         
         public let observedKeys: Set<ObservableKey> = [
-            .feature(.sessionProEnabled),
             .feature(.mockCurrentUserSessionProBuildVariant),
             .feature(.mockCurrentUserSessionProBackendStatus),
             .feature(.mockCurrentUserSessionProLoadingState),
@@ -253,8 +244,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         
         static func initialState(using dependencies: Dependencies) -> State {
             return State(
-                sessionProEnabled: dependencies[feature: .sessionProEnabled],
-                
                 mockCurrentUserSessionProBuildVariant: dependencies[feature: .mockCurrentUserSessionProBuildVariant],
                 mockCurrentUserSessionProBackendStatus: dependencies[feature: .mockCurrentUserSessionProBackendStatus],
                 mockCurrentUserSessionProLoadingState: dependencies[feature: .mockCurrentUserSessionProLoadingState],
@@ -344,7 +333,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         }
         
         return State(
-            sessionProEnabled: dependencies[feature: .sessionProEnabled],
             mockCurrentUserSessionProBuildVariant: dependencies[feature: .mockCurrentUserSessionProBuildVariant],
             mockCurrentUserSessionProBackendStatus: dependencies[feature: .mockCurrentUserSessionProBackendStatus],
             mockCurrentUserSessionProLoadingState: dependencies[feature: .mockCurrentUserSessionProLoadingState],
@@ -376,33 +364,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
         previousState: State,
         viewModel: DeveloperSettingsProViewModel
     ) -> [SectionModel] {
-        let general: SectionModel = SectionModel(
-            model: .general,
-            elements: [
-                SessionListScreenContent.ListItemInfo(
-                    id: .enableSessionPro,
-                    variant: .cell(
-                        info: ListItemCell.Info(
-                            title: SessionListScreenContent.TextInfo("Enable Session Pro", font: .Body.largeBold),
-                            description: .htmlTagged("""
-                            Enable Post Pro Release mode.
-                            Turning on this Settings will show Pro badge and CTA if needed.
-                            """),
-                            trailingAccessory: .toggle(
-                                state.sessionProEnabled,
-                                oldValue: previousState.sessionProEnabled
-                            )
-                        )
-                    ),
-                    onTap: { [weak viewModel] in
-                        viewModel?.updateSessionProEnabled(current: state.sessionProEnabled)
-                    }
-                )
-            ]
-        )
-        
-        guard state.sessionProEnabled else { return [general] }
-        
         // MARK: - Mockable Features
         
         let features: SectionModel = SectionModel(
@@ -942,14 +903,13 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
             ]
         )
         
-        return [general, proBackendServer, features, subscriptions, proBackend]
+        return [proBackendServer, features, subscriptions, proBackend]
     }
     
     // MARK: - Functions
     
     public static func disableDeveloperMode(using dependencies: Dependencies) {
         let features: [FeatureConfig<Bool>] = [
-            .sessionProEnabled,
             .proBadgeEverywhere,
             .fakeAppleSubscriptionForDev,
             .forceMessageFeatureProBadge,
@@ -973,18 +933,6 @@ class DeveloperSettingsProViewModel: SessionListScreenContent.ViewModelType, Nav
     }
     
     // MARK: - Internal Functions
-    
-    private func updateSessionProEnabled(current: Bool) {
-        dependencies.set(feature: .sessionProEnabled, to: !current)
-        
-        if dependencies.hasSet(feature: .proBadgeEverywhere) {
-            dependencies.reset(feature: .proBadgeEverywhere)
-        }
-        
-        if dependencies.hasSet(feature: .mockCurrentUserSessionProBackendStatus) {
-            dependencies.reset(feature: .mockCurrentUserSessionProBackendStatus)
-        }
-    }
     
     // MARK: - Custom Pro Backend
 

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
@@ -144,13 +144,6 @@ extension DeveloperSettingsViewModel {
             /// **Value:** Seconds since epoch
             case customFirstInstallDateTime
             
-            /// Controls whether Session Pro should be enabled
-            ///
-            /// **Value:** `true`/`false` (default: `false`)
-            ///
-            /// **Note:** This is the master gate - the `mockCurrentUser…` values below are only reflected in the UI when this is `true`
-            case sessionPro
-
             /// Controls the url which is used for the Session Pro backend
             ///
             /// **Value:** Valid url string
@@ -466,9 +459,6 @@ extension DeveloperSettingsViewModel {
                     
                     dependencies.set(feature: .customFirstInstallDateTime, to: value)
                     
-                case .sessionPro:
-                    dependencies.set(feature: .sessionProEnabled, to: (value == "true"))
-
                 case .mockCurrentUserSessionProBackendStatus:
                     guard
                         let mock: MockableFeature<Network.SessionPro.BackendUserProStatus> = mockedProFeature(

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -381,11 +381,10 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
             ]
         )
         
-        let sessionProStatus: String = (dependencies[feature: .sessionProEnabled] ? "Enabled" : "Disabled")
         let mockedProStatus: String = {
-            switch (dependencies[feature: .sessionProEnabled], dependencies[feature: .mockCurrentUserSessionProBackendStatus]) {
-                case (true, .simulate(let status)): return "<span>\(status)</span>"
-                case (false, _), (_, .useActual): return "<disabled>None</disabled>"
+            switch dependencies[feature: .mockCurrentUserSessionProBackendStatus] {
+                case .simulate(let status): return "<span>\(status)</span>"
+                case .useActual: return "<disabled>None</disabled>"
             }
         }()
         let sessionPro: SectionModel = SectionModel(
@@ -399,7 +398,6 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
                             description: .htmlTagged("""
                             Configure settings related to Session Pro.
 
-                            <b>Session Pro:</b> <span>\(sessionProStatus)</span>
                             <b>Mock Pro Status:</b> \(mockedProStatus)
                             <b>Session Pro Server:</b> <span>\(Network.SessionPro.server(using: dependencies))</span>
                             """),

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -370,10 +370,6 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                             font: Fonts.Headings.H4,
                             themeForegroundColor: .textPrimary,
                             imageAttachment: {
-                                guard viewModel.dependencies[feature: .sessionProEnabled] == true else {
-                                    return nil
-                                }
-                                
                                 switch state.proState.status {
                                     case .never, .unknown: return nil
                                     case .active:
@@ -470,248 +466,145 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
         let sessionProAndCommunity: SectionModel
         let donationAndNetwork: SectionModel
         
-        // FIXME: [PRO] Should be able to remove this once pro is properly enabled
-        if state.proState.sessionProEnabled {
-            sessionProAndCommunity = SectionModel(
-                model: .sessionProAndCommunity,
-                elements: [
-                    SessionListScreenContent.ListItemInfo(
-                        id: .sessionPro,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .proBadge(
-                                    size: .small,
-                                    themeBackgroundColor: .primary
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    {
-                                        switch state.proState.status {
-                                            case .never, .unknown:
-                                                return "upgradeSession"
-                                                    .localized()
+        sessionProAndCommunity = SectionModel(
+            model: .sessionProAndCommunity,
+            elements: [
+                SessionListScreenContent.ListItemInfo(
+                    id: .sessionPro,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            leadingAccessory: .proBadge(
+                                size: .small,
+                                themeBackgroundColor: .primary
+                            ),
+                            title: SessionListScreenContent.TextInfo(
+                                {
+                                    switch state.proState.status {
+                                        case .never, .unknown:
+                                            return "upgradeSession"
+                                                .localized()
 
-                                            case .active:
-                                                return "sessionProBeta"
-                                                    .localized()
+                                        case .active:
+                                            return "sessionProBeta"
+                                                .localized()
 
-                                            case .expired:
-                                                return "proRenewBeta"
-                                                    .localized()
-                                        }
-                                    }(),
-                                    font: .Headings.H8,
-                                    color: .sessionButton_text
-                                )
-                            )
-                        ),
-                        onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
-                            Task.detached(priority: .userInitiated) {
-                                try? await dependencies[singleton: .sessionProManager].refreshProState(forceLoadingState: true)
-                            }
-                            
-                            let viewController: SessionListHostingViewController = SessionListHostingViewController(
-                                viewModel: SessionProSettingsViewModel(using: dependencies),
-                                customizedNavigationBackground: .clear
-                            )
-                            viewModel?.transitionToScreen(viewController)
-                        }
-                    ),
-                    SessionListScreenContent.ListItemInfo(
-                        id: .inviteAFriend,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .icon(.userRoundPlus),
-                                title: SessionListScreenContent.TextInfo(
-                                    "sessionInviteAFriend".localized(),
-                                    font: .Headings.H8
-                                )
-                            )
-                        ),
-                        onTap: { [weak viewModel] in
-                            let invitation: String = "accountIdShare"
-                                .put(key: "account_id", value: state.profile.id)
-                                .localized()
-                            
-                            viewModel?.transitionToScreen(
-                                UIActivityViewController(
-                                    activityItems: [ invitation ],
-                                    applicationActivities: nil
-                                ),
-                                transitionType: .present
-                            )
-                        }
-                    )
-                ]
-            )
-            donationAndNetwork = SectionModel(
-                model: .donationAndNetwork,
-                elements: [
-                    SessionListScreenContent.ListItemInfo(
-                        id: .donate,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .icon(
-                                    .heart,
-                                    tintColor: .sessionButton_border
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    "donate".localized(),
-                                    font: .Headings.H8
-                                )
-                            )
-                        ),
-                        onTap: { [weak viewModel] in viewModel?.openDonationsUrl() }
-                    ),
-                    SessionListScreenContent.ListItemInfo(
-                        id: .path,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: SessionListScreenContent.ListItemAccessory(
-                                    padding: Values.mediumSmallSpacing,
-                                    accessoryView: {
-                                        PathStatusView_SwiftUI(
-                                            size: .large,
-                                            using: viewModel.dependencies
-                                        )
+                                        case .expired:
+                                            return "proRenewBeta"
+                                                .localized()
                                     }
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    "onionRoutingPath".localized(),
-                                    font: .Headings.H8
-                                )
+                                }(),
+                                font: .Headings.H8,
+                                color: .sessionButton_text
                             )
-                        ),
-                        onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
-                            viewModel?.transitionToScreen(PathVC(using: dependencies))
-                        }
+                        )
                     ),
-                    SessionListScreenContent.ListItemInfo(
-                        id: .sessionNetwork,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .icon(
-                                    UIImage(named: "icon_session_network")?
-                                        .withRenderingMode(.alwaysTemplate)
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    Constants.network_name,
-                                    font: .Headings.H8
-                                )
-                            )
-                        ),
-                        onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
-                            let viewController: SessionHostingViewController = SessionHostingViewController(
-                                rootView: SessionNetworkScreen(
-                                    viewModel: SessionNetworkScreenContent.ViewModel(dependencies: dependencies)
-                                )
-                            )
-                            viewController.setNavBarTitle(Constants.network_name)
-                            viewModel?.transitionToScreen(viewController)
+                    onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
+                        Task.detached(priority: .userInitiated) {
+                            try? await dependencies[singleton: .sessionProManager].refreshProState(forceLoadingState: true)
                         }
-                    )
-                ]
-            )
-        }
-        else {
-            sessionProAndCommunity = SectionModel(
-                model: .sessionProAndCommunity,
-                elements: [
-                    SessionListScreenContent.ListItemInfo(
-                        id: .donate,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .icon(
-                                    .heart,
-                                    tintColor: .sessionButton_border
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    "donate".localized(),
-                                    font: .Headings.H8
-                                )
+                        
+                        let viewController: SessionListHostingViewController = SessionListHostingViewController(
+                            viewModel: SessionProSettingsViewModel(using: dependencies),
+                            customizedNavigationBackground: .clear
+                        )
+                        viewModel?.transitionToScreen(viewController)
+                    }
+                ),
+                SessionListScreenContent.ListItemInfo(
+                    id: .inviteAFriend,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            leadingAccessory: .icon(.userRoundPlus),
+                            title: SessionListScreenContent.TextInfo(
+                                "sessionInviteAFriend".localized(),
+                                font: .Headings.H8
                             )
-                        ),
-                        onTap: { [weak viewModel] in viewModel?.openDonationsUrl() }
+                        )
                     ),
-                    SessionListScreenContent.ListItemInfo(
-                        id: .inviteAFriend,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .icon(.userRoundPlus),
-                                title: SessionListScreenContent.TextInfo(
-                                    "sessionInviteAFriend".localized(),
-                                    font: .Headings.H8
-                                )
+                    onTap: { [weak viewModel] in
+                        let invitation: String = "accountIdShare"
+                            .put(key: "account_id", value: state.profile.id)
+                            .localized()
+                        
+                        viewModel?.transitionToScreen(
+                            UIActivityViewController(
+                                activityItems: [ invitation ],
+                                applicationActivities: nil
+                            ),
+                            transitionType: .present
+                        )
+                    }
+                )
+            ]
+        )
+        donationAndNetwork = SectionModel(
+            model: .donationAndNetwork,
+            elements: [
+                SessionListScreenContent.ListItemInfo(
+                    id: .donate,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            leadingAccessory: .icon(
+                                .heart,
+                                tintColor: .sessionButton_border
+                            ),
+                            title: SessionListScreenContent.TextInfo(
+                                "donate".localized(),
+                                font: .Headings.H8
                             )
-                        ),
-                        onTap: { [weak viewModel] in
-                            let invitation: String = "accountIdShare"
-                                .put(key: "account_id", value: state.profile.id)
-                                .localized()
-                            
-                            viewModel?.transitionToScreen(
-                                UIActivityViewController(
-                                    activityItems: [ invitation ],
-                                    applicationActivities: nil
-                                ),
-                                transitionType: .present
-                            )
-                        }
-                    )
-                ]
-            )
-            donationAndNetwork = SectionModel(
-                model: .donationAndNetwork,
-                elements: [
-                    SessionListScreenContent.ListItemInfo(
-                        id: .path,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: SessionListScreenContent.ListItemAccessory(
-                                    padding: Values.mediumSmallSpacing,
-                                    accessoryView: {
-                                        PathStatusView_SwiftUI(
-                                            size: .large,
-                                            using: viewModel.dependencies
-                                        )
-                                    }
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    "onionRoutingPath".localized(),
-                                    font: .Headings.H8
-                                )
-                            )
-                        ),
-                        onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
-                            viewModel?.transitionToScreen(PathVC(using: dependencies))
-                        }
+                        )
                     ),
-                    SessionListScreenContent.ListItemInfo(
-                        id: .sessionNetwork,
-                        variant: .cell(
-                            info: ListItemCell.Info(
-                                leadingAccessory: .icon(
-                                    UIImage(named: "icon_session_network")?
-                                        .withRenderingMode(.alwaysTemplate)
-                                ),
-                                title: SessionListScreenContent.TextInfo(
-                                    Constants.network_name,
-                                    font: .Headings.H8
-                                )
+                    onTap: { [weak viewModel] in viewModel?.openDonationsUrl() }
+                ),
+                SessionListScreenContent.ListItemInfo(
+                    id: .path,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            leadingAccessory: SessionListScreenContent.ListItemAccessory(
+                                padding: Values.mediumSmallSpacing,
+                                accessoryView: {
+                                    PathStatusView_SwiftUI(
+                                        size: .large,
+                                        using: viewModel.dependencies
+                                    )
+                                }
+                            ),
+                            title: SessionListScreenContent.TextInfo(
+                                "onionRoutingPath".localized(),
+                                font: .Headings.H8
                             )
-                        ),
-                        onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
-                            let viewController: SessionHostingViewController = SessionHostingViewController(
-                                rootView: SessionNetworkScreen(
-                                    viewModel: SessionNetworkScreenContent.ViewModel(dependencies: dependencies)
-                                )
+                        )
+                    ),
+                    onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
+                        viewModel?.transitionToScreen(PathVC(using: dependencies))
+                    }
+                ),
+                SessionListScreenContent.ListItemInfo(
+                    id: .sessionNetwork,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            leadingAccessory: .icon(
+                                UIImage(named: "icon_session_network")?
+                                    .withRenderingMode(.alwaysTemplate)
+                            ),
+                            title: SessionListScreenContent.TextInfo(
+                                Constants.network_name,
+                                font: .Headings.H8
                             )
-                            viewController.setNavBarTitle(Constants.network_name)
-                            viewModel?.transitionToScreen(viewController)
-                        }
-                    )
-                ]
-            )
-        }
+                        )
+                    ),
+                    onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
+                        let viewController: SessionHostingViewController = SessionHostingViewController(
+                            rootView: SessionNetworkScreen(
+                                viewModel: SessionNetworkScreenContent.ViewModel(dependencies: dependencies)
+                            )
+                        )
+                        viewController.setNavBarTitle(Constants.network_name)
+                        viewModel?.transitionToScreen(viewController)
+                    }
+                )
+            ]
+        )
         
         let settings: SectionModel = SectionModel(
             model: .settings,
@@ -1026,9 +919,8 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
             trailingIcon: (currentUrl != nil ? .pencil : .rightPlus),
             style: .circular,
             description: {
-                switch (proState.sessionProEnabled, proState.status) {
-                    case (false, _): return nil
-                    case (true, .active):
+                switch proState.status {
+                    case .active:
                         return SessionListScreenContent.TextInfo(
                             "proAnimatedDisplayPictureModalDescription".localized(),
                             inlineImage: SessionListScreenContent.TextInfo.InlineImageInfo(
@@ -1048,7 +940,7 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                             )
                         )
                         
-                    case (true, _):
+                    default:
                         return SessionListScreenContent.TextInfo(
                             "proAnimatedDisplayPicturesNonProModalDescription".localized(),
                             inlineImage: SessionListScreenContent.TextInfo.InlineImageInfo(
@@ -1137,7 +1029,7 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                                 let isAnimatedImage: Bool = ImageDataManager.isAnimatedImage(source)
                                 var didShowCTAModal: Bool = false
                                 
-                                if isAnimatedImage && proState.sessionProEnabled && proState.status != .active {
+                                if isAnimatedImage && proState.status != .active {
                                     didShowCTAModal = dependencies[singleton: .sessionProManager].showSessionProCTAIfNeeded(
                                         .animatedProfileImage(
                                             isSessionProActivated: (proState.status == .active),

--- a/Session/Shared/BaseVC.swift
+++ b/Session/Shared/BaseVC.swift
@@ -99,10 +99,7 @@ public class BaseVC: UIViewController {
         headingImageView.set(.height, to: Values.mediumFontSize)
         
         let sessionProBadge: SessionProBadge = SessionProBadge(size: .medium)
-        sessionProBadge.isHidden = (
-            !sessionProUIManager.isSessionProEnabled ||
-            !sessionProUIManager.currentUserIsCurrentlyPro
-        )
+        sessionProBadge.isHidden = !sessionProUIManager.currentUserIsCurrentlyPro
         
         let stackView: UIStackView = UIStackView(arrangedSubviews: [ headingImageView, sessionProBadge ])
         stackView.semanticContentAttribute = .forceLeftToRight
@@ -114,7 +111,7 @@ public class BaseVC: UIViewController {
         proObservationTask = Task.detached(priority: .userInitiated) { [weak sessionProBadge] in
             for await isPro in sessionProUIManager.currentUserIsPro {
                 await MainActor.run { [weak sessionProBadge] in
-                    sessionProBadge?.isHidden = !sessionProUIManager.isSessionProEnabled || !isPro
+                    sessionProBadge?.isHidden = !isPro
                 }
             }
         }

--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -260,7 +260,6 @@ public extension UIContextualAction {
                             tableView: tableView
                         ) { _, _, completionHandler in
                             if
-                                dependencies[feature: .sessionProEnabled],
                                 !isCurrentlyPinned,
                                 !dependencies[singleton: .sessionProManager].currentUserIsCurrentlyPro,
                                 currentPinnedConversationCount >= SessionPro.PinnedConversationLimit

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -750,7 +750,7 @@ extension MessageReceiver {
         // FIXME: Replace this with a libSession-based truncation solution
         let utf16View = text.utf16
         let characterLimit: Int = (
-            !dependencies[feature: .sessionProEnabled] || proStatus == .valid ?
+            proStatus == .valid ?
                 SessionPro.ProCharacterLimit :
                 SessionPro.CharacterLimit
         )

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -60,12 +60,11 @@ public actor SessionProManager: SessionProManagerType {
     nonisolated public var currentUserCurrentRotatingKeyPair: KeyPair? { syncState.rotatingKeyPair }
     nonisolated public var currentUserCurrentProState: SessionPro.State { syncState.state }
     nonisolated public var currentUserIsCurrentlyPro: Bool { syncState.state.status == .active }
-    nonisolated public var isSessionProEnabled: Bool { syncState.isSessionProEnabled }
-    
+
     nonisolated public var pinnedConversationLimit: Int { SessionPro.PinnedConversationLimit }
     nonisolated public var characterLimit: Int {
         (
-            isSessionProEnabled && currentUserIsCurrentlyPro ?
+            currentUserIsCurrentlyPro ?
                 SessionPro.ProCharacterLimit :
                 SessionPro.CharacterLimit
         )
@@ -86,10 +85,7 @@ public actor SessionProManager: SessionProManagerType {
 
         Task.detached(priority: .medium) { [weak self] in
             await self?.startProMockingObservations()
-            
-            // TODO: [PRO] Probably need to kick of the below tasks within 'startProMockingObservations' if Session Pro gets enabled (will need to check that they aren't already running though)
-            guard dependencies[feature: .sessionProEnabled] else { return }
-            
+
             await self?.updateWithLatestFromUserConfig()
             await self?.startRevocationListTask()
             await self?.startStoreKitObservations()
@@ -173,7 +169,6 @@ public actor SessionProManager: SessionProManagerType {
     }
     
     nonisolated public func profileFeatures(for profile: Profile?) -> SessionPro.ProfileFeatures {
-        guard syncState.dependencies[feature: .sessionProEnabled] else { return .none }
         guard let profile else {
             /// If we are forcing the pro badge to appear everywhere then insert it
             if syncState.dependencies[feature: .proBadgeEverywhere] {
@@ -220,8 +215,6 @@ public actor SessionProManager: SessionProManagerType {
     }
     
     nonisolated public func messageProFeatureList(_ features: SessionPro.MessageFeatures) -> SessionPro.MessageFeatures {
-        guard syncState.dependencies[feature: .sessionProEnabled] else { return .none }
-        
         let updatedFeatures: SessionPro.MessageFeatures = features
         
         if syncState.dependencies[feature: .forceMessageFeatureLongMessage] {
@@ -232,8 +225,6 @@ public actor SessionProManager: SessionProManagerType {
     }
     
     nonisolated public func profileProFeatureList(_ features: SessionPro.ProfileFeatures) -> SessionPro.ProfileFeatures {
-        guard syncState.dependencies[feature: .sessionProEnabled] else { return .none }
-        
         var updatedFeatures: SessionPro.ProfileFeatures = features
         
         if syncState.dependencies[feature: .forceMessageFeatureProBadge] {
@@ -287,8 +278,6 @@ public actor SessionProManager: SessionProManagerType {
         afterClosed: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
     ) -> Bool {
-        guard syncState.isSessionProEnabled == true else { return false }
-        
         switch variant {
             /// The `groupLimit`, `animatedProfileImage`, and `expiring` CTA can be shown for Session Pro users as well
             case .groupLimit, .animatedProfileImage, .expiring: break
@@ -538,7 +527,6 @@ public actor SessionProManager: SessionProManagerType {
         proofRenewalWakeTask?.cancel()
         proofRenewalWakeTask = nil
 
-        guard dependencies[feature: .sessionProEnabled] else { return }
         guard dependencies[singleton: .appContext].isMainApp else { return }
 
         let nowMs: UInt64 = await dependencies.networkOffsetTimestampMs()
@@ -972,8 +960,6 @@ public actor SessionProManager: SessionProManagerType {
         proInvalidationTask?.cancel()
         proInvalidationTask = nil
 
-        guard dependencies[feature: .sessionProEnabled] else { return }
-
         /// Emit anything that lapsed since we last looked before arming the next wake-up - after the app has been suspended past
         /// an instant, the window between the last check and now can contain lapses we never emitted
         await catchUpProInvalidation()
@@ -1323,7 +1309,6 @@ private final class SessionProManagerSyncState {
     private var _revocationList: [RevocationItem] = []
     
     fileprivate var dependencies: Dependencies { lock.withLock { _dependencies } }
-    fileprivate var isSessionProEnabled: Bool { lock.withLock { _dependencies[feature: .sessionProEnabled] } }
     fileprivate var rotatingKeyPair: KeyPair? { lock.withLock { _rotatingKeyPair } }
     fileprivate var state: SessionPro.State { lock.withLock { _state } }
     fileprivate var revocationList: [RevocationItem] { lock.withLock { _revocationList } }
@@ -1348,7 +1333,6 @@ private final class SessionProManagerSyncState {
 // MARK: - SessionProManagerType
 
 public protocol SessionProManagerType: SessionProUIManagerType {
-    nonisolated var isSessionProEnabled: Bool { get }
     nonisolated var characterLimit: Int { get }
     nonisolated var currentUserCurrentRotatingKeyPair: KeyPair? { get }
     nonisolated var currentUserCurrentProState: SessionPro.State { get }
@@ -1423,17 +1407,6 @@ private extension SessionProManager {
             }
             .assign { [weak self] state in
                 Task.detached(priority: .userInitiated) {
-                    /// If the entire Session Pro feature is disabled then clear any state
-                    guard state.info.sessionProEnabled else {
-                        self?.syncState.update(
-                            rotatingKeyPair: .set(to: nil),
-                            state: .set(to: .invalid)
-                        )
-                        
-                        await self?.stateStream.send(.invalid)
-                        return
-                    }
-                    
                     /// If we need a state refresh then start a new task to do so (we don't want the mocking to be dependant on the
                     /// result of the refresh so don't wait for it to complete before doing any mock changes)
                     if state.needsRefresh {

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -10,8 +10,6 @@ import SessionUtilitiesKit
 
 public extension SessionPro {
     struct State: Sendable, Equatable, Hashable {
-        public let sessionProEnabled: Bool
-        
         public let buildVariant: BuildVariant
         public let products: [Product]
         public let plans: [SessionPro.Plan]
@@ -42,7 +40,6 @@ public extension SessionPro {
 
 public extension SessionPro.State {
     static let invalid: SessionPro.State = SessionPro.State(
-        sessionProEnabled: false,
         buildVariant: .appStore,
         products: [],
         plans: [],
@@ -144,7 +141,6 @@ internal extension SessionPro.State {
         }()
         
         return SessionPro.State(
-            sessionProEnabled: dependencies[feature: .sessionProEnabled],
             buildVariant: finalBuildVariant,
             products: products.or(self.products),
             plans: plans.or(self.plans),
@@ -188,7 +184,6 @@ extension SessionProUI.ClientPlatform {
 internal extension SessionPro {
     struct MockState: ObservableKeyProvider {
         struct Info: Sendable, Equatable {
-            let sessionProEnabled: Bool
             let mockBuildVariant: MockableFeature<BuildVariant>
             let mockProLoadingState: MockableFeature<SessionPro.LoadingState>
             let mockProBackendStatus: MockableFeature<Network.SessionPro.BackendUserProStatus>
@@ -214,7 +209,6 @@ internal extension SessionPro {
             }
             
             return (
-                (info.sessionProEnabled && !previousInfo.sessionProEnabled) ||
                 changedToUseActual(\.mockBuildVariant) ||
                 changedToUseActual(\.mockProLoadingState) ||
                 changedToUseActual(\.mockProBackendStatus) ||
@@ -226,7 +220,6 @@ internal extension SessionPro {
         }
         
         let observedKeys: Set<ObservableKey> = [
-            .feature(.sessionProEnabled),
             .feature(.mockCurrentUserSessionProBuildVariant),
             .feature(.mockCurrentUserSessionProLoadingState),
             .feature(.mockCurrentUserSessionProBackendStatus),
@@ -239,7 +232,6 @@ internal extension SessionPro {
         init(previousInfo: Info? = nil, using dependencies: Dependencies) {
             self.previousInfo = previousInfo
             self.info = Info(
-                sessionProEnabled: dependencies[feature: .sessionProEnabled],
                 mockBuildVariant: dependencies[feature: .mockCurrentUserSessionProBuildVariant],
                 mockProLoadingState: dependencies[feature: .mockCurrentUserSessionProLoadingState],
                 mockProBackendStatus: dependencies[feature: .mockCurrentUserSessionProBackendStatus],

--- a/SessionMessagingKit/Types/ConversationInfoViewModel.swift
+++ b/SessionMessagingKit/Types/ConversationInfoViewModel.swift
@@ -276,8 +276,6 @@ public struct ConversationInfoViewModel: PagableRecord, Sendable, Equatable, Has
         )
         
         self.shouldShowProBadge = {
-            guard dependencies[feature: .sessionProEnabled] else { return false }
-            
             switch thread.variant {
                 case .contact:
                     return (

--- a/SessionMessagingKit/Utilities/ProfilePictureView+Convenience.swift
+++ b/SessionMessagingKit/Utilities/ProfilePictureView+Convenience.swift
@@ -205,8 +205,6 @@ public extension ProfilePictureView {
     /// This will made a decision based on the current state of the profile data, it's up to the parent screen to observer changes and trigger
     /// a UI refresh to update this state
     static func canProfileAnimate(_ profile: Profile?, using dependencies: Dependencies) -> Bool {
-        guard dependencies[feature: .sessionProEnabled] else { return true }
-
         switch profile {
             case .none: return false
             

--- a/SessionUIKit/Components/Input View/InputView.swift
+++ b/SessionUIKit/Components/Input View/InputView.swift
@@ -302,10 +302,7 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
     
     private lazy var sessionProBadge: SessionProBadge = {
         let result: SessionProBadge = SessionProBadge(size: .medium)
-        result.isHidden = (
-            sessionProManager?.isSessionProEnabled != true ||
-            sessionProManager?.currentUserIsCurrentlyPro == true
-        )
+        result.isHidden = (sessionProManager?.currentUserIsCurrentlyPro == true)
         
         return result
     }()
@@ -366,7 +363,7 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
             for await isPro in sessionProManager.currentUserIsPro {
                 await MainActor.run { [weak self] in
                     /// The pro badge is a button to prompt a pro upgrade so hide it when already pro
-                    self?.sessionProBadge.isHidden = (sessionProManager.isSessionProEnabled != true || isPro)
+                    self?.sessionProBadge.isHidden = isPro
                     self?.updateNumberOfCharactersLeft((self?.inputTextView.text ?? ""))
                 }
             }

--- a/SessionUIKit/Types/SessionProUIManagerType.swift
+++ b/SessionUIKit/Types/SessionProUIManagerType.swift
@@ -3,7 +3,6 @@
 import UIKit
 
 public protocol SessionProUIManagerType: Actor {
-    nonisolated var isSessionProEnabled: Bool { get }
     nonisolated var characterLimit: Int { get }
     nonisolated var pinnedConversationLimit: Int { get }
     nonisolated var currentUserIsCurrentlyPro: Bool { get }
@@ -61,7 +60,6 @@ public extension SessionProUIManagerType {
 
 internal actor NoopSessionProUIManager: SessionProUIManagerType {
     private let isPro: Bool
-    nonisolated public var isSessionProEnabled: Bool { true }
     nonisolated public let characterLimit: Int
     nonisolated public let pinnedConversationLimit: Int
     nonisolated public let currentUserIsCurrentlyPro: Bool

--- a/SessionUtilitiesKit/General/Feature.swift
+++ b/SessionUtilitiesKit/General/Feature.swift
@@ -94,10 +94,6 @@ public extension FeatureStorage {
         identifier: "updatedGroupsDeleteAttachmentsBeforeNow"
     )
     
-    static let sessionProEnabled: FeatureConfig<Bool> = Dependencies.create(
-        identifier: "sessionPro"
-    )
-    
     static let proBadgeEverywhere: FeatureConfig<Bool> = Dependencies.create(
         identifier: "proBadgeEverywhere"
     )


### PR DESCRIPTION
The next release off the dev branch will be Pro-enabled (if we need another intermediate release we'll branch off stable): this removes all the Pro gating code so that dev builds are now always Pro enabled.