### PR TITLE
Pro: accessibility ids for the Pro surface, plus two VoiceOver fixes and a CTA copy bug

### DIFF
--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -2419,7 +2419,7 @@ class ThreadSettingsViewModel: SessionListScreenContent.ViewModelType, Navigatio
                 _ = await MainActor.run { [weak self, dependencies] in
                     dependencies[singleton: .sessionProManager].showSessionProCTAIfNeeded(
                         .morePinnedConvos(
-                            isGrandfathered: (numPinnedConversations > SessionPro.PinnedConversationLimit),
+                            isOverTheLimit: (numPinnedConversations > SessionPro.PinnedConversationLimit),
                             renew: (sessionProState.status == .expired)
                         ),
                         onConfirm: { [weak self] in

--- a/Session/Conversations/Views & Modals/ConversationTitleView.swift
+++ b/Session/Conversations/Views & Modals/ConversationTitleView.swift
@@ -77,7 +77,12 @@ final class ConversationTitleView: UIView {
         )
         result.accessibilityIdentifier = "Conversation header name"
         result.accessibilityLabel = "Conversation header name"
-        result.isAccessibilityElement = true
+        /// **Note:** Deliberately *not* an accessibility element - doing so prunes the subtree, which hides both
+        /// the name and the badge (see `SessionLabelWithProBadge.init`). The badge has to stay addressable so an
+        /// assertion on it can actually fail for a non-Pro sender, and VoiceOver announces the two in sequence
+        /// ("Alice", then "Session Pro") rather than as one merged string
+        result.isAccessibilityElement = false
+        result.proBadgeAccessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.conversationHeader
         result.font = Fonts.Headings.H5
         result.themeTextColor = .textPrimary
         result.lineBreakMode = .byTruncatingTail
@@ -211,10 +216,9 @@ final class ConversationTitleView: UIView {
         )
         
         self.titleLabel.text = viewModel.displayName
-        /// Fold the Pro badge into the label rather than relying on it being its own element - `titleLabel` is
-        /// an accessibility element (see its initialiser), which collapses `SessionLabelWithProBadge`'s children,
-        /// so without this VoiceOver announces a Pro user identically to a non-Pro one and the badge is
-        /// imperceptible to assistive technology
+        /// The badge is announced by its own element now that the container isn't one (see the initialiser), so
+        /// this combined string is no longer what VoiceOver reads - it is kept because the container still
+        /// carries it as `accessibilityLabel`, which is what existing `contains(@label, …)` locators match on
         self.titleLabel.accessibilityLabel = [
             viewModel.displayName,
             (viewModel.showProBadge ? SessionProBadge.accessibilityLabel : nil)

--- a/Session/Conversations/Views & Modals/ConversationTitleView.swift
+++ b/Session/Conversations/Views & Modals/ConversationTitleView.swift
@@ -211,7 +211,16 @@ final class ConversationTitleView: UIView {
         )
         
         self.titleLabel.text = viewModel.displayName
-        self.titleLabel.accessibilityLabel = viewModel.displayName
+        /// Fold the Pro badge into the label rather than relying on it being its own element - `titleLabel` is
+        /// an accessibility element (see its initialiser), which collapses `SessionLabelWithProBadge`'s children,
+        /// so without this VoiceOver announces a Pro user identically to a non-Pro one and the badge is
+        /// imperceptible to assistive technology
+        self.titleLabel.accessibilityLabel = [
+            viewModel.displayName,
+            (viewModel.showProBadge ? SessionProBadge.accessibilityLabel : nil)
+        ]
+        .compactMap { $0 }
+        .joined(separator: ", ")
         self.titleLabel.font = (shouldHaveSubtitle ? Fonts.Headings.H6 : Fonts.Headings.H5)
         self.titleLabel.isProBadgeHidden = !viewModel.showProBadge
         

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -498,6 +498,9 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                             )
                         )
                     ),
+                    accessibility: Accessibility(
+                        identifier: SessionProUI.AccessibilityIdentifier.menuItem
+                    ),
                     onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                         Task.detached(priority: .userInitiated) {
                             try? await dependencies[singleton: .sessionProManager].refreshProState(forceLoadingState: true)

--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -266,7 +266,11 @@ public extension UIContextualAction {
                             {
                                 dependencies[singleton: .sessionProManager].showSessionProCTAIfNeeded(
                                     .morePinnedConvos(
-                                        isGrandfathered: (currentPinnedConversationCount >= SessionPro.PinnedConversationLimit),
+                                        /// **Note:** Strictly greater than - *over* the limit, not merely at it. This
+                                        /// was previously `>=`, ie. the same expression as the guard above, so it was
+                                        /// always `true` here and a user at exactly the limit got the over-the-limit
+                                        /// copy. `ThreadSettingsViewModel` and both other platforms use `>`
+                                        isOverTheLimit: (currentPinnedConversationCount > SessionPro.PinnedConversationLimit),
                                         renew: (dependencies[singleton: .sessionProManager]
                                             .currentUserCurrentProState
                                             .status == .expired)

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -811,12 +811,19 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     font: .Headings.H8
                                 ),
                                 description: {
+                                    /// Every state of this line is the same slot, so they share the one identifier
+                                    /// and the state is distinguished by the text
+                                    let accessibility: Accessibility = Accessibility(
+                                        identifier: ListItemCell.AccessibilityIdentifier.subtitle
+                                    )
+
                                     switch state.proState.loadingState {
                                         case .loading:
                                             return SessionListScreenContent.TextInfo(
                                                 font: .Body.smallRegular,
                                                 attributedString: "proAccessLoadingEllipsis"
-                                                    .localizedFormatted(Fonts.Body.smallRegular)
+                                                    .localizedFormatted(Fonts.Body.smallRegular),
+                                                accessibility: accessibility
                                             )
 
                                         case .error:
@@ -824,7 +831,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                 font: .Body.smallRegular,
                                                 attributedString: "errorLoadingProAccess"
                                                     .localizedFormatted(Fonts.Body.smallRegular),
-                                                color: .warning
+                                                color: .warning,
+                                                accessibility: accessibility
                                             )
 
                                         case .success:
@@ -838,7 +846,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                     "proRenewalUnsuccessful"
                                                         .localized(),
                                                     font: .Body.smallRegular,
-                                                    color: .warning
+                                                    color: .warning,
+                                                    accessibility: accessibility
                                                 )
                                             }
                                             
@@ -860,7 +869,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                         "proExpiringTime"
                                                             .put(key: "time", value: expirationString)
                                                             .localizedFormatted(Fonts.Body.smallRegular)
-                                                )
+                                                ),
+                                                accessibility: accessibility
                                             )
                                     }
                                 }(),

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -814,7 +814,7 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     /// Every state of this line is the same slot, so they share the one identifier
                                     /// and the state is distinguished by the text
                                     let accessibility: Accessibility = Accessibility(
-                                        identifier: ListItemCell.AccessibilityIdentifier.subtitle
+                                        identifier: SessionProUI.AccessibilityIdentifier.updatePlanSubtitle
                                     )
 
                                     switch state.proState.loadingState {

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -140,6 +140,21 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                 default: return false
             }
         }
