### PR TITLE
Pro followup fixes

### DIFF
--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -338,8 +338,16 @@ public actor SessionProManager: SessionProManagerType {
         // Note: We have to make sure the initial pro status loading is finished, otherwise the pro status info and plan info
         // may not be correct
         await ensureInitialized()
-        
+
         let state: SessionPro.State = await stateStream.getCurrent()
+
+        /// Never fire an expiring/expired CTA off unconfirmed status. At (cold) launch `status` is inferred
+        /// from the LOCAL proof, so a single-device account whose subscription renewed while the app was
+        /// closed always looks `.expired` locally until a `get_pro_status` succeeds (there's no config write
+        /// at renewal to correct it). Firing here would flash a false "Pro expired". Gate on a confirmed
+        /// fetch (`.success`) — on `.loading`/`.error` we return `nil` and a later successful refresh
+        /// (foreground reconcile) re-triggers the CTA if the subscription genuinely lapsed.
+        guard state.loadingState == .success else { return nil }
         let dateNow: Date = dependencies.dateNow
         let expiryInSeconds: TimeInterval = (state.accessExpiryTimestampSeconds
             .map { Date(timeIntervalSince1970: Double($0)).timeIntervalSince(dateNow) } ?? 0)

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -651,13 +651,13 @@ public actor SessionProManager: SessionProManagerType {
                     case .success:
                         await applyProofSuccess(response, rotatingKeyPair: rotatingKeyPair)
 
-                    /// Lapsed / no subscription → clear, but only if we don't currently hold a valid proof
-                    /// (never let a stale failure wipe a fresh proof another device just landed).
-                    /// `subscription_expired` carries a now-past `account_expiry` to refresh `E`.
-                    case .subscriptionExpired:
-                        await applyProofClear(accountExpiryTimestampSeconds: response.accountExpiryTimestampSeconds)
-                    case .notSubscribed:
-                        await applyProofClear(accountExpiryTimestampSeconds: nil)
+                    /// Lapsed / no subscription → clear (proof `s` AND access-expiry `E`), but only if we
+                    /// don't currently hold a valid proof (never let a stale failure wipe a fresh proof
+                    /// another device just landed). Both outcomes mean "not entitled", so `E` must not be
+                    /// left future — clearing it (rather than re-setting a past value) is spin-safe and
+                    /// `get_pro_status` supplies the display horizon anyway.
+                    case .subscriptionExpired, .notSubscribed:
+                        await applyProofClear()
 
                     /// Revocation from a proof response is terminal: clear regardless of validity, no `E`
                     /// write, off the transient/backoff path.
@@ -713,23 +713,23 @@ public actor SessionProManager: SessionProManagerType {
 
     /// subscription_expired / not_subscribed clear — downgrade-guarded: apply only if there is no currently
     /// valid (unexpired) proof, read inside the write.
-    private func applyProofClear(accountExpiryTimestampSeconds: UInt64?) async {
+    private func applyProofClear() async {
         let nowSeconds: Int64 = Int64(await dependencies.networkOffsetTimestampMs() / 1000)
 
         try? await dependencies[singleton: .storage].write { [dependencies] db in
             try dependencies.mutate(cache: .libSession) { cache in
                 try cache.performAndPushChange(db, for: .userProfile) { _ in
                     /// Downgrade guard (read live config): never wipe a fresh, unexpired proof another device
-                    /// just landed. `remove_pro_config` clears only `s`/`E`; it deliberately leaves
-                    /// `pro_prepaid` so a pending purchase keeps polling (§7.3).
+                    /// just landed. `remove_pro_config` deliberately leaves `pro_prepaid` so a pending
+                    /// purchase keeps polling (§7.3).
                     let hasUnexpiredProof: Bool = ((cache.proConfig?.proProof.expiryUnixTimestampSeconds ?? 0) > UInt64(max(0, nowSeconds)))
                     guard !hasUnexpiredProof else { return }
 
+                    /// `remove_pro_config` clears ONLY the proof `s`. `E` does NOT self-age (unlike the proof
+                    /// `I`/`R`), so a stale future `E` left here would make `pro_renewal_target` fire on every
+                    /// eval and spin — clear it explicitly (`set_pro_access_expiry(nullopt)`, via `0`).
                     cache.removeProConfig()
-
-                    if let accountExpiryTimestampSeconds: UInt64 = accountExpiryTimestampSeconds {
-                        cache.updateProAccessExpiryTimestampSeconds(accountExpiryTimestampSeconds)
-                    }
+                    cache.updateProAccessExpiryTimestampSeconds(0)
                 }
             }
         }
@@ -737,13 +737,16 @@ public actor SessionProManager: SessionProManagerType {
         await updateWithLatestFromUserConfig()
     }
 
-    /// `revoked` from a proof response is authoritative and terminal — clear regardless of validity, no `E`
-    /// write (a horizon is meaningless once revoked). Mirrors the revocation-list path (§6.4).
+    /// `revoked` from a proof response is authoritative and terminal — clear regardless of validity. Clears
+    /// both the proof `s` and the access-expiry `E`: `remove_pro_config` only clears `s`, and a stale future
+    /// `E` would keep `pro_renewal_target` firing (spin), so clear it too (`set_pro_access_expiry(nullopt)`,
+    /// via `0`). Mirrors the revocation-list path (§6.4).
     private func applyProofRevoked() async {
         try? await dependencies[singleton: .storage].write { [dependencies] db in
             try dependencies.mutate(cache: .libSession) { cache in
                 try cache.performAndPushChange(db, for: .userProfile) { _ in
                     cache.removeProConfig()
+                    cache.updateProAccessExpiryTimestampSeconds(0)
                 }
             }
         }
@@ -841,8 +844,22 @@ public actor SessionProManager: SessionProManagerType {
             await self.stateStream.send(updatedState)
             oldState = updatedState
 
-            /// `get_pro_status` is DISPLAY-ONLY now (Rev 2 §1.3): it refreshes auto-renew / grace / refund /
-            /// access-expiry fields but does NOT mint or clear the proof. The proof lifecycle — generate on
+            /// `get_pro_status` is authoritative for the account paid-through end, so mirror `expiry_ts` into
+            /// config `E` (`set_pro_access_expiry`) unconditionally on every success. This is the crux that
+            /// lets `pro_renewal_target` fire for a server-side voucher / recovered subscription (account
+            /// active but with no local proof yet) — without it, `E` in config would stay absent and a proof
+            /// would never be fetched. libsession clears `E` when handed `<= 0` (the never/expired
+            /// `expiry_ts`) and only dirties the config on a real change, so the unconditional write is safe.
+            try? await dependencies[singleton: .storage].write { [dependencies] db in
+                try dependencies.mutate(cache: .libSession) { cache in
+                    try cache.performAndPushChange(db, for: .userProfile) { _ in
+                        cache.updateProAccessExpiryTimestampSeconds(response.expiryTimestampSeconds)
+                    }
+                }
+            }
+
+            /// `get_pro_status` is DISPLAY-ONLY for the PROOF (Rev 2 §1.3): it refreshes auto-renew / grace /
+            /// refund / access-expiry fields but does NOT mint or clear the proof. The proof lifecycle — generate on
             /// due, and the §4 clears on `subscription_expired` / `not_subscribed` / `revoked` — is owned
             /// entirely by the reconcile loop's `generate_pro_proof` path, so we just kick a reconcile here
             /// (a status change may make a renewal / acquisition due).

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -42,6 +42,7 @@ public actor SessionProManager: SessionProManagerType {
     /// are ephemeral spacing/backoff state (re-derived from config each pass, reset on process death).
     private var proofRenewalWakeTask: Task<Void, Never>?
     private var proofGenerationTask: Task<Void, Never>?
+    private var postPurchaseStatusPollTask: Task<Void, Never>?
     private var lastProofRequestAt: TimeInterval = -.greatestFiniteMagnitude
     private var darkAttempt: Int = 0
 
@@ -117,6 +118,7 @@ public actor SessionProManager: SessionProManagerType {
         appLifecycleObservingTask?.cancel()
         proofRenewalWakeTask?.cancel()
         proofGenerationTask?.cancel()
+        postPurchaseStatusPollTask?.cancel()
     }
     
     public func ensureInitialized() async {
@@ -463,6 +465,7 @@ public actor SessionProManager: SessionProManagerType {
             /// pull the entitlement through (redemption is implicit — there's no add-payment call).
             try await markPurchaseInFlight()
             await reconcileProofRenewal()
+            startPostPurchaseStatusPoll()
             return
         }
 
@@ -509,6 +512,61 @@ public actor SessionProManager: SessionProManagerType {
         try await markPurchaseInFlight()
         await transaction.finish()
         await reconcileProofRenewal()
+        startPostPurchaseStatusPoll()
+    }
+
+    /// After a StoreKit purchase, chase the ACCOUNT expiry (`E`) via `get_pro_status` rather than forcing
+    /// a proof rotation. When the user re-subscribes while a still-valid (grace) proof is held,
+    /// `pro_renewal_target` returns `nullopt` (correctly: rotating the proof early would leak the
+    /// subscription change via the rotating seed, so the current proof is ridden until it nears expiry)
+    /// and `pro_prepaid` is a no-op (already entitled) — so nothing else re-fetches, and the new
+    /// subscription period would stay invisible until the proof eventually lapses. The backend learns of
+    /// the payment from Apple asynchronously, so a one-shot refresh usually fires too early; re-fetch
+    /// `get_pro_status` until `E` advances (the new period landing) or it's been ≥2 min since the first
+    /// request. The first refresh is immediate — onion-request latency means Apple has very often already
+    /// notified the backend by the time our request arrives.
+    ///
+    /// Pacing is off COMPLETION, not a fixed cadence: a fresh `get_pro_status` is an onion request that can
+    /// take a while (or time out ~30s), so we fire, AWAIT the result (fresh response, or failure/timeout),
+    /// then apply a 5s gap before the next — never a new request while one is in flight. The sequential
+    /// `await` gives this for free. The 2-min window is measured from the first request; a request already
+    /// in flight when it elapses finishes, we just don't start new ones. (The per-request onion timeout is
+    /// the "never settles" backstop — a single `refreshProState` can't hang indefinitely.) Matches
+    /// Android's 2-min window / 5s-gap-after-settle pacing.
+    ///
+    /// Note we route through `get_pro_status`, not a direct proof-gen: each refresh's `E` write feeds the
+    /// trailing `reconcileProofRenewal`, so a fresh proof IS fetched *if and when* `pro_renewal_target`
+    /// says one is due (e.g. the proof was actually expired) and is correctly left alone when it isn't (the
+    /// grace re-subscribe case). We avoid forcing an early/unnecessary (seed-leaking) rotation — not proof
+    /// updates altogether.
+    private func startPostPurchaseStatusPoll() {
+        postPurchaseStatusPollTask?.cancel()
+        postPurchaseStatusPollTask = Task { [weak self] in
+            guard let self else { return }
+
+            let expiryBefore: UInt64 = (await self.stateStream.getCurrent().accessExpiryTimestampSeconds ?? 0)
+            let startSeconds: Int64 = Int64(await self.dependencies.networkOffsetTimestampMs() / 1000)
+            let windowSeconds: Int64 = 120   /// 2 minutes since the FIRST request
+
+            while true {
+                if Task.isCancelled { return }
+
+                /// Fire and AWAIT settle (fresh response, or failure/timeout — `try?` swallows the throw).
+                try? await self.refreshProState()
+
+                let expiryNow: UInt64 = (await self.stateStream.getCurrent().accessExpiryTimestampSeconds ?? 0)
+                if expiryNow > expiryBefore { return }   /// new period landed — done
+
+                /// Stop kicking off new requests once ≥2 min since the first fire (the just-completed one
+                /// was allowed to finish; we simply don't start another).
+                let nowSeconds: Int64 = Int64(await self.dependencies.networkOffsetTimestampMs() / 1000)
+                if (nowSeconds - startSeconds) >= windowSeconds { return }
+
+                /// 5s gap BETWEEN completed attempts (not a fixed tick).
+                do { try await Task.sleep(for: .seconds(5)) }
+                catch { return }
+            }
+        }
     }
 
     /// Records the "purchase in flight" marker in the synced user config so every device polls the

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -822,7 +822,6 @@ public actor SessionProManager: SessionProManagerType {
             updatedState = oldState.with(
                 status: .set(to: response.status),
                 autoRenewing: .set(to: response.autoRenewing),
-                nextAutoRenewingTimestampSeconds: .set(to: response.nextAutoRenewingTimestampSeconds),
                 accessExpiryTimestampSeconds: .set(to: response.expiryTimestampSeconds),
                 latestPaymentItem: .set(to: response.latestPaymentItem),
                 using: dependencies

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -23,7 +23,6 @@ public extension SessionPro {
         public let profileFeatures: SessionPro.ProfileFeatures
         
         public let autoRenewing: Bool
-        public let nextAutoRenewingTimestampSeconds: UInt64?
         public let accessExpiryTimestampSeconds: UInt64?
         /// Unix seconds at which a refund was requested (config-synced via `user_profile_get_refund_requested`),
         /// or `0` if none. Refund-pending is no longer a per-payment backend field — it's cross-device config
@@ -34,8 +33,11 @@ public extension SessionPro {
         public let originatingAccount: SessionPro.OriginatingAccount
         public let refundingStatus: SessionPro.RefundingStatus
         
+        /// Both the renewal countdown and the grace trigger key off the ACCOUNT paid-through end
+        /// (`get_pro_status` `expiry_ts`), never the latest payment's expiry — those differ when vouchers
+        /// or overlapping payments are involved. Matches Android/desktop.
         public var displayTimestampSeconds: UInt64? {
-            autoRenewing ? nextAutoRenewingTimestampSeconds : accessExpiryTimestampSeconds
+            accessExpiryTimestampSeconds
         }
     }
 }
@@ -52,7 +54,6 @@ public extension SessionPro.State {
         proof: nil,
         profileFeatures: .none,
         autoRenewing: false,
-        nextAutoRenewingTimestampSeconds: nil,
         accessExpiryTimestampSeconds: 0,
         refundRequestedTimestampSeconds: 0,
         latestPaymentItem: nil,
@@ -72,7 +73,6 @@ internal extension SessionPro.State {
         proof: Update<Network.SessionPro.ProProof?> = .useExisting,
         profileFeatures: Update<SessionPro.ProfileFeatures> = .useExisting,
         autoRenewing: Update<Bool> = .useExisting,
-        nextAutoRenewingTimestampSeconds: Update<UInt64?> = .useExisting,
         accessExpiryTimestampSeconds: Update<UInt64?> = .useExisting,
         refundRequestedTimestampSeconds: Update<UInt64> = .useExisting,
         latestPaymentItem: Update<Network.SessionPro.PaymentItem?> = .useExisting,
@@ -96,7 +96,6 @@ internal extension SessionPro.State {
                 case .useActual: return (status.or(self.status))
             }
         }()
-        let finalNextAutoRenewingTimestampSeconds: UInt64? = autoRenewing.or(self.autoRenewing) ? nextAutoRenewingTimestampSeconds.or(self.nextAutoRenewingTimestampSeconds) : nil
         let finalAccessExpiryTimestampSeconds: UInt64? = {
             let mockedValue: TimeInterval = dependencies[feature: .mockCurrentUserAccessExpiryTimestamp]
             
@@ -154,7 +153,6 @@ internal extension SessionPro.State {
             proof: proof.or(self.proof),
             profileFeatures: profileFeatures.or(self.profileFeatures),
             autoRenewing: autoRenewing.or(self.autoRenewing),
-            nextAutoRenewingTimestampSeconds: finalNextAutoRenewingTimestampSeconds,
             accessExpiryTimestampSeconds: finalAccessExpiryTimestampSeconds,
             refundRequestedTimestampSeconds: finalRefundRequestedTimestampSeconds,
             latestPaymentItem: finalLatestPaymentItem,

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -17,9 +17,6 @@ public extension Network.SessionPro {
         /// The most recent payment, or `nil` when the account has none (`has_latest_payment == false`).
         public let latestPaymentItem: PaymentItem?
 
-        /// There is no dedicated auto-renew field; it's the latest payment's expiry (newest payment).
-        public var nextAutoRenewingTimestampSeconds: UInt64? { latestPaymentItem?.expiryTimestampSeconds }
-
         /// Parse the RAW response bytes via libsession — the client never inspects/assumes the wire.
         public init(parsing data: Data) {
             var result = data.withUnsafeBytes { bytes in

--- a/SessionNetworkingKit/SessionPro/Types/PaymentProvider.swift
+++ b/SessionNetworkingKit/SessionPro/Types/PaymentProvider.swift
@@ -20,18 +20,13 @@ public extension Network.SessionPro {
         case other(String)
 
         /// Canonical wire slugs, derived once from libsession's `SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_*`
-        /// C constants (the single source of truth).
-        static let googlePlayCode: String = cString(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY)
-        static let appStoreCode: String = cString(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE)
-        static let stfCode: String = cString(SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF)
-
-        /// libsession exposes those constants as fixed-size `CChar` tuples (`static const char[]`);
-        /// read the NUL-terminated bytes into a Swift `String`.
-        private static func cString<T>(_ cArray: T) -> String {
-            withUnsafeBytes(of: cArray) { raw in
-                raw.bindMemory(to: CChar.self).baseAddress.map { String(cString: $0) } ?? ""
-            }
-        }
+        /// C constants (the single source of truth). These are `const char* const` pointers (NOT inline
+        /// `char[]` arrays), so we dereference the pointer to read the NUL-terminated string — mirroring how
+        /// `SESSION_PRO_BACKEND_URL` is read. (Reading them with `withUnsafeBytes(of:)` would read the bytes
+        /// of the pointer *value* instead, yielding garbage and collapsing every provider to `.other`.)
+        static let googlePlayCode: String = (SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_GOOGLE_PLAY.map { String(cString: $0) } ?? "")
+        static let appStoreCode: String = (SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_APP_STORE.map { String(cString: $0) } ?? "")
+        static let stfCode: String = (SESSION_PRO_BACKEND_PAYMENT_PROVIDER_CODE_STF.map { String(cString: $0) } ?? "")
 
         var code: String {
             switch self {


### PR DESCRIPTION
- Fixes an issue in iOS that was using the Apple provider display message for all non-apple providers
- Fix an issue where the renewal countdown was showing the expiry of the latest payment as the account expiry.  (Those are typically the same, but could be wrong if you had vouchers applied, or if you have overlapping payments from different accounts -- e.g. an older 1y google payment that extends longer than the most recent Apple 1m payment).
- Fix to go along with https://github.com/session-foundation/libsession-util/pull/118 -- make sure get_pro_status requests set the config-level pro expiry, so that all clients can use it to figure out "we are pro and have no proof -> we should get a proof right now"
- Fixes an issue where app closed / backgrounded across a renewal boundary could show the "Pro expired" CTA upon foregrounding if the get_pro_status request fails.
[Edit]:
- plus another commit that forces a `get_pro_status` repoll after a purchase, because when you are in the grace period and *don't* need a new proof, you could land back at pro settings reflecting a stale status showing you that you are still expired.