### PR TITLE
Acquire a Pro proof for an entitled account that has none

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ for harness setup and the run commands.
   extract/reuse it rather than copy-pasting. Pull shared logic into the appropriate
   lower-level module rather than repeating it across call sites.
 - **File header** (top of every new Swift file):
-  `// Copyright © <year> Rangeproof Pty Ltd. All rights reserved.`
+  `// Copyright © <year> Session Technology Foundation. All rights reserved.`
 - **C++** is formatted with `.clang-format` (WebKit base, 120-column, no tabs).
 - A `.swiftlint.yml` exists but SwiftLint is **not actually run** on this project — don't
   rely on it as a lint gate or spend effort satisfying it.

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -6591,7 +6591,7 @@
 				LastSwiftUpdateCheck = 2610;
 				LastTestingUpgradeCheck = 0600;
 				LastUpgradeCheck = 2610;
-				ORGANIZATIONNAME = "Rangeproof Pty Ltd";
+				ORGANIZATIONNAME = "Session Technology Foundation";
 				TargetAttributes = {
 					453518671FC635DD00210559 = {
 						CreatedOnToolsVersion = 9.2;

--- a/Session/Conversations/Views & Modals/ConversationTitleView.swift
+++ b/Session/Conversations/Views & Modals/ConversationTitleView.swift
@@ -211,7 +211,16 @@ final class ConversationTitleView: UIView {
         )
         
         self.titleLabel.text = viewModel.displayName
-        self.titleLabel.accessibilityLabel = viewModel.displayName
+        /// Fold the Pro badge into the label rather than relying on it being its own element - `titleLabel` is
+        /// an accessibility element (see its initialiser), which collapses `SessionLabelWithProBadge`'s children,
+        /// so without this VoiceOver announces a Pro user identically to a non-Pro one and the badge is
+        /// imperceptible to assistive technology
+        self.titleLabel.accessibilityLabel = [
+            viewModel.displayName,
+            (viewModel.showProBadge ? SessionProBadge.accessibilityLabel : nil)
+        ]
+        .compactMap { $0 }
+        .joined(separator: ", ")
         self.titleLabel.font = (shouldHaveSubtitle ? Fonts.Headings.H6 : Fonts.Headings.H5)
         self.titleLabel.isProBadgeHidden = !viewModel.showProBadge
         

--- a/Session/Meta/MainThreadUITripwire.swift
+++ b/Session/Meta/MainThreadUITripwire.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 // stringlint:disable
 
 #if DEBUG

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -504,6 +504,9 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                                 )
                             )
                         ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.menuItem