+
+        public var accessibility: Accessibility? {
+            switch self {
+                case .proStats:
+                    return Accessibility(identifier: SessionProUI.AccessibilityIdentifier.statsHeader)
+
+                case .proSettings:
+                    return Accessibility(identifier: SessionProUI.AccessibilityIdentifier.manageHeader)
+
+                case .proFeatures:
+                    return Accessibility(identifier: SessionProUI.AccessibilityIdentifier.featuresHeader)
+
+                default: return nil
+            }
+        }
     }
     
     public enum ListItem: Differentiable {
@@ -536,6 +551,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                             )
                         )
                     ),
+                    accessibility: Accessibility(
+                        identifier: SessionProUI.AccessibilityIdentifier.faq
+                    ),
                     onTap: { [weak viewModel] in viewModel?.openUrl(Constants.urls.proFaq) }
                 ),
                 SessionListScreenContent.ListItemInfo(
@@ -562,6 +580,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 }()
                             )
                         )
+                    ),
+                    accessibility: Accessibility(
+                        identifier: SessionProUI.AccessibilityIdentifier.support
                     ),
                     onTap: { [weak viewModel] in viewModel?.openUrl(Constants.urls.proSupport) }
                 )
@@ -599,7 +620,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .putNumber(state.numberOfLongerMessagesSent)
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfLongerMessagesSent))
                                         .localized(),
-                                    font: .Headings.H9
+                                    font: .Headings.H9,
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsLongerMessages
+                                    )
                                 ),
                                 isLoading: (state.proState.loadingState == .loading)
                             ),
@@ -614,7 +638,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .putNumber(state.numberOfPinnedConversations)
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfPinnedConversations))
                                         .localized(),
-                                    font: .Headings.H9
+                                    font: .Headings.H9,
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsPinnedConversations
+                                    )
                                 ),
                                 isLoading: (state.proState.loadingState == .loading)
                             )
@@ -631,7 +658,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .putNumber(state.numberOfProBadgesSent)
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfProBadgesSent))
                                         .localized(),
-                                    font: .Headings.H9
+                                    font: .Headings.H9,
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsBadgesSent
+                                    )
                                 ),
                                 isLoading: (state.proState.loadingState == .loading)
                             ),
@@ -647,7 +677,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfGroupsUpgraded))
                                         .localized(),
                                     font: .Headings.H9,
-                                    color: (state.proState.loadingState == .loading ? .textPrimary : .disabled)
+                                    color: (state.proState.loadingState == .loading ? .textPrimary : .disabled),
+                                    accessibility: Accessibility(
+                                        identifier: SessionProUI.AccessibilityIdentifier.statsGroupsUpgraded
+                                    )
                                 ),
                                 tooltipInfo: SessionListScreenContent.TooltipInfo(
                                     id: "SessionListScreen.DataMatrix.UpgradedGroups.ToolTip", // stringlint:ignore
@@ -785,7 +818,7 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                 attributedString: "proAccessLoadingEllipsis"
                                                     .localizedFormatted(Fonts.Body.smallRegular)
                                             )
-                                            
+
                                         case .error:
                                             return SessionListScreenContent.TextInfo(
                                                 font: .Body.smallRegular,
@@ -793,7 +826,7 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                     .localizedFormatted(Fonts.Body.smallRegular),
                                                 color: .warning
                                             )
-                                            
+
                                         case .success:
                                             let expirationTimestamp: TimeInterval = Double(state.proState.displayTimestampSeconds ?? 0)
                                             let isInAutoRenewingGracePeriod: Bool = (
@@ -836,6 +869,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     .icon(.chevronRight, size: .large)
                                 )
                             )
+                        ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.updatePlan
                         ),
                         onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                             switch state.proState.loadingState {
@@ -951,9 +987,15 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                         ),
                         trailingAccessory: .toggle(
                             state.profile.proFeatures.contains(.proBadge),
-                            oldValue: previousState.profile.proFeatures.contains(.proBadge)
+                            oldValue: previousState.profile.proFeatures.contains(.proBadge),
+                            accessibility: Accessibility(
+                                identifier: SessionProUI.AccessibilityIdentifier.showBadgeToggle
+                            )
                         )
                     )
+                ),
+                accessibility: Accessibility(
+                    identifier: SessionProUI.AccessibilityIdentifier.showBadge
                 ),
                 onTap: { [dependencies = viewModel.dependencies] in
                     Task.detached(priority: .userInitiated) {
@@ -995,10 +1037,13 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 )
                             )
                         ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.recoverPlan
+                        ),
                         onTap: { [weak viewModel] in viewModel?.recoverProPlan() }
                     )
                 ]
-                
+
             case (.active, .notRefunding):
                 var renewingItems: [SessionListScreenContent.ListItemInfo<ListItem>] = []
                 