+                        ),
                         onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                             Task.detached(priority: .userInitiated) {
                                 try? await dependencies[singleton: .sessionProManager].refreshProState(forceLoadingState: true)

--- a/SessionMessagingKit/Database/Migrations/_052_RecoverBrokenCommunityAttachments.swift
+++ b/SessionMessagingKit/Database/Migrations/_052_RecoverBrokenCommunityAttachments.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 //
 // stringlint:disable
 

--- a/SessionMessagingKit/Database/Migrations/_053_RenameProColumnsForWireFormat.swift
+++ b/SessionMessagingKit/Database/Migrations/_053_RenameProColumnsForWireFormat.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import GRDB

--- a/SessionMessagingKit/SessionPro/ProErrorMessage.swift
+++ b/SessionMessagingKit/SessionPro/ProErrorMessage.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2025 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import SessionNetworkingKit

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -860,6 +860,24 @@ public actor SessionProManager: SessionProManagerType {
             startStoreKitEntitlementsObservations()
             await entitlementsObservingTask?.value
 
+            /// An entitlement can exist with no proof on **any** device: a server-side grant (promotional
+            /// or complimentary), or a store subscription restored without a purchase flow. Nothing else
+            /// marks those accounts as acquiring — `markPurchaseInFlight` is only reached from the purchase
+            /// paths — so `pro_renewal_target` stays `nullopt` and the account can never prove Pro, while
+            /// still rendering as Pro locally.
+            ///
+            /// Gated on having polled our own swarm at least once, so a device that is merely *waiting* for
+            /// a proof to arrive by config sync (a restore, or a newly linked device) doesn't mint a
+            /// redundant one — those cases resolve themselves and are not what this is for.
+            if
+                updatedState.status == .active,
+                updatedState.proof == nil,
+                await dependencies[singleton: .currentUserPoller].pollCount > 0
+            {
+                Log.info(.sessionPro, "Entitled with no proof on any device; marking acquisition pending.")
+                try? await markPurchaseInFlight()
+            }
+
             await reconcileProofRenewal()
         } catch {
             Log.error(.sessionPro, "Failed to retrieve pro status due to error(s): \(error)")

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -811,12 +811,19 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     font: .Headings.H8
                                 ),
                                 description: {
+                                    /// Every state of this line is the same slot, so they share the one identifier
+                                    /// and the state is distinguished by the text
+                                    let accessibility: Accessibility = Accessibility(
+                                        identifier: ListItemCell.AccessibilityIdentifier.subtitle
+                                    )
+
                                     switch state.proState.loadingState {
                                         case .loading:
                                             return SessionListScreenContent.TextInfo(
                                                 font: .Body.smallRegular,
                                                 attributedString: "proAccessLoadingEllipsis"
-                                                    .localizedFormatted(Fonts.Body.smallRegular)
+                                                    .localizedFormatted(Fonts.Body.smallRegular),
+                                                accessibility: accessibility
                                             )
 
                                         case .error:
@@ -824,7 +831,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                 font: .Body.smallRegular,
                                                 attributedString: "errorLoadingProAccess"
                                                     .localizedFormatted(Fonts.Body.smallRegular),
-                                                color: .warning
+                                                color: .warning,
+                                                accessibility: accessibility
                                             )
 
                                         case .success:
@@ -838,7 +846,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                     "proRenewalUnsuccessful"
                                                         .localized(),
                                                     font: .Body.smallRegular,
-                                                    color: .warning
+                                                    color: .warning,
+                                                    accessibility: accessibility
                                                 )
                                             }
                                             
@@ -860,7 +869,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                         "proExpiringTime"
                                                             .put(key: "time", value: expirationString)
                                                             .localizedFormatted(Fonts.Body.smallRegular)
-                                                )
+                                                ),
+                                                accessibility: accessibility
                                             )
                                     }
                                 }(),

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -140,6 +140,21 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                 default: return false
             }
         }
+
+        public var accessibility: Accessibility? {
+            switch self {
+                case .proStats:
+                    return Accessibility(identifier: SessionProUI.AccessibilityIdentifier.statsHeader)
+
+                case .proSettings:
+                    return Accessibility(identifier: SessionProUI.AccessibilityIdentifier.manageHeader)
+
+                case .proFeatures:
+                    return Accessibility(identifier: SessionProUI.AccessibilityIdentifier.featuresHeader)
+
+                default: return nil
+            }
+        }
     }
     
     public enum ListItem: Differentiable {
@@ -536,6 +551,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                             )
                         )
                     ),
+                    accessibility: Accessibility(
+                        identifier: SessionProUI.AccessibilityIdentifier.faq
+                    ),
                     onTap: { [weak viewModel] in viewModel?.openUrl(Constants.urls.proFaq) }
                 ),
                 SessionListScreenContent.ListItemInfo(
@@ -562,6 +580,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 }()
                             )
                         )
+                    ),
+                    accessibility: Accessibility(
+                        identifier: SessionProUI.AccessibilityIdentifier.support
                     ),
                     onTap: { [weak viewModel] in viewModel?.openUrl(Constants.urls.proSupport) }
                 )
@@ -599,7 +620,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .putNumber(state.numberOfLongerMessagesSent)
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfLongerMessagesSent))
                                         .localized(),
-                                    font: .Headings.H9
+                                    font: .Headings.H9,
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsLongerMessages
+                                    )
                                 ),
                                 isLoading: (state.proState.loadingState == .loading)
                             ),