@@ -1017,6 +1062,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     trailingAccessory: .icon(.circleX, size: .medium, tintColor: .danger)
                                 )
                             ),
+                            accessibility: Accessibility(
+                                identifier: SessionProUI.AccessibilityIdentifier.cancelPlan
+                            ),
                             onTap: { [weak viewModel] in viewModel?.cancelPlan(state: state) }
                         )
                     )
@@ -1034,6 +1082,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 ),
                                 trailingAccessory: .icon(.circleAlert, size: .medium, tintColor: .danger)
                             )
+                        ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.requestRefund
                         ),
                         onTap: { [weak viewModel] in viewModel?.requestRefund(state: state) }
                     )
@@ -1082,6 +1133,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 )
                             )
                         ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.renewPlan
+                        ),
                         onTap: { [weak viewModel] in
                             switch state.proState.loadingState {
                                 case .success: viewModel?.updateProPlan(state: state)
@@ -1119,6 +1173,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                     size: .medium
                                 )
                             )
+                        ),
+                        accessibility: Accessibility(
+                            identifier: SessionProUI.AccessibilityIdentifier.recoverPlan
                         ),
                         onTap: { [weak viewModel] in viewModel?.recoverProPlan() }
                     )

--- a/SessionUIKit/Components/SessionLabelWithProBadge.swift
+++ b/SessionUIKit/Components/SessionLabelWithProBadge.swift
@@ -80,6 +80,15 @@ public class SessionLabelWithProBadge: UIView {
         get { sessionProBadge.isHidden }
         set { sessionProBadge.isHidden = newValue }
     }