@@ -614,7 +638,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .putNumber(state.numberOfPinnedConversations)
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfPinnedConversations))
                                         .localized(),
-                                    font: .Headings.H9
+                                    font: .Headings.H9,
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsPinnedConversations
+                                    )
                                 ),
                                 isLoading: (state.proState.loadingState == .loading)
                             )
@@ -631,7 +658,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .putNumber(state.numberOfProBadgesSent)
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfProBadgesSent))
                                         .localized(),
-                                    font: .Headings.H9
+                                    font: .Headings.H9,
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsBadgesSent
+                                    )
                                 ),
                                 isLoading: (state.proState.loadingState == .loading)
                             ),
@@ -647,7 +677,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfGroupsUpgraded))
                                         .localized(),
                                     font: .Headings.H9,
-                                    color: (state.proState.loadingState == .loading ? .textPrimary : .disabled)
+                                    color: (state.proState.loadingState == .loading ? .textPrimary : .disabled),
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsGroupsUpgraded
+                                    )
                                 ),
                                 tooltipInfo: SessionListScreenContent.TooltipInfo(
                                     id: "SessionListScreen.DataMatrix.UpgradedGroups.ToolTip", // stringlint:ignore
@@ -785,7 +818,7 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                 attributedString: "proAccessLoadingEllipsis"
                                                     .localizedFormatted(Fonts.Body.smallRegular)
                                             )
-                                            
+
                                         case .error:
                                             return SessionListScreenContent.TextInfo(
                                                 font: .Body.smallRegular,
@@ -793,7 +826,7 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                     .localizedFormatted(Fonts.Body.smallRegular),
                                                 color: .warning
                                             )
-                                            
+
                                         case .success:
                                             let expirationTimestamp: TimeInterval = Double(state.proState.displayTimestampSeconds ?? 0)
                                             let isInAutoRenewingGracePeriod: Bool = (
@@ -836,6 +869,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     .icon(.chevronRight, size: .large)
                                 )
                             )
+                        ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.updatePlan
                         ),
                         onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                             switch state.proState.loadingState {
@@ -951,9 +987,15 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                         ),
                         trailingAccessory: .toggle(
                             state.profile.proFeatures.contains(.proBadge),
-                            oldValue: previousState.profile.proFeatures.contains(.proBadge)
+                            oldValue: previousState.profile.proFeatures.contains(.proBadge),
+                            accessibility: Accessibility(
+                                identifier: SessionProUI.AccessibilityIdentifier.showBadgeToggle
+                            )
                         )
                     )
+                ),
+                accessibility: Accessibility(
+                    identifier: SessionProUI.AccessibilityIdentifier.showBadge
                 ),
                 onTap: { [dependencies = viewModel.dependencies] in
                     Task.detached(priority: .userInitiated) {
@@ -995,10 +1037,13 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 )
                             )
                         ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.recoverPlan
+                        ),
                         onTap: { [weak viewModel] in viewModel?.recoverProPlan() }
                     )
                 ]
-                
+
             case (.active, .notRefunding):
                 var renewingItems: [SessionListScreenContent.ListItemInfo<ListItem>] = []
                 
@@ -1017,6 +1062,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     trailingAccessory: .icon(.circleX, size: .medium, tintColor: .danger)
                                 )
                             ),
+                            accessibility: Accessibility(
+                                identifier: SessionProUI.AccessibilityIdentifier.cancelPlan
+                            ),
                             onTap: { [weak viewModel] in viewModel?.cancelPlan(state: state) }
                         )
                     )
@@ -1034,6 +1082,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 ),
                                 trailingAccessory: .icon(.circleAlert, size: .medium, tintColor: .danger)
                             )
+                        ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.requestRefund
                         ),
                         onTap: { [weak viewModel] in viewModel?.requestRefund(state: state) }
                     )
@@ -1082,6 +1133,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 )
                             )
                         ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.renewPlan
+                        ),
                         onTap: { [weak viewModel] in
                             switch state.proState.loadingState {
                                 case .success: viewModel?.updateProPlan(state: state)
@@ -1119,6 +1173,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     size: .medium
                                 )
                             )
+                        ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.recoverPlan
                         ),
                         onTap: { [weak viewModel] in viewModel?.recoverProPlan() }
                     )

--- a/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
@@ -1,4 +1,4 @@
-// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import GRDB

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2025 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import SessionUtil

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -11,7 +11,6 @@ public extension Network.SessionPro {
     struct GetProStatusResponse: Equatable {
         public let header: ResponseHeader
         public let status: BackendUserProStatus
-        public let errorReport: ErrorReport
         public let autoRenewing: Bool
         public let expiryTimestampSeconds: UInt64
         public let gracePeriodDurationSeconds: UInt64
@@ -34,35 +33,14 @@ public extension Network.SessionPro {
             self.header = ResponseHeader(result.header)
             /// `status` (the account user-status) is an opaque NUL-terminated `const char*` code.
             self.status = BackendUserProStatus(code: result.get(\.status))
-            self.errorReport = ErrorReport(result.error_report)
+            /// `error_report` is being dropped from the response (buggy-by-design: e.g. on Apple it can
+            /// never clear once set, and a set value carries no actionable signal) — we stop reading it.
             self.autoRenewing = result.auto_renewing
             /// Whole unix seconds on the wire and in our domain — direct assigns, no conversion.
             self.expiryTimestampSeconds = UInt64(max(0, result.expiry_ts))
             self.gracePeriodDurationSeconds = UInt64(max(0, result.grace_period_duration))
             /// `refund_requested_ts` is gone from the response — refund-pending is config-synced state now.
             self.latestPaymentItem = (result.has_latest_payment ? PaymentItem(result.latest_payment) : nil)
-        }
-    }
-}
-
-public extension Network.SessionPro.GetProStatusResponse {
-    enum ErrorReport: CaseIterable {
-        case success
-        case genericError
-
-        var libSessionValue: SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT {
-            switch self {
-                case .success: return SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_SUCCESS
-                case .genericError: return SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR
-            }
-        }
-
-        init(_ libSessionValue: SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT) {
-            switch libSessionValue {
-                case SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_SUCCESS: self = .success
-                case SESSION_PRO_BACKEND_GET_PRO_STATUS_ERROR_REPORT_GENERIC_ERROR: self = .genericError
-                default: self = .genericError
-            }
         }
     }
 }

--- a/SessionNetworkingKit/SessionPro/Types/ProRequest.swift
+++ b/SessionNetworkingKit/SessionPro/Types/ProRequest.swift
@@ -1,4 +1,4 @@
-// Copyright © 2025 Rangeproof Pty Ltd. All rights reserved.
+// Copyright © 2025 Session Technology Foundation. All rights reserved.
 
 import Foundation
 import SessionUtil

--- a/SessionUIKit/Components/SessionLabelWithProBadge.swift
+++ b/SessionUIKit/Components/SessionLabelWithProBadge.swift
@@ -142,6 +142,15 @@ public class SessionLabelWithProBadge: UIView {
         self.withStretchingSpacer = withStretchingSpacer
         
         super.init(frame: .zero)
+
+        /// This is iOS' equivalent of Android's `ProBadgeText` so it carries the same identifiers - the container
+        /// and the label, with the badge tagging itself (see `SessionProBadge.AccessibilityIdentifier`)
+        ///
+        /// **Note:** Deliberately not setting `isAccessibilityElement` on the container, doing so would hide the
+        /// label and the badge from the accessibility tree
+        self.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.component
+        label.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.text
+
         self.addSubview(stackView)
         stackView.pin(to: self)
     }