+
+    /// The accessibility identifier of the badge itself, for surfaces which need to address it by a
+    /// surface-specific name rather than the shared `SessionProBadge.AccessibilityIdentifier.icon`
+    ///
+    /// **Note:** Only reachable while the container is *not* an accessibility element - see the note in `init`
+    public var proBadgeAccessibilityIdentifier: String? {
+        get { sessionProBadge.accessibilityIdentifier }
+        set { sessionProBadge.accessibilityIdentifier = newValue }
+    }
     
     public override var isUserInteractionEnabled: Bool {
         get { super.isUserInteractionEnabled }

--- a/SessionUIKit/Components/SessionLabelWithProBadge.swift
+++ b/SessionUIKit/Components/SessionLabelWithProBadge.swift
@@ -142,6 +142,15 @@ public class SessionLabelWithProBadge: UIView {
         self.withStretchingSpacer = withStretchingSpacer
         
         super.init(frame: .zero)
+
+        /// This is iOS' equivalent of Android's `ProBadgeText` so it carries the same identifiers - the container
+        /// and the label, with the badge tagging itself (see `SessionProBadge.AccessibilityIdentifier`)
+        ///
+        /// **Note:** Deliberately not setting `isAccessibilityElement` on the container, doing so would hide the
+        /// label and the badge from the accessibility tree
+        self.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.component
+        label.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.text
+
         self.addSubview(stackView)
         stackView.pin(to: self)
     }

--- a/SessionUIKit/Components/SessionProBadge.swift
+++ b/SessionUIKit/Components/SessionProBadge.swift
@@ -4,9 +4,26 @@ import UIKit
 
 public class SessionProBadge: UIView {
     public static let accessibilityLabel: String = Constants.app_pro
-    
+
     public static let identifier: String = "ProBadge"   // stringlint:ignore
-    
+
+    /// Accessibility identifiers for the pro badge and the label it sits beside
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Android (its
+    /// `content-descriptions` module defines the same values as `qa_pro_badge_component` / `_text` / `_icon`)
+    /// so a single Appium locator serves both platforms - renaming one means renaming it in three repos
+    // stringlint:ignore_contents
+    public enum AccessibilityIdentifier {
+        /// The container holding the label and the badge together (Android: `ProBadgeText`'s row)
+        public static let component: String = "pro-badge-component"
+
+        /// The label beside the badge (ie. the display name), **not** the badge itself
+        public static let text: String = "pro-badge-text"
+
+        /// The badge itself
+        public static let icon: String = "pro-badge-icon"
+    }
+
     public enum Size {
         case mini, small, medium, large
         
@@ -77,6 +94,13 @@ public class SessionProBadge: UIView {
     public init(size: Size, themeBackgroundColor: ThemeValue = .primary) {
         self.size = size
         super.init(frame: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+
+        /// The badge is a plain `UIView` wrapping an image so it wouldn't otherwise appear in the accessibility
+        /// tree at all - make it an element in its own right (it has no accessible children to hide)
+        self.isAccessibilityElement = true
+        self.accessibilityLabel = SessionProBadge.accessibilityLabel
+        self.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.icon
+
         setUpViewHierarchy()
         self.themeBackgroundColor = themeBackgroundColor
     }

--- a/SessionUIKit/Components/SessionProBadge.swift
+++ b/SessionUIKit/Components/SessionProBadge.swift
@@ -22,6 +22,13 @@ public class SessionProBadge: UIView {
 
         /// The badge itself
         public static let icon: String = "pro-badge-icon"
+
+        /// The badge in the conversation header specifically
+        ///
+        /// **Note:** Deliberately on the *badge* rather than the header name - the name renders for every
+        /// conversation while the badge renders only for a Pro sender, so an assertion scoped to the name
+        /// can never fail. Android made the same distinction after it caught a false positive
+        public static let conversationHeader: String = "conversation-header-pro-badge"
     }
 
     public enum Size {

--- a/SessionUIKit/Components/SwiftUI/ProCTAModal.swift
+++ b/SessionUIKit/Components/SwiftUI/ProCTAModal.swift
@@ -9,7 +9,7 @@ public struct ProCTAModal: View {
         case generic(renew: Bool)
         case longerMessages(renew: Bool)
         case animatedProfileImage(isSessionProActivated: Bool, renew: Bool)
-        case morePinnedConvos(isGrandfathered: Bool, renew: Bool)
+        case morePinnedConvos(isOverTheLimit: Bool, renew: Bool)
         case groupLimit(isAdmin: Bool, isSessionProActivated: Bool, proBadgeImage: UIImage)
         case expiring(timeLeft: String?)
     }
@@ -464,20 +464,20 @@ public extension ProCTAModal.Variant {
                 return "proAnimatedDisplayPictureCallToActionDescription"
                     .localizedFormatted(baseFont: Fonts.Body.largeRegular)
             
-            case .morePinnedConvos(isGrandfathered: true, renew: false):
+            case .morePinnedConvos(isOverTheLimit: true, renew: false):
                 return "proCallToActionPinnedConversations"
                     .localizedFormatted(baseFont: Fonts.Body.largeRegular)
                 
-            case .morePinnedConvos(isGrandfathered: false, renew: false):
+            case .morePinnedConvos(isOverTheLimit: false, renew: false):
                 return "proCallToActionPinnedConversationsMoreThan"
                     .put(key: "limit", value: sessionProUIManager.pinnedConversationLimit)
                     .localizedFormatted(baseFont: Fonts.Body.largeRegular)
                 
-            case .morePinnedConvos(isGrandfathered: true, renew: true):
+            case .morePinnedConvos(isOverTheLimit: true, renew: true):
                 return "proRenewPinMoreConversations"
                     .localizedFormatted(baseFont: Fonts.Body.largeRegular)
                 
-            case .morePinnedConvos(isGrandfathered: false, renew: true):
+            case .morePinnedConvos(isOverTheLimit: false, renew: true):
                 return "proRenewPinFiveConversations"
                     .put(key: "limit", value: sessionProUIManager.pinnedConversationLimit)
                     .localizedFormatted(baseFont: Fonts.Body.largeRegular)

--- a/SessionUIKit/Components/SwiftUI/SessionProBadge+SwiftUI.swift
+++ b/SessionUIKit/Components/SwiftUI/SessionProBadge+SwiftUI.swift
@@ -23,5 +23,11 @@ public struct SessionProBadge_SwiftUI: View {
         }
         .frame(width: size.width, height: size.height)
         .clipped()
+        .accessibility(
+            Accessibility(
+                identifier: SessionProBadge.AccessibilityIdentifier.icon,
+                label: SessionProBadge.accessibilityLabel
+            )
+        )
     }
 }

--- a/SessionUIKit/Screens/SessionListScreen/ListContentModels/SessionListScreen+Section.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListContentModels/SessionListScreen+Section.swift
@@ -12,6 +12,9 @@ public extension SessionListScreenContent {
         var extraVerticalPadding: CGFloat { get }
         var footer: String? { get }
         var shadow: Bool { get }
+
+        /// Applied to the section's *header*, not to its rows - rows carry their own via `ListItemInfo.accessibility`
+        var accessibility: Accessibility? { get }
     }
     
     enum ListSectionStyle: Equatable, Hashable, Differentiable {
@@ -71,5 +74,12 @@ public extension SessionListScreenContent {
             }
         }
     }
+}
+
+// MARK: - Defaults
+
+public extension SessionListScreenContent.ListSection {
+    /// Most sections don't need their header addressed directly, so only the ones which do have to provide this
+    var accessibility: Accessibility? { nil }
 }
 

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemCell.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemCell.swift
@@ -22,6 +22,20 @@ private struct FullTextHeightKey: PreferenceKey {
 // MARK: - ListItemCell
 
 public struct ListItemCell: View {
+    /// Accessibility identifiers for the parts of a row, for tests that need to address the title or subtitle
+    /// separately rather than reading the row's own combined label
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Android, whose shared `ActionRowItem`
+    /// component tags the same two elements - so a single Appium locator, scoped to the row's own identifier,
+    /// serves both platforms. They are deliberately **opt-in per call site** rather than defaulted onto every
+    /// cell: setting an identifier makes it the element's `name` and pushes the display text to `label`, which
+    /// would silently break every text-based locator in the app if applied wholesale
+    // stringlint:ignore_contents
+    public enum AccessibilityIdentifier {
+        public static let title: String = "action-item-title"
+        public static let subtitle: String = "action-item-subtitle"
+    }
+
     public struct Info: Equatable, Hashable, Differentiable {
         let leadingAccessory: SessionListScreenContent.ListItemAccessory?
         let title: SessionListScreenContent.TextInfo?

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
@@ -134,6 +134,8 @@ public struct ListItemLogoWithPro: View {
                 .padding(.top, Values.mediumSpacing)
                 .environment(\.layoutDirection, .leftToRight)
                 
+                /// **Note:** The loading and error banners deliberately share a single accessibility identifier -
+                /// they're the same slot, and their messages already distinguish the states
                 if case .error(let message) = info.state {
                     HStack(spacing: Values.verySmallSpacing) {
                         Text(message)
@@ -142,8 +144,12 @@ public struct ListItemLogoWithPro: View {
                     .font(.Body.baseRegular)
                     .foregroundColor(themeColor: .warning)
                     .padding(.top, Values.mediumSpacing)
+                    .accessibilityElement(children: .combine)
+                    .accessibility(
+                        Accessibility(identifier: SessionProUI.AccessibilityIdentifier.statusBanner)
+                    )
                 }
-                
+
                 if case .loading(let message) = info.state {
                     HStack(spacing: Values.verySmallSpacing) {
                         Text(message)
@@ -156,6 +162,10 @@ public struct ListItemLogoWithPro: View {
                     .font(.Body.baseRegular)
                     .foregroundColor(themeColor: .textPrimary)
                     .padding(.top, Values.mediumSpacing)
+                    .accessibilityElement(children: .combine)
+                    .accessibility(
+                        Accessibility(identifier: SessionProUI.AccessibilityIdentifier.statusBanner)
+                    )
                 }
                 
                 if let description = info.description {

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
@@ -158,6 +158,10 @@ public struct ListItemLogoWithPro: View {
                             .controlSize(.regular)
                             .scaleEffect(0.8)
                             .frame(width: 16, height: 16)
+                            /// Hidden from accessibility so the combined banner reports the *message* - a
+                            /// `ProgressView` contributes its progress as a value, which otherwise wins and the
+                            /// banner reads as "1" to both VoiceOver and any test asserting on the state
+                            .accessibilityHidden(true)
                     }
                     .font(.Body.baseRegular)
                     .foregroundColor(themeColor: .textPrimary)

--- a/SessionUIKit/Screens/SessionListScreen/SessionListScreen.swift
+++ b/SessionUIKit/Screens/SessionListScreen/SessionListScreen.swift
@@ -205,6 +205,7 @@ public struct SessionListScreen<ViewModel: SessionListScreenContent.ViewModelTyp
                             }
                         }
                         .frame(minHeight: section.model.style.height)
+                        .accessibility(section.model.accessibility)
                         .listRowInsets(.init(top: 0, leading: section.model.style.edgePadding, bottom: 0, trailing: section.model.style.edgePadding))
                         .listRowBackground(Color.clear)
                     }

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
@@ -4,6 +4,77 @@ import Foundation
 
 public enum SessionProUI {}
 
+// MARK: - AccessibilityIdentifier
+
+public extension SessionProUI {
+    /// Accessibility identifiers for the Pro settings surface
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Android (its `content-descriptions` module
+    /// defines the same values) so a single Appium locator serves both platforms - renaming one means renaming it
+    /// in three repos. See `SessionProBadge.AccessibilityIdentifier` for the badge itself
+    // stringlint:ignore_contents
+    enum AccessibilityIdentifier {
+        /// The Pro entry in the main settings list, which opens this screen
+        public static let menuItem: String = "pro-menu-item"
+
+        /// The loading/error banner under the logo - one identifier for the slot, with the individual states
+        /// distinguished by their text (`checkingProStatus`, `proStatusLoading`, `errorCheckingProStatus`,
+        /// `proErrorRefreshingStatus`) rather than by separate identifiers
+        public static let statusBanner: String = "pro-settings-status-banner"
+
+        /// The "Your Pro Stats" section header
+        public static let statsHeader: String = "pro-settings-stats-header"
+
+        /// The four cells of the "Your Pro Stats" matrix
+        ///
+        /// **Note:** These sit on the cell's *title*, which is the whole "N badges sent" string - so an assertion
+        /// reads the value from the element's accessibility **label**, since the identifier takes over `name`
+        public static let statsLongerMessages: String = "pro-stats-longer-messages"
+        public static let statsPinnedConversations: String = "pro-stats-pinned-conversations"
+        public static let statsBadgesSent: String = "pro-stats-badges-sent"
+        public static let statsGroupsUpgraded: String = "pro-stats-groups-upgraded"
+
+        /// The "Pro Settings" section header
+        public static let manageHeader: String = "pro-settings-manage-header"
+
+        /// The "Pro Beta Features" section header
+        public static let featuresHeader: String = "pro-settings-features-header"
+
+        /// The "Update Pro Access" row
+        ///
+        /// **Note:** `ListItemCell` is a `Button`, so its title and subtitle merge into this one element rather
+        /// than staying separately addressable - the expiry text is part of *this* element's accessibility label
+        public static let updatePlan: String = "pro-settings-update-plan"
+
+        /// The "Pro Badge" visibility row
+        public static let showBadge: String = "pro-settings-show-badge"
+
+        /// The toggle within the "Pro Badge" visibility row
+        public static let showBadgeToggle: String = "pro-settings-show-badge-toggle"
+
+        /// The "Request Refund" **action** in the "Manage Pro" section
+        ///
+        /// **Note:** Not the read-only "Refund requested" row shown while a refund is being processed - Android has
+        /// no equivalent of that row, so it stays unnamed until both platforms agree on a string
+        public static let requestRefund: String = "pro-settings-request-refund"
+
+        /// The "Cancel Pro Access" action
+        public static let cancelPlan: String = "pro-settings-cancel-plan"
+
+        /// The "Renew Pro Access" action, shown when access has expired
+        public static let renewPlan: String = "pro-settings-renew-plan"
+
+        /// The "Recover Pro Access" action
+        public static let recoverPlan: String = "pro-settings-recover-plan"
+
+        /// The "Pro FAQ" row in the help section
+        public static let faq: String = "pro-settings-faq"
+
+        /// The "Support" row in the help section
+        public static let support: String = "pro-settings-support"
+    }
+}
+
 // MARK: - ClientPlatform
 
 public extension SessionProUI {

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
@@ -46,6 +46,13 @@ public extension SessionProUI {
         /// than staying separately addressable - the expiry text is part of *this* element's accessibility label
         public static let updatePlan: String = "pro-settings-update-plan"
 
+        /// The remaining-access line within the "Update Pro Access" row
+        ///
+        /// **Note:** A flat identifier rather than the generic `ListItemCell.AccessibilityIdentifier.subtitle`,
+        /// so a locator can address it without a parent traversal. One element carries one identifier, so this
+        /// replaces `action-item-subtitle` on this row rather than sitting alongside it
+        public static let updatePlanSubtitle: String = "pro-settings-update-plan-subtitle"
+
         /// The "Pro Badge" visibility row
         public static let showBadge: String = "pro-settings-show-badge"
 


### PR DESCRIPTION
Makes the Session Pro surface addressable by identifier rather than by localized display
text. Four of the five commits are accessibility; the fifth is a user-visible copy bug
found while writing the tests.

#### Identifiers

The strings are a **cross-platform contract with Android**. Where Android had already
settled a name in its `content-descriptions` module it is reused verbatim — `pro-menu-item`,
`pro-settings-update-plan`, `-show-badge`, `-show-badge-toggle`, `-request-refund`,
`-cancel-plan`, `-renew-plan`, `-recover-plan`, `-faq`, `-support` — so a single Appium
locator serves both platforms. The rest (three section headers, the status banner, four
stats cells) are new on both sides and named by role rather than by visible title, so they
don't rot when the copy changes.

For the badge, mapping is against Android's `ProBadgeText` rather than by name:
`pro-badge-text` is the display *name* beside the badge, not the badge's wordmark, so it
belongs on `SessionLabelWithProBadge`'s label while `pro-badge-icon` goes on the badge
itself.

`ListSection` had no accessibility affordance, so one is added with a `nil` default — the
section headers are the only thing that needs it and every existing conformer is unchanged.

#### VoiceOver fixes

Three places where the accessibility tree was actively wrong, all found because Appium
could not see the element:

- The UIKit badge is a bare `UIView` wrapping an image, which can be pruned from the tree
  entirely. It is now an accessibility element in its own right.
- The loading banner combined a `ProgressView`, whose progress won the merge — VoiceOver
  announced the banner as **"1"** instead of its message.
- `titleLabel` on the conversation header is an accessibility element, which collapsed the
  badge out of the tree, so VoiceOver announced a Pro sender identically to a non-Pro one.

#### CTA copy bug

The swipe-action call site derived its flag from the same expression as its own enclosing
guard, so it was **unconditionally true**. Every non-Pro user at or above the pin limit got
the over-the-limit copy, and the variant naming the limit was unreachable from that path —
a user with exactly the maximum was told "Want more pins?" rather than "Want more than 5
pins?".

`isGrandfathered` is renamed to `isOverTheLimit`, matching Android's `overTheLimit`. The old
name was wrong on its own terms: the `renew: true` variants are for someone whose Pro lapsed
while over the limit, who was never grandfathered.

Thread settings already compared correctly, as do Android and Desktop — 4 call sites to 1,
which is what settled it.

#### Known limitation

`ListItemCell` is a `Button`, so its title and subtitle merge into a single accessibility
element: a row's expiry text is part of the row's own label rather than separately
addressable. Android's nested `action-item-subtitle` has no iOS equivalent without opting
the cell into exposing children, which would fragment VoiceOver app-wide. Not done.

### Testing

Drives the 15 `@pro @ios` tests in the Appium suite (PR 1), all passing against this branch.