--- a/SessionUIKit/Components/SessionProBadge.swift
+++ b/SessionUIKit/Components/SessionProBadge.swift
@@ -4,9 +4,26 @@ import UIKit
 
 public class SessionProBadge: UIView {
     public static let accessibilityLabel: String = Constants.app_pro
-    
+
     public static let identifier: String = "ProBadge"   // stringlint:ignore
-    
+
+    /// Accessibility identifiers for the pro badge and the label it sits beside
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Android (its
+    /// `content-descriptions` module defines the same values as `qa_pro_badge_component` / `_text` / `_icon`)
+    /// so a single Appium locator serves both platforms - renaming one means renaming it in three repos
+    // stringlint:ignore_contents
+    public enum AccessibilityIdentifier {
+        /// The container holding the label and the badge together (Android: `ProBadgeText`'s row)
+        public static let component: String = "pro-badge-component"
+
+        /// The label beside the badge (ie. the display name), **not** the badge itself
+        public static let text: String = "pro-badge-text"
+
+        /// The badge itself
+        public static let icon: String = "pro-badge-icon"
+    }
+
     public enum Size {
         case mini, small, medium, large
         
@@ -77,6 +94,13 @@ public class SessionProBadge: UIView {
     public init(size: Size, themeBackgroundColor: ThemeValue = .primary) {
         self.size = size
         super.init(frame: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+
+        /// The badge is a plain `UIView` wrapping an image so it wouldn't otherwise appear in the accessibility
+        /// tree at all - make it an element in its own right (it has no accessible children to hide)
+        self.isAccessibilityElement = true
+        self.accessibilityLabel = SessionProBadge.accessibilityLabel
+        self.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.icon
+
         setUpViewHierarchy()
         self.themeBackgroundColor = themeBackgroundColor
     }

--- a/SessionUIKit/Components/SwiftUI/SessionProBadge+SwiftUI.swift
+++ b/SessionUIKit/Components/SwiftUI/SessionProBadge+SwiftUI.swift
@@ -23,5 +23,11 @@ public struct SessionProBadge_SwiftUI: View {
         }
         .frame(width: size.width, height: size.height)
         .clipped()
+        .accessibility(
+            Accessibility(
+                identifier: SessionProBadge.AccessibilityIdentifier.icon,
+                label: SessionProBadge.accessibilityLabel
+            )
+        )
     }
 }

--- a/SessionUIKit/Screens/SessionListScreen/ListContentModels/SessionListScreen+Section.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListContentModels/SessionListScreen+Section.swift
@@ -12,6 +12,9 @@ public extension SessionListScreenContent {
         var extraVerticalPadding: CGFloat { get }
         var footer: String? { get }
         var shadow: Bool { get }
+
+        /// Applied to the section's *header*, not to its rows - rows carry their own via `ListItemInfo.accessibility`
+        var accessibility: Accessibility? { get }
     }
     
     enum ListSectionStyle: Equatable, Hashable, Differentiable {
@@ -71,5 +74,12 @@ public extension SessionListScreenContent {
             }
         }
     }
+}
+
+// MARK: - Defaults
+
+public extension SessionListScreenContent.ListSection {
+    /// Most sections don't need their header addressed directly, so only the ones which do have to provide this
+    var accessibility: Accessibility? { nil }
 }
 

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemCell.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemCell.swift
@@ -22,6 +22,20 @@ private struct FullTextHeightKey: PreferenceKey {
 // MARK: - ListItemCell
 
 public struct ListItemCell: View {
+    /// Accessibility identifiers for the parts of a row, for tests that need to address the title or subtitle
+    /// separately rather than reading the row's own combined label
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Android, whose shared `ActionRowItem`
+    /// component tags the same two elements - so a single Appium locator, scoped to the row's own identifier,
+    /// serves both platforms. They are deliberately **opt-in per call site** rather than defaulted onto every
+    /// cell: setting an identifier makes it the element's `name` and pushes the display text to `label`, which
+    /// would silently break every text-based locator in the app if applied wholesale
+    // stringlint:ignore_contents
+    public enum AccessibilityIdentifier {
+        public static let title: String = "action-item-title"
+        public static let subtitle: String = "action-item-subtitle"
+    }
+
     public struct Info: Equatable, Hashable, Differentiable {
         let leadingAccessory: SessionListScreenContent.ListItemAccessory?
         let title: SessionListScreenContent.TextInfo?

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
@@ -134,6 +134,8 @@ public struct ListItemLogoWithPro: View {
                 .padding(.top, Values.mediumSpacing)
                 .environment(\.layoutDirection, .leftToRight)
                 
+                /// **Note:** The loading and error banners deliberately share a single accessibility identifier -
+                /// they're the same slot, and their messages already distinguish the states
                 if case .error(let message) = info.state {
                     HStack(spacing: Values.verySmallSpacing) {
                         Text(message)
@@ -142,8 +144,12 @@ public struct ListItemLogoWithPro: View {
                     .font(.Body.baseRegular)
                     .foregroundColor(themeColor: .warning)
                     .padding(.top, Values.mediumSpacing)
+                    .accessibilityElement(children: .combine)
+                    .accessibility(
+                        Accessibility(identifier: SessionProUI.AccessibilityIdentifier.statusBanner)
+                    )
                 }
-                
+
                 if case .loading(let message) = info.state {
                     HStack(spacing: Values.verySmallSpacing) {
                         Text(message)
@@ -156,6 +162,10 @@ public struct ListItemLogoWithPro: View {
                     .font(.Body.baseRegular)
                     .foregroundColor(themeColor: .textPrimary)
                     .padding(.top, Values.mediumSpacing)
+                    .accessibilityElement(children: .combine)
+                    .accessibility(
+                        Accessibility(identifier: SessionProUI.AccessibilityIdentifier.statusBanner)
+                    )
                 }
                 
                 if let description = info.description {

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
@@ -158,6 +158,10 @@ public struct ListItemLogoWithPro: View {
                             .controlSize(.regular)
                             .scaleEffect(0.8)
                             .frame(width: 16, height: 16)
+                            /// Hidden from accessibility so the combined banner reports the *message* - a
+                            /// `ProgressView` contributes its progress as a value, which otherwise wins and the
+                            /// banner reads as "1" to both VoiceOver and any test asserting on the state
+                            .accessibilityHidden(true)
                     }
                     .font(.Body.baseRegular)
                     .foregroundColor(themeColor: .textPrimary)

--- a/SessionUIKit/Screens/SessionListScreen/SessionListScreen.swift
+++ b/SessionUIKit/Screens/SessionListScreen/SessionListScreen.swift
@@ -205,6 +205,7 @@ public struct SessionListScreen<ViewModel: SessionListScreenContent.ViewModelTyp
                             }
                         }
                         .frame(minHeight: section.model.style.height)
+                        .accessibility(section.model.accessibility)
                         .listRowInsets(.init(top: 0, leading: section.model.style.edgePadding, bottom: 0, trailing: section.model.style.edgePadding))
                         .listRowBackground(Color.clear)
                     }

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProPaymentScreen+Purchase.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProPaymentScreen+Purchase.swift
@@ -91,7 +91,7 @@ struct  SessionProPlanPurchaseContent: View {
                     "proTosDescription"
                         .put(key: "action_type", value: actionType)
                         .put(key: "activation_type", value: activationType)
-                        .put(key: "entity", value: Constants.entity_rangeproof)
+                        .put(key: "entity", value: Constants.entity_stf)
                         .localizedFormatted(Fonts.Body.smallRegular)
                 )
                 .font(.Body.smallRegular)

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
@@ -4,6 +4,77 @@ import Foundation
 
 public enum SessionProUI {}
 
+// MARK: - AccessibilityIdentifier
+
+public extension SessionProUI {
+    /// Accessibility identifiers for the Pro settings surface
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Android (its `content-descriptions` module
+    /// defines the same values) so a single Appium locator serves both platforms - renaming one means renaming it
+    /// in three repos. See `SessionProBadge.AccessibilityIdentifier` for the badge itself
+    // stringlint:ignore_contents
+    enum AccessibilityIdentifier {
+        /// The Pro entry in the main settings list, which opens this screen
+        public static let menuItem: String = "pro-menu-item"
+
+        /// The loading/error banner under the logo - one identifier for the slot, with the individual states
+        /// distinguished by their text (`checkingProStatus`, `proStatusLoading`, `errorCheckingProStatus`,
+        /// `proErrorRefreshingStatus`) rather than by separate identifiers
+        public static let statusBanner: String = "pro-settings-status-banner"
+
+        /// The "Your Pro Stats" section header
+        public static let statsHeader: String = "pro-settings-stats-header"
+
+        /// The four cells of the "Your Pro Stats" matrix
+        ///
+        /// **Note:** These sit on the cell's *title*, which is the whole "N badges sent" string - so an assertion
+        /// reads the value from the element's accessibility **label**, since the identifier takes over `name`
+        public static let statsLongerMessages: String = "pro-stats-longer-messages"
+        public static let statsPinnedConversations: String = "pro-stats-pinned-conversations"
+        public static let statsBadgesSent: String = "pro-stats-badges-sent"
+        public static let statsGroupsUpgraded: String = "pro-stats-groups-upgraded"
+
+        /// The "Pro Settings" section header
+        public static let manageHeader: String = "pro-settings-manage-header"
+
+        /// The "Pro Beta Features" section header
+        public static let featuresHeader: String = "pro-settings-features-header"
+
+        /// The "Update Pro Access" row
+        ///
+        /// **Note:** `ListItemCell` is a `Button`, so its title and subtitle merge into this one element rather
+        /// than staying separately addressable - the expiry text is part of *this* element's accessibility label
+        public static let updatePlan: String = "pro-settings-update-plan"
+
+        /// The "Pro Badge" visibility row
+        public static let showBadge: String = "pro-settings-show-badge"
+
+        /// The toggle within the "Pro Badge" visibility row
+        public static let showBadgeToggle: String = "pro-settings-show-badge-toggle"
+
+        /// The "Request Refund" **action** in the "Manage Pro" section
+        ///
+        /// **Note:** Not the read-only "Refund requested" row shown while a refund is being processed - Android has
+        /// no equivalent of that row, so it stays unnamed until both platforms agree on a string
+        public static let requestRefund: String = "pro-settings-request-refund"
+
+        /// The "Cancel Pro Access" action
+        public static let cancelPlan: String = "pro-settings-cancel-plan"
+
+        /// The "Renew Pro Access" action, shown when access has expired
+        public static let renewPlan: String = "pro-settings-renew-plan"
+
+        /// The "Recover Pro Access" action
+        public static let recoverPlan: String = "pro-settings-recover-plan"
+
+        /// The "Pro FAQ" row in the help section
+        public static let faq: String = "pro-settings-faq"
+
+        /// The "Support" row in the help section
+        public static let support: String = "pro-settings-support"
+    }
+}
+
 // MARK: - ClientPlatform
 
 public extension SessionProUI {

--- a/SessionUIKit/Style Guide/Constants.swift
+++ b/SessionUIKit/Style Guide/Constants.swift
@@ -17,7 +17,6 @@ public enum Constants {
     public static let app_pro: String = "Session Pro"
     public static let session_foundation: String = "Session Foundation"
     public static let pro: String = "Pro"
-    public static let entity_rangeproof: String = "Rangeproof PTY LTD"
     public static let entity_stf: String = "The Session Technology Foundation"
     public static let donate_appeal_name: String = "Cofounder of Session Chris McCabe"
     public static let entity_stf_short: String = "Session Technology Foundation (STF)"


### PR DESCRIPTION
A server-side grant, or a store subscription restored without a purchase flow, entitles the account without any device minting a proof, and nothing marks those accounts as acquiring -- the prepaid marker is only set from the purchase paths. Such an account renders as Pro locally while being unable to prove it to anyone.

Gated on having polled our own swarm at least once, so a device merely waiting for a proof to arrive by config sync does not mint a redundant one.