### PR TITLE
Pro: unify the `get_pro_status` refresh design (iOS)

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -12340,7 +12340,7 @@
 			repositoryURL = "https://github.com/session-foundation/libsession-util-spm";
 			requirement = {
 				kind = exactVersion;
-				version = 1.6.7;
+				version = 1.8.0;
 			};
 		};
 		FD6A38E72C2A630E00762359 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {

--- a/Session.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Session.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/session-foundation/libsession-util-spm",
       "state" : {
-        "revision" : "57c3d926b0f8b51fbfb3339c84cff610b75a417a",
-        "version" : "1.6.7"
+        "revision" : "9aa4acf89167bc68d30459fe619ba8d2aadfce6b",
+        "version" : "1.8.0"
       }
     },
     {

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
@@ -354,12 +354,17 @@ public extension LibSession.Cache {
         user_profile_set_pro_auto_renewing(conf, (proAutoRenewing ? 1 : 0))
     }
 
-    /// The account's grace period in seconds (`get_pro_status.grace_period_duration`), or `0` if none.
+    /// The account's grace period in seconds (`get_pro_status.grace_period_duration` — the **root** field), or
+    /// `0` if none.
     ///
-    /// **This is what makes the paid-through instant derivable.** The backend folds the grace period into the
-    /// stored expiry for auto-renewing subscriptions, so `E` is the end of *coverage*, not the date the
-    /// renewal falls due — `E - G` is the latter. `0` whenever the subscription isn't auto-renewing, so
-    /// `E - 0 == E` and no caller needs to branch on the provider or the renewal state.
+    /// **This is what makes the coverage end derivable.** `E` is the date the account expires, the honest thing
+    /// to show a user; `G` is how much longer the backend keeps serving past it, so coverage ends at `E + G` and
+    /// the grace window is `[E, E + G)`. `0` whenever the subscription isn't auto-renewing, so `E + 0 == E` and
+    /// no caller needs to branch on the provider or the renewal state.
+    ///
+    /// 🔴 **The root field, not `latest_payment.grace_period_duration`.** Both exist and they are different
+    /// quantities: the payment-level one is the raw store value and is *not* gated on `auto_renewing`, so a
+    /// cancelled subscriber retains a multi-week value there. Reading it would put coverage weeks late.
     var proGracePeriodSeconds: UInt64 {
         guard case .userProfile(let conf) = config(for: .userProfile, sessionId: userSessionId) else { return 0 }
 
@@ -367,7 +372,7 @@ public extension LibSession.Cache {
     }
 
     /// Record the account's grace period. Write it **from the same `get_pro_status` response as `E`** —
-    /// `E - G` is only meaningful for a pair that arrived together. libsession enforces the other half
+    /// `E + G` is only meaningful for a pair that arrived together. libsession enforces the other half
     /// (clearing `E` erases `G`), so a stranded `G` can't pair with a later, unrelated `E`.
     func updateProGracePeriodSeconds(_ proGracePeriodSeconds: UInt64) {
         guard case .userProfile(let conf) = config(for: .userProfile, sessionId: userSessionId) else { return }

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
@@ -246,7 +246,20 @@ public extension LibSession.Cache {
         /// Whole unix seconds on the libsession side and in our domain — direct read, no conversion.
         return UInt64(max(0, user_profile_get_pro_access_expiry(conf)))
     }
-    
+
+    /// Whether the account's Pro subscription is auto-renewing, as last reported by `get_pro_status` and
+    /// mirrored into config alongside the access expiry `E`.
+    ///
+    /// **Note:** libsession stores this presence-only (config key `A`: `1` when auto-renewing, erased
+    /// otherwise), so `false` means "not auto-renewing **or** never fetched" — it cannot distinguish the two.
+    /// Anything user-facing must therefore be gated on a confirmed fetch as well (see
+    /// `SessionProManager.sessionProExpiringCTAInfo`), not on this value alone.
+    var proAutoRenewing: Bool {
+        guard case .userProfile(let conf) = config(for: .userProfile, sessionId: userSessionId) else { return false }
+
+        return (user_profile_get_pro_auto_renewing(conf) != 0)
+    }
+
     /// This function should not be called outside of the `Profile.updateIfNeeded` function to avoid duplicating changes and events,
     /// as a result this function doesn't emit profile change events itself (use `Profile.updateLocal` instead)
     func updateProfile(
@@ -330,6 +343,15 @@ public extension LibSession.Cache {
 
         /// Whole unix seconds on both sides — hand libsession the value directly.
         user_profile_set_pro_access_expiry(conf, Int64(proAccessExpiryTimestampSeconds))
+    }
+
+    /// Record whether the Pro subscription is auto-renewing (`false` clears it, which is also how it is
+    /// cleared when the subscription lapses). Backend-derived, so libsession stores it without bumping the
+    /// profile's `t`/`T` timestamps — same treatment as `E`/`I`/`R`.
+    func updateProAutoRenewing(_ proAutoRenewing: Bool) {
+        guard case .userProfile(let conf) = config(for: .userProfile, sessionId: userSessionId) else { return }
+
+        user_profile_set_pro_auto_renewing(conf, (proAutoRenewing ? 1 : 0))
     }
 
     /// The unix timestamp (seconds) at which the user requested a refund, config-synced across devices, or

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
@@ -354,6 +354,27 @@ public extension LibSession.Cache {
         user_profile_set_pro_auto_renewing(conf, (proAutoRenewing ? 1 : 0))
     }
 
+    /// The account's grace period in seconds (`get_pro_status.grace_period_duration`), or `0` if none.
+    ///
+    /// **This is what makes the paid-through instant derivable.** The backend folds the grace period into the
+    /// stored expiry for auto-renewing subscriptions, so `E` is the end of *coverage*, not the date the
+    /// renewal falls due — `E - G` is the latter. `0` whenever the subscription isn't auto-renewing, so
+    /// `E - 0 == E` and no caller needs to branch on the provider or the renewal state.
+    var proGracePeriodSeconds: UInt64 {
+        guard case .userProfile(let conf) = config(for: .userProfile, sessionId: userSessionId) else { return 0 }
+
+        return UInt64(max(0, user_profile_get_pro_grace_period(conf)))
+    }
+
+    /// Record the account's grace period. Write it **from the same `get_pro_status` response as `E`** —
+    /// `E - G` is only meaningful for a pair that arrived together. libsession enforces the other half
+    /// (clearing `E` erases `G`), so a stranded `G` can't pair with a later, unrelated `E`.
+    func updateProGracePeriodSeconds(_ proGracePeriodSeconds: UInt64) {
+        guard case .userProfile(let conf) = config(for: .userProfile, sessionId: userSessionId) else { return }
+
+        user_profile_set_pro_grace_period(conf, Int64(proGracePeriodSeconds))
+    }
+
     /// The unix timestamp (seconds) at which the user requested a refund, config-synced across devices, or
     /// `0` if none (libsession also returns `0` for a value more than a week old — the staleness gate lives
     /// there, not here). Replaces the old per-payment `refund_requested_ts` backend field.

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserProfile.swift
@@ -362,7 +362,7 @@ public extension LibSession.Cache {
     /// the grace window is `[E, E + G)`. `0` whenever the subscription isn't auto-renewing, so `E + 0 == E` and
     /// no caller needs to branch on the provider or the renewal state.
     ///
-    /// 🔴 **The root field, not `latest_payment.grace_period_duration`.** Both exist and they are different
+    /// The root field, not `latest_payment.grace_period_duration`. Both exist and they are different
     /// quantities: the payment-level one is the raw store value and is *not* gated on `auto_renewing`, so a
     /// cancelled subscriber retains a multi-week value there. Reading it would put coverage weeks late.
     var proGracePeriodSeconds: UInt64 {

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -1180,7 +1180,8 @@ public protocol LibSessionCacheType: LibSessionImmutableCacheType, MutableCacheT
     var displayName: String? { get }
     var proConfig: SessionPro.ProConfig? { get }
     var proAccessExpiryTimestampSeconds: UInt64 { get }
-    
+    var proAutoRenewing: Bool { get }
+
     /// This function should not be called outside of the `Profile.updateIfNeeded` function to avoid duplicating changes and events,
     /// as a result this function doesn't emit profile change events itself (use `Profile.updateLocal` instead)
     func updateProfile(
@@ -1193,6 +1194,7 @@ public protocol LibSessionCacheType: LibSessionImmutableCacheType, MutableCacheT
     func updateProConfig(proConfig: SessionPro.ProConfig)
     func removeProConfig()
     func updateProAccessExpiryTimestampSeconds(_ proAccessExpiryTimestampSeconds: UInt64)
+    func updateProAutoRenewing(_ proAutoRenewing: Bool)
     var refundRequestedTimestampSeconds: UInt64 { get }
     var proPrepaidTimestampSeconds: UInt64 { get }
     func updateRefundRequested(_ refundRequestedTimestampSeconds: UInt64)
@@ -1474,7 +1476,8 @@ private final class NoopLibSessionCache: LibSessionCacheType, NoopDependency {
     var displayName: String? { return nil }
     var proConfig: SessionPro.ProConfig? { return nil }
     var proAccessExpiryTimestampSeconds: UInt64 { return 0 }
-    
+    var proAutoRenewing: Bool { return false }
+
     func set(_ key: Setting.BoolKey, _ value: Bool?) {}
     func set<T: LibSessionConvertibleEnum>(_ key: Setting.EnumKey, _ value: T?) {}
     func updateProfile(
@@ -1487,6 +1490,7 @@ private final class NoopLibSessionCache: LibSessionCacheType, NoopDependency {
     func updateProConfig(proConfig: SessionPro.ProConfig) {}
     func removeProConfig() {}
     func updateProAccessExpiryTimestampSeconds(_ proAccessExpiryTimestampSeconds: UInt64) {}
+    func updateProAutoRenewing(_ proAutoRenewing: Bool) {}
     var refundRequestedTimestampSeconds: UInt64 { return 0 }
     var proPrepaidTimestampSeconds: UInt64 { return 0 }
     func updateRefundRequested(_ refundRequestedTimestampSeconds: UInt64) {}

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -1181,6 +1181,7 @@ public protocol LibSessionCacheType: LibSessionImmutableCacheType, MutableCacheT
     var proConfig: SessionPro.ProConfig? { get }
     var proAccessExpiryTimestampSeconds: UInt64 { get }
     var proAutoRenewing: Bool { get }
+    var proGracePeriodSeconds: UInt64 { get }
 
     /// This function should not be called outside of the `Profile.updateIfNeeded` function to avoid duplicating changes and events,
     /// as a result this function doesn't emit profile change events itself (use `Profile.updateLocal` instead)
@@ -1195,6 +1196,7 @@ public protocol LibSessionCacheType: LibSessionImmutableCacheType, MutableCacheT
     func removeProConfig()
     func updateProAccessExpiryTimestampSeconds(_ proAccessExpiryTimestampSeconds: UInt64)
     func updateProAutoRenewing(_ proAutoRenewing: Bool)
+    func updateProGracePeriodSeconds(_ proGracePeriodSeconds: UInt64)
     var refundRequestedTimestampSeconds: UInt64 { get }
     var proPrepaidTimestampSeconds: UInt64 { get }
     func updateRefundRequested(_ refundRequestedTimestampSeconds: UInt64)
@@ -1477,6 +1479,7 @@ private final class NoopLibSessionCache: LibSessionCacheType, NoopDependency {
     var proConfig: SessionPro.ProConfig? { return nil }
     var proAccessExpiryTimestampSeconds: UInt64 { return 0 }
     var proAutoRenewing: Bool { return false }
+    var proGracePeriodSeconds: UInt64 { return 0 }
 
     func set(_ key: Setting.BoolKey, _ value: Bool?) {}
     func set<T: LibSessionConvertibleEnum>(_ key: Setting.EnumKey, _ value: T?) {}
@@ -1491,6 +1494,7 @@ private final class NoopLibSessionCache: LibSessionCacheType, NoopDependency {
     func removeProConfig() {}
     func updateProAccessExpiryTimestampSeconds(_ proAccessExpiryTimestampSeconds: UInt64) {}
     func updateProAutoRenewing(_ proAutoRenewing: Bool) {}
+    func updateProGracePeriodSeconds(_ proGracePeriodSeconds: UInt64) {}
     var refundRequestedTimestampSeconds: UInt64 { return 0 }
     var proPrepaidTimestampSeconds: UInt64 { return 0 }
     func updateRefundRequested(_ refundRequestedTimestampSeconds: UInt64) {}

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -124,9 +124,16 @@ public actor SessionProManager: SessionProManagerType {
     private var userExpiryWakeTasks: [Task<Void, Never>] = []
     private var firedUserExpiryWakeInstants: Set<UInt64> = []
 
-    /// Config-change detection state for the status trigger. `lastKnownPrepaidTimestampSeconds` tracks `I`, which isn't
-    /// carried in `SessionPro.State` and so has nothing to diff against otherwise; `hasProjectedUserConfig`
-    /// distinguishes the first projection of a process (not a change) from a genuine one.
+    /// Config-change detection state for the status trigger, tracked here rather than read back out of
+    /// `SessionPro.State`.
+    ///
+    /// 🔴 **These must not be display state.** `E` used to be diffed as two `SessionPro.State` snapshots, which tied
+    /// "did config change" to "what does the UI currently show" — so anything that made the displayed expiry
+    /// response-sourced rather than config-sourced would silently stop the config trigger firing at all, taking the
+    /// remote-merge path with it. Nothing about the display can reach this now.
+    ///
+    /// `hasProjectedUserConfig` distinguishes the first projection of a process (not a change) from a genuine one.
+    private var lastKnownAccessExpirySeconds: UInt64 = 0
     private var lastKnownPrepaidTimestampSeconds: UInt64 = 0
     private var hasProjectedUserConfig: Bool = false
 
@@ -548,9 +555,15 @@ public actor SessionProManager: SessionProManagerType {
         ///
         /// **`I` is included, not just `E`.** A purchase started on another device sets only `I` — with `E` unchanged
         /// until the entitlement actually lands — so watching `E` alone leaves that case with no status refresh.
-        let expiryChanged: Bool = (updatedState.accessExpiryTimestampSeconds != oldState.accessExpiryTimestampSeconds)
+        ///
+        /// Both diffed against the **config** values last seen, never against display state — see the note on
+        /// `lastKnownAccessExpirySeconds`. `G` is deliberately not watched: a grace change *is* the information rather
+        /// than a signal that the server moved, so fetching to confirm what we were just told is a wasted round trip.
+        /// Same reason `A` isn't watched.
+        let expiryChanged: Bool = (proInfo.accessExpiryTimestampSeconds != lastKnownAccessExpirySeconds)
         let prepaidChanged: Bool = (proInfo.prepaidTimestampSeconds != lastKnownPrepaidTimestampSeconds)
         let isFirstProjection: Bool = !hasProjectedUserConfig
+        lastKnownAccessExpirySeconds = proInfo.accessExpiryTimestampSeconds
         lastKnownPrepaidTimestampSeconds = proInfo.prepaidTimestampSeconds
         hasProjectedUserConfig = true
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -418,7 +418,7 @@ public actor SessionProManager: SessionProManagerType {
         /// fetch (`.success`) — on `.loading`/`.error` we return `nil` and a later successful refresh
         /// (foreground reconcile) re-triggers the CTA if the subscription genuinely lapsed.
         guard state.loadingState == .success else { return nil }
-        let dateNow: Date = dependencies.dateNow
+        let dateNow: Date = await dependencies.networkOffsetDateNow()
 
         /// Time remaining until the renewal falls due — positive before `E`, negative after it.
         let expiryInSeconds: TimeInterval = (state.accessExpiryTimestampSeconds
@@ -764,16 +764,17 @@ public actor SessionProManager: SessionProManagerType {
         /// ones rather than accumulating them for the life of the process.
         firedUserExpiryWakeInstants = firedUserExpiryWakeInstants.intersection(instants)
 
-        /// Anything already past — we were suspended across it, or the values arrived stale from another
-        /// device. Mark them all and take one refresh: they ask the same question of the same fetch, and
-        /// the trailing re-evaluation below re-arms whatever remains.
+        /// Anything already past — we were suspended across it, or the values arrived stale from another device.
+        /// Marking them fired here is what makes the arming loop below skip them, so there is one arming path
+        /// rather than a past-due branch that has to remember to arm the rest.
+        ///
+        /// They ask the same question of the same fetch, so one refresh covers all of them, and it happens after
+        /// arming: a refresh can return without reaching its own trailing re-evaluation — the single-flight guard,
+        /// the floor and a non-success response all exit before it, and `try?` hides each — so anything not armed
+        /// before that call may never be armed at all.
         let pastDueInstants: [UInt64] = instants.filter { nowSeconds >= $0 && !firedUserExpiryWakeInstants.contains($0) }
 
-        guard pastDueInstants.isEmpty else {
-            pastDueInstants.forEach { firedUserExpiryWakeInstants.insert($0) }
-            try? await refreshProState()
-            return
-        }
+        pastDueInstants.forEach { firedUserExpiryWakeInstants.insert($0) }
 
         for instant in instants where !firedUserExpiryWakeInstants.contains(instant) {
             userExpiryWakeTasks.append(
@@ -786,10 +787,17 @@ public actor SessionProManager: SessionProManagerType {
                 }
             )
         }
+
+        /// A side effect of the pass, not a step the arming depends on. Re-entrant — the refresh's own tail
+        /// re-enters here — and it terminates: the past-due instants are in `fired` by now, so the re-entry finds
+        /// none and issues no further refresh.
+        guard !pastDueInstants.isEmpty else { return }
+
+        try? await refreshProState()
     }
 
     /// Fire the wake for one instant, at most once for that instant. Floored, not `immediate`: this is a routine
-    /// trigger, and the trailing re-evaluation re-arms whatever remains.
+    /// trigger. Both instants are armed by the same evaluation pass, so firing one does not need to arm the other.
     private func fireUserExpiryStatusWake(atInstantSeconds instantSeconds: UInt64) async {
         guard !firedUserExpiryWakeInstants.contains(instantSeconds) else { return }
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1033,13 +1033,16 @@ public actor SessionProManager: SessionProManagerType {
                     /// `E - G` — the paid-through instant the gate and the renewal date are both derived from —
                     /// silently means nothing.
                     ///
-                    /// Unconditional, because libsession requires both on a successful proof and fails the parse
-                    /// otherwise — so there is no "the backend didn't say" case to distinguish from a real
-                    /// zero/false. That matters more than it reads: config stores both presence-only, so a
-                    /// *defaulted* value here would not be inert, it would erase state learned from
-                    /// `get_pro_status`. Failing the parse instead keeps what we already have.
-                    cache.updateProGracePeriodSeconds(response.accountGracePeriodSeconds)
-                    cache.updateProAutoRenewing(response.accountAutoRenewing)
+                    /// `accountRenewalInfo` is `nil` unless this response actually carried a proof. That check
+                    /// is the whole protection: on any other outcome libsession leaves these as the C struct's
+                    /// zero-initialised defaults, which are indistinguishable from "no grace, not renewing" —
+                    /// and writing that `false` would *erase* a flag `get_pro_status` had learned, because the
+                    /// config keys are presence-only. Reaching this line already implies success, so the bind
+                    /// is belt-and-braces; keep it anyway, since nothing else here would catch the mistake.
+                    if let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo = response.accountRenewalInfo {
+                        cache.updateProGracePeriodSeconds(renewalInfo.gracePeriodSeconds)
+                        cache.updateProAutoRenewing(renewalInfo.autoRenewing)
+                    }
                 }
             }
         }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -531,13 +531,25 @@ public actor SessionProManager: SessionProManagerType {
             return (proofIsActive ? .active : .expired)
         }()
         let oldState: SessionPro.State = await stateStream.getCurrent()
+
+        /// 🔴 **`E`, `G` and `A` are deliberately NOT projected here — the display copies of those three are owned by
+        /// whichever response last spoke.** Both `get_pro_status` and `generate_pro_proof` return all three, and only
+        /// a response carries the rest of the picture that has to agree with them (`latest_payment` — provider, plan,
+        /// refund window — has no config representation at all), so sourcing one field from config would leave the
+        /// screen showing a mix of two different moments.
+        ///
+        /// Config keeps the same three for two other jobs, which is why they still exist there: it is the
+        /// **fetch trigger** (`expiryChanged` below) and the **cross-device carrier**. This is the whole split —
+        /// *config answers "should I fetch"; a response answers "what do I show"*.
+        ///
+        /// **So every proof outcome writes these itself** — `applyProofSuccess`, `applyProofClear` and
+        /// `applyProofRevoked` — because a purchase learns its new expiry from the *proof* response, and until this
+        /// method stopped projecting them, that write was what carried it to the display. Adding a fourth writer of
+        /// config `E`/`G`/`A` without a matching display write would silently leave the screen a period behind.
         let updatedState: SessionPro.State = oldState.with(
             status: .set(to: proStatus),
             proof: .set(to: proInfo.proConfig?.proProof),
             profileFeatures: .set(to: proInfo.profile.proFeatures),
-            autoRenewing: .set(to: proInfo.autoRenewing),
-            accessExpiryTimestampSeconds: .set(to: proInfo.accessExpiryTimestampSeconds),
-            gracePeriodSeconds: .set(to: proInfo.gracePeriodSeconds),
             refundRequestedTimestampSeconds: .set(to: proInfo.refundRequestedTimestampSeconds),
             using: dependencies
         )
@@ -677,7 +689,17 @@ public actor SessionProManager: SessionProManagerType {
         postPurchaseStatusPollTask = Task { [weak self] in
             guard let self else { return }
 
-            let expiryBefore: UInt64 = (await self.stateStream.getCurrent().accessExpiryTimestampSeconds ?? 0)
+            /// The baseline "a new period landed" is measured against.
+            ///
+            /// 🔴 **Optional, and deliberately not `?? 0`.** Display state carries no account expiry until a
+            /// response has supplied one, and this poll starts before either the proof response or the first
+            /// `get_pro_status` has landed (the proof generation is an unawaited task, so `purchasePro` returns
+            /// ahead of it). Reading "we don't know yet" as `0` makes the first response look like an advance from
+            /// nothing — including when it is carrying the *pre-purchase* expiry because the payment hasn't
+            /// registered yet — which ends the poll on its first attempt at exactly the moment it exists to keep
+            /// chasing. With no baseline, the first response supplies one instead of being compared against a
+            /// value we never had.
+            var expiryBefore: UInt64? = await self.stateStream.getCurrent().accessExpiryTimestampSeconds
             let startSeconds: Int64 = Int64(await self.dependencies.networkOffsetTimestampMs() / 1000)
             let windowSeconds: Int64 = SessionPro.StatusRefresh.postPurchasePollWindowSeconds
 
@@ -690,8 +712,14 @@ public actor SessionProManager: SessionProManagerType {
                 /// re-ask faster than the routine floor allows, and it carries its own cadence and termination.
                 try? await self.refreshProState(immediate: true)
 
-                let expiryNow: UInt64 = (await self.stateStream.getCurrent().accessExpiryTimestampSeconds ?? 0)
-                if expiryNow > expiryBefore { return }   /// new period landed — done
+                let expiryNow: UInt64? = await self.stateStream.getCurrent().accessExpiryTimestampSeconds
+
+                if let baseline: UInt64 = expiryBefore {
+                    if let expiryNow: UInt64 = expiryNow, expiryNow > baseline { return }   /// new period landed
+                }
+                else {
+                    expiryBefore = expiryNow   /// no baseline to compare against — this response becomes it
+                }
 
                 /// Stop kicking off new requests once ≥2 min since the first fire (the just-completed one
                 /// was allowed to finish; we simply don't start another).
@@ -1066,9 +1094,41 @@ public actor SessionProManager: SessionProManagerType {
             }
         }
 
-        /// Re-project the (now-updated) config into state — proof, rotating key, status, `E` all re-derive
-        /// consistently (and if the winning proof was an existing longer one, the rotating key matches it).
+        /// Write the account triple straight to display state: a proof response is a response, and display state is
+        /// owned by whichever response last spoke.
+        ///
+        /// 🔴 **Before the re-projection below, not after, and the ordering IS load-bearing.** Not because the
+        /// projection would clobber it — it no longer writes these three — but because
+        /// `updateWithLatestFromUserConfig` sees the config `E` just written, and its change trigger *awaits* a
+        /// `get_pro_status`. That response is strictly newer than this one, so it has to be the one that survives.
+        /// Writing afterwards would let this proof's `account_expiry` overwrite a status response that had already
+        /// landed — the same "whichever ran last wins" bug this design removes, just between two responses instead
+        /// of between config and a response.
+        ///
+        /// **The same two conditions as the config writes above, for the same reasons.** A response that carried no
+        /// account expiry must not be read as "expires at 0", and on any non-success outcome libsession leaves the
+        /// grace/renewal pair at the C struct's zero-initialised defaults, which are indistinguishable from "no
+        /// grace, not renewing" — `accountRenewalInfo` is `nil` in exactly that case. Both fall back to
+        /// `.useExisting` rather than to a zero value.
+        let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo? = response.accountRenewalInfo
+        await updateProState(
+            to: (await stateStream.getCurrent()).with(
+                autoRenewing: (renewalInfo.map { .set(to: $0.autoRenewing) } ?? .useExisting),
+                accessExpiryTimestampSeconds: (
+                    response.accountExpiryTimestampSeconds > 0 ?
+                        .set(to: response.accountExpiryTimestampSeconds) :
+                        .useExisting
+                ),
+                gracePeriodSeconds: (renewalInfo.map { .set(to: $0.gracePeriodSeconds) } ?? .useExisting),
+                using: dependencies
+            )
+        )
+
+        /// Re-project the (now-updated) config into state — proof, rotating key and status re-derive consistently
+        /// (and if the winning proof was an existing longer one, the rotating key matches it). It deliberately does
+        /// **not** carry `E`/`G`/`A` any more, which is why they are written explicitly above.
         await updateWithLatestFromUserConfig()
+
         try? await Profile.updateLocal(proFeatures: syncState.state.profileFeatures, using: dependencies)
     }
 
@@ -1077,15 +1137,22 @@ public actor SessionProManager: SessionProManagerType {
     private func applyProofClear() async {
         let nowSeconds: Int64 = Int64(await dependencies.networkOffsetTimestampMs() / 1000)
 
-        try? await dependencies[singleton: .storage].write { [dependencies] db in
-            try dependencies.mutate(cache: .libSession) { cache in
-                try cache.performAndPushChange(db, for: .userProfile) { _ in
-                    /// Downgrade guard (read live config): never wipe a fresh, unexpired proof another device
-                    /// just landed. `remove_pro_config` deliberately leaves `pro_prepaid` so a pending
-                    /// purchase keeps polling (§7.3).
-                    let hasUnexpiredProof: Bool = ((cache.proConfig?.proProof.expiryUnixTimestampSeconds ?? 0) > UInt64(max(0, nowSeconds)))
-                    guard !hasUnexpiredProof else { return }
+        /// Whether the clear actually applied — the downgrade guard decides, and the display write at the end
+        /// needs the answer.
+        ///
+        /// The guard's read stays inside `mutate(cache:)`, which is the lock; `performAndPushChange` adds no
+        /// further synchronisation of its own, so hoisting the read just outside it keeps the read and the write
+        /// atomic with respect to an incoming merge exactly as before. A vetoed clear now also skips
+        /// `performAndPushChange` entirely instead of entering it to make no change.
+        let didClear: Bool = ((try? await dependencies[singleton: .storage].write { [dependencies] db -> Bool in
+            try dependencies.mutate(cache: .libSession) { cache -> Bool in
+                /// Downgrade guard (read live config): never wipe a fresh, unexpired proof another device
+                /// just landed. `remove_pro_config` deliberately leaves `pro_prepaid` so a pending
+                /// purchase keeps polling (§7.3).
+                let hasUnexpiredProof: Bool = ((cache.proConfig?.proProof.expiryUnixTimestampSeconds ?? 0) > UInt64(max(0, nowSeconds)))
+                guard !hasUnexpiredProof else { return false }
 
+                try cache.performAndPushChange(db, for: .userProfile) { _ in
                     /// `remove_pro_config` clears ONLY the proof `s`. `E` does NOT self-age (unlike the proof
                     /// `I`/`R`), so a stale future `E` left here would make `pro_renewal_target` fire on every
                     /// eval and spin — clear it explicitly (`set_pro_access_expiry(nullopt)`, via `0`).
@@ -1098,7 +1165,21 @@ public actor SessionProManager: SessionProManagerType {
                     cache.removeProConfig()
                     cache.updateProAccessExpiryTimestampSeconds(0)
                 }
+
+                return true
             }
+        }) ?? false)
+
+        /// Only when the clear applied. If the downgrade guard vetoed, config now describes another device's
+        /// fresher proof and display state must be left alone — clearing it here would throw away a newer
+        /// `get_pro_status` answer on the strength of an outcome we just decided not to act on.
+        ///
+        /// Before the re-projection, for the reason spelled out in `applyProofSuccess`: clearing config `E` makes
+        /// the change trigger fire, and the `get_pro_status` it awaits is strictly newer than this outcome. If the
+        /// backend says the account is in fact still active, that answer has to survive rather than be cleared by
+        /// a verdict we reached from a stale proof.
+        if didClear {
+            await clearProAccountDisplayState()
         }
 
         await updateWithLatestFromUserConfig()
@@ -1118,7 +1199,31 @@ public actor SessionProManager: SessionProManagerType {
             }
         }
 
+        /// Unconditional, unlike `applyProofClear` — `revoked` is terminal and has no downgrade guard to veto it.
+        /// Before the re-projection, for the same ordering reason as the other two paths.
+        await clearProAccountDisplayState()
+
         await updateWithLatestFromUserConfig()
+    }
+
+    /// Clear the account triple in **display** state.
+    ///
+    /// A cleared proof outcome is a response speaking too, and what it says is "you have nothing" — so it owns these
+    /// three exactly as a success does. Config's version of this is a cascade inside libsession (clearing `E` clears
+    /// `G` and `A` with it, since both describe the subscription `E` denotes); display state has no such cascade, so
+    /// it is spelled out here.
+    ///
+    /// `status`, the proof and `profileFeatures` are not touched — `updateWithLatestFromUserConfig` re-derives those
+    /// from the now-cleared config, and it still projects them.
+    private func clearProAccountDisplayState() async {
+        await updateProState(
+            to: (await stateStream.getCurrent()).with(
+                autoRenewing: .set(to: false),
+                accessExpiryTimestampSeconds: .set(to: nil),
+                gracePeriodSeconds: .set(to: 0),
+                using: dependencies
+            )
+        )
     }
 
     // MARK: - Pro State Management

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -36,7 +36,7 @@ public enum SessionPro {
         /// because a throttled proof acquisition still has to eventually happen. Don't unify the two.
         ///
         /// ⚠️ **A scheduled wake depends on this value not being crossed.** The `user_expiry` wakes fire at
-        /// `(E - G) + 30s` and `E + 30s`, so they are `G` apart, and **both go through the floored fetch path**
+        /// `E + 30s` and `(E + G) + 30s`, so they are `G` apart, and **both go through the floored fetch path**
         /// (not `immediate`). Whenever `G < floorSeconds` the second wake's fetch is therefore dropped by the
         /// floor — silently, and looking exactly as though the wake had never been scheduled.
         ///
@@ -789,19 +789,19 @@ public actor SessionProManager: SessionProManagerType {
             return
         }
 
-        /// Clamped, not trapping — see `startupStatusFetchIsCTAWorthy`. The degenerate branch yields `E`, so
-        /// the two instants coincide and this schedules a single wake, which is the right answer when there
-        /// is no meaningful paid-through instant to ask about separately.
-        let paidThroughSeconds: UInt64 = (
-            graceSeconds < expirySeconds ? expirySeconds - graceSeconds : expirySeconds
+        /// Clamped, not trapping — see `startupStatusFetchIsCTAWorthy`. With `G == 0` this yields `E`, so the two
+        /// instants coincide and a single wake is scheduled, which is the right answer when there is no grace
+        /// window to ask about separately.
+        let coverageEndSeconds: UInt64 = (
+            expirySeconds > (UInt64.max - graceSeconds) ? UInt64.max : expirySeconds + graceSeconds
         )
         let slackSeconds: UInt64 = SessionPro.StatusRefresh.userExpiryWakeSlackSeconds
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
 
         /// **Two instants, and they answer different questions.**
         ///
-        /// - `(E - G) + 30s` — the renewal has just fallen due: did the charge succeed or fail?
-        /// - `E + 30s` — coverage has just ended: did grace run out without a recovery?
+        /// - `E + 30s` — the renewal has just fallen due: did the charge succeed or fail?
+        /// - `(E + G) + 30s` — coverage has just ended: did grace run out without a recovery?
         ///
         /// The second is armed **only when the two instants don't coincide**. That is the condition itself,
         /// not a proxy for it: when they land on the same second there is one thing to ask, so there is one
@@ -823,10 +823,10 @@ public actor SessionProManager: SessionProManagerType {
         /// seconds. **Deliberately not worked around here** — the escape hatch is an env-var override of the
         /// floor, owned by the Pro UI-test work. Don't make these emits `immediate` to "fix" it: that would give
         /// two floor-exempt fetches on every renewal in production to serve a test-only configuration.
-        var instants: [UInt64] = [paidThroughSeconds + slackSeconds]
+        var instants: [UInt64] = [expirySeconds + slackSeconds]
 
-        if paidThroughSeconds != expirySeconds {
-            instants.append(expirySeconds + slackSeconds)
+        if coverageEndSeconds != expirySeconds {
+            instants.append(coverageEndSeconds + slackSeconds)
         }
 
         /// Re-derive the fired set against the instants currently scheduled, so a moved `E` forgets the old
@@ -1073,8 +1073,8 @@ public actor SessionProManager: SessionProManagerType {
 
                     /// Keep `G` and `A` coherent with the `E` just written. Without this a proof outcome moves
                     /// the access expiry while leaving a grace period paired with the *previous* one, and
-                    /// `E - G` — the paid-through instant the gate and the renewal date are both derived from —
-                    /// silently means nothing.
+                    /// `E + G` — the coverage end the gate and the second wake are both derived from — silently
+                    /// means nothing.
                     ///
                     /// `accountRenewalInfo` is `nil` unless this response actually carried a proof. That check
                     /// is the whole protection: on any other outcome libsession leaves these as the C struct's
@@ -1241,23 +1241,21 @@ public actor SessionProManager: SessionProManagerType {
     /// startup fetch's only real consumer is the home CTAs, so it is gated on "could a CTA fire", computed from synced
     /// config, plus a persisted min-interval.
     ///
-    /// The test is against the **paid-through** instant, `E - G`, not against `E`. `E` is the end of *coverage*:
-    /// the backend folds the grace period into the stored expiry for auto-renewing subscriptions, so `now >= E`
-    /// is the grace *exit*, and gating on it would put the whole grace window in the no-fetch branch — the one
-    /// state this refresh design exists to surface. Both halves are synced (`E`, `G`), so the whole decision is
+    /// The test is against `E`, the date the renewal falls due — **not** against the end of coverage, `E + G`.
+    /// Gating on `E + G` would put the whole grace window in the no-fetch branch, which is the one state this
+    /// refresh design exists to surface. Both halves are synced (`E`, `G`), so the whole decision is
     /// config-derivable with no branching on provider or renewal state (`G` is 0 when not auto-renewing):
     ///
     /// | config state | action |
     /// |---|---|
-    /// | `A && now < E - G`  | comfortably active, renewal not yet due → **no fetch** |
-    /// | `A && now >= E - G` | renewal due or overdue → fetch, so grace can be surfaced while it is happening |
-    /// | `!A && E - G` within the CTA window | expiring → fetch (the CTA is separately gated on the result) |
-    /// | `!A && now >= E - G`| expired — with `!A` there is no renewal in flight and `G` is 0, so this is also
-    ///                        `now >= E`. Confirm-fetch first, so a renewal that landed elsewhere and hasn't
-    ///                        synced can't produce a false "Pro expired" |
+    /// | `A && now < E`            | comfortably active, renewal not yet due → **no fetch** |
+    /// | `A && E <= now < E + G`   | renewal due or overdue, still served → fetch, so grace can be surfaced while it is happening |
+    /// | `!A && E` within the CTA window | expiring → fetch (the CTA is separately gated on the result) |
+    /// | `now >= E + G`            | lapsed. Confirm-fetch first, so a renewal that landed elsewhere and hasn't
+    ///                              synced can't produce a false "Pro expired" |
     ///
-    /// Fetching once past the paid-through end is still bounded on the far side: past `E` the grace has run out,
-    /// and the persisted 24h interval below is what stops a lapsed account re-asking on every launch.
+    /// Fetching once past `E` is still bounded on the far side by the persisted 24h interval below, which is what
+    /// stops a lapsed account re-asking on every launch.
     ///
     /// **Not a Pro user at all** (no `E`, no proof) → never fetch. Note what that gives up: a purely server-side
     /// entitlement, e.g. a voucher, leaves no config trace, so this device won't discover it on its own. On iOS an
@@ -1310,11 +1308,11 @@ public actor SessionProManager: SessionProManagerType {
         return true
     }
 
-    /// The CTA-worthiness half of the startup gate — the four rows of the table above, measured against the
-    /// **paid-through** instant `E - G` rather than against `E`.
+    /// The CTA-worthiness half of the startup gate — the four rows of the table above, measured against `E` (the
+    /// renewal date) rather than against the end of coverage `E + G`.
     ///
-    /// The `!A && now < E - G` row outside the CTA window returns false (no fetch), and that is now **correct
-    /// rather than merely assumed** — worth recording why, because it was held for a long time.
+    /// The `!A && now < E` row outside the CTA window returns false (no fetch), and that is now **correct rather
+    /// than merely assumed** — worth recording why, because it was held for a long time.
     ///
     /// `A` is stored presence-only: libsession's setter *erases* the key on false, so the key is present iff its
     /// value is 1, and "not auto-renewing" and "never written" are the same stored state. That is a property of
@@ -1331,35 +1329,34 @@ public actor SessionProManager: SessionProManagerType {
         graceSeconds: UInt64,
         nowSeconds: UInt64
     ) async -> Bool {
-        /// The date the renewal falls due. `E` overshoots it by exactly one grace period for an auto-renewing
-        /// subscription, and by nothing at all otherwise (the backend sends `grace = 0` when `!A`).
+        /// The instant we stop being served: `E` plus however much longer the backend keeps serving past it. `G`
+        /// is 0 whenever the subscription isn't auto-renewing, so this collapses to `E` there and needs no
+        /// branching on provider or renewal state.
         ///
-        /// Clamp rather than trap: these are `UInt64` and both arrive from **synced config**, so a corrupt
-        /// value is reachable from another device rather than only from local logic — and an unsigned
-        /// underflow there would crash on every launch, which is a worse failure than any wrong date. The
-        /// degenerate branch treats "grace at least as large as the expiry" as *no grace*, since `G` is a
-        /// duration and `E` a ~1.7-billion-second timestamp, so it cannot arise from real data.
-        let paidThroughSeconds: UInt64 = (
-            graceSeconds < expirySeconds ? expirySeconds - graceSeconds : expirySeconds
+        /// Clamp rather than trap: these are `UInt64` and both arrive from **synced config**, so a corrupt value
+        /// is reachable from another device rather than only from local logic — and an unsigned overflow there
+        /// would crash on every launch, which is a worse failure than any wrong date.
+        let coverageEndSeconds: UInt64 = (
+            expirySeconds > (UInt64.max - graceSeconds) ? UInt64.max : expirySeconds + graceSeconds
         )
 
-        /// Past the end of coverage. Fetch to confirm before claiming expired — a renewal may have landed
-        /// elsewhere and not synced yet — but only while an Expired CTA could still fire.
-        guard nowSeconds < expirySeconds else {
-            return ((nowSeconds - expirySeconds) <= SessionPro.StatusRefresh.expiredCTAWindowSeconds)
+        /// Lapsed — past the end of coverage. Fetch to confirm before claiming expired, since a renewal may have
+        /// landed elsewhere and not synced yet, but only while an Expired CTA could still fire.
+        guard nowSeconds < coverageEndSeconds else {
+            return ((nowSeconds - coverageEndSeconds) <= SessionPro.StatusRefresh.expiredCTAWindowSeconds)
         }
 
-        /// Renewal due or overdue, still covered: the grace window. **Always fetch** — this is the state the whole
-        /// refresh design exists to surface, and gating it on `E` instead is what used to swallow it entirely.
-        /// Empty when `!A`, since `G` is 0 there and this collapses to the branch above.
-        guard nowSeconds < paidThroughSeconds else { return true }
+        /// Renewal due or overdue but still being served: the grace window `[E, E + G)`. **Always fetch** — this is
+        /// the state the whole refresh design exists to surface, and gating on the coverage end instead is what
+        /// would swallow it entirely. Empty when `!A`, since `G` is 0 there and this collapses into the branch above.
+        guard nowSeconds < expirySeconds else { return true }
 
         /// Comfortably active and renewing itself — the case the gate exists to stop fetching for. The
         /// `user_expiry` wake covers the crossing; the config-change trigger covers another device.
         guard !autoRenewing else { return false }
 
         /// Not renewing and inside the CTA window — the Expiring CTA may be due.
-        return ((paidThroughSeconds - nowSeconds) <= SessionPro.StatusRefresh.expiringCTAWindowSeconds)
+        return ((expirySeconds - nowSeconds) <= SessionPro.StatusRefresh.expiringCTAWindowSeconds)
     }
 
     /// The drop-on-fresh status floor: whether enough time has passed since the last `get_pro_status` for a *routine*
@@ -1516,7 +1513,7 @@ public actor SessionProManager: SessionProManagerType {
             await self.stateStream.send(updatedState)
             oldState = updatedState
 
-            /// `get_pro_status` is authoritative for the account paid-through end, so mirror `expiry_ts` into
+            /// `get_pro_status` is authoritative for the account expiry, so mirror `expiry_ts` into
             /// config `E` (`set_pro_access_expiry`) unconditionally on every success. This is the crux that
             /// lets `pro_renewal_target` fire for a server-side voucher / recovered subscription (account
             /// active but with no local proof yet) — without it, `E` in config would stay absent and a proof

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -23,6 +23,56 @@ public enum SessionPro {
     public static var CharacterLimit: Int { Int(SESSION_PROTOCOL_STANDARD_CHARACTER_LIMIT) }
     public static var ProCharacterLimit: Int { Int(SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT) }
     public static var PinnedConversationLimit: Int { Int(SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION_LIMIT) }
+
+    /// The `get_pro_status` refresh timings.
+    ///
+    /// **These are a deliberate cross-client contract, not iOS tuning knobs** — Android and desktop carry the same
+    /// values under their own names, and the whole point of unifying the refresh design was that nobody tunes one
+    /// platform in isolation. Change them together or not at all.
+    public enum StatusRefresh {
+        /// Minimum gap between routine `get_pro_status` fetches. **Drop-on-fresh, never re-arm:** a re-arming floor
+        /// turns every routine trigger into a self-sustaining once-a-minute poll, which during grace (when `E` is
+        /// static) is pure noise. The *proof* loop is deliberately the opposite — it re-arms rather than skips,
+        /// because a throttled proof acquisition still has to eventually happen. Don't unify the two.
+        public static let floorSeconds: UInt64 = 60
+
+        /// Minimum gap between **startup-gate** fetches. Cold starts are frequent on mobile, so the gate needs its
+        /// own rate limit; this also doubles as the backstop that lets a stale `auto_renewing`/`E` self-correct
+        /// within a day.
+        public static let startupMinIntervalSeconds: UInt64 = 24 * 60 * 60
+
+        /// How far before `E` a non-renewing subscription counts as "expiring" — the startup gate's CTA window, and
+        /// the same 7 days the Expiring CTA itself uses.
+        public static let expiringCTAWindowSeconds: UInt64 = 7 * 24 * 60 * 60
+
+        /// How long after `E` an expired subscription still warrants the Expired CTA.
+        public static let expiredCTAWindowSeconds: UInt64 = 30 * 24 * 60 * 60
+
+        /// Slack added to `E` for the single `user_expiry` wake. Firing at exactly `E` would routinely re-read the
+        /// same un-renewed period a moment before the backend rolls it over, spending a fetch to learn nothing.
+        public static let userExpiryWakeSlackSeconds: UInt64 = 30
+
+        /// The post-purchase chase (trigger #7). Floor-exempt, so these two *are* its bound: the window is measured
+        /// from the FIRST request, and the gap is applied after each attempt SETTLES rather than as a fixed tick, so a
+        /// slow onion request can never overlap itself.
+        public static let postPurchasePollWindowSeconds: Int64 = 120
+        public static let postPurchasePollGapSeconds: Int = 5
+    }
+
+    /// The proof-acquisition floor (Loop 1).
+    ///
+    /// **Deliberately re-arms rather than drops**, which is the opposite of the status floor above: a throttled proof
+    /// acquisition is load-bearing and must still eventually happen, whereas a dropped status refresh is display-only
+    /// and backstopped by six other triggers. Don't unify the two — the asymmetry is the design.
+    public enum ProofAcquisition {
+        /// Spacing while COVERED — a currently-valid proof is in hand, so renewal is preemptive and can be leisurely.
+        public static let coveredIntervalSeconds: TimeInterval = 60
+
+        /// Spacing while DARK — no proof, or an expired one (renewal-after-offline, or a prepaid acquisition). Linear
+        /// in the attempt count so an abandoned purchase decays to the cap rather than polling forever at 15s.
+        public static let darkIntervalStepSeconds: Int = 15
+        public static let darkIntervalCapSeconds: Int = 900
+    }
 }
 
 // MARK: - SessionProManager
@@ -46,6 +96,19 @@ public actor SessionProManager: SessionProManagerType {
     private var lastProofRequestAt: TimeInterval = -.greatestFiniteMagnitude
     private var darkAttempt: Int = 0
 
+    /// The single `user_expiry` status wake (trigger #6). `userExpiryWakeTask` is the advisory in-foreground
+    /// wake; `lastUserExpiryWakeExpirySeconds` is the access-expiry value it has already fired for, which is
+    /// what makes it fire once per period rather than repeat. Both are ephemeral — re-derived from config on
+    /// every evaluation, reset on process death.
+    private var userExpiryWakeTask: Task<Void, Never>?
+    private var lastUserExpiryWakeExpirySeconds: UInt64 = 0
+
+    /// Config-change detection state for the status trigger. `lastKnownPrepaidTimestampSeconds` tracks `I`, which isn't
+    /// carried in `SessionPro.State` and so has nothing to diff against otherwise; `hasProjectedUserConfig`
+    /// distinguishes the first projection of a process (not a change) from a genuine one.
+    private var lastKnownPrepaidTimestampSeconds: UInt64 = 0
+    private var hasProjectedUserConfig: Bool = false
+
     /// The instant up to which we have already emitted "this profile's pro state just went stale" events
     ///
     /// Used as the lower bound of the window in `emitProInvalidationEvents(since:until:)` so that each lapse is emitted exactly
@@ -53,6 +116,21 @@ public actor SessionProManager: SessionProManagerType {
     private var lastProInvalidationCheck: TimeInterval = 0
 
     private var isRefreshingState: Bool = false
+
+    /// Whether a `get_pro_status` has been attempted at all in this process. Exempts the first attempt from the
+    /// (persisted) status floor — see `statusFloorPermitsFetch`.
+    ///
+    /// **It is load-bearing for two independent reasons, so removing it needs both answered.** Beyond the
+    /// spinner case below, the floor is the *other* thing in this file that can decline to start a fetch — and
+    /// without this exemption a fresh process whose floor is still armed from the previous one cannot fetch,
+    /// which is the same dead-end as gating a refresh on `LoadingState.loading` (see that type's note).
+    ///
+    /// **Sole consumer is that exemption.** Deleting this and letting the persisted timestamp govern the first attempt
+    /// too *was tried*, and it ships a **permanent spinner**: relaunch within 60s of a previous fetch and the floor
+    /// drops the startup fetch, leaving `loadingState` on its initial `.loading` with nothing to resolve it — and both
+    /// the Pro screen and the CTA gate on a confirmed fetch. So it is removable only once a fresh process can resolve
+    /// its load state without a network round-trip; if that ever becomes true, delete this then and not before.
+    private var hasAttemptedStatusFetch: Bool = false
     private var rotatingKeyPair: KeyPair?
     
     nonisolated private let stateStream: CurrentValueAsyncStream<SessionPro.State> = CurrentValueAsyncStream(.invalid)
@@ -93,8 +171,9 @@ public actor SessionProManager: SessionProManagerType {
             await self?.startProInvalidationRescheduleObservations()
             await self?.scheduleNextProInvalidation()
             
-            /// Kick off a refresh so we know we have the latest state (if it's the main app)
-            if dependencies[singleton: .appContext].isMainApp {
+            /// Kick off a refresh so we know we have the latest state (if it's the main app), but only when
+            /// the config we just projected says it's warranted — see `startupStatusFetchIsNeeded`.
+            if dependencies[singleton: .appContext].isMainApp, await self?.startupStatusFetchIsNeeded() == true {
                 try? await self?.refreshProState()
             }
 
@@ -115,6 +194,7 @@ public actor SessionProManager: SessionProManagerType {
         proofRenewalWakeTask?.cancel()
         proofGenerationTask?.cancel()
         postPurchaseStatusPollTask?.cancel()
+        userExpiryWakeTask?.cancel()
     }
     
     public func ensureInitialized() async {
@@ -386,10 +466,11 @@ public actor SessionProManager: SessionProManagerType {
             profile: Profile,
             accessExpiryTimestampSeconds: UInt64,
             refundRequestedTimestampSeconds: UInt64,
-            prepaidTimestampSeconds: UInt64
+            prepaidTimestampSeconds: UInt64,
+            autoRenewing: Bool
         )
         let proInfo: ProInfo = dependencies.mutate(cache: .libSession) {
-            ($0.proConfig, $0.profile, $0.proAccessExpiryTimestampSeconds, $0.refundRequestedTimestampSeconds, $0.proPrepaidTimestampSeconds)
+            ($0.proConfig, $0.profile, $0.proAccessExpiryTimestampSeconds, $0.refundRequestedTimestampSeconds, $0.proPrepaidTimestampSeconds, $0.proAutoRenewing)
         }
         
         let rotatingKeyPair: KeyPair? = try? proInfo.proConfig.map { config in
@@ -417,6 +498,7 @@ public actor SessionProManager: SessionProManagerType {
             status: .set(to: proStatus),
             proof: .set(to: proInfo.proConfig?.proProof),
             profileFeatures: .set(to: proInfo.profile.proFeatures),
+            autoRenewing: .set(to: proInfo.autoRenewing),
             accessExpiryTimestampSeconds: .set(to: proInfo.accessExpiryTimestampSeconds),
             refundRequestedTimestampSeconds: .set(to: proInfo.refundRequestedTimestampSeconds),
             using: dependencies
@@ -430,11 +512,25 @@ public actor SessionProManager: SessionProManagerType {
         self.rotatingKeyPair = rotatingKeyPair
         await self.stateStream.send(updatedState)
 
-        /// If the `accessExpiryTimestampSeconds` value changed then we should trigger a refresh because it generally means that
-        /// other device did something that should refresh the pro state
-        if updatedState.accessExpiryTimestampSeconds != oldState.accessExpiryTimestampSeconds {
-            try? await refreshProState()
+        /// A change to `E` or the prepaid marker `I` generally means another device did something that should refresh
+        /// the pro state.
+        ///
+        /// **`I` is included, not just `E`.** A purchase started on another device sets only `I` — with `E` unchanged
+        /// until the entitlement actually lands — so watching `E` alone leaves that case with no status refresh.
+        let expiryChanged: Bool = (updatedState.accessExpiryTimestampSeconds != oldState.accessExpiryTimestampSeconds)
+        let prepaidChanged: Bool = (proInfo.prepaidTimestampSeconds != lastKnownPrepaidTimestampSeconds)
+        let isFirstProjection: Bool = !hasProjectedUserConfig
+        lastKnownPrepaidTimestampSeconds = proInfo.prepaidTimestampSeconds
+        hasProjectedUserConfig = true
 
+        /// The first pass of a process is a *projection* of config we already had, not a config *change*. Treating it
+        /// as one would fire this refresh on every cold launch — before, and regardless of, the startup gate — which
+        /// would walk straight past the gate and leave the startup hammering the gate exists to remove.
+        if !isFirstProjection, (expiryChanged || prepaidChanged) {
+            try? await refreshProState()
+        }
+
+        if expiryChanged {
             await dependencies.notify(
                 key: .proAccessExpiryUpdated,
                 value: proInfo.accessExpiryTimestampSeconds
@@ -446,6 +542,10 @@ public actor SessionProManager: SessionProManagerType {
         /// `renewal_target <= now` via the gate, so the reconcile's dark path IS the acquisition poll — no
         /// separate prepaid poll.
         await reconcileProofRenewal()
+
+        /// `E` may have just moved (our own write, or another device's config push), so re-evaluate the
+        /// `user_expiry` wake against it.
+        await evaluateUserExpiryStatusWake()
     }
     
     public func purchasePro(productId: String) async throws {
@@ -535,13 +635,16 @@ public actor SessionProManager: SessionProManagerType {
 
             let expiryBefore: UInt64 = (await self.stateStream.getCurrent().accessExpiryTimestampSeconds ?? 0)
             let startSeconds: Int64 = Int64(await self.dependencies.networkOffsetTimestampMs() / 1000)
-            let windowSeconds: Int64 = 120   /// 2 minutes since the FIRST request
+            let windowSeconds: Int64 = SessionPro.StatusRefresh.postPurchasePollWindowSeconds
 
             while true {
                 if Task.isCancelled { return }
 
                 /// Fire and AWAIT settle (fresh response, or failure/timeout — `try?` swallows the throw).
-                try? await self.refreshProState()
+                ///
+                /// `immediate` because this poll is one of the two floor-exempt bounded chases: its whole job is to
+                /// re-ask faster than the routine floor allows, and it carries its own cadence and termination.
+                try? await self.refreshProState(immediate: true)
 
                 let expiryNow: UInt64 = (await self.stateStream.getCurrent().accessExpiryTimestampSeconds ?? 0)
                 if expiryNow > expiryBefore { return }   /// new period landed — done
@@ -552,7 +655,7 @@ public actor SessionProManager: SessionProManagerType {
                 if (nowSeconds - startSeconds) >= windowSeconds { return }
 
                 /// 5s gap BETWEEN completed attempts (not a fixed tick).
-                do { try await Task.sleep(for: .seconds(5)) }
+                do { try await Task.sleep(for: .seconds(SessionPro.StatusRefresh.postPurchasePollGapSeconds)) }
                 catch { return }
             }
         }
@@ -570,6 +673,83 @@ public actor SessionProManager: SessionProManagerType {
                 }
             }
         }
+    }
+
+    // MARK: -- User Expiry Status Wake (trigger #6)
+
+    /// The single `user_expiry` wake: one `get_pro_status` refetch shortly after the account's paid-through
+    /// end (`E`) passes, and no more.
+    ///
+    /// This is the gap it exists to close. The proof is clamped to expire well short of `E`, so the proof
+    /// reconcile's wake (~the proof's own renewal target) is the *next* thing that goes to the network after
+    /// `E` — and a renewal actually lands somewhere in between. Until this wake existed, an account whose
+    /// renewal was overdue showed a stale "active until `E`" for that whole interval, and the "renewal
+    /// pending / overdue" display can't be driven off anything we hadn't re-read. The while-open grace poll
+    /// only covers the case where the Pro settings screen happens to be open.
+    ///
+    /// The slack added to `E` (see `StatusRefresh.userExpiryWakeSlackSeconds`) is for clock skew against the backend:
+    /// firing at exactly `E` would routinely re-read the same un-renewed period a moment before it rolls over.
+    ///
+    /// **Single, not repeating.** `lastUserExpiryWakeExpirySeconds` records the `E` already fired for, so a
+    /// refetch that leaves `E` unchanged is not retried from here — the ongoing chase belongs to the
+    /// while-open grace poll and the other triggers. A refetch that *does* advance `E` arms the next
+    /// period's wake for free, and since that `E` is in the future it cannot spin.
+    ///
+    /// The wake is advisory, like the proof one: iOS suspends the process, so a `Task.sleep` spanning `E`
+    /// will not fire on time. `willEnterForeground` re-enters here and the already-past branch below is what
+    /// catches up a crossing missed while suspended.
+    private func evaluateUserExpiryStatusWake() async {
+        userExpiryWakeTask?.cancel()
+        userExpiryWakeTask = nil
+
+        guard dependencies[singleton: .appContext].isMainApp else { return }
+
+        /// Read `E` from config rather than from `state`: config is the authoritative cross-device value and
+        /// is what the startup gate and the proof reconcile both key off, so all three agree on one clock.
+        let expirySeconds: UInt64 = dependencies.mutate(cache: .libSession) {
+            $0.proAccessExpiryTimestampSeconds
+        }
+
+        /// No known paid-through end (never Pro, or cleared by a not-entitled proof outcome) — nothing to
+        /// wake for. Reset the marker so a later subscription starting on the *same* `E` isn't swallowed.
+        guard expirySeconds > 0 else {
+            lastUserExpiryWakeExpirySeconds = 0
+            return
+        }
+
+        let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
+        let fireAtSeconds: UInt64 = (expirySeconds + SessionPro.StatusRefresh.userExpiryWakeSlackSeconds)
+
+        guard nowSeconds < fireAtSeconds else {
+            /// The crossing is already behind us — either we were suspended across it, or this `E` arrived
+            /// already stale from another device. Catch up now, still only once per `E`.
+            await fireUserExpiryStatusWake(forExpirySeconds: expirySeconds)
+            return
+        }
+
+        userExpiryWakeTask = Task { [weak self] in
+            /// Integer `.seconds` overload — the `Double` one is iOS 16+.
+            do { try await Task.sleep(for: .seconds(Int(fireAtSeconds - nowSeconds))) }
+            catch { return }
+
+            await self?.fireUserExpiryStatusWake(forExpirySeconds: expirySeconds)
+        }
+    }
+
+    /// Fire the wake for `expirySeconds`, at most once for that value.
+    ///
+    /// **Note:** when this is reached from the already-past branch during a `refreshProState` that is still
+    /// in flight, the refresh below is a no-op (`isRefreshingState`) — which is the right outcome: the
+    /// in-flight fetch is itself the post-`E` read the wake wanted, so the wake is legitimately consumed.
+    private func fireUserExpiryStatusWake(forExpirySeconds expirySeconds: UInt64) async {
+        guard lastUserExpiryWakeExpirySeconds != expirySeconds else { return }
+
+        /// Marked BEFORE the fetch deliberately: a failing network must not turn a single wake into a
+        /// refetch on every trigger that re-enters here. Recovering from a failed fetch belongs to the other
+        /// triggers, not to this one.
+        lastUserExpiryWakeExpirySeconds = expirySeconds
+
+        try? await refreshProState()
     }
 
     // MARK: -- Proof Renewal (Rev 2 reconcile loop)
@@ -618,7 +798,7 @@ public actor SessionProManager: SessionProManagerType {
         /// abandoned purchase to ~15-min spacing. Covered resets the dark backoff (§2).
         let haveValidProof: Bool = currentUserProofIsValid(atTimestampMs: nowMs)
         if haveValidProof { darkAttempt = 0 }
-        let interval: TimeInterval = (haveValidProof ? 60 : TimeInterval(min(15 * darkAttempt, 900)))
+        let interval: TimeInterval = proofAcquisitionInterval(haveValidProof: haveValidProof)
 
         /// Spacing / best-effort single-flight / lost-completion recovery: if a request started too recently,
         /// just (re)arm the wake for when the interval elapses and bail.
@@ -631,9 +811,24 @@ public actor SessionProManager: SessionProManagerType {
         if !haveValidProof { darkAttempt += 1 }
 
         /// Arm the next wake now (it also re-checks a lost/frozen completion), then fire the generate.
-        let nextInterval: TimeInterval = (haveValidProof ? 60 : TimeInterval(min(15 * darkAttempt, 900)))
+        let nextInterval: TimeInterval = proofAcquisitionInterval(haveValidProof: haveValidProof)
         armProofRenewalWake(afterSeconds: nextInterval)
         startProofGeneration(nowUnixTimestampSeconds: nowSeconds)
+    }
+
+    /// The proof-acquisition spacing for the current pass — flat while covered, linear-with-cap while dark.
+    ///
+    /// Read twice per pass (once to decide whether to fire, once to arm the next wake), which is exactly why it is a
+    /// function: the two must not be able to drift apart, and as duplicated literals they previously could.
+    private func proofAcquisitionInterval(haveValidProof: Bool) -> TimeInterval {
+        guard !haveValidProof else { return SessionPro.ProofAcquisition.coveredIntervalSeconds }
+
+        return TimeInterval(
+            min(
+                SessionPro.ProofAcquisition.darkIntervalStepSeconds * darkAttempt,
+                SessionPro.ProofAcquisition.darkIntervalCapSeconds
+            )
+        )
     }
 
     /// The advisory in-foreground wake. Unreliable across suspension (fine — a trigger re-runs reconcile);
@@ -815,13 +1010,183 @@ public actor SessionProManager: SessionProManagerType {
         await self.stateStream.send(newState)
     }
     
-    public func refreshProState(forceLoadingState: Bool) async throws {
+    /// Whether a cold launch needs to go to the network for `get_pro_status`.
+    ///
+    /// Every client used to fetch unconditionally on startup — non-Pro users included — and a cold start is something
+    /// mobile triggers constantly, so that was the bulk of the backend load for no benefit: entitlement comes from the
+    /// proof, the settings screen refreshes on open, and account-expiry awareness is the `user_expiry` wake's job. The
+    /// startup fetch's only real consumer is the home CTAs, so it is gated on "could a CTA fire", computed from synced
+    /// config, plus a persisted min-interval.
+    ///
+    /// The expiry test is deliberately **not** `E + grace <= now`. Grace isn't reliably knowable before you're in it,
+    /// so it is never carried in config (libSession PR #121 adds `auto_renewing` and nothing else) — you fetch once
+    /// past `E` and learn grace from the response:
+    ///
+    /// | config state | action |
+    /// |---|---|
+    /// | `A && now < E`  | comfortably active → **no fetch** |
+    /// | `A && now >= E` | in/near grace, length unknowable → fetch, learn grace from the response |
+    /// | `!A && E` within the CTA window | expiring → fetch (the CTA is separately gated on the result) |
+    /// | `!A && now >= E`| expired (grace covers renewals in flight, and there is none) → confirm-fetch first, so a
+    ///                     renewal that landed elsewhere and hasn't synced can't produce a false "Pro expired" |
+    ///
+    /// **Not a Pro user at all** (no `E`, no proof) → never fetch. Note what that gives up: a purely server-side
+    /// entitlement, e.g. a voucher, leaves no config trace, so this device won't discover it on its own. On iOS an
+    /// Apple subscription still self-recovers through StoreKit (`Transaction.updates`), and everything else is what
+    /// the manual recover action exists for.
+    private func startupStatusFetchIsNeeded() async -> Bool {
+        /// One mutation for all three, so they can't be read either side of an incoming config merge.
+        let (autoRenewing, expirySeconds, hasProof): (Bool, UInt64, Bool) = dependencies.mutate(cache: .libSession) {
+            ($0.proAutoRenewing, $0.proAccessExpiryTimestampSeconds, $0.proConfig?.proProof != nil)
+        }
+
+        /// Never subscribed as far as this device can tell — the case the gate exists to stop fetching for.
+        guard expirySeconds > 0 || hasProof else { return false }
+
+        /// Network time, not the device clock: skew must not be what flips a near-boundary `E` decision (and a device
+        /// whose clock is days out would otherwise fetch, or fail to, on every launch).
+        let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
+
+        guard await startupStatusFetchIsCTAWorthy(
+            autoRenewing: autoRenewing,
+            expirySeconds: expirySeconds,
+            nowSeconds: nowSeconds
+        ) else { return false }
+
+        /// The gate's own rate limit. Checked last so a launch that wasn't CTA-worthy doesn't consume the interval.
+        let lastStartupFetchSeconds: UInt64? = try? await dependencies[singleton: .storage].read { db in
+            db[.proStatusLastStartupFetchAttemptTimestamp].map { UInt64(max(0, $0)) }
+        }
+
+        if
+            let lastStartupFetchSeconds: UInt64,
+            nowSeconds >= lastStartupFetchSeconds,
+            (nowSeconds - lastStartupFetchSeconds) < SessionPro.StatusRefresh.startupMinIntervalSeconds
+        { return false }
+
+        /// Recorded on the attempt, not on success: this bounds cold-start load, and a launch with no connectivity
+        /// must not be able to retry on every relaunch. The other triggers still cover a genuinely needed refresh.
+        try? await dependencies[singleton: .storage].write { db in
+            db[.proStatusLastStartupFetchAttemptTimestamp] = Int(nowSeconds)
+        }
+
+        return true
+    }
+
+    /// The CTA-worthiness half of the startup gate — the four rows of the table above.
+    ///
+    /// 🔴 **One case is deliberately left unresolved here**: `!A && now < E` with `E` beyond the CTA window, which is
+    /// where **every existing subscriber lands on their first launch after this ships** (`E` set and far future, `A`
+    /// not yet written by anyone). Because libSession stores `A` presence-only, `get_pro_auto_renewing()` returning
+    /// false conflates *not auto-renewing*, *never fetched*, and *written by a client predating the field* — and the C
+    /// API returns an `int`, so absent and false are not even distinguishable to us.
+    ///
+    /// The design's own pitfall list says to trust the config value and specifically *not* to "fetch regardless of
+    /// `auto_renewing`", which is why this returns false. But the design elsewhere leans on a once-a-day re-check to
+    /// let a stale flag self-correct, and under this reading a comfortably-active subscriber never startup-fetches, so
+    /// nothing writes `A` from that path. That contradiction is with the architect; do not resolve it locally.
+    ///
+    /// It is less load-bearing here than on the other clients: on-enter, the `user_expiry` wake, config change,
+    /// `Transaction.updates` and manual recover all write `A` too, so iOS populates it through ordinary use rather
+    /// than depending on the startup path. If the ruling needs a genuine "have we ever fetched" signal, that has to be
+    /// **local** persisted state — it cannot come from config.
+    private func startupStatusFetchIsCTAWorthy(
+        autoRenewing: Bool,
+        expirySeconds: UInt64,
+        nowSeconds: UInt64
+    ) async -> Bool {
+        /// Past the paid-through end. Fetch whether or not we think it renews: renewing means we're in grace and need
+        /// the length, not renewing means we need to confirm before claiming expired.
+        guard nowSeconds < expirySeconds else {
+            /// Long past `E` and outside the Expired CTA window there is no CTA left to fire, so nothing to confirm.
+            return ((nowSeconds - expirySeconds) <= SessionPro.StatusRefresh.expiredCTAWindowSeconds)
+        }
+
+        /// Comfortably active and renewing itself — the other case the gate exists to stop fetching for. The
+        /// `user_expiry` wake covers the crossing; the config-change trigger covers another device.
+        guard !autoRenewing else { return false }
+
+        /// Non-renewing and inside the CTA window — the Expiring CTA may be due.
+        return ((expirySeconds - nowSeconds) <= SessionPro.StatusRefresh.expiringCTAWindowSeconds)
+    }
+
+    /// The drop-on-fresh status floor: whether enough time has passed since the last `get_pro_status` for a *routine*
+    /// trigger to go to the network.
+    ///
+    /// Two exemptions, and the second one matters more than it looks:
+    ///
+    /// - `immediate` callers bypass it outright (manual/recover and the post-purchase poll).
+    /// - **The first attempt of a process is never floored.** The persisted timestamp is what stops repeated cold
+    ///   starts from hammering the backend, but it must not leave a *fresh* process unable to fetch at all:
+    ///   `loadingState` would sit on its initial `.loading` with nothing to resolve it, which on this client means a
+    ///   permanent spinner on the Pro screen and no CTA, since both gate on a confirmed fetch. Android gets this free
+    ///   because its floor only applies once the load state leaves `Init`; this flag is the same condition. Note it is
+    ///   keyed on having *attempted*, not succeeded — after a failure the state is `.error`, which the UI renders as a
+    ///   retry (itself `immediate`), so the spinner problem is gone and there is no reason to keep bypassing.
+    ///   Cold-start load stays bounded by the startup gate's own 24h interval, not by this floor.
+    ///
+    /// Fails **open** on a storage error — the floor is a backend-load optimisation, so an unreadable timestamp should
+    /// cost an extra request rather than silently stop the client ever refreshing its status.
+    private func statusFloorPermitsFetch(immediate: Bool) async -> Bool {
+        guard !immediate else { return true }
+        guard hasAttemptedStatusFetch else { return true }
+
+        let lastFetchSeconds: UInt64? = try? await dependencies[singleton: .storage].read { db in
+            db[.proStatusLastFetchAttemptTimestamp].map { UInt64(max(0, $0)) }
+        }
+
+        guard let lastFetchSeconds: UInt64 else { return true }
+
+        let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
+
+        /// A timestamp in the future means the clock moved backwards; treat it as "just fetched" rather than as a
+        /// licence to fetch, since the alternative lets a clock change unlock an unbounded run of requests.
+        guard nowSeconds >= lastFetchSeconds else { return false }
+
+        return ((nowSeconds - lastFetchSeconds) >= SessionPro.StatusRefresh.floorSeconds)
+    }
+
+    /// Record that a `get_pro_status` was **started** (not that it succeeded): the floor exists to bound requests, and
+    /// a failing request costs the backend the same as a succeeding one.
+    private func recordStatusFetchAttempt() async {
+        let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
+
+        try? await dependencies[singleton: .storage].write { db in
+            db[.proStatusLastFetchAttemptTimestamp] = Int(nowSeconds)
+        }
+    }
+
+    public func refreshProState(immediate: Bool, forceLoadingState: Bool) async throws {
         /// No point refreshing the state if there is a refresh in progress
+        ///
+        /// **Note:** this is single-flight, *not* the floor — it stops concurrent fetches, not frequent ones, and
+        /// `immediate` deliberately does not bypass it.
         guard !isRefreshingState else { return }
-        
+
+        /// Drop (don't re-arm) when the last fetch is still fresh. Deliberately before the loading-state change below,
+        /// so a dropped refresh leaves the displayed state exactly as it was rather than parking it on a spinner.
+        ///
+        /// **Still reconcile the proof on the way out.** Every call to this function used to end in a
+        /// `reconcileProofRenewal()`, and callers rely on that: when the proof loop is dormant
+        /// (`pro_renewal_target == 0`) it has no wake of its own, so a nudge it would otherwise have received is not
+        /// merely delayed, it is *lost*. Adding the floor must not silently remove that edge — most obviously for the
+        /// case where the preceding fetch **failed**, which arms the floor (we stamp on attempt) without ever having
+        /// reached its own reconcile. The reconcile is local and separately floored, so paying it on a dropped status
+        /// refresh costs nothing.
+        guard await statusFloorPermitsFetch(immediate: immediate) else {
+            await reconcileProofRenewal()
+            return
+        }
+
         isRefreshingState = true
         defer { isRefreshingState = false }
-        
+
+        /// Arm the floor as soon as we commit to fetching, rather than on success — a request that fails costs the
+        /// backend the same as one that succeeds, and recording it here means an early throw below can't leave the
+        /// floor un-armed and the next trigger free to retry immediately.
+        hasAttemptedStatusFetch = true
+        await recordStatusFetchAttempt()
+
         /// Only reset the `loadingState` if it's currently in an error state
         var oldState: SessionPro.State = await stateStream.getCurrent()
         var updatedState: SessionPro.State = oldState
@@ -904,10 +1269,16 @@ public actor SessionProManager: SessionProManagerType {
             /// active but with no local proof yet) — without it, `E` in config would stay absent and a proof
             /// would never be fetched. libsession clears `E` when handed `<= 0` (the never/expired
             /// `expiry_ts`) and only dirties the config on a real change, so the unconditional write is safe.
+            ///
+            /// `auto_renewing` (config `A`) is mirrored on the same terms and in the same mutation: it is the
+            /// other half of what the startup gate needs to decide whether a fetch is warranted before the
+            /// network is available, and without it every cold launch would have to fetch to learn it. Same
+            /// churn properties as `E` — libsession stores it presence-only and only dirties on a real change.
             try? await dependencies[singleton: .storage].write { [dependencies] db in
                 try dependencies.mutate(cache: .libSession) { cache in
                     try cache.performAndPushChange(db, for: .userProfile) { _ in
                         cache.updateProAccessExpiryTimestampSeconds(response.expiryTimestampSeconds)
+                        cache.updateProAutoRenewing(response.autoRenewing)
                     }
                 }
             }
@@ -918,8 +1289,12 @@ public actor SessionProManager: SessionProManagerType {
             /// entirely by the reconcile loop's `generate_pro_proof` path, so we just kick a reconcile here
             /// (a status change may make a renewal / acquisition due).
 
+            /// Stamp when this fetch completed, not when it started: a warning that keys off "we have asked
+            /// since the threshold passed" must not be satisfied by a request that was already in flight when
+            /// the threshold went by.
             updatedState = oldState.with(
                 loadingState: .set(to: .success),
+                lastConfirmedStatusFetchSeconds: .set(to: (await dependencies.networkOffsetTimestampMs() / 1000)),
                 using: dependencies
             )
 
@@ -931,6 +1306,10 @@ public actor SessionProManager: SessionProManagerType {
             await entitlementsObservingTask?.value
 
             await reconcileProofRenewal()
+
+            /// A successful fetch is the one thing that can advance `E`, so re-arm the `user_expiry` wake for
+            /// whatever period we just learned about.
+            await evaluateUserExpiryStatusWake()
         } catch {
             Log.error(.sessionPro, "Failed to retrieve pro status due to error(s): \(error)")
             
@@ -948,8 +1327,10 @@ public actor SessionProManager: SessionProManagerType {
     @MainActor public func cancelPro(scene: UIWindowScene) async throws {
         do {
             try await AppStore.showManageSubscriptions(in: scene)
-            
-            try await refreshProState()
+
+            /// `immediate`: the user has just come back from Apple's manage-subscriptions sheet having possibly
+            /// cancelled, and is looking at the screen waiting for it to reflect that. Same class as a manual refresh.
+            try await refreshProState(immediate: true)
         }
         catch {
             throw SessionProError.failedToShowStoreKitUI("Manage Subscriptions")
@@ -1202,6 +1583,10 @@ public actor SessionProManager: SessionProManagerType {
                             /// other observed key — doesn't thrash the renewal task.
                             if key == .appLifecycle(.willEnterForeground) {
                                 await self?.reconcileProofRenewal()
+
+                                /// Same reasoning for the `user_expiry` wake: a `Task.sleep` doesn't survive
+                                /// suspension, so this is what catches up an `E` crossing we slept through.
+                                await self?.evaluateUserExpiryStatusWake()
                             }
                         }
                     }
@@ -1437,14 +1822,34 @@ public protocol SessionProManagerType: SessionProUIManagerType {
     func updateWithLatestFromUserConfig() async
     
     func purchasePro(productId: String) async throws
-    func refreshProState(forceLoadingState: Bool) async throws
+    /// - Parameters:
+    ///   - immediate: Bypass the status-refresh floor. **Reserved to the two genuine "go right now" callers** — a
+    ///   manual refresh/recover the user is waiting on, and the bounded post-purchase poll — plus the bounded
+    ///   while-open grace poll and developer-only paths, which the design lists as floor-exempt for the same reason
+    ///   (they carry their own cadence and their own termination). Routine triggers (startup, config change, on-enter,
+    ///   the `user_expiry` wake) must **not** pass it; a routine caller bypassing the floor is how the equivalent flag
+    ///   on Android ended up dead in the first place.
+    ///   - forceLoadingState: Show the spinner even when the current state isn't an error. **Orthogonal to
+    ///   `immediate`** — spinner UI is a separate concern from bypassing the floor, and conflating them is what the
+    ///   rename to `immediate` exists to prevent.
+    func refreshProState(immediate: Bool, forceLoadingState: Bool) async throws
     @MainActor func requestRefund(scene: UIWindowScene) async throws
     @MainActor func cancelPro(scene: UIWindowScene) async throws
 }
 
 public extension SessionProManagerType {
+    /// A routine, floored refresh with no spinner — the correct default for every trigger that isn't one of the
+    /// explicitly floor-exempt ones.
     func refreshProState() async throws {
-        try await refreshProState(forceLoadingState: false)
+        try await refreshProState(immediate: false, forceLoadingState: false)
+    }
+
+    func refreshProState(immediate: Bool) async throws {
+        try await refreshProState(immediate: immediate, forceLoadingState: false)
+    }
+
+    func refreshProState(forceLoadingState: Bool) async throws {
+        try await refreshProState(immediate: false, forceLoadingState: forceLoadingState)
     }
 }
 
@@ -1492,7 +1897,9 @@ private extension SessionProManager {
                     /// If we need a state refresh then start a new task to do so (we don't want the mocking to be dependant on the
                     /// result of the refresh so don't wait for it to complete before doing any mock changes)
                     if state.needsRefresh {
-                        Task.detached { [weak self] in try await self?.refreshProState() }
+                        /// `immediate`: a developer flipping a mock in Developer Settings expects the change to take
+                        /// effect now, and the floor would silently swallow rapid toggles. Developer-only path.
+                        Task.detached { [weak self] in try await self?.refreshProState(immediate: true) }
                     }
                     
                     /// While it would be easier to just rely on `refreshProState` to update the mocked values, that would

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -748,6 +748,9 @@ public actor SessionProManager: SessionProManagerType {
             return
         }
 
+        /// `min` is the underflow guard (see `startupStatusFetchIsCTAWorthy` for why `max(0, …)` would be
+        /// wrong on `UInt64`). Clamping to `0` degrades this to a single wake at `E`, which is correct: with
+        /// no meaningful paid-through instant there is only one thing left to ask about.
         let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
         let slackSeconds: UInt64 = SessionPro.StatusRefresh.userExpiryWakeSlackSeconds
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
@@ -1030,18 +1033,13 @@ public actor SessionProManager: SessionProManagerType {
                     /// `E - G` — the paid-through instant the gate and the renewal date are both derived from —
                     /// silently means nothing.
                     ///
-                    /// **Only written when the backend actually said.** Both are `Optional` precisely so absence
-                    /// can't be collapsed: config stores them presence-only, so writing `0`/`false` *erases*
-                    /// them, and against a backend predating these fields that would wipe values correctly
-                    /// learned from `get_pro_status` on every proof fetch. Absent means leave alone — worse to
-                    /// destroy a good value than to leave a stale one the next status fetch will correct.
-                    if let accountGracePeriodSeconds: UInt64 = response.accountGracePeriodSeconds {
-                        cache.updateProGracePeriodSeconds(accountGracePeriodSeconds)
-                    }
-
-                    if let accountAutoRenewing: Bool = response.accountAutoRenewing {
-                        cache.updateProAutoRenewing(accountAutoRenewing)
-                    }
+                    /// Unconditional, because libsession requires both on a successful proof and fails the parse
+                    /// otherwise — so there is no "the backend didn't say" case to distinguish from a real
+                    /// zero/false. That matters more than it reads: config stores both presence-only, so a
+                    /// *defaulted* value here would not be inert, it would erase state learned from
+                    /// `get_pro_status`. Failing the parse instead keeps what we already have.
+                    cache.updateProGracePeriodSeconds(response.accountGracePeriodSeconds)
+                    cache.updateProAutoRenewing(response.accountAutoRenewing)
                 }
             }
         }
@@ -1202,6 +1200,13 @@ public actor SessionProManager: SessionProManagerType {
     ) async -> Bool {
         /// The date the renewal falls due. `E` overshoots it by exactly one grace period for an auto-renewing
         /// subscription, and by nothing at all otherwise (the backend sends `grace = 0` when `!A`).
+        ///
+        /// **The `min` is an underflow guard, not defensive noise — do not "simplify" it.** Both operands are
+        /// `UInt64`, so `expirySeconds - graceSeconds` *traps* if grace ever exceeds expiry, and the
+        /// signed-arithmetic instinct `max(0, graceSeconds)` is a no-op on an unsigned type. It clamps to `0`,
+        /// which is a handled degenerate case here: `0 < nowSeconds` for any real clock, so the gate falls
+        /// through to "fetch" — fail-safe. It only arises if `E` is unset or garbage, since a real `E` is a
+        /// ~1.7-billion-second timestamp and no grace period approaches that.
         let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
 
         /// Past the end of coverage. Fetch to confirm before claiming expired — a renewal may have landed

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -966,6 +966,24 @@ public actor SessionProManager: SessionProManagerType {
                     if response.accountExpiryTimestampSeconds > 0 {
                         cache.updateProAccessExpiryTimestampSeconds(response.accountExpiryTimestampSeconds)
                     }
+
+                    /// Keep `G` and `A` coherent with the `E` just written. Without this a proof outcome moves
+                    /// the access expiry while leaving a grace period paired with the *previous* one, and
+                    /// `E - G` — the paid-through instant the gate and the renewal date are both derived from —
+                    /// silently means nothing.
+                    ///
+                    /// **Only written when the backend actually said.** Both are `Optional` precisely so absence
+                    /// can't be collapsed: config stores them presence-only, so writing `0`/`false` *erases*
+                    /// them, and against a backend predating these fields that would wipe values correctly
+                    /// learned from `get_pro_status` on every proof fetch. Absent means leave alone — worse to
+                    /// destroy a good value than to leave a stale one the next status fetch will correct.
+                    if let accountGracePeriodSeconds: UInt64 = response.accountGracePeriodSeconds {
+                        cache.updateProGracePeriodSeconds(accountGracePeriodSeconds)
+                    }
+
+                    if let accountAutoRenewing: Bool = response.accountAutoRenewing {
+                        cache.updateProAutoRenewing(accountAutoRenewing)
+                    }
                 }
             }
         }
@@ -1106,20 +1124,18 @@ public actor SessionProManager: SessionProManagerType {
     /// The CTA-worthiness half of the startup gate — the four rows of the table above, measured against the
     /// **paid-through** instant `E - G` rather than against `E`.
     ///
-    /// 🔴 **One case remains held**: `!A && now < E - G` with the paid-through end beyond the CTA window, which
-    /// returns false (no fetch). `A` is stored presence-only — libsession's setter *erases* the key on false — so
-    /// the key is present iff its value is 1, and "not auto-renewing" and "never written" are the same stored
-    /// state. That is a property of the **encoding**, not of the accessor: a companion "has it been written"
-    /// predicate cannot recover the distinction, which is why one that was built for this was withdrawn.
+    /// The `!A && now < E - G` row outside the CTA window returns false (no fetch), and that is now **correct
+    /// rather than merely assumed** — worth recording why, because it was held for a long time.
     ///
-    /// What would settle it is making absent-`A` genuinely mean not-renewing, and there is exactly **one** thing
-    /// standing in the way. `A` has a single writer in this client — the `get_pro_status` success path — and the
-    /// proof-success path writes `E` **without** `A` (see `applyProofSuccess`), so an account renewed via a proof
-    /// outcome can hold a future `E` with no `A`. The backend now sends `account_auto_renewing` on the proof
-    /// response for exactly this, but libsession's proof parser does not yet surface it, and this client has no
-    /// other access to that wire. Until it does, absent-`A` is genuinely ambiguous and the row stays held.
+    /// `A` is stored presence-only: libsession's setter *erases* the key on false, so the key is present iff its
+    /// value is 1, and "not auto-renewing" and "never written" are the same stored state. That is a property of
+    /// the **encoding**, not of the accessor — a companion "has it ever been written" predicate cannot recover
+    /// the distinction, which is why one built for exactly that was withdrawn as vacuous.
     ///
-    /// Do not resolve this locally: the same row exists on the other clients and must move with them.
+    /// So the row is only sound if absent-`A` genuinely means not-renewing, and the one path that could break
+    /// that was the proof outcome: it writes `E`, and used to leave `A` alone, so an account renewed via a proof
+    /// could hold a future `E` with no `A`. `applyProofSuccess` now writes `A` (and `G`) from the proof response
+    /// whenever the backend supplies them, which closes it. Absent-`A` on a live account means not renewing.
     private func startupStatusFetchIsCTAWorthy(
         autoRenewing: Bool,
         expirySeconds: UInt64,

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1188,7 +1188,14 @@ public actor SessionProManager: SessionProManagerType {
     /// `revoked` from a proof response is authoritative and terminal — clear regardless of validity. Clears
     /// both the proof `s` and the access-expiry `E`: `remove_pro_config` only clears `s`, and a stale future
     /// `E` would keep `pro_renewal_target` firing (spin), so clear it too (`set_pro_access_expiry(nullopt)`,
-    /// via `0`). Mirrors the revocation-list path (§6.4).
+    /// via `0`).
+    ///
+    /// **Deliberately NOT the same as `clearOwnCredentialIfRevoked` (§6.4), and the difference is the source of
+    /// the verdict.** Here the backend answered our proof request with `revoked`: that is terminal and about the
+    /// account, so we clear `E` and there is nothing left to ask. §6.4 instead *infers* revocation by matching our
+    /// own tag against the revocation list — a statement about one credential, not about entitlement — so it
+    /// clears only the proof and then asks the server what the account's state actually is. Neither should be
+    /// changed to match the other.
     private func applyProofRevoked() async {
         try? await dependencies[singleton: .storage].write { [dependencies] db in
             try dependencies.mutate(cache: .libSession) { cache in
@@ -1987,7 +1994,8 @@ public actor SessionProManager: SessionProManagerType {
     
     /// §6.4 self-revocation clear: if the current user's own proof's revocation tag is on the (now-updated)
     /// revocation list with an effective instant that has passed, remove the credential — authoritative,
-    /// regardless of expiry. No-op when we hold no proof or it isn't revoked.
+    /// regardless of expiry — then refresh the account status so the server settles what the state now is.
+    /// No-op when we hold no proof or it isn't revoked, so the refresh only happens on an actual revocation.
     private func clearOwnCredentialIfRevoked() async {
         let nowSeconds: TimeInterval = dependencies.dateNow.timeIntervalSince1970
 
@@ -2005,15 +2013,56 @@ public actor SessionProManager: SessionProManagerType {
         guard isRevoked else { return }
 
         Log.warn(.sessionPro, "Own Pro proof was revoked; clearing the credential.")
-        try? await dependencies[singleton: .storage].write { [dependencies] db in
-            try dependencies.mutate(cache: .libSession) { cache in
+
+        /// 🔴 **Re-read the tag under the cache lock before clearing — the decision above is made outside it.**
+        /// `removeProConfig` wipes whatever proof is stored, unconditionally, and the read that identified it as
+        /// revoked happened in a *separate* lock acquisition. An incoming config merge mutates the libSession
+        /// config object directly, so between the two a device can land a **new, unrevoked** proof — and clearing
+        /// then throws away a valid credential on the strength of a verdict about the one it replaced. Actor
+        /// isolation does not help: the storage write suspends, and the merge does not run on this actor.
+        ///
+        /// Same hazard, and the same shape, as `applyProofClear`'s downgrade guard.
+        let didClear: Bool = ((try? await dependencies[singleton: .storage].write { [dependencies] db -> Bool in
+            try dependencies.mutate(cache: .libSession) { cache -> Bool in
+                guard
+                    cache.proConfig?.proProof.revocationTag.toHexString() == ownProofRevocationTagHex
+                else { return false }
+
                 try cache.performAndPushChange(db, for: .userProfile) { _ in
                     cache.removeProConfig()
                 }
+
+                return true
             }
-        }
+        }) ?? false)
+
+        /// Nothing was cleared, so there is nothing to project or reconcile: either the proof had already been
+        /// replaced, or the write failed and the next revocation-list fetch re-enters here. A merge that replaced
+        /// it carries its own projection and refresh.
+        ///
+        /// Note this returns earlier than `applyProofClear`, which projects unconditionally even when its guard
+        /// vetoes. The difference is what each path holds when it declines to act: that one is applying a *response*
+        /// and still has its contents to project, whereas this one only ever had a local verdict about a credential —
+        /// so when the verdict no longer applies there is nothing left to do here.
+        guard didClear else { return }
 
         await updateWithLatestFromUserConfig()
+
+        /// Then ask the server what the account's state actually is.
+        ///
+        /// **`E` is deliberately left alone**, unlike `applyProofRevoked`. A tag on the revocation list says this
+        /// *credential* is dead; it does not say the *account* has lapsed, and only the server can tell us which.
+        /// Clearing `E` here would be this client deciding the account's fate from a statement about one proof.
+        ///
+        /// 🔴 **This fetch is what makes leaving `E` safe — don't remove one without the other.** Nothing else on
+        /// this path reaches the network: `updateWithLatestFromUserConfig` above is a projection, and its
+        /// config-change trigger needs `E` or `I` to move, neither of which this path touches since it clears only
+        /// the proof `s`. Drop the fetch and the account is left holding a stale future `E` with no proof and
+        /// nothing scheduled to correct it — the `pro_renewal_target` spin that clearing `E` elsewhere avoids.
+        ///
+        /// Routine and floored, not `immediate`: nobody is waiting on a screen, and the floor exists for exactly
+        /// this kind of background reconcile.
+        try? await refreshProState()
     }
 }
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -522,17 +522,15 @@ public actor SessionProManager: SessionProManagerType {
                 )
                 
             case (.expired, _, _):
-                /// Anchored at coverage end, `E + G`: the backend reports `Expired` only once it has stopped serving,
-                /// so measuring the window from `E` shortens it by exactly `G` — to nothing at all where the store's
-                /// grace reaches the window length. It also puts this deadline on the same instant as the startup
-                /// gate's own bound, so the gate and the CTA agree about when an account is too stale to chase.
+                /// Measured from coverage end, `E + G`, so the window is the same length whatever the store's grace
+                /// is, and its deadline is the instant the startup gate stops chasing the account.
                 ///
-                /// Both ends are required: without the lower bound the window is open-ended into the past, and the
-                /// only thing left limiting the CTA is the shown-once flag, so an account that lapsed years ago
-                /// still gets it the first time it is seen.
+                /// **Upper bound only.** Reaching here means the backend said `Expired`, and it is revocation-aware:
+                /// a refunded or charged-back account reports `Expired` while its coverage end is still in the
+                /// future, so `secondsSinceCoverageEnd` is negative. A lower bound would suppress the CTA for
+                /// exactly those accounts. Staleness is the upper bound's job.
                 guard
                     let secondsSinceCoverageEnd: TimeInterval = secondsSinceCoverageEnd,
-                    secondsSinceCoverageEnd >= 0,
                     secondsSinceCoverageEnd < TimeInterval(SessionPro.StatusRefresh.expiredCTAWindowSeconds),
                     !dependencies[defaults: .standard, key: .hasShownProExpiredCTA]
                 else { return nil }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -24,6 +24,26 @@ public enum SessionPro {
     public static var ProCharacterLimit: Int { Int(SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT) }
     public static var PinnedConversationLimit: Int { Int(SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION_LIMIT) }
 
+    /// The instant coverage ends: `E + G`.
+    ///
+    /// `E` is when the account expires — the date shown to the user — and `G` is how much longer the backend keeps
+    /// serving past it, so this is the instant it stops. `G` is `0` whenever the subscription isn't auto-renewing,
+    /// which collapses this to `E` and is why no caller branches on the provider or the renewal state.
+    ///
+    /// 🔴 **Saturating rather than trapping, and the direction is deliberate.** Both operands arrive from **synced
+    /// config**, so a corrupt value is reachable from another device rather than only from local logic, and `+` on
+    /// `UInt64` traps — which here would mean crashing on every launch. Saturating to `.max` is safe because
+    /// entitlement comes from the signed proof: a wrong value can mislead the displayed date and the fetch schedule,
+    /// but it cannot grant Pro.
+    ///
+    /// **Read `G` as the pair that arrived with this `E`.** They describe one subscription, and not every writer of
+    /// `E` reaches config, so combining values from two moments silently moves where coverage ends.
+    static func coverageEndSeconds(expirySeconds: UInt64, gracePeriodSeconds: UInt64) -> UInt64 {
+        let (sum, overflowed) = expirySeconds.addingReportingOverflow(gracePeriodSeconds)
+
+        return (overflowed ? .max : sum)
+    }
+
     /// The `get_pro_status` refresh timings.
     ///
     /// 🔴 **A cross-client contract, not iOS tuning knobs.** Every client's refresh design is specified against
@@ -830,11 +850,11 @@ public actor SessionProManager: SessionProManagerType {
             return
         }
 
-        /// Clamped, not trapping — see `startupStatusFetchIsCTAWorthy`. With `G == 0` this yields `E`, so the two
-        /// instants coincide and a single wake is scheduled, which is the right answer when there is no grace
-        /// window to ask about separately.
-        let coverageEndSeconds: UInt64 = (
-            expirySeconds > (UInt64.max - graceSeconds) ? UInt64.max : expirySeconds + graceSeconds
+        /// With `G == 0` this yields `E`, so the two instants coincide and a single wake is scheduled — the right
+        /// answer when there is no grace window to ask about separately.
+        let coverageEndSeconds: UInt64 = SessionPro.coverageEndSeconds(
+            expirySeconds: expirySeconds,
+            gracePeriodSeconds: graceSeconds
         )
         let slackSeconds: UInt64 = SessionPro.StatusRefresh.userExpiryWakeSlackSeconds
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
@@ -1396,15 +1416,10 @@ public actor SessionProManager: SessionProManagerType {
         graceSeconds: UInt64,
         nowSeconds: UInt64
     ) async -> Bool {
-        /// The instant we stop being served: `E` plus however much longer the backend keeps serving past it. `G`
-        /// is 0 whenever the subscription isn't auto-renewing, so this collapses to `E` there and needs no
-        /// branching on provider or renewal state.
-        ///
-        /// Clamp rather than trap: these are `UInt64` and both arrive from **synced config**, so a corrupt value
-        /// is reachable from another device rather than only from local logic — and an unsigned overflow there
-        /// would crash on every launch, which is a worse failure than any wrong date.
-        let coverageEndSeconds: UInt64 = (
-            expirySeconds > (UInt64.max - graceSeconds) ? UInt64.max : expirySeconds + graceSeconds
+        /// The instant we stop being served, which is what the lapsed test below measures against.
+        let coverageEndSeconds: UInt64 = SessionPro.coverageEndSeconds(
+            expirySeconds: expirySeconds,
+            gracePeriodSeconds: graceSeconds
         )
 
         /// Lapsed — past the end of coverage. Fetch to confirm before claiming expired, since a renewal may have

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1282,7 +1282,10 @@ public actor SessionProManager: SessionProManagerType {
             }
 
         /// Never subscribed as far as this device can tell — the case the gate exists to stop fetching for.
-        guard expirySeconds > 0 || hasProof else { return false }
+        guard expirySeconds > 0 || hasProof else {
+            Log.info(.sessionPro, "Startup gate: no access expiry and no proof, skipping the startup fetch.")
+            return false
+        }
 
         /// Network time, not the device clock: skew must not be what flips a near-boundary `E` decision (and a device
         /// whose clock is days out would otherwise fetch, or fail to, on every launch).
@@ -1293,7 +1296,10 @@ public actor SessionProManager: SessionProManagerType {
             expirySeconds: expirySeconds,
             graceSeconds: graceSeconds,
             nowSeconds: nowSeconds
-        ) else { return false }
+        ) else {
+            Log.info(.sessionPro, "Startup gate: no CTA could fire, skipping the startup fetch.")
+            return false
+        }
 
         /// The gate's own rate limit. Checked last so a launch that wasn't CTA-worthy doesn't consume the interval.
         let lastStartupFetchSeconds: UInt64? = try? await dependencies[singleton: .storage].read { db in
@@ -1304,13 +1310,24 @@ public actor SessionProManager: SessionProManagerType {
             let lastStartupFetchSeconds: UInt64,
             nowSeconds >= lastStartupFetchSeconds,
             (nowSeconds - lastStartupFetchSeconds) < SessionPro.StatusRefresh.startupMinIntervalSeconds
-        { return false }
+        {
+            Log.info(
+                .sessionPro,
+                "Startup gate: fetched within the last \(SessionPro.StatusRefresh.startupMinIntervalSeconds)s, skipping the startup fetch."
+            )
+            return false
+        }
 
         /// Recorded on the attempt, not on success: this bounds cold-start load, and a launch with no connectivity
         /// must not be able to retry on every relaunch. The other triggers still cover a genuinely needed refresh.
         try? await dependencies[singleton: .storage].write { db in
             db[.proStatusLastStartupFetchAttemptTimestamp] = Int(nowSeconds)
         }
+
+        Log.info(
+            .sessionPro,
+            "Startup gate: a CTA could fire (autoRenewing: \(autoRenewing), expiry: \(expirySeconds), grace: \(graceSeconds)), fetching pro status."
+        )
 
         return true
     }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -34,6 +34,21 @@ public enum SessionPro {
         /// turns every routine trigger into a self-sustaining once-a-minute poll, which during grace (when `E` is
         /// static) is pure noise. The *proof* loop is deliberately the opposite — it re-arms rather than skips,
         /// because a throttled proof acquisition still has to eventually happen. Don't unify the two.
+        ///
+        /// ⚠️ **A scheduled wake depends on this value not being crossed.** The `user_expiry` wakes fire at
+        /// `(E - G) + 30s` and `E + 30s`, so they are `G` apart, and **both go through the floored fetch path**
+        /// (not `immediate`). Whenever `G < floorSeconds` the second wake's fetch is therefore dropped by the
+        /// floor — silently, and looking exactly as though the wake had never been scheduled.
+        ///
+        /// In production `G` is ~1 hour, so this never bites. It bites on a **compressed testing backend**: the
+        /// Google testing provider sets the grace period to ~10 seconds, and the backend scales its whole test
+        /// clock (clamp, renewal lead, grid) while this fixed client-side floor doesn't participate in that
+        /// compression. Any client interval shorter than the compressed equivalent has the same property — the
+        /// second wake is just where the mismatch first became visible.
+        ///
+        /// **Deliberately not solved here.** The sanctioned escape hatch is an env-var override of this floor,
+        /// owned by the Pro UI-test work; do not add one to the client, make the wake `immediate`, or widen the
+        /// wake's guard to compensate. Raising or removing this constant likewise needs the wakes re-checked.
         public static let floorSeconds: UInt64 = 60
 
         /// Minimum gap between **startup-gate** fetches. Cold starts are frequent on mobile, so the gate needs its
@@ -96,12 +111,18 @@ public actor SessionProManager: SessionProManagerType {
     private var lastProofRequestAt: TimeInterval = -.greatestFiniteMagnitude
     private var darkAttempt: Int = 0
 
-    /// The single `user_expiry` status wake (trigger #6). `userExpiryWakeTask` is the advisory in-foreground
-    /// wake; `lastUserExpiryWakeExpirySeconds` is the access-expiry value it has already fired for, which is
-    /// what makes it fire once per period rather than repeat. Both are ephemeral — re-derived from config on
-    /// every evaluation, reset on process death.
-    private var userExpiryWakeTask: Task<Void, Never>?
-    private var lastUserExpiryWakeExpirySeconds: UInt64 = 0
+    /// The `user_expiry` status wakes (trigger #6) — **two instants, so a collection**.
+    ///
+    /// `userExpiryWakeTasks` holds one advisory in-foreground wake per scheduled instant;
+    /// `firedUserExpiryWakeInstants` records which have already fired, which is what makes each fire once per
+    /// period rather than repeat. Both are ephemeral — re-derived from config on every evaluation, reset on
+    /// process death.
+    ///
+    /// **This must stay a collection.** A single handle, cancelled once while scheduling two timers, silently
+    /// orphans the first and leaks a timer every renewal period — and it would not show up in a test asserting
+    /// the wakes fire at the right times, because they both still do.
+    private var userExpiryWakeTasks: [Task<Void, Never>] = []
+    private var firedUserExpiryWakeInstants: Set<UInt64> = []
 
     /// Config-change detection state for the status trigger. `lastKnownPrepaidTimestampSeconds` tracks `I`, which isn't
     /// carried in `SessionPro.State` and so has nothing to diff against otherwise; `hasProjectedUserConfig`
@@ -194,7 +215,7 @@ public actor SessionProManager: SessionProManagerType {
         proofRenewalWakeTask?.cancel()
         proofGenerationTask?.cancel()
         postPurchaseStatusPollTask?.cancel()
-        userExpiryWakeTask?.cancel()
+        userExpiryWakeTasks.forEach { $0.cancel() }
     }
     
     public func ensureInitialized() async {
@@ -687,30 +708,29 @@ public actor SessionProManager: SessionProManagerType {
 
     // MARK: -- User Expiry Status Wake (trigger #6)
 
-    /// The single `user_expiry` wake: one `get_pro_status` refetch shortly after the account's paid-through
-    /// end (`E`) passes, and no more.
+    /// The `user_expiry` wakes: a `get_pro_status` refetch shortly after the renewal falls due, and a second
+    /// shortly after coverage ends. Each fires once per period.
     ///
-    /// This is the gap it exists to close. The proof is clamped to expire well short of `E`, so the proof
-    /// reconcile's wake (~the proof's own renewal target) is the *next* thing that goes to the network after
-    /// `E` — and a renewal actually lands somewhere in between. Until this wake existed, an account whose
-    /// renewal was overdue showed a stale "active until `E`" for that whole interval, and the "renewal
-    /// pending / overdue" display can't be driven off anything we hadn't re-read. The while-open grace poll
-    /// only covers the case where the Pro settings screen happens to be open.
+    /// This is the gap they exist to close. The proof is clamped to expire well short of the account horizon,
+    /// so the proof reconcile's wake is otherwise the *next* thing that goes to the network — and the renewal
+    /// lands somewhere in between. Without these, an account whose renewal was overdue showed a stale "active"
+    /// for that whole interval, and a "renewal pending / overdue" display cannot be driven off anything we
+    /// haven't re-read. The while-open grace poll only covers the case where the Pro screen happens to be open.
     ///
-    /// The slack added to `E` (see `StatusRefresh.userExpiryWakeSlackSeconds`) is for clock skew against the backend:
-    /// firing at exactly `E` would routinely re-read the same un-renewed period a moment before it rolls over.
+    /// The slack (see `StatusRefresh.userExpiryWakeSlackSeconds`) is for clock skew against the backend: firing
+    /// at exactly the instant would routinely re-read the same period a moment before it rolls over.
     ///
-    /// **Single, not repeating.** `lastUserExpiryWakeExpirySeconds` records the `E` already fired for, so a
-    /// refetch that leaves `E` unchanged is not retried from here — the ongoing chase belongs to the
-    /// while-open grace poll and the other triggers. A refetch that *does* advance `E` arms the next
-    /// period's wake for free, and since that `E` is in the future it cannot spin.
+    /// **Once per instant, not repeating.** `firedUserExpiryWakeInstants` records what has fired, so a refetch
+    /// that changes nothing is not retried from here — the ongoing chase belongs to the while-open grace poll
+    /// and the other triggers. A refetch that *does* move `E` yields new instants, and since those are in the
+    /// future they cannot spin.
     ///
-    /// The wake is advisory, like the proof one: iOS suspends the process, so a `Task.sleep` spanning `E`
-    /// will not fire on time. `willEnterForeground` re-enters here and the already-past branch below is what
-    /// catches up a crossing missed while suspended.
+    /// The wakes are advisory, like the proof one: iOS suspends the process, so a `Task.sleep` spanning either
+    /// instant will not fire on time. `willEnterForeground` re-enters here, and the past-due branch below is
+    /// what catches up a crossing missed while suspended.
     private func evaluateUserExpiryStatusWake() async {
-        userExpiryWakeTask?.cancel()
-        userExpiryWakeTask = nil
+        userExpiryWakeTasks.forEach { $0.cancel() }
+        userExpiryWakeTasks = []
 
         guard dependencies[singleton: .appContext].isMainApp else { return }
 
@@ -721,49 +741,87 @@ public actor SessionProManager: SessionProManagerType {
             ($0.proAccessExpiryTimestampSeconds, $0.proGracePeriodSeconds)
         }
 
-        /// Nothing known (never Pro, or cleared by a not-entitled proof outcome) — nothing to wake for. Reset the
-        /// marker so a later subscription landing on the *same* instant isn't swallowed.
+        /// Nothing known (never Pro, or cleared by a not-entitled proof outcome) — nothing to wake for. Forget
+        /// what we fired for, so a later subscription landing on the *same* instants isn't swallowed.
         guard expirySeconds > 0 else {
-            lastUserExpiryWakeExpirySeconds = 0
+            firedUserExpiryWakeInstants = []
             return
         }
 
-        /// Wake at the **paid-through** instant, not at `E`. `E` is the end of coverage, i.e. the grace *exit* —
-        /// firing there would ask after the window it exists to catch had already closed. `E - G` is when the
-        /// renewal actually falls due, which is the moment worth re-reading status.
         let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
-
+        let slackSeconds: UInt64 = SessionPro.StatusRefresh.userExpiryWakeSlackSeconds
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
-        let fireAtSeconds: UInt64 = (paidThroughSeconds + SessionPro.StatusRefresh.userExpiryWakeSlackSeconds)
 
-        guard nowSeconds < fireAtSeconds else {
-            /// The crossing is already behind us — either we were suspended across it, or this `E` arrived
-            /// already stale from another device. Catch up now, still only once per paid-through instant.
-            await fireUserExpiryStatusWake(forExpirySeconds: paidThroughSeconds)
+        /// **Two instants, and they answer different questions.**
+        ///
+        /// - `(E - G) + 30s` — the renewal has just fallen due: did the charge succeed or fail?
+        /// - `E + 30s` — coverage has just ended: did grace run out without a recovery?
+        ///
+        /// The second is armed **only when the two instants don't coincide**. That is the condition itself,
+        /// not a proxy for it: when they land on the same second there is one thing to ask, so there is one
+        /// wake. Deliberately *not* phrased as "when a grace period exists" — that invites replacing the
+        /// comparison with a `graceSeconds > 0` test, which is a different predicate that happens to agree
+        /// today. (It's the non-auto-renewing accounts that coincide, since the backend sends `G = 0` there.)
+        ///
+        /// The second is not redundant with the proof loop landing near `E`: that chain reaches a status
+        /// refresh only via the config-change trigger, which fires on `E` *changing*. A renewal that **failed**
+        /// leaves `E` untouched, so nothing would wake — which is exactly the case worth waking for.
+        ///
+        /// ⚠️ **If you are here because the second wake "didn't fire" on a QA backend, it probably did.** Both
+        /// emits below go through the *floored* fetch path, and the two instants are `G` apart — so whenever
+        /// `G < SessionPro.StatusRefresh.floorSeconds` (60s) the first fetch arms the floor and the second is
+        /// dropped. The wake was scheduled and did run; only its fetch was skipped, which is indistinguishable
+        /// from never having been scheduled unless you know to look.
+        ///
+        /// Production `G` is ~1 hour so it can't happen there; a compressed testing backend sets it to ~10
+        /// seconds. **Deliberately not worked around here** — the escape hatch is an env-var override of the
+        /// floor, owned by the Pro UI-test work. Don't make these emits `immediate` to "fix" it: that would give
+        /// two floor-exempt fetches on every renewal in production to serve a test-only configuration.
+        var instants: [UInt64] = [paidThroughSeconds + slackSeconds]
+
+        if paidThroughSeconds != expirySeconds {
+            instants.append(expirySeconds + slackSeconds)
+        }
+
+        /// Re-derive the fired set against the instants currently scheduled, so a moved `E` forgets the old
+        /// ones rather than accumulating them for the life of the process.
+        firedUserExpiryWakeInstants = firedUserExpiryWakeInstants.intersection(instants)
+
+        /// Anything already past — we were suspended across it, or the values arrived stale from another
+        /// device. Mark them all and take **one** refresh: they ask the same question of the same fetch, and
+        /// the trailing re-evaluation below re-arms whatever remains.
+        let pastDueInstants: [UInt64] = instants.filter { nowSeconds >= $0 && !firedUserExpiryWakeInstants.contains($0) }
+
+        guard pastDueInstants.isEmpty else {
+            pastDueInstants.forEach { firedUserExpiryWakeInstants.insert($0) }
+            try? await refreshProState()
             return
         }
 
-        userExpiryWakeTask = Task { [weak self] in
-            /// Integer `.seconds` overload — the `Double` one is iOS 16+.
-            do { try await Task.sleep(for: .seconds(Int(fireAtSeconds - nowSeconds))) }
-            catch { return }
+        for instant in instants where !firedUserExpiryWakeInstants.contains(instant) {
+            userExpiryWakeTasks.append(
+                Task { [weak self] in
+                    /// Integer `.seconds` overload — the `Double` one is iOS 16+.
+                    do { try await Task.sleep(for: .seconds(Int(instant - nowSeconds))) }
+                    catch { return }
 
-            await self?.fireUserExpiryStatusWake(forExpirySeconds: paidThroughSeconds)
+                    await self?.fireUserExpiryStatusWake(atInstantSeconds: instant)
+                }
+            )
         }
     }
 
-    /// Fire the wake for `expirySeconds`, at most once for that value.
+    /// Fire the wake for one instant, at most once for that instant.
     ///
-    /// **Note:** when this is reached from the already-past branch during a `refreshProState` that is still
-    /// in flight, the refresh below is a no-op (`isRefreshingState`) — which is the right outcome: the
-    /// in-flight fetch is itself the post-`E` read the wake wanted, so the wake is legitimately consumed.
-    private func fireUserExpiryStatusWake(forExpirySeconds expirySeconds: UInt64) async {
-        guard lastUserExpiryWakeExpirySeconds != expirySeconds else { return }
+    /// **Note:** when this is reached during a `refreshProState` that is still in flight, the refresh below is a
+    /// no-op (`isRefreshingState`) — which is the right outcome: the in-flight fetch is itself the read the wake
+    /// wanted, so the wake is legitimately consumed.
+    private func fireUserExpiryStatusWake(atInstantSeconds instantSeconds: UInt64) async {
+        guard !firedUserExpiryWakeInstants.contains(instantSeconds) else { return }
 
-        /// Marked BEFORE the fetch deliberately: a failing network must not turn a single wake into a
-        /// refetch on every trigger that re-enters here. Recovering from a failed fetch belongs to the other
-        /// triggers, not to this one.
-        lastUserExpiryWakeExpirySeconds = expirySeconds
+        /// Marked BEFORE the fetch deliberately: a failing network must not turn a one-shot wake into a refetch
+        /// on every trigger that re-enters here. Recovering from a failed fetch belongs to the other triggers.
+        firedUserExpiryWakeInstants.insert(instantSeconds)
 
         try? await refreshProState()
     }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -467,10 +467,19 @@ public actor SessionProManager: SessionProManagerType {
             accessExpiryTimestampSeconds: UInt64,
             refundRequestedTimestampSeconds: UInt64,
             prepaidTimestampSeconds: UInt64,
-            autoRenewing: Bool
+            autoRenewing: Bool,
+            gracePeriodSeconds: UInt64
         )
         let proInfo: ProInfo = dependencies.mutate(cache: .libSession) {
-            ($0.proConfig, $0.profile, $0.proAccessExpiryTimestampSeconds, $0.refundRequestedTimestampSeconds, $0.proPrepaidTimestampSeconds, $0.proAutoRenewing)
+            (
+                $0.proConfig,
+                $0.profile,
+                $0.proAccessExpiryTimestampSeconds,
+                $0.refundRequestedTimestampSeconds,
+                $0.proPrepaidTimestampSeconds,
+                $0.proAutoRenewing,
+                $0.proGracePeriodSeconds
+            )
         }
         
         let rotatingKeyPair: KeyPair? = try? proInfo.proConfig.map { config in
@@ -500,6 +509,7 @@ public actor SessionProManager: SessionProManagerType {
             profileFeatures: .set(to: proInfo.profile.proFeatures),
             autoRenewing: .set(to: proInfo.autoRenewing),
             accessExpiryTimestampSeconds: .set(to: proInfo.accessExpiryTimestampSeconds),
+            gracePeriodSeconds: .set(to: proInfo.gracePeriodSeconds),
             refundRequestedTimestampSeconds: .set(to: proInfo.refundRequestedTimestampSeconds),
             using: dependencies
         )
@@ -704,26 +714,32 @@ public actor SessionProManager: SessionProManagerType {
 
         guard dependencies[singleton: .appContext].isMainApp else { return }
 
-        /// Read `E` from config rather than from `state`: config is the authoritative cross-device value and
-        /// is what the startup gate and the proof reconcile both key off, so all three agree on one clock.
-        let expirySeconds: UInt64 = dependencies.mutate(cache: .libSession) {
-            $0.proAccessExpiryTimestampSeconds
+        /// Read from config rather than from `state`: config is the authoritative cross-device value and is what
+        /// the startup gate and the proof reconcile both key off, so all three agree on one clock. One mutation,
+        /// since `E` and `G` are only comparable as the pair that arrived together.
+        let (expirySeconds, graceSeconds): (UInt64, UInt64) = dependencies.mutate(cache: .libSession) {
+            ($0.proAccessExpiryTimestampSeconds, $0.proGracePeriodSeconds)
         }
 
-        /// No known paid-through end (never Pro, or cleared by a not-entitled proof outcome) — nothing to
-        /// wake for. Reset the marker so a later subscription starting on the *same* `E` isn't swallowed.
+        /// Nothing known (never Pro, or cleared by a not-entitled proof outcome) — nothing to wake for. Reset the
+        /// marker so a later subscription landing on the *same* instant isn't swallowed.
         guard expirySeconds > 0 else {
             lastUserExpiryWakeExpirySeconds = 0
             return
         }
 
+        /// Wake at the **paid-through** instant, not at `E`. `E` is the end of coverage, i.e. the grace *exit* —
+        /// firing there would ask after the window it exists to catch had already closed. `E - G` is when the
+        /// renewal actually falls due, which is the moment worth re-reading status.
+        let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
+
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
-        let fireAtSeconds: UInt64 = (expirySeconds + SessionPro.StatusRefresh.userExpiryWakeSlackSeconds)
+        let fireAtSeconds: UInt64 = (paidThroughSeconds + SessionPro.StatusRefresh.userExpiryWakeSlackSeconds)
 
         guard nowSeconds < fireAtSeconds else {
             /// The crossing is already behind us — either we were suspended across it, or this `E` arrived
-            /// already stale from another device. Catch up now, still only once per `E`.
-            await fireUserExpiryStatusWake(forExpirySeconds: expirySeconds)
+            /// already stale from another device. Catch up now, still only once per paid-through instant.
+            await fireUserExpiryStatusWake(forExpirySeconds: paidThroughSeconds)
             return
         }
 
@@ -732,7 +748,7 @@ public actor SessionProManager: SessionProManagerType {
             do { try await Task.sleep(for: .seconds(Int(fireAtSeconds - nowSeconds))) }
             catch { return }
 
-            await self?.fireUserExpiryStatusWake(forExpirySeconds: expirySeconds)
+            await self?.fireUserExpiryStatusWake(forExpirySeconds: paidThroughSeconds)
         }
     }
 
@@ -1018,27 +1034,40 @@ public actor SessionProManager: SessionProManagerType {
     /// startup fetch's only real consumer is the home CTAs, so it is gated on "could a CTA fire", computed from synced
     /// config, plus a persisted min-interval.
     ///
-    /// The expiry test is deliberately **not** `E + grace <= now`. Grace isn't reliably knowable before you're in it,
-    /// so it is never carried in config (libSession PR #121 adds `auto_renewing` and nothing else) — you fetch once
-    /// past `E` and learn grace from the response:
+    /// The test is against the **paid-through** instant, `E - G`, not against `E`. `E` is the end of *coverage*:
+    /// the backend folds the grace period into the stored expiry for auto-renewing subscriptions, so `now >= E`
+    /// is the grace *exit*, and gating on it would put the whole grace window in the no-fetch branch — the one
+    /// state this refresh design exists to surface. Both halves are synced (`E`, `G`), so the whole decision is
+    /// config-derivable with no branching on provider or renewal state (`G` is 0 when not auto-renewing):
     ///
     /// | config state | action |
     /// |---|---|
-    /// | `A && now < E`  | comfortably active → **no fetch** |
-    /// | `A && now >= E` | in/near grace, length unknowable → fetch, learn grace from the response |
-    /// | `!A && E` within the CTA window | expiring → fetch (the CTA is separately gated on the result) |
-    /// | `!A && now >= E`| expired (grace covers renewals in flight, and there is none) → confirm-fetch first, so a
-    ///                     renewal that landed elsewhere and hasn't synced can't produce a false "Pro expired" |
+    /// | `A && now < E - G`  | comfortably active, renewal not yet due → **no fetch** |
+    /// | `A && now >= E - G` | renewal due or overdue → fetch, so grace can be surfaced while it is happening |
+    /// | `!A && E - G` within the CTA window | expiring → fetch (the CTA is separately gated on the result) |
+    /// | `!A && now >= E - G`| expired — with `!A` there is no renewal in flight and `G` is 0, so this is also
+    ///                        `now >= E`. Confirm-fetch first, so a renewal that landed elsewhere and hasn't
+    ///                        synced can't produce a false "Pro expired" |
+    ///
+    /// Fetching once past the paid-through end is still bounded on the far side: past `E` the grace has run out,
+    /// and the persisted 24h interval below is what stops a lapsed account re-asking on every launch.
     ///
     /// **Not a Pro user at all** (no `E`, no proof) → never fetch. Note what that gives up: a purely server-side
     /// entitlement, e.g. a voucher, leaves no config trace, so this device won't discover it on its own. On iOS an
     /// Apple subscription still self-recovers through StoreKit (`Transaction.updates`), and everything else is what
     /// the manual recover action exists for.
     private func startupStatusFetchIsNeeded() async -> Bool {
-        /// One mutation for all three, so they can't be read either side of an incoming config merge.
-        let (autoRenewing, expirySeconds, hasProof): (Bool, UInt64, Bool) = dependencies.mutate(cache: .libSession) {
-            ($0.proAutoRenewing, $0.proAccessExpiryTimestampSeconds, $0.proConfig?.proProof != nil)
-        }
+        /// One mutation for all four, so they can't be read either side of an incoming config merge — `E` and `G`
+        /// especially, since they are only comparable as the pair that arrived together.
+        let (autoRenewing, expirySeconds, graceSeconds, hasProof): (Bool, UInt64, UInt64, Bool) = dependencies
+            .mutate(cache: .libSession) {
+                (
+                    $0.proAutoRenewing,
+                    $0.proAccessExpiryTimestampSeconds,
+                    $0.proGracePeriodSeconds,
+                    $0.proConfig?.proProof != nil
+                )
+            }
 
         /// Never subscribed as far as this device can tell — the case the gate exists to stop fetching for.
         guard expirySeconds > 0 || hasProof else { return false }
@@ -1050,6 +1079,7 @@ public actor SessionProManager: SessionProManagerType {
         guard await startupStatusFetchIsCTAWorthy(
             autoRenewing: autoRenewing,
             expirySeconds: expirySeconds,
+            graceSeconds: graceSeconds,
             nowSeconds: nowSeconds
         ) else { return false }
 
@@ -1073,41 +1103,50 @@ public actor SessionProManager: SessionProManagerType {
         return true
     }
 
-    /// The CTA-worthiness half of the startup gate — the four rows of the table above.
+    /// The CTA-worthiness half of the startup gate — the four rows of the table above, measured against the
+    /// **paid-through** instant `E - G` rather than against `E`.
     ///
-    /// 🔴 **One case is deliberately left unresolved here**: `!A && now < E` with `E` beyond the CTA window, which is
-    /// where **every existing subscriber lands on their first launch after this ships** (`E` set and far future, `A`
-    /// not yet written by anyone). Because libSession stores `A` presence-only, `get_pro_auto_renewing()` returning
-    /// false conflates *not auto-renewing*, *never fetched*, and *written by a client predating the field* — and the C
-    /// API returns an `int`, so absent and false are not even distinguishable to us.
+    /// 🔴 **One case remains held**: `!A && now < E - G` with the paid-through end beyond the CTA window, which
+    /// returns false (no fetch). `A` is stored presence-only — libsession's setter *erases* the key on false — so
+    /// the key is present iff its value is 1, and "not auto-renewing" and "never written" are the same stored
+    /// state. That is a property of the **encoding**, not of the accessor: a companion "has it been written"
+    /// predicate cannot recover the distinction, which is why one that was built for this was withdrawn.
     ///
-    /// The design's own pitfall list says to trust the config value and specifically *not* to "fetch regardless of
-    /// `auto_renewing`", which is why this returns false. But the design elsewhere leans on a once-a-day re-check to
-    /// let a stale flag self-correct, and under this reading a comfortably-active subscriber never startup-fetches, so
-    /// nothing writes `A` from that path. That contradiction is with the architect; do not resolve it locally.
+    /// What would settle it is making absent-`A` genuinely mean not-renewing, and there is exactly **one** thing
+    /// standing in the way. `A` has a single writer in this client — the `get_pro_status` success path — and the
+    /// proof-success path writes `E` **without** `A` (see `applyProofSuccess`), so an account renewed via a proof
+    /// outcome can hold a future `E` with no `A`. The backend now sends `account_auto_renewing` on the proof
+    /// response for exactly this, but libsession's proof parser does not yet surface it, and this client has no
+    /// other access to that wire. Until it does, absent-`A` is genuinely ambiguous and the row stays held.
     ///
-    /// It is less load-bearing here than on the other clients: on-enter, the `user_expiry` wake, config change,
-    /// `Transaction.updates` and manual recover all write `A` too, so iOS populates it through ordinary use rather
-    /// than depending on the startup path. If the ruling needs a genuine "have we ever fetched" signal, that has to be
-    /// **local** persisted state — it cannot come from config.
+    /// Do not resolve this locally: the same row exists on the other clients and must move with them.
     private func startupStatusFetchIsCTAWorthy(
         autoRenewing: Bool,
         expirySeconds: UInt64,
+        graceSeconds: UInt64,
         nowSeconds: UInt64
     ) async -> Bool {
-        /// Past the paid-through end. Fetch whether or not we think it renews: renewing means we're in grace and need
-        /// the length, not renewing means we need to confirm before claiming expired.
+        /// The date the renewal falls due. `E` overshoots it by exactly one grace period for an auto-renewing
+        /// subscription, and by nothing at all otherwise (the backend sends `grace = 0` when `!A`).
+        let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
+
+        /// Past the end of coverage. Fetch to confirm before claiming expired — a renewal may have landed
+        /// elsewhere and not synced yet — but only while an Expired CTA could still fire.
         guard nowSeconds < expirySeconds else {
-            /// Long past `E` and outside the Expired CTA window there is no CTA left to fire, so nothing to confirm.
             return ((nowSeconds - expirySeconds) <= SessionPro.StatusRefresh.expiredCTAWindowSeconds)
         }
 
-        /// Comfortably active and renewing itself — the other case the gate exists to stop fetching for. The
+        /// Renewal due or overdue, still covered: the grace window. **Always fetch** — this is the state the whole
+        /// refresh design exists to surface, and gating it on `E` instead is what used to swallow it entirely.
+        /// Empty when `!A`, since `G` is 0 there and this collapses to the branch above.
+        guard nowSeconds < paidThroughSeconds else { return true }
+
+        /// Comfortably active and renewing itself — the case the gate exists to stop fetching for. The
         /// `user_expiry` wake covers the crossing; the config-change trigger covers another device.
         guard !autoRenewing else { return false }
 
-        /// Non-renewing and inside the CTA window — the Expiring CTA may be due.
-        return ((expirySeconds - nowSeconds) <= SessionPro.StatusRefresh.expiringCTAWindowSeconds)
+        /// Not renewing and inside the CTA window — the Expiring CTA may be due.
+        return ((paidThroughSeconds - nowSeconds) <= SessionPro.StatusRefresh.expiringCTAWindowSeconds)
     }
 
     /// The drop-on-fresh status floor: whether enough time has passed since the last `get_pro_status` for a *routine*
@@ -1245,6 +1284,7 @@ public actor SessionProManager: SessionProManagerType {
                 status: .set(to: response.status),
                 autoRenewing: .set(to: response.autoRenewing),
                 accessExpiryTimestampSeconds: .set(to: response.expiryTimestampSeconds),
+                gracePeriodSeconds: .set(to: response.gracePeriodDurationSeconds),
                 latestPaymentItem: .set(to: response.latestPaymentItem),
                 using: dependencies
             )
@@ -1279,6 +1319,7 @@ public actor SessionProManager: SessionProManagerType {
                     try cache.performAndPushChange(db, for: .userProfile) { _ in
                         cache.updateProAccessExpiryTimestampSeconds(response.expiryTimestampSeconds)
                         cache.updateProAutoRenewing(response.autoRenewing)
+                        cache.updateProGracePeriodSeconds(response.gracePeriodDurationSeconds)
                     }
                 }
             }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1009,10 +1009,10 @@ public actor SessionProManager: SessionProManagerType {
                     /// Keep `G` and `A` coherent with the `E` just written: a grace period paired with the previous expiry makes
                     /// `E + G` meaningless.
                     ///
-                    /// `accountRenewalInfo` is `nil` unless this response carried a proof, which is the protection — on any other
-                    /// outcome libsession leaves these at zero defaults, indistinguishable from "no grace, not renewing", and the
-                    /// config keys are presence-only so writing that `false` erases what `get_pro_status` learned. The protection is
-                    /// the placement: reaching this line already implies success.
+                    /// `accountRenewalInfo` is `nil` unless the outcome was success, which is the protection: on a transport
+                    /// or protocol failure these are `0`/`false` parsed from nothing, and the config keys are presence-only, so
+                    /// writing that `false` erases what `get_pro_status` learned. The protection is the placement — reaching this
+                    /// line already implies success. A parsed `0`/`false` is a real answer and writing it is correct.
                     if let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo = response.accountRenewalInfo {
                         cache.updateProGracePeriodSeconds(renewalInfo.gracePeriodSeconds)
                         cache.updateProAutoRenewing(renewalInfo.autoRenewing)

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -449,16 +449,48 @@ public actor SessionProManager: SessionProManagerType {
         /// (foreground reconcile) re-triggers the CTA if the subscription genuinely lapsed.
         guard state.loadingState == .success else { return nil }
         let dateNow: Date = dependencies.dateNow
+
+        /// Time remaining until the renewal falls due — positive before `E`, negative after it.
         let expiryInSeconds: TimeInterval = (state.accessExpiryTimestampSeconds
             .map { Date(timeIntervalSince1970: Double($0)).timeIntervalSince(dateNow) } ?? 0)
+
+        /// Time elapsed since **coverage** ended — negative while still covered, positive once lapsed.
+        ///
+        /// 🔴 **Signed, and `TimeInterval` rather than `UInt64` subtraction, deliberately.** `E + G` can sit in the
+        /// future relative to `now` here — clock skew, or a config that arrived from another device — and an unsigned
+        /// `now - (E + G)` underflows to an enormous positive number, which would silently satisfy any upper bound
+        /// placed on it. The sign is the whole point of the value, so the type has to carry it.
+        ///
+        /// `nil` when no coverage end is known: an account can report `.expired` with no expiry at all once the
+        /// backend has pruned its history, and "how long since it lapsed" then has no answer rather than the answer
+        /// zero.
+        ///
+        /// 🔴 **Off `state`, and it must stay that way — `E` and `G` are only meaningful as the pair that arrived
+        /// together.** Every writer sets them in one mutation, so any `E` here is accompanied by the `G` from the
+        /// same response. Config cannot promise that: not every status branch writes `G` there, so a config read
+        /// would pair this response's expiry with a grace period from a different moment, or with none — and the
+        /// window would silently collapse back onto `E` in exactly the lapsed case this measures.
+        let secondsSinceCoverageEnd: TimeInterval? = state.coverageEndTimestampSeconds
+            .flatMap { coverageEnd in
+                guard coverageEnd > 0 else { return nil }
+
+                return dateNow.timeIntervalSince(Date(timeIntervalSince1970: Double(coverageEnd)))
+            }
         let variant: ProCTAModal.Variant
         
         switch (state.status, state.autoRenewing, state.refundingStatus) {
             // Fail closed: an unrecognised backend status behaves like `.never` (no CTA, no Pro).
             case (.never, _, _), (.unknown, _, _), (.active, _, .refunding), (.active, true, .notRefunding): return nil
             case (.active, false, .notRefunding):
+                /// Anchored at `E`, which is correct for this one: "your payment is due soon" is a statement about
+                /// the payment date, not about how long we keep serving.
+                ///
+                /// The bound is one-sided, so it also admits a negative `expiryInSeconds` — an `.active` account
+                /// already past `E`. That is unreachable, but by an invariant **elsewhere** rather than by anything
+                /// on this line: `G` is 0 whenever the subscription isn't auto-renewing, so `.active` with `!A` past
+                /// `E` would mean the backend still serving beyond `E + 0`.
                 guard
-                    expiryInSeconds <= 7 * 24 * 60 * 60 &&
+                    expiryInSeconds <= TimeInterval(SessionPro.StatusRefresh.expiringCTAWindowSeconds),
                     !dependencies[defaults: .standard, key: .hasShownProExpiringCTA]
                 else { return nil }
                 
@@ -470,8 +502,18 @@ public actor SessionProManager: SessionProManagerType {
                 )
                 
             case (.expired, _, _):
+                /// Anchored at coverage end, `E + G`: the backend reports `Expired` only once it has stopped serving,
+                /// so measuring the window from `E` shortens it by exactly `G` — to nothing at all where the store's
+                /// grace reaches the window length. It also puts this deadline on the same instant as the startup
+                /// gate's own bound, so the gate and the CTA agree about when an account is too stale to chase.
+                ///
+                /// Both ends are required: without the lower bound the window is open-ended into the past, and the
+                /// only thing left limiting the CTA is the shown-once flag, so an account that lapsed years ago
+                /// still gets it the first time it is seen.
                 guard
-                    expiryInSeconds <= 30 * 24 * 60 * 60 &&
+                    let secondsSinceCoverageEnd: TimeInterval = secondsSinceCoverageEnd,
+                    secondsSinceCoverageEnd >= 0,
+                    secondsSinceCoverageEnd < TimeInterval(SessionPro.StatusRefresh.expiredCTAWindowSeconds),
                     !dependencies[defaults: .standard, key: .hasShownProExpiredCTA]
                 else { return nil }
                 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -26,9 +26,9 @@ public enum SessionPro {
 
     /// The `get_pro_status` refresh timings.
     ///
-    /// **These are a deliberate cross-client contract, not iOS tuning knobs** — Android and desktop carry the same
-    /// values under their own names, and the whole point of unifying the refresh design was that nobody tunes one
-    /// platform in isolation. Change them together or not at all.
+    /// 🔴 **A cross-client contract, not iOS tuning knobs.** Every client's refresh design is specified against
+    /// these same values, so changing one here in isolation silently desynchronises the platforms' backend load and
+    /// their user-visible timing. They move by agreement across clients or not at all.
     public enum StatusRefresh {
         /// Minimum gap between routine `get_pro_status` fetches. **Drop-on-fresh, never re-arm:** a re-arming floor
         /// turns every routine trigger into a self-sustaining once-a-minute poll, which during grace (when `E` is
@@ -127,10 +127,11 @@ public actor SessionProManager: SessionProManagerType {
     /// Config-change detection state for the status trigger, tracked here rather than read back out of
     /// `SessionPro.State`.
     ///
-    /// 🔴 **These must not be display state.** `E` used to be diffed as two `SessionPro.State` snapshots, which tied
-    /// "did config change" to "what does the UI currently show" — so anything that made the displayed expiry
-    /// response-sourced rather than config-sourced would silently stop the config trigger firing at all, taking the
-    /// remote-merge path with it. Nothing about the display can reach this now.
+    /// 🔴 **These must not be display state.** Diffing `SessionPro.State` here would tie "did config change" to
+    /// "what does the UI show" — and the display is owned by whichever response last spoke, so the trigger would
+    /// stop firing for any account whose displayed expiry came from a response rather than from config, taking the
+    /// remote-merge path with it. The dependency is invisible at the diff site, which is why these are held
+    /// separately.
     ///
     /// `hasProjectedUserConfig` distinguishes the first projection of a process (not a change) from a genuine one.
     private var lastKnownAccessExpirySeconds: UInt64 = 0
@@ -676,8 +677,7 @@ public actor SessionProManager: SessionProManagerType {
     /// then apply a 5s gap before the next — never a new request while one is in flight. The sequential
     /// `await` gives this for free. The 2-min window is measured from the first request; a request already
     /// in flight when it elapses finishes, we just don't start new ones. (The per-request onion timeout is
-    /// the "never settles" backstop — a single `refreshProState` can't hang indefinitely.) Matches
-    /// Android's 2-min window / 5s-gap-after-settle pacing.
+    /// the "never settles" backstop — a single `refreshProState` can't hang indefinitely.)
     ///
     /// Note we route through `get_pro_status`, not a direct proof-gen: each refresh's `E` write feeds the
     /// trailing `reconcileProofRenewal`, so a fresh proof IS fetched *if and when* `pro_renewal_target`
@@ -691,14 +691,13 @@ public actor SessionProManager: SessionProManagerType {
 
             /// The baseline "a new period landed" is measured against.
             ///
-            /// 🔴 **Optional, and deliberately not `?? 0`.** Display state carries no account expiry until a
-            /// response has supplied one, and this poll starts before either the proof response or the first
-            /// `get_pro_status` has landed (the proof generation is an unawaited task, so `purchasePro` returns
-            /// ahead of it). Reading "we don't know yet" as `0` makes the first response look like an advance from
-            /// nothing — including when it is carrying the *pre-purchase* expiry because the payment hasn't
-            /// registered yet — which ends the poll on its first attempt at exactly the moment it exists to keep
-            /// chasing. With no baseline, the first response supplies one instead of being compared against a
-            /// value we never had.
+            /// 🔴 **"No baseline yet" must stay distinguishable from "expires at 0" — hence the optional.** This
+            /// poll starts before any response has landed (the proof generation is an unawaited task, so
+            /// `purchasePro` returns ahead of it), so display state may carry no account expiry at all. Collapsing
+            /// that to `0` makes the first response look like an advance from nothing — including when it carries
+            /// the *pre-purchase* expiry because the payment hasn't registered yet — ending the poll on its first
+            /// attempt, at exactly the moment it exists to keep chasing. With no baseline the first response
+            /// supplies one instead.
             var expiryBefore: UInt64? = await self.stateStream.getCurrent().accessExpiryTimestampSeconds
             let startSeconds: Int64 = Int64(await self.dependencies.networkOffsetTimestampMs() / 1000)
             let windowSeconds: Int64 = SessionPro.StatusRefresh.postPurchasePollWindowSeconds
@@ -938,8 +937,9 @@ public actor SessionProManager: SessionProManagerType {
 
     /// The proof-acquisition spacing for the current pass — flat while covered, linear-with-cap while dark.
     ///
-    /// Read twice per pass (once to decide whether to fire, once to arm the next wake), which is exactly why it is a
-    /// function: the two must not be able to drift apart, and as duplicated literals they previously could.
+    /// 🔴 Read twice per pass — once to decide whether to fire, once to arm the next wake — and the two **must**
+    /// agree, or the loop arms a wake for an interval it didn't honour. That is why this is a function rather than
+    /// the literals inlined at both sites.
     private func proofAcquisitionInterval(haveValidProof: Bool) -> TimeInterval {
         guard !haveValidProof else { return SessionPro.ProofAcquisition.coveredIntervalSeconds }
 
@@ -1097,13 +1097,11 @@ public actor SessionProManager: SessionProManagerType {
         /// Write the account triple straight to display state: a proof response is a response, and display state is
         /// owned by whichever response last spoke.
         ///
-        /// 🔴 **Before the re-projection below, not after, and the ordering IS load-bearing.** Not because the
-        /// projection would clobber it — it no longer writes these three — but because
-        /// `updateWithLatestFromUserConfig` sees the config `E` just written, and its change trigger *awaits* a
-        /// `get_pro_status`. That response is strictly newer than this one, so it has to be the one that survives.
-        /// Writing afterwards would let this proof's `account_expiry` overwrite a status response that had already
-        /// landed — the same "whichever ran last wins" bug this design removes, just between two responses instead
-        /// of between config and a response.
+        /// 🔴 **Must precede the re-projection below — this is an ordering requirement, not tidiness.**
+        /// `updateWithLatestFromUserConfig` sees the config `E` written just above, so its change trigger fires and
+        /// *awaits* a `get_pro_status`. That response is strictly newer than this one, so it has to be the survivor;
+        /// writing after the re-projection would let this proof's `account_expiry` overwrite a status response that
+        /// had already landed.
         ///
         /// **The same two conditions as the config writes above, for the same reasons.** A response that carried no
         /// account expiry must not be read as "expires at 0", and on any non-success outcome libsession leaves the
@@ -1140,10 +1138,10 @@ public actor SessionProManager: SessionProManagerType {
         /// Whether the clear actually applied — the downgrade guard decides, and the display write at the end
         /// needs the answer.
         ///
-        /// The guard's read stays inside `mutate(cache:)`, which is the lock; `performAndPushChange` adds no
-        /// further synchronisation of its own, so hoisting the read just outside it keeps the read and the write
-        /// atomic with respect to an incoming merge exactly as before. A vetoed clear now also skips
-        /// `performAndPushChange` entirely instead of entering it to make no change.
+        /// 🔴 **The guard's read must stay inside `mutate(cache:)`** — that closure is the lock, so the read and
+        /// the write it authorises are atomic against an incoming config merge. `performAndPushChange` adds no
+        /// synchronisation of its own, so the read is equally safe just outside it; moving it out of the `mutate`
+        /// would let a merge land between deciding and clearing.
         let didClear: Bool = ((try? await dependencies[singleton: .storage].write { [dependencies] db -> Bool in
             try dependencies.mutate(cache: .libSession) { cache -> Bool in
                 /// Downgrade guard (read live config): never wipe a fresh, unexpired proof another device
@@ -1157,11 +1155,14 @@ public actor SessionProManager: SessionProManagerType {
                     /// `I`/`R`), so a stale future `E` left here would make `pro_renewal_target` fire on every
                     /// eval and spin — clear it explicitly (`set_pro_access_expiry(nullopt)`, via `0`).
                     ///
-                    /// **That also clears `G` and `A`**, inside libsession: both describe the subscription `E`
-                    /// denotes, so a stranded grace period would pair with whatever `E` is written next, and a
-                    /// stranded renewing flag would describe a subscription that no longer exists. Don't add
-                    /// explicit clears for them here — the cascade is deliberate, and duplicating it would
-                    /// invite someone to "tidy" the version that isn't load-bearing.
+                    /// 🔴 **This path must leave no `G` or `A` stranded beside the cleared `E`.** They describe the
+                    /// subscription `E` denotes, so a surviving grace period pairs with whatever `E` is written next
+                    /// — silently changing where coverage ends — and a surviving renewing flag describes a
+                    /// subscription that no longer exists, which the startup gate then reads as "still renewing".
+                    ///
+                    /// Clearing `E` is expected to take both with it, so no explicit clears appear here. If you are
+                    /// reading this because they *are* being left behind, the obligation above is what has to hold —
+                    /// add the clears here rather than treating it as cosmetic.
                     cache.removeProConfig()
                     cache.updateProAccessExpiryTimestampSeconds(0)
                 }
@@ -1216,9 +1217,8 @@ public actor SessionProManager: SessionProManagerType {
     /// Clear the account triple in **display** state.
     ///
     /// A cleared proof outcome is a response speaking too, and what it says is "you have nothing" — so it owns these
-    /// three exactly as a success does. Config's version of this is a cascade inside libsession (clearing `E` clears
-    /// `G` and `A` with it, since both describe the subscription `E` denotes); display state has no such cascade, so
-    /// it is spelled out here.
+    /// three exactly as a success does. All three are cleared together because they describe one subscription: a
+    /// surviving grace period or renewing flag beside an absent expiry describes something that no longer exists.
     ///
     /// `status`, the proof and `profileFeatures` are not touched — `updateWithLatestFromUserConfig` re-derives those
     /// from the now-cleared config, and it still projects them.
@@ -1242,11 +1242,11 @@ public actor SessionProManager: SessionProManagerType {
     
     /// Whether a cold launch needs to go to the network for `get_pro_status`.
     ///
-    /// Every client used to fetch unconditionally on startup — non-Pro users included — and a cold start is something
-    /// mobile triggers constantly, so that was the bulk of the backend load for no benefit: entitlement comes from the
-    /// proof, the settings screen refreshes on open, and account-expiry awareness is the `user_expiry` wake's job. The
-    /// startup fetch's only real consumer is the home CTAs, so it is gated on "could a CTA fire", computed from synced
-    /// config, plus a persisted min-interval.
+    /// Gated rather than unconditional because a cold start is something mobile triggers constantly, and an
+    /// unconditional fetch here is backend load for no benefit: entitlement comes from the proof, the settings screen
+    /// refreshes on open, and account-expiry awareness is the `user_expiry` wake's job. The startup fetch's only real
+    /// consumer is the home CTAs, so the gate is "could a CTA fire", computed from synced config, plus a persisted
+    /// min-interval.
     ///
     /// The test is against `E`, the date the renewal falls due — **not** against the end of coverage, `E + G`.
     /// Gating on `E + G` would put the whole grace window in the no-fetch branch, which is the one state this
@@ -1335,18 +1335,19 @@ public actor SessionProManager: SessionProManagerType {
     /// The CTA-worthiness half of the startup gate — the four rows of the table above, measured against `E` (the
     /// renewal date) rather than against the end of coverage `E + G`.
     ///
-    /// The `!A && now < E` row outside the CTA window returns false (no fetch), and that is now **correct rather
-    /// than merely assumed** — worth recording why, because it was held for a long time.
+    /// The `!A && now < E` row outside the CTA window returns false (no fetch), which is sound only because of the
+    /// encoding property below.
     ///
     /// `A` is stored presence-only: libsession's setter *erases* the key on false, so the key is present iff its
     /// value is 1, and "not auto-renewing" and "never written" are the same stored state. That is a property of
-    /// the **encoding**, not of the accessor — a companion "has it ever been written" predicate cannot recover
-    /// the distinction, which is why one built for exactly that was withdrawn as vacuous.
+    /// the **encoding**, not of the accessor: no "has it ever been written" companion predicate can recover the
+    /// distinction, because storage does not hold it.
     ///
-    /// So the row is only sound if absent-`A` genuinely means not-renewing, and the one path that could break
-    /// that was the proof outcome: it writes `E`, and used to leave `A` alone, so an account renewed via a proof
-    /// could hold a future `E` with no `A`. `applyProofSuccess` now writes `A` (and `G`) from the proof response
-    /// whenever the backend supplies them, which closes it. Absent-`A` on a live account means not renewing.
+    /// So the row is sound only while absent-`A` genuinely means not-renewing, and that is an invariant the
+    /// **write** side has to maintain: 🔴 **every path that writes `E` must write `A` alongside it.** A path that
+    /// advanced the expiry while leaving `A` untouched would leave a live, renewing account holding a future `E`
+    /// with no `A`, and this row would then decide "not renewing" about a subscription that is. Both writers
+    /// (`get_pro_status` success and `applyProofSuccess`) do so.
     private func startupStatusFetchIsCTAWorthy(
         autoRenewing: Bool,
         expirySeconds: UInt64,
@@ -1392,8 +1393,7 @@ public actor SessionProManager: SessionProManagerType {
     /// - **The first attempt of a process is never floored.** The persisted timestamp is what stops repeated cold
     ///   starts from hammering the backend, but it must not leave a *fresh* process unable to fetch at all:
     ///   `loadingState` would sit on its initial `.loading` with nothing to resolve it, which on this client means a
-    ///   permanent spinner on the Pro screen and no CTA, since both gate on a confirmed fetch. Android gets this free
-    ///   because its floor only applies once the load state leaves `Init`; this flag is the same condition. Note it is
+    ///   permanent spinner on the Pro screen and no CTA, since both gate on a confirmed fetch. Note it is
     ///   keyed on having *attempted*, not succeeded — after a failure the state is `.error`, which the UI renders as a
     ///   retry (itself `immediate`), so the spinner problem is gone and there is no reason to keep bypassing.
     ///   Cold-start load stays bounded by the startup gate's own 24h interval, not by this floor.
@@ -1439,13 +1439,12 @@ public actor SessionProManager: SessionProManagerType {
         /// Drop (don't re-arm) when the last fetch is still fresh. Deliberately before the loading-state change below,
         /// so a dropped refresh leaves the displayed state exactly as it was rather than parking it on a spinner.
         ///
-        /// **Still reconcile the proof on the way out.** Every call to this function used to end in a
-        /// `reconcileProofRenewal()`, and callers rely on that: when the proof loop is dormant
-        /// (`pro_renewal_target == 0`) it has no wake of its own, so a nudge it would otherwise have received is not
-        /// merely delayed, it is *lost*. Adding the floor must not silently remove that edge — most obviously for the
-        /// case where the preceding fetch **failed**, which arms the floor (we stamp on attempt) without ever having
-        /// reached its own reconcile. The reconcile is local and separately floored, so paying it on a dropped status
-        /// refresh costs nothing.
+        /// 🔴 **A dropped refresh must still reconcile the proof.** Callers rely on every call to this function
+        /// reaching `reconcileProofRenewal()`: when the proof loop is dormant (`pro_renewal_target == 0`) it has no
+        /// wake of its own, so a nudge it would otherwise have received is not merely delayed, it is *lost*. The case
+        /// that makes this concrete is a preceding fetch that **failed** — the floor is armed on attempt, so it can
+        /// drop this call without the previous one ever having reached its own reconcile. The reconcile is local and
+        /// separately floored, so paying it here costs nothing.
         guard await statusFloorPermitsFetch(immediate: immediate) else {
             await reconcileProofRenewal()
             return
@@ -2144,8 +2143,8 @@ public protocol SessionProManagerType: SessionProUIManagerType {
     ///   manual refresh/recover the user is waiting on, and the bounded post-purchase poll — plus the bounded
     ///   while-open grace poll and developer-only paths, which the design lists as floor-exempt for the same reason
     ///   (they carry their own cadence and their own termination). Routine triggers (startup, config change, on-enter,
-    ///   the `user_expiry` wake) must **not** pass it; a routine caller bypassing the floor is how the equivalent flag
-    ///   on Android ended up dead in the first place.
+    ///   the `user_expiry` wake) must **not** pass it: once routine triggers bypass the floor, the floor stops
+    ///   bounding anything and the parameter becomes decoration.
     ///   - forceLoadingState: Show the spinner even when the current state isn't an error. **Orthogonal to
     ///   `immediate`** — spinner UI is a separate concern from bypassing the floor, and conflating them is what the
     ///   rename to `immediate` exists to prevent.

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -748,10 +748,12 @@ public actor SessionProManager: SessionProManagerType {
             return
         }
 
-        /// `min` is the underflow guard (see `startupStatusFetchIsCTAWorthy` for why `max(0, …)` would be
-        /// wrong on `UInt64`). Clamping to `0` degrades this to a single wake at `E`, which is correct: with
-        /// no meaningful paid-through instant there is only one thing left to ask about.
-        let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
+        /// Clamped, not trapping — see `startupStatusFetchIsCTAWorthy`. The degenerate branch yields `E`, so
+        /// the two instants coincide and this schedules a single wake, which is the right answer when there
+        /// is no meaningful paid-through instant to ask about separately.
+        let paidThroughSeconds: UInt64 = (
+            graceSeconds < expirySeconds ? expirySeconds - graceSeconds : expirySeconds
+        )
         let slackSeconds: UInt64 = SessionPro.StatusRefresh.userExpiryWakeSlackSeconds
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
 
@@ -1037,8 +1039,12 @@ public actor SessionProManager: SessionProManagerType {
                     /// is the whole protection: on any other outcome libsession leaves these as the C struct's
                     /// zero-initialised defaults, which are indistinguishable from "no grace, not renewing" —
                     /// and writing that `false` would *erase* a flag `get_pro_status` had learned, because the
-                    /// config keys are presence-only. Reaching this line already implies success, so the bind
-                    /// is belt-and-braces; keep it anyway, since nothing else here would catch the mistake.
+                    /// config keys are presence-only.
+                    ///
+                    /// 🔴 **The protection is the PLACEMENT, not the parse and not the type — do not hoist
+                    /// these writes out of the success branch.** Reaching this line already implies success,
+                    /// so the bind looks redundant here; it is what would fail loudly if the call ever moved,
+                    /// and nothing else in this file would catch that.
                     if let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo = response.accountRenewalInfo {
                         cache.updateProGracePeriodSeconds(renewalInfo.gracePeriodSeconds)
                         cache.updateProAutoRenewing(renewalInfo.autoRenewing)
@@ -1070,6 +1076,12 @@ public actor SessionProManager: SessionProManagerType {
                     /// `remove_pro_config` clears ONLY the proof `s`. `E` does NOT self-age (unlike the proof
                     /// `I`/`R`), so a stale future `E` left here would make `pro_renewal_target` fire on every
                     /// eval and spin — clear it explicitly (`set_pro_access_expiry(nullopt)`, via `0`).
+                    ///
+                    /// **That also clears `G` and `A`**, inside libsession: both describe the subscription `E`
+                    /// denotes, so a stranded grace period would pair with whatever `E` is written next, and a
+                    /// stranded renewing flag would describe a subscription that no longer exists. Don't add
+                    /// explicit clears for them here — the cascade is deliberate, and duplicating it would
+                    /// invite someone to "tidy" the version that isn't load-bearing.
                     cache.removeProConfig()
                     cache.updateProAccessExpiryTimestampSeconds(0)
                 }
@@ -1204,13 +1216,14 @@ public actor SessionProManager: SessionProManagerType {
         /// The date the renewal falls due. `E` overshoots it by exactly one grace period for an auto-renewing
         /// subscription, and by nothing at all otherwise (the backend sends `grace = 0` when `!A`).
         ///
-        /// **The `min` is an underflow guard, not defensive noise — do not "simplify" it.** Both operands are
-        /// `UInt64`, so `expirySeconds - graceSeconds` *traps* if grace ever exceeds expiry, and the
-        /// signed-arithmetic instinct `max(0, graceSeconds)` is a no-op on an unsigned type. It clamps to `0`,
-        /// which is a handled degenerate case here: `0 < nowSeconds` for any real clock, so the gate falls
-        /// through to "fetch" — fail-safe. It only arises if `E` is unset or garbage, since a real `E` is a
-        /// ~1.7-billion-second timestamp and no grace period approaches that.
-        let paidThroughSeconds: UInt64 = (expirySeconds - min(expirySeconds, graceSeconds))
+        /// Clamp rather than trap: these are `UInt64` and both arrive from **synced config**, so a corrupt
+        /// value is reachable from another device rather than only from local logic — and an unsigned
+        /// underflow there would crash on every launch, which is a worse failure than any wrong date. The
+        /// degenerate branch treats "grace at least as large as the expiry" as *no grace*, since `G` is a
+        /// duration and `E` a ~1.7-billion-second timestamp, so it cannot arise from real data.
+        let paidThroughSeconds: UInt64 = (
+            graceSeconds < expirySeconds ? expirySeconds - graceSeconds : expirySeconds
+        )
 
         /// Past the end of coverage. Fetch to confirm before claiming expired — a renewal may have landed
         /// elsewhere and not synced yet — but only while an Expired CTA could still fire.

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -24,20 +24,10 @@ public enum SessionPro {
     public static var ProCharacterLimit: Int { Int(SESSION_PROTOCOL_PRO_HIGHER_CHARACTER_LIMIT) }
     public static var PinnedConversationLimit: Int { Int(SESSION_PROTOCOL_STANDARD_PINNED_CONVERSATION_LIMIT) }
 
-    /// The instant coverage ends: `E + G`.
+    /// The instant coverage ends: `E + G`. `G` is `0` when not auto-renewing, collapsing this to `E`.
     ///
-    /// `E` is when the account expires — the date shown to the user — and `G` is how much longer the backend keeps
-    /// serving past it, so this is the instant it stops. `G` is `0` whenever the subscription isn't auto-renewing,
-    /// which collapses this to `E` and is why no caller branches on the provider or the renewal state.
-    ///
-    /// 🔴 **Saturating rather than trapping, and the direction is deliberate.** Both operands arrive from **synced
-    /// config**, so a corrupt value is reachable from another device rather than only from local logic, and `+` on
-    /// `UInt64` traps — which here would mean crashing on every launch. Saturating to `.max` is safe because
-    /// entitlement comes from the signed proof: a wrong value can mislead the displayed date and the fetch schedule,
-    /// but it cannot grant Pro.
-    ///
-    /// **Read `G` as the pair that arrived with this `E`.** They describe one subscription, and not every writer of
-    /// `E` reaches config, so combining values from two moments silently moves where coverage ends.
+    /// Saturates rather than traps: the operands come from synced config, so a corrupt value is reachable from
+    /// another device and `+` on `UInt64` would crash at launch. Safe because entitlement comes from the proof.
     static func coverageEndSeconds(expirySeconds: UInt64, gracePeriodSeconds: UInt64) -> UInt64 {
         let (sum, overflowed) = expirySeconds.addingReportingOverflow(gracePeriodSeconds)
 
@@ -46,32 +36,17 @@ public enum SessionPro {
 
     /// The `get_pro_status` refresh timings.
     ///
-    /// 🔴 **A cross-client contract, not iOS tuning knobs.** Every client's refresh design is specified against
-    /// these same values, so changing one here in isolation silently desynchronises the platforms' backend load and
-    /// their user-visible timing. They move by agreement across clients or not at all.
+    /// A cross-client contract, not iOS tuning knobs: every client's refresh design is specified against these
+    /// same values, so they move by agreement across clients or not at all.
     public enum StatusRefresh {
-        /// Minimum gap between routine `get_pro_status` fetches. **Drop-on-fresh, never re-arm:** a re-arming floor
-        /// turns every routine trigger into a self-sustaining once-a-minute poll, which during grace (when `E` is
-        /// static) is pure noise. The *proof* loop is deliberately the opposite — it re-arms rather than skips,
-        /// because a throttled proof acquisition still has to eventually happen. Don't unify the two.
+        /// Minimum gap between routine `get_pro_status` fetches. Drop-on-fresh, never re-arm: re-arming would turn every
+        /// trigger into a once-a-minute poll that discovers nothing while `E` is static.
         ///
-        /// ⚠️ **A scheduled wake depends on this value not being crossed.** The `user_expiry` wakes fire at
-        /// `E + 30s` and `(E + G) + 30s`, so they are `G` apart, and **both go through the floored fetch path**
-        /// (not `immediate`). Whenever `G < floorSeconds` the second wake's fetch is therefore dropped by the
-        /// floor — silently, and looking exactly as though the wake had never been scheduled.
-        ///
-        /// In production `G` is ~1 hour, so this never bites. It bites on a **compressed testing backend**: the
-        /// Google testing provider sets the grace period to ~10 seconds, and the backend scales its whole test
-        /// clock (clamp, renewal lead, grid) while this fixed client-side floor doesn't participate in that
-        /// compression. Any client interval shorter than the compressed equivalent has the same property — the
-        /// second wake is just where the mismatch first became visible.
-        ///
-        /// **Deliberately not solved here.** The sanctioned escape hatch is an env-var override of this floor,
-        /// owned by the Pro UI-test work; do not add one to the client, make the wake `immediate`, or widen the
-        /// wake's guard to compensate. Raising or removing this constant likewise needs the wakes re-checked.
+        /// Changing this needs the `user_expiry` wakes re-checked — both are floored and `G` apart, so where `G` is
+        /// shorter the second wake's fetch is dropped.
         public static let floorSeconds: UInt64 = 60
 
-        /// Minimum gap between **startup-gate** fetches. Cold starts are frequent on mobile, so the gate needs its
+        /// Minimum gap between startup-gate fetches. Cold starts are frequent on mobile, so the gate needs its
         /// own rate limit; this also doubles as the backstop that lets a stale `auto_renewing`/`E` self-correct
         /// within a day.
         public static let startupMinIntervalSeconds: UInt64 = 24 * 60 * 60
@@ -87,18 +62,16 @@ public enum SessionPro {
         /// same un-renewed period a moment before the backend rolls it over, spending a fetch to learn nothing.
         public static let userExpiryWakeSlackSeconds: UInt64 = 30
 
-        /// The post-purchase chase (trigger #7). Floor-exempt, so these two *are* its bound: the window is measured
+        /// The post-purchase chase (trigger #7). Floor-exempt, so these two are its bound: the window is measured
         /// from the FIRST request, and the gap is applied after each attempt SETTLES rather than as a fixed tick, so a
         /// slow onion request can never overlap itself.
         public static let postPurchasePollWindowSeconds: Int64 = 120
         public static let postPurchasePollGapSeconds: Int = 5
     }
 
-    /// The proof-acquisition floor (Loop 1).
-    ///
-    /// **Deliberately re-arms rather than drops**, which is the opposite of the status floor above: a throttled proof
-    /// acquisition is load-bearing and must still eventually happen, whereas a dropped status refresh is display-only
-    /// and backstopped by six other triggers. Don't unify the two — the asymmetry is the design.
+    /// The proof-acquisition floor (Loop 1). Re-arms rather than drops — the opposite of the status floor above,
+    /// because a throttled proof acquisition still has to happen, whereas a dropped status refresh is display-only
+    /// and backstopped by the other triggers.
     public enum ProofAcquisition {
         /// Spacing while COVERED — a currently-valid proof is in hand, so renewal is preemptive and can be leisurely.
         public static let coveredIntervalSeconds: TimeInterval = 60
@@ -131,29 +104,17 @@ public actor SessionProManager: SessionProManagerType {
     private var lastProofRequestAt: TimeInterval = -.greatestFiniteMagnitude
     private var darkAttempt: Int = 0
 
-    /// The `user_expiry` status wakes (trigger #6) — **two instants, so a collection**.
-    ///
-    /// `userExpiryWakeTasks` holds one advisory in-foreground wake per scheduled instant;
-    /// `firedUserExpiryWakeInstants` records which have already fired, which is what makes each fire once per
-    /// period rather than repeat. Both are ephemeral — re-derived from config on every evaluation, reset on
-    /// process death.
-    ///
-    /// **This must stay a collection.** A single handle, cancelled once while scheduling two timers, silently
-    /// orphans the first and leaks a timer every renewal period — and it would not show up in a test asserting
-    /// the wakes fire at the right times, because they both still do.
+    /// The `user_expiry` status wakes: one advisory wake per scheduled instant, plus the instants already fired so
+    /// each fires once per period. Must stay a collection — a single handle, cancelled once while scheduling two,
+    /// orphans the first and leaks a timer per period without any test noticing.
     private var userExpiryWakeTasks: [Task<Void, Never>] = []
     private var firedUserExpiryWakeInstants: Set<UInt64> = []
 
-    /// Config-change detection state for the status trigger, tracked here rather than read back out of
-    /// `SessionPro.State`.
+    /// Config-change detection for the status trigger.
     ///
-    /// 🔴 **These must not be display state.** Diffing `SessionPro.State` here would tie "did config change" to
-    /// "what does the UI show" — and the display is owned by whichever response last spoke, so the trigger would
-    /// stop firing for any account whose displayed expiry came from a response rather than from config, taking the
-    /// remote-merge path with it. The dependency is invisible at the diff site, which is why these are held
-    /// separately.
-    ///
-    /// `hasProjectedUserConfig` distinguishes the first projection of a process (not a change) from a genuine one.
+    /// These must not be display state: the display is owned by whichever response last spoke, so diffing it would
+    /// stop the trigger firing for any account whose expiry came from a response — a dependency invisible at the
+    /// diff site. `hasProjectedUserConfig` separates a process's first projection from a genuine change.
     private var lastKnownAccessExpirySeconds: UInt64 = 0
     private var lastKnownPrepaidTimestampSeconds: UInt64 = 0
     private var hasProjectedUserConfig: Bool = false
@@ -166,19 +127,8 @@ public actor SessionProManager: SessionProManagerType {
 
     private var isRefreshingState: Bool = false
 
-    /// Whether a `get_pro_status` has been attempted at all in this process. Exempts the first attempt from the
-    /// (persisted) status floor — see `statusFloorPermitsFetch`.
-    ///
-    /// **It is load-bearing for two independent reasons, so removing it needs both answered.** Beyond the
-    /// spinner case below, the floor is the *other* thing in this file that can decline to start a fetch — and
-    /// without this exemption a fresh process whose floor is still armed from the previous one cannot fetch,
-    /// which is the same dead-end as gating a refresh on `LoadingState.loading` (see that type's note).
-    ///
-    /// **Sole consumer is that exemption.** Deleting this and letting the persisted timestamp govern the first attempt
-    /// too *was tried*, and it ships a **permanent spinner**: relaunch within 60s of a previous fetch and the floor
-    /// drops the startup fetch, leaving `loadingState` on its initial `.loading` with nothing to resolve it — and both
-    /// the Pro screen and the CTA gate on a confirmed fetch. So it is removable only once a fresh process can resolve
-    /// its load state without a network round-trip; if that ever becomes true, delete this then and not before.
+    /// Whether a `get_pro_status` has been attempted this process; exempts the first attempt from the persisted
+    /// floor. Without it, a relaunch inside the floor leaves `loadingState` on `.loading` with nothing to resolve it.
     private var hasAttemptedStatusFetch: Bool = false
     private var rotatingKeyPair: KeyPair?
     
@@ -474,22 +424,11 @@ public actor SessionProManager: SessionProManagerType {
         let expiryInSeconds: TimeInterval = (state.accessExpiryTimestampSeconds
             .map { Date(timeIntervalSince1970: Double($0)).timeIntervalSince(dateNow) } ?? 0)
 
-        /// Time elapsed since **coverage** ended — negative while still covered, positive once lapsed.
+        /// Time elapsed since coverage ended — negative while still covered, positive once lapsed.
         ///
-        /// 🔴 **Signed, and `TimeInterval` rather than `UInt64` subtraction, deliberately.** `E + G` can sit in the
-        /// future relative to `now` here — clock skew, or a config that arrived from another device — and an unsigned
-        /// `now - (E + G)` underflows to an enormous positive number, which would silently satisfy any upper bound
-        /// placed on it. The sign is the whole point of the value, so the type has to carry it.
-        ///
-        /// `nil` when no coverage end is known: an account can report `.expired` with no expiry at all once the
-        /// backend has pruned its history, and "how long since it lapsed" then has no answer rather than the answer
-        /// zero.
-        ///
-        /// 🔴 **Off `state`, and it must stay that way — `E` and `G` are only meaningful as the pair that arrived
-        /// together.** Every writer sets them in one mutation, so any `E` here is accompanied by the `G` from the
-        /// same response. Config cannot promise that: not every status branch writes `G` there, so a config read
-        /// would pair this response's expiry with a grace period from a different moment, or with none — and the
-        /// window would silently collapse back onto `E` in exactly the lapsed case this measures.
+        /// Signed `TimeInterval`: `E + G` can sit ahead of `now` on clock skew or a config from another device, and an
+        /// unsigned subtraction underflows to a huge positive that satisfies any upper bound. `nil` when no coverage end
+        /// is known, since an account can report `.expired` with no expiry once history is pruned.
         let secondsSinceCoverageEnd: TimeInterval? = state.coverageEndTimestampSeconds
             .flatMap { coverageEnd in
                 guard coverageEnd > 0 else { return nil }
@@ -502,13 +441,10 @@ public actor SessionProManager: SessionProManagerType {
             // Fail closed: an unrecognised backend status behaves like `.never` (no CTA, no Pro).
             case (.never, _, _), (.unknown, _, _), (.active, _, .refunding), (.active, true, .notRefunding): return nil
             case (.active, false, .notRefunding):
-                /// Anchored at `E`, which is correct for this one: "your payment is due soon" is a statement about
-                /// the payment date, not about how long we keep serving.
+                /// Anchored at `E`: "your payment is due soon" is about the payment date, not about how long we keep serving.
                 ///
-                /// The bound is one-sided, so it also admits a negative `expiryInSeconds` — an `.active` account
-                /// already past `E`. That is unreachable, but by an invariant **elsewhere** rather than by anything
-                /// on this line: `G` is 0 whenever the subscription isn't auto-renewing, so `.active` with `!A` past
-                /// `E` would mean the backend still serving beyond `E + 0`.
+                /// One-sided, so it also admits a negative interval — an `.active` account past `E`. Unreachable, but by an
+                /// invariant elsewhere: `G` is 0 when not auto-renewing, so that would mean the backend serving past `E + 0`.
                 guard
                     expiryInSeconds <= TimeInterval(SessionPro.StatusRefresh.expiringCTAWindowSeconds),
                     !dependencies[defaults: .standard, key: .hasShownProExpiringCTA]
@@ -522,13 +458,10 @@ public actor SessionProManager: SessionProManagerType {
                 )
                 
             case (.expired, _, _):
-                /// Measured from coverage end, `E + G`, so the window is the same length whatever the store's grace
-                /// is, and its deadline is the instant the startup gate stops chasing the account.
+                /// Measured from coverage end, so the window is the same length whatever the store's grace is.
                 ///
-                /// **Upper bound only.** Reaching here means the backend said `Expired`, and it is revocation-aware:
-                /// a refunded or charged-back account reports `Expired` while its coverage end is still in the
-                /// future, so `secondsSinceCoverageEnd` is negative. A lower bound would suppress the CTA for
-                /// exactly those accounts. Staleness is the upper bound's job.
+                /// Upper bound only: the backend forces `Expired` on revocation, so a refunded account reports `Expired` with
+                /// its coverage end still ahead and a negative interval here.
                 guard
                     let secondsSinceCoverageEnd: TimeInterval = secondsSinceCoverageEnd,
                     secondsSinceCoverageEnd < TimeInterval(SessionPro.StatusRefresh.expiredCTAWindowSeconds),
@@ -593,20 +526,9 @@ public actor SessionProManager: SessionProManagerType {
         }()
         let oldState: SessionPro.State = await stateStream.getCurrent()
 
-        /// 🔴 **`E`, `G` and `A` are deliberately NOT projected here — the display copies of those three are owned by
-        /// whichever response last spoke.** Both `get_pro_status` and `generate_pro_proof` return all three, and only
-        /// a response carries the rest of the picture that has to agree with them (`latest_payment` — provider, plan,
-        /// refund window — has no config representation at all), so sourcing one field from config would leave the
-        /// screen showing a mix of two different moments.
-        ///
-        /// Config keeps the same three for two other jobs, which is why they still exist there: it is the
-        /// **fetch trigger** (`expiryChanged` below) and the **cross-device carrier**. This is the whole split —
-        /// *config answers "should I fetch"; a response answers "what do I show"*.
-        ///
-        /// **So every proof outcome writes these itself** — `applyProofSuccess`, `applyProofClear` and
-        /// `applyProofRevoked` — because a purchase learns its new expiry from the *proof* response, and until this
-        /// method stopped projecting them, that write was what carried it to the display. Adding a fourth writer of
-        /// config `E`/`G`/`A` without a matching display write would silently leave the screen a period behind.
+        /// `E`, `G` and `A` are not projected here — their display copies are owned by whichever response last spoke,
+        /// since only a response carries `latest_payment` and the rest that has to agree with them. Config keeps the
+        /// three as the fetch trigger and the cross-device carrier, so every proof outcome writes the display itself.
         let updatedState: SessionPro.State = oldState.with(
             status: .set(to: proStatus),
             proof: .set(to: proInfo.proConfig?.proProof),
@@ -623,16 +545,9 @@ public actor SessionProManager: SessionProManagerType {
         self.rotatingKeyPair = rotatingKeyPair
         await self.stateStream.send(updatedState)
 
-        /// A change to `E` or the prepaid marker `I` generally means another device did something that should refresh
-        /// the pro state.
-        ///
-        /// **`I` is included, not just `E`.** A purchase started on another device sets only `I` — with `E` unchanged
-        /// until the entitlement actually lands — so watching `E` alone leaves that case with no status refresh.
-        ///
-        /// Both diffed against the **config** values last seen, never against display state — see the note on
-        /// `lastKnownAccessExpirySeconds`. `G` is deliberately not watched: a grace change *is* the information rather
-        /// than a signal that the server moved, so fetching to confirm what we were just told is a wasted round trip.
-        /// Same reason `A` isn't watched.
+        /// A change to `E` or `I` means another device did something worth refreshing for; `I` is included because a
+        /// purchase started elsewhere sets only `I`. Both diffed against the config values last seen, never display
+        /// state. `G` is not watched — a grace change is the information, not a signal the server moved.
         let expiryChanged: Bool = (proInfo.accessExpiryTimestampSeconds != lastKnownAccessExpirySeconds)
         let prepaidChanged: Bool = (proInfo.prepaidTimestampSeconds != lastKnownPrepaidTimestampSeconds)
         let isFirstProjection: Bool = !hasProjectedUserConfig
@@ -640,7 +555,7 @@ public actor SessionProManager: SessionProManagerType {
         lastKnownPrepaidTimestampSeconds = proInfo.prepaidTimestampSeconds
         hasProjectedUserConfig = true
 
-        /// The first pass of a process is a *projection* of config we already had, not a config *change*. Treating it
+        /// The first pass of a process is a projection of config we already had, not a config change. Treating it
         /// as one would fire this refresh on every cold launch — before, and regardless of, the startup gate — which
         /// would walk straight past the gate and leave the startup hammering the gate exists to remove.
         if !isFirstProjection, (expiryChanged || prepaidChanged) {
@@ -749,15 +664,9 @@ public actor SessionProManager: SessionProManagerType {
         postPurchaseStatusPollTask = Task { [weak self] in
             guard let self else { return }
 
-            /// The baseline "a new period landed" is measured against.
-            ///
-            /// 🔴 **"No baseline yet" must stay distinguishable from "expires at 0" — hence the optional.** This
-            /// poll starts before any response has landed (the proof generation is an unawaited task, so
-            /// `purchasePro` returns ahead of it), so display state may carry no account expiry at all. Collapsing
-            /// that to `0` makes the first response look like an advance from nothing — including when it carries
-            /// the *pre-purchase* expiry because the payment hasn't registered yet — ending the poll on its first
-            /// attempt, at exactly the moment it exists to keep chasing. With no baseline the first response
-            /// supplies one instead.
+            /// "No baseline yet" must stay distinguishable from "expires at 0": this poll starts before any response has
+            /// landed, so collapsing an absent expiry to `0` makes the first response look like an advance and ends the poll
+            /// on its first attempt.
             var expiryBefore: UInt64? = await self.stateStream.getCurrent().accessExpiryTimestampSeconds
             let startSeconds: Int64 = Int64(await self.dependencies.networkOffsetTimestampMs() / 1000)
             let windowSeconds: Int64 = SessionPro.StatusRefresh.postPurchasePollWindowSeconds
@@ -808,26 +717,9 @@ public actor SessionProManager: SessionProManagerType {
 
     // MARK: -- User Expiry Status Wake (trigger #6)
 
-    /// The `user_expiry` wakes: a `get_pro_status` refetch shortly after the renewal falls due, and a second
-    /// shortly after coverage ends. Each fires once per period.
-    ///
-    /// This is the gap they exist to close. The proof is clamped to expire well short of the account horizon,
-    /// so the proof reconcile's wake is otherwise the *next* thing that goes to the network — and the renewal
-    /// lands somewhere in between. Without these, an account whose renewal was overdue showed a stale "active"
-    /// for that whole interval, and a "renewal pending / overdue" display cannot be driven off anything we
-    /// haven't re-read. The while-open grace poll only covers the case where the Pro screen happens to be open.
-    ///
-    /// The slack (see `StatusRefresh.userExpiryWakeSlackSeconds`) is for clock skew against the backend: firing
-    /// at exactly the instant would routinely re-read the same period a moment before it rolls over.
-    ///
-    /// **Once per instant, not repeating.** `firedUserExpiryWakeInstants` records what has fired, so a refetch
-    /// that changes nothing is not retried from here — the ongoing chase belongs to the while-open grace poll
-    /// and the other triggers. A refetch that *does* move `E` yields new instants, and since those are in the
-    /// future they cannot spin.
-    ///
-    /// The wakes are advisory, like the proof one: iOS suspends the process, so a `Task.sleep` spanning either
-    /// instant will not fire on time. `willEnterForeground` re-enters here, and the past-due branch below is
-    /// what catches up a crossing missed while suspended.
+    /// The `user_expiry` wakes: a refetch shortly after the renewal falls due, and a second shortly after coverage
+    /// ends, each once per period. The proof is clamped well short of the account horizon, so without these an
+    /// overdue renewal shows a stale "active". Advisory — `willEnterForeground` catches a crossing slept through.
     private func evaluateUserExpiryStatusWake() async {
         userExpiryWakeTasks.forEach { $0.cancel() }
         userExpiryWakeTasks = []
@@ -842,7 +734,7 @@ public actor SessionProManager: SessionProManagerType {
         }
 
         /// Nothing known (never Pro, or cleared by a not-entitled proof outcome) — nothing to wake for. Forget
-        /// what we fired for, so a later subscription landing on the *same* instants isn't swallowed.
+        /// what we fired for, so a later subscription landing on the same instants isn't swallowed.
         guard expirySeconds > 0 else {
             firedUserExpiryWakeInstants = []
             return
@@ -857,31 +749,11 @@ public actor SessionProManager: SessionProManagerType {
         let slackSeconds: UInt64 = SessionPro.StatusRefresh.userExpiryWakeSlackSeconds
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
 
-        /// **Two instants, and they answer different questions.**
+        /// Two instants: `E + 30s` asks whether the renewal charge succeeded, `(E + G) + 30s` whether grace ran out. The
+        /// second is armed only when they don't coincide, which is the condition itself rather than a `G > 0` proxy.
         ///
-        /// - `E + 30s` — the renewal has just fallen due: did the charge succeed or fail?
-        /// - `(E + G) + 30s` — coverage has just ended: did grace run out without a recovery?
-        ///
-        /// The second is armed **only when the two instants don't coincide**. That is the condition itself,
-        /// not a proxy for it: when they land on the same second there is one thing to ask, so there is one
-        /// wake. Deliberately *not* phrased as "when a grace period exists" — that invites replacing the
-        /// comparison with a `graceSeconds > 0` test, which is a different predicate that happens to agree
-        /// today. (It's the non-auto-renewing accounts that coincide, since the backend sends `G = 0` there.)
-        ///
-        /// The second is not redundant with the proof loop landing near `E`: that chain reaches a status
-        /// refresh only via the config-change trigger, which fires on `E` *changing*. A renewal that **failed**
-        /// leaves `E` untouched, so nothing would wake — which is exactly the case worth waking for.
-        ///
-        /// ⚠️ **If you are here because the second wake "didn't fire" on a QA backend, it probably did.** Both
-        /// emits below go through the *floored* fetch path, and the two instants are `G` apart — so whenever
-        /// `G < SessionPro.StatusRefresh.floorSeconds` (60s) the first fetch arms the floor and the second is
-        /// dropped. The wake was scheduled and did run; only its fetch was skipped, which is indistinguishable
-        /// from never having been scheduled unless you know to look.
-        ///
-        /// Production `G` is ~1 hour so it can't happen there; a compressed testing backend sets it to ~10
-        /// seconds. **Deliberately not worked around here** — the escape hatch is an env-var override of the
-        /// floor, owned by the Pro UI-test work. Don't make these emits `immediate` to "fix" it: that would give
-        /// two floor-exempt fetches on every renewal in production to serve a test-only configuration.
+        /// Not redundant with the proof loop landing near `E`: that reaches a status refresh only via the config-change
+        /// trigger, which fires on `E` changing, and a failed renewal leaves `E` untouched.
         var instants: [UInt64] = [expirySeconds + slackSeconds]
 
         if coverageEndSeconds != expirySeconds {
@@ -893,7 +765,7 @@ public actor SessionProManager: SessionProManagerType {
         firedUserExpiryWakeInstants = firedUserExpiryWakeInstants.intersection(instants)
 
         /// Anything already past — we were suspended across it, or the values arrived stale from another
-        /// device. Mark them all and take **one** refresh: they ask the same question of the same fetch, and
+        /// device. Mark them all and take one refresh: they ask the same question of the same fetch, and
         /// the trailing re-evaluation below re-arms whatever remains.
         let pastDueInstants: [UInt64] = instants.filter { nowSeconds >= $0 && !firedUserExpiryWakeInstants.contains($0) }
 
@@ -916,15 +788,12 @@ public actor SessionProManager: SessionProManagerType {
         }
     }
 
-    /// Fire the wake for one instant, at most once for that instant.
-    ///
-    /// **Note:** when this is reached during a `refreshProState` that is still in flight, the refresh below is a
-    /// no-op (`isRefreshingState`) — which is the right outcome: the in-flight fetch is itself the read the wake
-    /// wanted, so the wake is legitimately consumed.
+    /// Fire the wake for one instant, at most once for that instant. Floored, not `immediate`: this is a routine
+    /// trigger, and the trailing re-evaluation re-arms whatever remains.
     private func fireUserExpiryStatusWake(atInstantSeconds instantSeconds: UInt64) async {
         guard !firedUserExpiryWakeInstants.contains(instantSeconds) else { return }
 
-        /// Marked BEFORE the fetch deliberately: a failing network must not turn a one-shot wake into a refetch
+        /// Marked before the fetch: a failing network must not turn a one-shot wake into a refetch
         /// on every trigger that re-enters here. Recovering from a failed fetch belongs to the other triggers.
         firedUserExpiryWakeInstants.insert(instantSeconds)
 
@@ -997,9 +866,7 @@ public actor SessionProManager: SessionProManagerType {
 
     /// The proof-acquisition spacing for the current pass — flat while covered, linear-with-cap while dark.
     ///
-    /// 🔴 Read twice per pass — once to decide whether to fire, once to arm the next wake — and the two **must**
-    /// agree, or the loop arms a wake for an interval it didn't honour. That is why this is a function rather than
-    /// the literals inlined at both sites.
+    /// Read twice per pass, and the two reads must agree or the loop arms a wake for an interval it didn't honour.
     private func proofAcquisitionInterval(haveValidProof: Bool) -> TimeInterval {
         guard !haveValidProof else { return SessionPro.ProofAcquisition.coveredIntervalSeconds }
 
@@ -1131,21 +998,13 @@ public actor SessionProManager: SessionProManagerType {
                         cache.updateProAccessExpiryTimestampSeconds(response.accountExpiryTimestampSeconds)
                     }
 
-                    /// Keep `G` and `A` coherent with the `E` just written. Without this a proof outcome moves
-                    /// the access expiry while leaving a grace period paired with the *previous* one, and
-                    /// `E + G` — the coverage end the gate and the second wake are both derived from — silently
-                    /// means nothing.
+                    /// Keep `G` and `A` coherent with the `E` just written: a grace period paired with the previous expiry makes
+                    /// `E + G` meaningless.
                     ///
-                    /// `accountRenewalInfo` is `nil` unless this response actually carried a proof. That check
-                    /// is the whole protection: on any other outcome libsession leaves these as the C struct's
-                    /// zero-initialised defaults, which are indistinguishable from "no grace, not renewing" —
-                    /// and writing that `false` would *erase* a flag `get_pro_status` had learned, because the
-                    /// config keys are presence-only.
-                    ///
-                    /// 🔴 **The protection is the PLACEMENT, not the parse and not the type — do not hoist
-                    /// these writes out of the success branch.** Reaching this line already implies success,
-                    /// so the bind looks redundant here; it is what would fail loudly if the call ever moved,
-                    /// and nothing else in this file would catch that.
+                    /// `accountRenewalInfo` is `nil` unless this response carried a proof, which is the protection — on any other
+                    /// outcome libsession leaves these at zero defaults, indistinguishable from "no grace, not renewing", and the
+                    /// config keys are presence-only so writing that `false` erases what `get_pro_status` learned. The protection is
+                    /// the placement: reaching this line already implies success.
                     if let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo = response.accountRenewalInfo {
                         cache.updateProGracePeriodSeconds(renewalInfo.gracePeriodSeconds)
                         cache.updateProAutoRenewing(renewalInfo.autoRenewing)
@@ -1154,20 +1013,10 @@ public actor SessionProManager: SessionProManagerType {
             }
         }
 
-        /// Write the account triple straight to display state: a proof response is a response, and display state is
-        /// owned by whichever response last spoke.
+        /// A proof response is a response, so it owns the display triple too.
         ///
-        /// 🔴 **Must precede the re-projection below — this is an ordering requirement, not tidiness.**
-        /// `updateWithLatestFromUserConfig` sees the config `E` written just above, so its change trigger fires and
-        /// *awaits* a `get_pro_status`. That response is strictly newer than this one, so it has to be the survivor;
-        /// writing after the re-projection would let this proof's `account_expiry` overwrite a status response that
-        /// had already landed.
-        ///
-        /// **The same two conditions as the config writes above, for the same reasons.** A response that carried no
-        /// account expiry must not be read as "expires at 0", and on any non-success outcome libsession leaves the
-        /// grace/renewal pair at the C struct's zero-initialised defaults, which are indistinguishable from "no
-        /// grace, not renewing" — `accountRenewalInfo` is `nil` in exactly that case. Both fall back to
-        /// `.useExisting` rather than to a zero value.
+        /// Must precede the re-projection: writing config `E` fires the change trigger, which awaits a `get_pro_status`
+        /// — newer than this response, so it has to be the survivor. Same two conditions as the config writes above.
         let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo? = response.accountRenewalInfo
         await updateProState(
             to: (await stateStream.getCurrent()).with(
@@ -1184,7 +1033,7 @@ public actor SessionProManager: SessionProManagerType {
 
         /// Re-project the (now-updated) config into state — proof, rotating key and status re-derive consistently
         /// (and if the winning proof was an existing longer one, the rotating key matches it). It deliberately does
-        /// **not** carry `E`/`G`/`A` any more, which is why they are written explicitly above.
+        /// not carry `E`/`G`/`A` any more, which is why they are written explicitly above.
         await updateWithLatestFromUserConfig()
 
         try? await Profile.updateLocal(proFeatures: syncState.state.profileFeatures, using: dependencies)
@@ -1195,13 +1044,10 @@ public actor SessionProManager: SessionProManagerType {
     private func applyProofClear() async {
         let nowSeconds: Int64 = Int64(await dependencies.networkOffsetTimestampMs() / 1000)
 
-        /// Whether the clear actually applied — the downgrade guard decides, and the display write at the end
-        /// needs the answer.
+        /// Whether the clear actually applied, which the display write at the end needs.
         ///
-        /// 🔴 **The guard's read must stay inside `mutate(cache:)`** — that closure is the lock, so the read and
-        /// the write it authorises are atomic against an incoming config merge. `performAndPushChange` adds no
-        /// synchronisation of its own, so the read is equally safe just outside it; moving it out of the `mutate`
-        /// would let a merge land between deciding and clearing.
+        /// The guard's read must stay inside `mutate(cache:)` — that closure is the lock, so the read and the write it
+        /// authorises are atomic against an incoming merge.
         let didClear: Bool = ((try? await dependencies[singleton: .storage].write { [dependencies] db -> Bool in
             try dependencies.mutate(cache: .libSession) { cache -> Bool in
                 /// Downgrade guard (read live config): never wipe a fresh, unexpired proof another device
@@ -1215,7 +1061,7 @@ public actor SessionProManager: SessionProManagerType {
                     /// `I`/`R`), so a stale future `E` left here would make `pro_renewal_target` fire on every
                     /// eval and spin — clear it explicitly (`set_pro_access_expiry(nullopt)`, via `0`).
                     ///
-                    /// 🔴 **This path must leave no `G` or `A` stranded beside the cleared `E`.** They describe the
+                    /// This path must leave no `G` or `A` stranded beside the cleared `E`. They describe the
                     /// subscription `E` denotes, so a surviving grace period pairs with whatever `E` is written next
                     /// — silently changing where coverage ends — and a surviving renewing flag describes a
                     /// subscription that no longer exists, which the startup gate then reads as "still renewing".
@@ -1231,14 +1077,8 @@ public actor SessionProManager: SessionProManagerType {
             }
         }) ?? false)
 
-        /// Only when the clear applied. If the downgrade guard vetoed, config now describes another device's
-        /// fresher proof and display state must be left alone — clearing it here would throw away a newer
-        /// `get_pro_status` answer on the strength of an outcome we just decided not to act on.
-        ///
-        /// Before the re-projection, for the reason spelled out in `applyProofSuccess`: clearing config `E` makes
-        /// the change trigger fire, and the `get_pro_status` it awaits is strictly newer than this outcome. If the
-        /// backend says the account is in fact still active, that answer has to survive rather than be cleared by
-        /// a verdict we reached from a stale proof.
+        /// Only when the clear applied: on a veto, config describes another device's fresher proof. Before the
+        /// re-projection, since clearing `E` fires the change trigger and the response it awaits is newer.
         if didClear {
             await clearProAccountDisplayState()
         }
@@ -1274,14 +1114,8 @@ public actor SessionProManager: SessionProManagerType {
         await updateWithLatestFromUserConfig()
     }
 
-    /// Clear the account triple in **display** state.
-    ///
-    /// A cleared proof outcome is a response speaking too, and what it says is "you have nothing" — so it owns these
-    /// three exactly as a success does. All three are cleared together because they describe one subscription: a
-    /// surviving grace period or renewing flag beside an absent expiry describes something that no longer exists.
-    ///
-    /// `status`, the proof and `profileFeatures` are not touched — `updateWithLatestFromUserConfig` re-derives those
-    /// from the now-cleared config, and it still projects them.
+    /// Clear the account triple in display state — a cleared outcome is a response too, and it says "you have
+    /// nothing". `status`, the proof and `profileFeatures` re-derive from the cleared config.
     private func clearProAccountDisplayState() async {
         await updateProState(
             to: (await stateStream.getCurrent()).with(
@@ -1300,34 +1134,18 @@ public actor SessionProManager: SessionProManagerType {
         await self.stateStream.send(newState)
     }
     
-    /// Whether a cold launch needs to go to the network for `get_pro_status`.
+    /// Whether a cold launch needs to go to the network for `get_pro_status`. Gated on "could a CTA fire", computed
+    /// from synced config, plus a persisted min-interval; entitlement itself comes from the proof.
     ///
-    /// Gated rather than unconditional because a cold start is something mobile triggers constantly, and an
-    /// unconditional fetch here is backend load for no benefit: entitlement comes from the proof, the settings screen
-    /// refreshes on open, and account-expiry awareness is the `user_expiry` wake's job. The startup fetch's only real
-    /// consumer is the home CTAs, so the gate is "could a CTA fire", computed from synced config, plus a persisted
-    /// min-interval.
+    /// Measured against `E`, not `E + G` — gating on the coverage end would put the whole grace window in the
+    /// no-fetch branch.
     ///
-    /// The test is against `E`, the date the renewal falls due — **not** against the end of coverage, `E + G`.
-    /// Gating on `E + G` would put the whole grace window in the no-fetch branch, which is the one state this
-    /// refresh design exists to surface. Both halves are synced (`E`, `G`), so the whole decision is
-    /// config-derivable with no branching on provider or renewal state (`G` is 0 when not auto-renewing):
+    /// | `A && now < E` | comfortably active → no fetch |
+    /// | `A && E <= now < E + G` | renewal due, still served → fetch |
+    /// | `!A && E` within the CTA window | expiring → fetch |
+    /// | `now >= E + G` | lapsed → confirm-fetch, so a renewal landed elsewhere can't show a false expiry |
     ///
-    /// | config state | action |
-    /// |---|---|
-    /// | `A && now < E`            | comfortably active, renewal not yet due → **no fetch** |
-    /// | `A && E <= now < E + G`   | renewal due or overdue, still served → fetch, so grace can be surfaced while it is happening |
-    /// | `!A && E` within the CTA window | expiring → fetch (the CTA is separately gated on the result) |
-    /// | `now >= E + G`            | lapsed. Confirm-fetch first, so a renewal that landed elsewhere and hasn't
-    ///                              synced can't produce a false "Pro expired" |
-    ///
-    /// Fetching once past `E` is still bounded on the far side by the persisted 24h interval below, which is what
-    /// stops a lapsed account re-asking on every launch.
-    ///
-    /// **Not a Pro user at all** (no `E`, no proof) → never fetch. Note what that gives up: a purely server-side
-    /// entitlement, e.g. a voucher, leaves no config trace, so this device won't discover it on its own. On iOS an
-    /// Apple subscription still self-recovers through StoreKit (`Transaction.updates`), and everything else is what
-    /// the manual recover action exists for.
+    /// No `E` and no proof → never fetch, which gives up discovering a server-side entitlement such as a voucher.
     private func startupStatusFetchIsNeeded() async -> Bool {
         /// One mutation for all four, so they can't be read either side of an incoming config merge — `E` and `G`
         /// especially, since they are only comparable as the pair that arrived together.
@@ -1392,22 +1210,12 @@ public actor SessionProManager: SessionProManagerType {
         return true
     }
 
-    /// The CTA-worthiness half of the startup gate — the four rows of the table above, measured against `E` (the
-    /// renewal date) rather than against the end of coverage `E + G`.
+    /// The CTA-worthiness half of the gate, measured against `E`.
     ///
-    /// The `!A && now < E` row outside the CTA window returns false (no fetch), which is sound only because of the
-    /// encoding property below.
-    ///
-    /// `A` is stored presence-only: libsession's setter *erases* the key on false, so the key is present iff its
-    /// value is 1, and "not auto-renewing" and "never written" are the same stored state. That is a property of
-    /// the **encoding**, not of the accessor: no "has it ever been written" companion predicate can recover the
-    /// distinction, because storage does not hold it.
-    ///
-    /// So the row is sound only while absent-`A` genuinely means not-renewing, and that is an invariant the
-    /// **write** side has to maintain: 🔴 **every path that writes `E` must write `A` alongside it.** A path that
-    /// advanced the expiry while leaving `A` untouched would leave a live, renewing account holding a future `E`
-    /// with no `A`, and this row would then decide "not renewing" about a subscription that is. Both writers
-    /// (`get_pro_status` success and `applyProofSuccess`) do so.
+    /// The `!A && now < E` row is sound only because libsession erases `A` on false, making "not auto-renewing" and
+    /// "never written" the same stored state. So it is an invariant the write side maintains: every path that writes
+    /// `E` must write `A` alongside it, or a renewing account holds a future `E` with no `A` and this row calls it
+    /// non-renewing.
     private func startupStatusFetchIsCTAWorthy(
         autoRenewing: Bool,
         expirySeconds: UInt64,
@@ -1426,7 +1234,7 @@ public actor SessionProManager: SessionProManagerType {
             return ((nowSeconds - coverageEndSeconds) <= SessionPro.StatusRefresh.expiredCTAWindowSeconds)
         }
 
-        /// Renewal due or overdue but still being served: the grace window `[E, E + G)`. **Always fetch** — this is
+        /// Renewal due or overdue but still being served: the grace window `[E, E + G)`. Always fetch — this is
         /// the state the whole refresh design exists to surface, and gating on the coverage end instead is what
         /// would swallow it entirely. Empty when `!A`, since `G` is 0 there and this collapses into the branch above.
         guard nowSeconds < expirySeconds else { return true }
@@ -1439,22 +1247,13 @@ public actor SessionProManager: SessionProManagerType {
         return ((expirySeconds - nowSeconds) <= SessionPro.StatusRefresh.expiringCTAWindowSeconds)
     }
 
-    /// The drop-on-fresh status floor: whether enough time has passed since the last `get_pro_status` for a *routine*
+    /// The drop-on-fresh status floor: whether enough time has passed since the last `get_pro_status` for a routine
     /// trigger to go to the network.
     ///
-    /// Two exemptions, and the second one matters more than it looks:
+    /// Exempt: `immediate` callers, and a process's first attempt — without the second, a relaunch inside the floor
+    /// leaves `loadingState` on `.loading` with nothing to resolve it. Keyed on attempted, not succeeded.
     ///
-    /// - `immediate` callers bypass it outright (manual/recover and the post-purchase poll).
-    /// - **The first attempt of a process is never floored.** The persisted timestamp is what stops repeated cold
-    ///   starts from hammering the backend, but it must not leave a *fresh* process unable to fetch at all:
-    ///   `loadingState` would sit on its initial `.loading` with nothing to resolve it, which on this client means a
-    ///   permanent spinner on the Pro screen and no CTA, since both gate on a confirmed fetch. Note it is
-    ///   keyed on having *attempted*, not succeeded — after a failure the state is `.error`, which the UI renders as a
-    ///   retry (itself `immediate`), so the spinner problem is gone and there is no reason to keep bypassing.
-    ///   Cold-start load stays bounded by the startup gate's own 24h interval, not by this floor.
-    ///
-    /// Fails **open** on a storage error — the floor is a backend-load optimisation, so an unreadable timestamp should
-    /// cost an extra request rather than silently stop the client ever refreshing its status.
+    /// Fails open on a storage error.
     private func statusFloorPermitsFetch(immediate: Bool) async -> Bool {
         guard !immediate else { return true }
         guard hasAttemptedStatusFetch else { return true }
@@ -1474,7 +1273,7 @@ public actor SessionProManager: SessionProManagerType {
         return ((nowSeconds - lastFetchSeconds) >= SessionPro.StatusRefresh.floorSeconds)
     }
 
-    /// Record that a `get_pro_status` was **started** (not that it succeeded): the floor exists to bound requests, and
+    /// Record that a `get_pro_status` was started (not that it succeeded): the floor exists to bound requests, and
     /// a failing request costs the backend the same as a succeeding one.
     private func recordStatusFetchAttempt() async {
         let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
@@ -1487,19 +1286,15 @@ public actor SessionProManager: SessionProManagerType {
     public func refreshProState(immediate: Bool, forceLoadingState: Bool) async throws {
         /// No point refreshing the state if there is a refresh in progress
         ///
-        /// **Note:** this is single-flight, *not* the floor — it stops concurrent fetches, not frequent ones, and
-        /// `immediate` deliberately does not bypass it.
+        /// Note: this is single-flight, not the floor — it stops concurrent fetches, not frequent ones, and
+        /// `immediate` does not bypass it.
         guard !isRefreshingState else { return }
 
-        /// Drop (don't re-arm) when the last fetch is still fresh. Deliberately before the loading-state change below,
-        /// so a dropped refresh leaves the displayed state exactly as it was rather than parking it on a spinner.
+        /// Drop rather than re-arm while the last fetch is fresh, and before the loading-state change so a dropped
+        /// refresh leaves the display as it was.
         ///
-        /// 🔴 **A dropped refresh must still reconcile the proof.** Callers rely on every call to this function
-        /// reaching `reconcileProofRenewal()`: when the proof loop is dormant (`pro_renewal_target == 0`) it has no
-        /// wake of its own, so a nudge it would otherwise have received is not merely delayed, it is *lost*. The case
-        /// that makes this concrete is a preceding fetch that **failed** — the floor is armed on attempt, so it can
-        /// drop this call without the previous one ever having reached its own reconcile. The reconcile is local and
-        /// separately floored, so paying it here costs nothing.
+        /// A dropped refresh must still reconcile the proof: when the proof loop is dormant it has no wake of its own,
+        /// so a nudge it would have received is lost rather than delayed.
         guard await statusFloorPermitsFetch(immediate: immediate) else {
             await reconcileProofRenewal()
             return
@@ -2085,14 +1880,10 @@ public actor SessionProManager: SessionProManagerType {
 
         Log.warn(.sessionPro, "Own Pro proof was revoked; clearing the credential.")
 
-        /// 🔴 **Re-read the tag under the cache lock before clearing — the decision above is made outside it.**
-        /// `removeProConfig` wipes whatever proof is stored, unconditionally, and the read that identified it as
-        /// revoked happened in a *separate* lock acquisition. An incoming config merge mutates the libSession
-        /// config object directly, so between the two a device can land a **new, unrevoked** proof — and clearing
-        /// then throws away a valid credential on the strength of a verdict about the one it replaced. Actor
-        /// isolation does not help: the storage write suspends, and the merge does not run on this actor.
-        ///
-        /// Same hazard, and the same shape, as `applyProofClear`'s downgrade guard.
+        /// Re-read the tag under the cache lock before clearing. `removeProConfig` wipes whatever proof is stored, and
+        /// the read that identified it as revoked happens in a separate lock acquisition — an incoming merge mutates the
+        /// config object directly, so between the two a device can land a new, unrevoked proof. Actor isolation does not
+        /// help: the storage write suspends and the merge does not run on this actor. Same guard as `applyProofClear`.
         let didClear: Bool = ((try? await dependencies[singleton: .storage].write { [dependencies] db -> Bool in
             try dependencies.mutate(cache: .libSession) { cache -> Bool in
                 guard
@@ -2107,32 +1898,18 @@ public actor SessionProManager: SessionProManagerType {
             }
         }) ?? false)
 
-        /// Nothing was cleared, so there is nothing to project or reconcile: either the proof had already been
-        /// replaced, or the write failed and the next revocation-list fetch re-enters here. A merge that replaced
-        /// it carries its own projection and refresh.
-        ///
-        /// Note this returns earlier than `applyProofClear`, which projects unconditionally even when its guard
-        /// vetoes. The difference is what each path holds when it declines to act: that one is applying a *response*
-        /// and still has its contents to project, whereas this one only ever had a local verdict about a credential —
-        /// so when the verdict no longer applies there is nothing left to do here.
+        /// Nothing was cleared, so nothing to project: the proof was already replaced, or the write failed and the next
+        /// revocation-list fetch re-enters. Returns earlier than `applyProofClear`, which is applying a response and
+        /// still has its contents to project.
         guard didClear else { return }
 
         await updateWithLatestFromUserConfig()
 
-        /// Then ask the server what the account's state actually is.
+        /// Then ask the server what the account's state actually is. `E` is left alone: a revocation-list match says the
+        /// credential is dead, not that the account lapsed.
         ///
-        /// **`E` is deliberately left alone**, unlike `applyProofRevoked`. A tag on the revocation list says this
-        /// *credential* is dead; it does not say the *account* has lapsed, and only the server can tell us which.
-        /// Clearing `E` here would be this client deciding the account's fate from a statement about one proof.
-        ///
-        /// 🔴 **This fetch is what makes leaving `E` safe — don't remove one without the other.** Nothing else on
-        /// this path reaches the network: `updateWithLatestFromUserConfig` above is a projection, and its
-        /// config-change trigger needs `E` or `I` to move, neither of which this path touches since it clears only
-        /// the proof `s`. Drop the fetch and the account is left holding a stale future `E` with no proof and
-        /// nothing scheduled to correct it — the `pro_renewal_target` spin that clearing `E` elsewhere avoids.
-        ///
-        /// Routine and floored, not `immediate`: nobody is waiting on a screen, and the floor exists for exactly
-        /// this kind of background reconcile.
+        /// This fetch is what makes leaving `E` safe — nothing else on this path reaches the network, so without it the
+        /// account holds a stale future `E` with no proof and nothing scheduled to correct it.
         try? await refreshProState()
     }
 }
@@ -2194,15 +1971,11 @@ public protocol SessionProManagerType: SessionProUIManagerType {
     
     func purchasePro(productId: String) async throws
     /// - Parameters:
-    ///   - immediate: Bypass the status-refresh floor. **Reserved to the two genuine "go right now" callers** — a
-    ///   manual refresh/recover the user is waiting on, and the bounded post-purchase poll — plus the bounded
-    ///   while-open grace poll and developer-only paths, which the design lists as floor-exempt for the same reason
-    ///   (they carry their own cadence and their own termination). Routine triggers (startup, config change, on-enter,
-    ///   the `user_expiry` wake) must **not** pass it: once routine triggers bypass the floor, the floor stops
-    ///   bounding anything and the parameter becomes decoration.
-    ///   - forceLoadingState: Show the spinner even when the current state isn't an error. **Orthogonal to
-    ///   `immediate`** — spinner UI is a separate concern from bypassing the floor, and conflating them is what the
-    ///   rename to `immediate` exists to prevent.
+    ///   - immediate: Bypass the status-refresh floor. Reserved to callers that carry their own cadence and
+    ///   termination — manual refresh/recover, the post-purchase poll, the while-open grace poll. Routine triggers
+    ///   must not pass it; once they do, the floor stops bounding anything.
+    ///   - forceLoadingState: Show the spinner even when the current state isn't an error. Orthogonal to
+    ///   `immediate`.
     func refreshProState(immediate: Bool, forceLoadingState: Bool) async throws
     @MainActor func requestRefund(scene: UIWindowScene) async throws
     @MainActor func cancelPro(scene: UIWindowScene) async throws

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -1077,7 +1077,15 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
             case (.active, .notRefunding):
                 var renewingItems: [SessionListScreenContent.ListItemInfo<ListItem>] = []
                 
-                if state.proState.autoRenewing {
+                /// Gated on a confirmed fetch, not just on the flag: `autoRenewing` is owned by `get_pro_status`, so
+                /// before one has succeeded this reads `false` for everyone — including a renewing subscriber, who
+                /// would then be shown no way to cancel. The design has this row wait for the status rather than
+                /// guess at it, which is also what the Android and Desktop clients do.
+                ///
+                /// Latched (`hasConfirmedStatusFetch`) rather than `loadingState == .success` so that a later failed
+                /// refresh doesn't retract a control the user could already see — the last confirmed answer is still
+                /// the best one we have.
+                if state.proState.hasConfirmedStatusFetch, state.proState.autoRenewing {
                     renewingItems.append(
                         SessionListScreenContent.ListItemInfo(
                             id: .cancelPlan,

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -64,9 +64,30 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
 
         refreshTimer = Timer.scheduledTimerOnMainThread(withTimeInterval: 60, repeats: true) { [weak self] _ in
             guard let self else { return }
-            if (Double(internalState.proState.displayTimestampSeconds ?? 0) < dependencies.dateNow.timeIntervalSince1970) {
+
+            /// Network time, not the device clock, for every `E`-vs-now comparison — clock skew must not be what
+            /// decides whether we think the paid-through end has passed.
+            let nowMs: UInt64 = dependencies.networkOffsetTimestampMs()
+            let nowSeconds: UInt64 = (nowMs / 1000)
+
+            /// The grace poll exists to catch a renewal we are *waiting on*, so it is gated on `autoRenewing`:
+            /// with no renewal in flight there is nothing for a refetch to discover, and the poll is floor-exempt,
+            /// so every un-gated tick is an unthrottled request. Without this, a non-renewing subscription lapsing
+            /// with this screen open fires at least one such fetch and keeps firing every 60s.
+            ///
+            /// Deliberately this guard and **not** a `coverage_end` bound: where the past-grace boundary actually
+            /// sits is still disputed, whereas "not renewing ⇒ nothing to poll for" holds either way. Termination
+            /// past grace is left to `status` leaving `.active`, which tears the timer down via the guard above.
+            if
+                (internalState.proState.displayTimestampSeconds ?? 0) < nowSeconds,
+                internalState.proState.autoRenewing
+            {
                 Task { [dependencies] in
-                    try? await dependencies[singleton: .sessionProManager].refreshProState()
+                    /// `immediate` because the while-open grace poll is floor-exempt: its cadence is the same 60s as
+                    /// the floor, so leaving it floored would drop roughly every other tick to timing jitter and
+                    /// silently halve the poll rate. It is bounded instead by being screen-scoped and self-terminating
+                    /// (it stops re-fetching the moment `E` advances, and the timer is torn down past grace or on close).
+                    try? await dependencies[singleton: .sessionProManager].refreshProState(immediate: true)
                 }
             } else {
                 self.state.updateTableData(
@@ -837,9 +858,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
 
                                         case .success:
                                             let expirationTimestamp: TimeInterval = Double(state.proState.displayTimestampSeconds ?? 0)
-                                            let isInAutoRenewingGracePeriod: Bool = (
-                                                (expirationTimestamp < viewModel.dependencies.dateNow.timeIntervalSince1970) &&
-                                                state.proState.autoRenewing
+                                            let isInAutoRenewingGracePeriod: Bool = state.proState.isRenewalOverdue(
+                                                atTimestampSeconds: (
+                                                    viewModel.dependencies.networkOffsetTimestampMs() / 1000
+                                                )
                                             )
                                             if isInAutoRenewingGracePeriod {
                                                 return SessionListScreenContent.TextInfo(
@@ -886,10 +908,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                         onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                             switch state.proState.loadingState {
                                 case .success:
-                                    let expirationTimestamp: TimeInterval = Double(state.proState.displayTimestampSeconds ?? 0)
-                                    let isInAutoRenewingGracePeriod: Bool = (
-                                        (expirationTimestamp < dependencies.dateNow.timeIntervalSince1970) &&
-                                        state.proState.autoRenewing
+                                    let isInAutoRenewingGracePeriod: Bool = state.proState.isRenewalOverdue(
+                                        atTimestampSeconds: (dependencies.networkOffsetTimestampMs() / 1000)
                                     )
                                     if isInAutoRenewingGracePeriod {
                                         let modal: ConfirmationModal = ConfirmationModal(
@@ -1263,7 +1283,9 @@ extension SessionProSettingsViewModel {
                 cancelStyle: .alert_text,
                 onConfirm:  { [dependencies] _ in
                     Task.detached(priority: .userInitiated) {
-                        try? await dependencies[singleton: .sessionProManager].refreshProState()
+                        /// Manual retry — `immediate`, one of the two callers the floor bypass is reserved for. A user
+                        /// who taps "retry" and gets a silently-dropped refresh has been told the button is broken.
+                        try? await dependencies[singleton: .sessionProManager].refreshProState(immediate: true)
                     }
                 },
                 onCancel: { [weak self] _ in self?.openUrl(Constants.urls.proSupport) }
@@ -1295,8 +1317,12 @@ extension SessionProSettingsViewModel {
     
     @MainActor func recoverProPlan() {
         Task.detached(priority: .userInitiated) { [weak self, manager = dependencies[singleton: .sessionProManager]] in
-            try? await manager.refreshProState()
-            
+            /// Recover — `immediate`. This is the path a user with a server-side entitlement (a voucher, or a
+            /// subscription the startup gate deliberately doesn't go looking for) relies on, and its whole outcome is
+            /// the modal below reporting what the fetch found, so it must not be dropped by the floor.
+            try? await manager.refreshProState(immediate: true)
+
+
             let state: SessionPro.State = manager.currentUserCurrentProState
             
             await MainActor.run { [weak self] in

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -70,17 +70,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
             let nowMs: UInt64 = dependencies.networkOffsetTimestampMs()
             let nowSeconds: UInt64 = (nowMs / 1000)
 
-            /// Poll only inside the grace window, `[E, E + G)` — the renewal has fallen due and we are still being
-            /// served, so a refetch has something to discover: did the charge land?
-            ///
-            /// Also gated on `autoRenewing`, which is not redundant with the window: with no renewal in flight there
-            /// is nothing to wait for, and the poll is floor-exempt, so every un-gated tick is an unthrottled
-            /// request. `G` is 0 when `!A`, making the window empty there anyway — the explicit guard states the
-            /// intent rather than relying on that arithmetic holding.
-            ///
-            /// The upper bound is what terminates the poll. Without it the timer depends on `status` leaving
-            /// `.active` to be torn down, which is a different event arriving from a different source — so a stalled
-            /// or failing status refresh would leave a floor-exempt poll running past the end of coverage.
+            /// Poll only inside the grace window, `[E, E + G)`, so a refetch can discover whether the charge landed. Also
+            /// gated on `autoRenewing`, since the poll is floor-exempt and an un-gated tick is unthrottled. The upper bound
+            /// terminates the poll; without it teardown depends on `status` leaving `.active`.
             if
                 let expirySeconds: UInt64 = internalState.proState.accessExpiryTimestampSeconds,
                 let coverageEndSeconds: UInt64 = internalState.proState.coverageEndTimestampSeconds,
@@ -1083,14 +1075,11 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
             case (.active, .notRefunding):
                 var renewingItems: [SessionListScreenContent.ListItemInfo<ListItem>] = []
                 
-                /// Gated on a confirmed fetch, not just on the flag: `autoRenewing` is owned by `get_pro_status`, so
-                /// before one has succeeded this reads `false` for everyone — including a renewing subscriber, who
-                /// would then be shown no way to cancel. The row therefore waits for the status rather than
-                /// guessing at it.
+                /// Gated on a confirmed fetch, not just the flag: `autoRenewing` is owned by `get_pro_status`, so before one
+                /// succeeds it reads `false` for everyone — including a renewing subscriber, who would be shown no way to cancel.
                 ///
-                /// Latched (`hasConfirmedStatusFetch`) rather than `loadingState == .success` so that a later failed
-                /// refresh doesn't retract a control the user could already see — the last confirmed answer is still
-                /// the best one we have.
+                /// Latched rather than `loadingState == .success`, so a later failed refresh doesn't retract a control the user
+                /// could already see.
                 if state.proState.hasConfirmedStatusFetch, state.proState.autoRenewing {
                     renewingItems.append(
                         SessionListScreenContent.ListItemInfo(

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -78,9 +78,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
             /// request. `G` is 0 when `!A`, making the window empty there anyway — the explicit guard states the
             /// intent rather than relying on that arithmetic holding.
             ///
-            /// The upper bound is new: it used to be omitted because where the past-grace boundary sat was disputed,
-            /// and termination was left to `status` leaving `.active`. It isn't disputed any more — coverage ends at
-            /// `E + G` — so the poll now stops itself rather than depending on a status change to tear the timer down.
+            /// The upper bound is what terminates the poll. Without it the timer depends on `status` leaving
+            /// `.active` to be torn down, which is a different event arriving from a different source — so a stalled
+            /// or failing status refresh would leave a floor-exempt poll running past the end of coverage.
             if
                 let expirySeconds: UInt64 = internalState.proState.accessExpiryTimestampSeconds,
                 let coverageEndSeconds: UInt64 = internalState.proState.coverageEndTimestampSeconds,
@@ -1085,8 +1085,8 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                 
                 /// Gated on a confirmed fetch, not just on the flag: `autoRenewing` is owned by `get_pro_status`, so
                 /// before one has succeeded this reads `false` for everyone — including a renewing subscriber, who
-                /// would then be shown no way to cancel. The design has this row wait for the status rather than
-                /// guess at it, which is also what the Android and Desktop clients do.
+                /// would then be shown no way to cancel. The row therefore waits for the status rather than
+                /// guessing at it.
                 ///
                 /// Latched (`hasConfirmedStatusFetch`) rather than `loadingState == .success` so that a later failed
                 /// refresh doesn't retract a control the user could already see — the last confirmed answer is still

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -66,20 +66,26 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
             guard let self else { return }
 
             /// Network time, not the device clock, for every `E`-vs-now comparison — clock skew must not be what
-            /// decides whether we think the paid-through end has passed.
+            /// decides whether we think the renewal has fallen due.
             let nowMs: UInt64 = dependencies.networkOffsetTimestampMs()
             let nowSeconds: UInt64 = (nowMs / 1000)
 
-            /// The grace poll exists to catch a renewal we are *waiting on*, so it is gated on `autoRenewing`:
-            /// with no renewal in flight there is nothing for a refetch to discover, and the poll is floor-exempt,
-            /// so every un-gated tick is an unthrottled request. Without this, a non-renewing subscription lapsing
-            /// with this screen open fires at least one such fetch and keeps firing every 60s.
+            /// Poll only inside the grace window, `[E, E + G)` — the renewal has fallen due and we are still being
+            /// served, so a refetch has something to discover: did the charge land?
             ///
-            /// Deliberately this guard and **not** a `coverage_end` bound: where the past-grace boundary actually
-            /// sits is still disputed, whereas "not renewing ⇒ nothing to poll for" holds either way. Termination
-            /// past grace is left to `status` leaving `.active`, which tears the timer down via the guard above.
+            /// Also gated on `autoRenewing`, which is not redundant with the window: with no renewal in flight there
+            /// is nothing to wait for, and the poll is floor-exempt, so every un-gated tick is an unthrottled
+            /// request. `G` is 0 when `!A`, making the window empty there anyway — the explicit guard states the
+            /// intent rather than relying on that arithmetic holding.
+            ///
+            /// The upper bound is new: it used to be omitted because where the past-grace boundary sat was disputed,
+            /// and termination was left to `status` leaving `.active`. It isn't disputed any more — coverage ends at
+            /// `E + G` — so the poll now stops itself rather than depending on a status change to tear the timer down.
             if
-                (internalState.proState.displayTimestampSeconds ?? 0) < nowSeconds,
+                let expirySeconds: UInt64 = internalState.proState.accessExpiryTimestampSeconds,
+                let coverageEndSeconds: UInt64 = internalState.proState.coverageEndTimestampSeconds,
+                nowSeconds >= expirySeconds,
+                nowSeconds < coverageEndSeconds,
                 internalState.proState.autoRenewing
             {
                 Task { [dependencies] in

--- a/SessionMessagingKit/SessionPro/Types/SessionProLoadingState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProLoadingState.swift
@@ -18,7 +18,7 @@ public extension SessionPro {
     /// `guard loadingState != .loading` anywhere on the way into a refresh — the obvious way to avoid a
     /// duplicate request — and a process that has never fetched can never start one, because the state that
     /// would be resolved *by* the fetch is the state blocking it. The Pro screen then spins forever and no CTA
-    /// can fire, since both gate on a confirmed fetch. Android hit exactly this on the equivalent enum.
+    /// can fire, since both gate on a confirmed fetch.
     ///
     /// So: single-flight belongs in the manager, freshness belongs in the refresh floor, and this type answers
     /// only *"what should the UI show, and has a fetch confirmed?"*

--- a/SessionMessagingKit/SessionPro/Types/SessionProLoadingState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProLoadingState.swift
@@ -6,6 +6,22 @@ import Foundation
 import SessionUtilitiesKit
 
 public extension SessionPro {
+    /// 🔴 **This is a DISPLAY state. It is not a mutex — never gate a fetch on it.**
+    ///
+    /// `.loading` conflates two different things: *"nothing has been fetched yet"* and *"a fetch is in flight"*.
+    /// That is safe only because nothing in the app treats it as *"a request is already running, don't start
+    /// another"* — every reader uses it for a spinner, a placeholder, or `== .success` as a confirmed-status
+    /// gate. The single-flight mutex is `SessionProManager.isRefreshingState`, a dedicated bool read in exactly
+    /// one place.
+    ///
+    /// **What goes wrong if you conflate them**, so this isn't an abstract rule: add a
+    /// `guard loadingState != .loading` anywhere on the way into a refresh — the obvious way to avoid a
+    /// duplicate request — and a process that has never fetched can never start one, because the state that
+    /// would be resolved *by* the fetch is the state blocking it. The Pro screen then spins forever and no CTA
+    /// can fire, since both gate on a confirmed fetch. Android hit exactly this on the equivalent enum.
+    ///
+    /// So: single-flight belongs in the manager, freshness belongs in the refresh floor, and this type answers
+    /// only *"what should the UI show, and has a fetch confirmed?"*
     enum LoadingState: Sendable, CaseIterable, Equatable, CustomStringConvertible {
         case loading
         case error

--- a/SessionMessagingKit/SessionPro/Types/SessionProLoadingState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProLoadingState.swift
@@ -6,22 +6,14 @@ import Foundation
 import SessionUtilitiesKit
 
 public extension SessionPro {
-    /// 🔴 **This is a DISPLAY state. It is not a mutex — never gate a fetch on it.**
+    /// This is a DISPLAY state. It is not a mutex — never gate a fetch on it.
     ///
-    /// `.loading` conflates two different things: *"nothing has been fetched yet"* and *"a fetch is in flight"*.
-    /// That is safe only because nothing in the app treats it as *"a request is already running, don't start
-    /// another"* — every reader uses it for a spinner, a placeholder, or `== .success` as a confirmed-status
-    /// gate. The single-flight mutex is `SessionProManager.isRefreshingState`, a dedicated bool read in exactly
-    /// one place.
+    /// `.loading` conflates "nothing fetched yet" with "a fetch is in flight", which is safe only because every
+    /// reader uses it for a spinner, a placeholder, or `== .success` as a confirmed-status gate. The single-flight
+    /// mutex is `SessionProManager.isRefreshingState`.
     ///
-    /// **What goes wrong if you conflate them**, so this isn't an abstract rule: add a
-    /// `guard loadingState != .loading` anywhere on the way into a refresh — the obvious way to avoid a
-    /// duplicate request — and a process that has never fetched can never start one, because the state that
-    /// would be resolved *by* the fetch is the state blocking it. The Pro screen then spins forever and no CTA
-    /// can fire, since both gate on a confirmed fetch.
-    ///
-    /// So: single-flight belongs in the manager, freshness belongs in the refresh floor, and this type answers
-    /// only *"what should the UI show, and has a fetch confirmed?"*
+    /// Gating a refresh on `!= .loading` means a process that has never fetched can never start one, because the
+    /// state the fetch would resolve is the state blocking it — the Pro screen then spins forever and no CTA fires.
     enum LoadingState: Sendable, CaseIterable, Equatable, CustomStringConvertible {
         case loading
         case error

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -22,6 +22,9 @@ public extension SessionPro {
         
         public let autoRenewing: Bool
         public let accessExpiryTimestampSeconds: UInt64?
+        /// The account's grace period in seconds, `0` if none. Only meaningful paired with the `E` it arrived
+        /// with — see `displayTimestampSeconds`, which is the only thing that should be subtracting it.
+        public let gracePeriodSeconds: UInt64
         /// Unix seconds at which a refund was requested (config-synced via `user_profile_get_refund_requested`),
         /// or `0` if none. Refund-pending is no longer a per-payment backend field — it's cross-device config
         /// state — so the manager reads it from libsession and stashes it here to drive `refundingStatus`.
@@ -48,65 +51,38 @@ public extension SessionPro {
         /// `loadingState` itself carries *when*; if that happens, delete this then and not before.
         public let lastConfirmedStatusFetchSeconds: UInt64
 
-        /// 🔴 **The comment below asserts a premise that is WRONG, and the fix is deliberately not here.**
-        /// `get_pro_status`'s `expiry_ts` is **grace-INCLUSIVE**: verified against `Session-Pro-Backend`
-        /// @ `a5efbf9`, the backend folds grace in at *write* time
-        /// (`payment_expiry_at = expiry_at + grace if auto_renewing`) and judges `Active`/`Expired` against
-        /// that same value — its own test subtracts grace to recover the store's paid-through date. So this
-        /// is **`coverage_end`**, not paid-through: `now ≥ E` is the grace **exit**, and the real grace
-        /// window is `E − grace ≤ now < E`.
+        /// The instant the renewal falls due — the account's paid-through end.
         ///
-        /// Two consequences. The first is severe everywhere; the second's magnitude depends on the **payment
-        /// provider**, which is *not* the same thing as the platform doing the displaying:
-        /// - 🔴 **The real defect, provider-independent:** a grace indicator written as `now ≥ E` *inside* an
-        ///   Active branch is **dead code**. Active requires `now ≤ E`, so the two meet only at a single
-        ///   instant, and the "renewal overdue, still covered" state is therefore **unreachable** — which is
-        ///   the entire state this refresh redesign exists to surface.
-        /// - **A renewal date rendered as `E` is late by one grace period.** For an **App Store** payment
-        ///   that is ~1 hour (Apple configures no grace period, so the backend's is entirely its own) and
-        ///   effectively cosmetic. For a **Play Store** payment it is the base plan's operator-configured
-        ///   grace — *days* — and the backend stores the real value at the moment the user **enters** grace,
-        ///   i.e. exactly when this screen is the one they are looking at.
+        /// **`E` alone is the end of COVERAGE, not the renewal date.** The backend folds the grace period into
+        /// the stored expiry for auto-renewing subscriptions (`payment_expiry_at = expiry_at + grace`) and
+        /// judges `Active`/`Expired` against that same value, so `E` overshoots the date the user is actually
+        /// paid up to by exactly one grace period. Subtracting `G` recovers it, and needs no branching on the
+        /// provider or the renewal state: the backend sends `grace = 0` whenever the subscription isn't
+        /// auto-renewing, so `E - 0 == E` there.
         ///
-        /// **That second case reaches this client.** `latestPaymentItem.paymentProvider` can be `.playStore`
-        /// (see `originatingPlatform`, which the grace modal interpolates as the store name), so a user who
-        /// subscribed on Android and views on iOS gets the multi-day error here. Do not simplify this to
-        /// "iOS is Apple, therefore an hour" — the purchase path is Apple-only, the *display* path is not.
-        ///
-        /// Not corrected here because all three clients wrote the same wrong premise in three different
-        /// wordings — which is why it read as corroboration rather than one mistake — so the correction is
-        /// one uniform change that must land on all three together. With the architect.
-        ///
-        /// Original text kept verbatim below, superseded, so it stays greppable alongside the Android and
-        /// desktop copies it echoes:
-        ///
-        /// > Both the renewal countdown and the grace trigger key off the ACCOUNT paid-through end
-        /// > (`get_pro_status` `expiry_ts`), never the latest payment's expiry — those differ when vouchers
-        /// > or overlapping payments are involved. Matches Android/desktop.
+        /// `E` and `G` are only comparable as a pair from one response — libsession enforces that by erasing
+        /// `G` when `E` is cleared, so a stranded `G` can't pair with a later, unrelated `E`.
         public var displayTimestampSeconds: UInt64? {
-            accessExpiryTimestampSeconds
+            accessExpiryTimestampSeconds.map { $0 - min($0, gracePeriodSeconds) }
         }
 
-        /// Whether we are past the account's paid-through end while still auto-renewing — i.e. the renewal is
-        /// overdue but the account is still covered by the backend's grace period.
+        /// Whether the renewal is overdue but the account is still covered — i.e. we are inside the grace
+        /// window, `paid-through <= now < E`.
         ///
-        /// **Debounced against the crossing**, which is the point: at the instant `E` passes, the newest
-        /// status we hold was fetched *before* it, and a subscription that renewed cleanly looks identical to
-        /// one that failed until we ask again. Requiring a fetch that completed at or after `E` is what stops
-        /// the warning firing off that stale snapshot. The `E+30s` `user_expiry` wake is what supplies that
-        /// fetch promptly; without it this would stay false for as long as nothing else went to the network.
-        ///
-        /// 🔴 **The THRESHOLD here inherits the wrong premise flagged on `displayTimestampSeconds` above.**
-        /// `E` is grace-*inclusive*, so `now ≥ E` is the grace **exit** — on a correct reading this can only
-        /// become true once coverage has fully lapsed, and the real window is `E − grace ≤ now < E`. The
-        /// *debounce* (requiring a confirmed fetch past the threshold) is correct wherever the threshold
-        /// sits; it is the comparison that moves. Left for the one uniform cross-client correction.
+        /// **Debounced against the crossing**, which is the point: at the instant paid-through passes, the
+        /// newest status we hold was fetched *before* it, and a subscription that renewed cleanly looks
+        /// identical to one that failed until we ask again. Requiring a fetch that completed at or after the
+        /// threshold is what stops the warning firing off that stale snapshot. The `user_expiry` wake is what
+        /// supplies that fetch promptly; without it this would stay false until something else went to the
+        /// network.
         public func isRenewalOverdue(atTimestampSeconds nowSeconds: UInt64) -> Bool {
-            guard autoRenewing, let expirySeconds: UInt64 = accessExpiryTimestampSeconds, expirySeconds > 0 else {
-                return false
-            }
+            guard
+                autoRenewing,
+                let paidThroughSeconds: UInt64 = displayTimestampSeconds,
+                paidThroughSeconds > 0
+            else { return false }
 
-            return (nowSeconds >= expirySeconds && lastConfirmedStatusFetchSeconds >= expirySeconds)
+            return (nowSeconds >= paidThroughSeconds && lastConfirmedStatusFetchSeconds >= paidThroughSeconds)
         }
     }
 }
@@ -123,6 +99,7 @@ public extension SessionPro.State {
         profileFeatures: .none,
         autoRenewing: false,
         accessExpiryTimestampSeconds: 0,
+        gracePeriodSeconds: 0,
         refundRequestedTimestampSeconds: 0,
         latestPaymentItem: nil,
         originatingPlatform: .iOS,
@@ -143,6 +120,7 @@ internal extension SessionPro.State {
         profileFeatures: Update<SessionPro.ProfileFeatures> = .useExisting,
         autoRenewing: Update<Bool> = .useExisting,
         accessExpiryTimestampSeconds: Update<UInt64?> = .useExisting,
+        gracePeriodSeconds: Update<UInt64> = .useExisting,
         refundRequestedTimestampSeconds: Update<UInt64> = .useExisting,
         latestPaymentItem: Update<Network.SessionPro.PaymentItem?> = .useExisting,
         lastConfirmedStatusFetchSeconds: Update<UInt64> = .useExisting,
@@ -223,6 +201,7 @@ internal extension SessionPro.State {
             profileFeatures: profileFeatures.or(self.profileFeatures),
             autoRenewing: autoRenewing.or(self.autoRenewing),
             accessExpiryTimestampSeconds: finalAccessExpiryTimestampSeconds,
+            gracePeriodSeconds: gracePeriodSeconds.or(self.gracePeriodSeconds),
             refundRequestedTimestampSeconds: finalRefundRequestedTimestampSeconds,
             latestPaymentItem: finalLatestPaymentItem,
             originatingPlatform: finalOriginatingPlatform,

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -62,12 +62,15 @@ public extension SessionPro {
         ///
         /// `E` and `G` are only comparable as a pair from one response — libsession enforces that by erasing
         /// `G` when `E` is cleared, so a stranded `G` can't pair with a later, unrelated `E`.
-        /// **The `min` is an underflow guard.** These are `UInt64`, so a bare `$0 - gracePeriodSeconds` traps
-        /// when grace exceeds expiry, and `max(0, …)` — the signed-arithmetic reflex — is a no-op here. It
-        /// clamps to `0`, which `isRenewalOverdue` and every other consumer treat as "no meaningful
-        /// paid-through instant"; it only arises for an unset or garbage `E`.
+        /// Clamps rather than traps: these are `UInt64` and both arrive from **synced config**, so a corrupt
+        /// value is reachable from another device — and an unsigned underflow would crash on every launch,
+        /// which is worse than any wrong date. The degenerate branch treats "grace at least as large as the
+        /// expiry" as *no grace*; `G` is a duration and `E` a ~1.7-billion-second timestamp, so it cannot
+        /// arise from real data.
         public var displayTimestampSeconds: UInt64? {
-            accessExpiryTimestampSeconds.map { $0 - min($0, gracePeriodSeconds) }
+            accessExpiryTimestampSeconds.map { expiry in
+                (gracePeriodSeconds < expiry ? expiry - gracePeriodSeconds : expiry)
+            }
         }
 
         /// Whether the renewal is overdue but the account is still covered — i.e. we are inside the grace

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -22,8 +22,9 @@ public extension SessionPro {
         
         public let autoRenewing: Bool
         public let accessExpiryTimestampSeconds: UInt64?
-        /// The account's grace period in seconds, `0` if none. Only meaningful paired with the `E` it arrived
-        /// with — see `displayTimestampSeconds`, which is the only thing that should be subtracting it.
+        /// How much longer the account is served past `E`, in seconds; `0` if none. Only meaningful paired with the
+        /// `E` it arrived with — see `coverageEndTimestampSeconds`, which is the only thing that should be adding it.
+        /// It is **not** part of the date shown to the user; that is `E` alone.
         public let gracePeriodSeconds: UInt64
         /// Unix seconds at which a refund was requested (config-synced via `user_profile_get_refund_requested`),
         /// or `0` if none. Refund-pending is no longer a per-payment backend field — it's cross-device config
@@ -64,45 +65,65 @@ public extension SessionPro {
         /// the question is "do we know enough to show this at all".
         public var hasConfirmedStatusFetch: Bool { (lastConfirmedStatusFetchSeconds > 0) }
 
-        /// The instant the renewal falls due — the account's paid-through end.
+        /// The date to show the user: when the account expires, i.e. when the renewal falls due.
         ///
-        /// **`E` alone is the end of COVERAGE, not the renewal date.** The backend folds the grace period into
-        /// the stored expiry for auto-renewing subscriptions (`payment_expiry_at = expiry_at + grace`) and
-        /// judges `Active`/`Expired` against that same value, so `E` overshoots the date the user is actually
-        /// paid up to by exactly one grace period. Subtracting `G` recovers it, and needs no branching on the
-        /// provider or the renewal state: the backend sends `grace = 0` whenever the subscription isn't
-        /// auto-renewing, so `E - 0 == E` there.
+        /// **This is `E` itself — there is no arithmetic.** `E` (`expiry_ts`) is the end of the paid term, the
+        /// honest thing to show; it is deliberately *not* the instant we stop serving. Two questions, two
+        /// values, and this type answers them separately so they can't be confused again:
         ///
-        /// `E` and `G` are only comparable as a pair from one response — libsession enforces that by erasing
-        /// `G` when `E` is cleared, so a stranded `G` can't pair with a later, unrelated `E`.
-        /// Clamps rather than traps: these are `UInt64` and both arrive from **synced config**, so a corrupt
-        /// value is reachable from another device — and an unsigned underflow would crash on every launch,
-        /// which is worse than any wrong date. The degenerate branch treats "grace at least as large as the
-        /// expiry" as *no grace*; `G` is a duration and `E` a ~1.7-billion-second timestamp, so it cannot
-        /// arise from real data.
-        public var displayTimestampSeconds: UInt64? {
+        /// | question | value |
+        /// |---|---|
+        /// | what date do I show? | `displayTimestampSeconds` — `E` |
+        /// | until when are we served? | `coverageEndTimestampSeconds` — `E + G` |
+        ///
+        /// The property is kept rather than folded into `accessExpiryTimestampSeconds` because naming the
+        /// *question* is what stops a coverage test being written against the display value; they were once the
+        /// same quantity expressed two ways and are now genuinely different instants.
+        public var displayTimestampSeconds: UInt64? { accessExpiryTimestampSeconds }
+
+        /// The instant we stop being served — the end of coverage, `E + G`.
+        ///
+        /// `G` is how much longer the backend keeps serving past the expiry it reported: the store's dunning
+        /// grace plus a latency allowance, and `0` whenever the subscription isn't auto-renewing, so `E + 0 == E`
+        /// there and no branching on provider or renewal state is needed. The backend judges `Active`/`Expired`
+        /// against exactly this instant.
+        ///
+        /// 🔴 **Read `G` from the response root, never from `latest_payment`.** Both carry a field of that name
+        /// and they are different quantities — the payment-level one is the raw store value and is *not* gated on
+        /// `auto_renewing`, so a cancelled subscriber keeps a multi-week value there and coverage would run weeks
+        /// late. See `GetProStatusResponse`.
+        ///
+        /// `E` and `G` are only comparable as a pair from one response — libsession enforces that by erasing `G`
+        /// when `E` is cleared, so a stranded `G` can't pair with a later, unrelated `E`. Clamps rather than
+        /// traps: both arrive from **synced config**, so a corrupt value is reachable from another device, and an
+        /// unsigned overflow would crash on every launch — worse than any wrong date.
+        public var coverageEndTimestampSeconds: UInt64? {
             accessExpiryTimestampSeconds.map { expiry in
-                (gracePeriodSeconds < expiry ? expiry - gracePeriodSeconds : expiry)
+                (expiry > (UInt64.max - gracePeriodSeconds) ? UInt64.max : expiry + gracePeriodSeconds)
             }
         }
 
-        /// Whether the renewal is overdue but the account is still covered — i.e. we are inside the grace
-        /// window, `paid-through <= now < E`.
+        /// Whether the renewal is overdue but the account is still being served — i.e. inside the grace window,
+        /// `E <= now < E + G`.
         ///
-        /// **Debounced against the crossing**, which is the point: at the instant paid-through passes, the
-        /// newest status we hold was fetched *before* it, and a subscription that renewed cleanly looks
-        /// identical to one that failed until we ask again. Requiring a fetch that completed at or after the
-        /// threshold is what stops the warning firing off that stale snapshot. The `user_expiry` wake is what
-        /// supplies that fetch promptly; without it this would stay false until something else went to the
-        /// network.
+        /// **Debounced against the crossing**, which is the point: at the instant `E` passes, the newest status we
+        /// hold was fetched *before* it, and a subscription that renewed cleanly looks identical to one that
+        /// failed until we ask again. Requiring a fetch that completed at or after `E` is what stops the warning
+        /// firing off that stale snapshot. The `user_expiry` wake is what supplies that fetch promptly; without it
+        /// this would stay false until something else went to the network.
         public func isRenewalOverdue(atTimestampSeconds nowSeconds: UInt64) -> Bool {
             guard
                 autoRenewing,
-                let paidThroughSeconds: UInt64 = displayTimestampSeconds,
-                paidThroughSeconds > 0
+                let expirySeconds: UInt64 = accessExpiryTimestampSeconds,
+                expirySeconds > 0,
+                let coverageEndSeconds: UInt64 = coverageEndTimestampSeconds
             else { return false }
 
-            return (nowSeconds >= paidThroughSeconds && lastConfirmedStatusFetchSeconds >= paidThroughSeconds)
+            return (
+                nowSeconds >= expirySeconds &&
+                nowSeconds < coverageEndSeconds &&
+                lastConfirmedStatusFetchSeconds >= expirySeconds
+            )
         }
     }
 }

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -24,7 +24,7 @@ public extension SessionPro {
         public let accessExpiryTimestampSeconds: UInt64?
         /// How much longer the account is served past `E`, in seconds; `0` if none. Only meaningful paired with the
         /// `E` it arrived with — see `coverageEndTimestampSeconds`, which is the only thing that should be adding it.
-        /// It is **not** part of the date shown to the user; that is `E` alone.
+        /// It is not part of the date shown to the user; that is `E` alone.
         public let gracePeriodSeconds: UInt64
         /// Unix seconds at which a refund was requested (config-synced via `user_profile_get_refund_requested`),
         /// or `0` if none. Refund-pending is no longer a per-payment backend field — it's cross-device config
@@ -35,73 +35,38 @@ public extension SessionPro {
         public let originatingAccount: SessionPro.OriginatingAccount
         public let refundingStatus: SessionPro.RefundingStatus
 
-        /// Unix seconds at which the last `get_pro_status` **completed successfully**, or `0` if none has this
-        /// process. `loadingState == .success` only says a fetch succeeded at *some* point; this says *when*, which is
-        /// what a warning needs before it can claim the status behind it is post-threshold rather than a pre-crossing
-        /// snapshot. Not persisted — a warning should re-confirm after a cold launch.
-        ///
-        /// **This is the "have we CONFIRMED?" value. Its counterpart is the "have we ASKED?" value**, the persisted
-        /// `proStatusLastFetchAttemptTimestamp` backing the refresh floor. Substituting one for the other is the bug
-        /// both names exist to prevent, so they are named after the question they answer rather than after what they
-        /// are: anything gating a *display* claim reads this one; anything rate-limiting a *request* reads that one.
-        ///
-        /// Read for *when* by `isRenewalOverdue(atTimestampSeconds:)` and for *whether* by
-        /// `hasConfirmedStatusFetch`. The `when` is the part that can't be recovered from `loadingState`: gating
-        /// `isRenewalOverdue` on `loadingState == .success` alone is what shipped before, and it fires the alarming
-        /// "renewal unsuccessful" copy off a **pre-crossing snapshot** the moment `E` passes — `.success` means "a
-        /// fetch succeeded at some point", which at that instant is necessarily a fetch from before the threshold.
-        /// Removable only once `loadingState` itself carries *when*; if that happens, delete this then and not before.
+        /// Unix seconds at which the last `get_pro_status` completed successfully, or `0` if none this process.
+        /// `loadingState == .success` says a fetch succeeded at some point; this says when, which is what a warning needs
+        /// before claiming its status is post-threshold. Its counterpart is the persisted
+        /// `proStatusLastFetchAttemptTimestamp`: this gates display claims, that rate-limits requests.
         public let lastConfirmedStatusFetchSeconds: UInt64
 
-        /// Whether a `get_pro_status` has confirmed this state at any point this process.
+        /// Whether a `get_pro_status` has confirmed this state at any point this process, for anything that must not
+        /// render off unconfirmed status — at cold launch the fields a response owns are absent and `status` is inferred
+        /// from the local proof.
         ///
-        /// **For anything that must not be rendered off unconfirmed status.** At cold launch the fields a
-        /// `get_pro_status` owns are simply absent, and `status` is inferred from the local proof — so a control that
-        /// keys off, say, `autoRenewing` would render its "not renewing" shape before we have asked anyone.
-        ///
-        /// 🔴 **Latched, not tracked — this is the difference from `loadingState == .success`.** Set once on the first
-        /// success and never cleared, so a later failure doesn't retract a control the user could already see. Use
-        /// `loadingState` where the question is "what is the request doing *now*" (spinner, retry copy); use this where
-        /// the question is "do we know enough to show this at all".
+        /// Latched, not tracked: set once on the first success and never cleared, so a later failure doesn't retract a
+        /// control the user could already see.
         public var hasConfirmedStatusFetch: Bool { (lastConfirmedStatusFetchSeconds > 0) }
 
-        /// The date to show the user: when the account expires, i.e. when the renewal falls due.
-        ///
-        /// **This is `E` itself — there is no arithmetic.** `E` (`expiry_ts`) is the end of the paid term, the
-        /// honest thing to show; it is deliberately *not* the instant we stop serving. Two questions, two
-        /// values, and this type answers them separately so they can't be confused again:
-        ///
-        /// | question | value |
-        /// |---|---|
-        /// | what date do I show? | `displayTimestampSeconds` — `E` |
-        /// | until when are we served? | `coverageEndTimestampSeconds` — `E + G` |
-        ///
-        /// The property is kept rather than folded into `accessExpiryTimestampSeconds` because naming the
-        /// *question* is what stops a coverage test being written against the display value; they were once the
-        /// same quantity expressed two ways and are now genuinely different instants.
+        /// The date to show the user: `E` itself, no arithmetic. Named separately from `accessExpiryTimestampSeconds` so
+        /// a coverage test can't be written against the value the UI renders.
         public var displayTimestampSeconds: UInt64? { accessExpiryTimestampSeconds }
 
-        /// The instant we stop being served — the end of coverage, `E + G`. The backend judges `Active`/`Expired`
-        /// against exactly this instant. See `SessionPro.coverageEndSeconds` for why the addition saturates.
+        /// The instant we stop being served — `E + G`, which is what the backend judges `Active`/`Expired` against.
         ///
-        /// 🔴 **`G` here must be the response's ROOT `grace_period_duration`, never `latest_payment`'s.** Both carry
-        /// a field of that name and they are different quantities: the payment-level one is the raw store value and
-        /// is *not* gated on `auto_renewing`, so a cancelled subscriber keeps a multi-week value there and coverage
-        /// would run weeks late. See `GetProStatusResponse`.
+        /// `G` must be the response's root `grace_period_duration`, never `latest_payment`'s: that one is not gated on
+        /// `auto_renewing`, so a cancelled subscriber keeps a multi-week value there.
         public var coverageEndTimestampSeconds: UInt64? {
             accessExpiryTimestampSeconds.map { expiry in
                 SessionPro.coverageEndSeconds(expirySeconds: expiry, gracePeriodSeconds: gracePeriodSeconds)
             }
         }
 
-        /// Whether the renewal is overdue but the account is still being served — i.e. inside the grace window,
-        /// `E <= now < E + G`.
+        /// Whether the renewal is overdue but the account is still being served — inside `[E, E + G)`.
         ///
-        /// **Debounced against the crossing**, which is the point: at the instant `E` passes, the newest status we
-        /// hold was fetched *before* it, and a subscription that renewed cleanly looks identical to one that
-        /// failed until we ask again. Requiring a fetch that completed at or after `E` is what stops the warning
-        /// firing off that stale snapshot. The `user_expiry` wake is what supplies that fetch promptly; without it
-        /// this would stay false until something else went to the network.
+        /// Debounced against the crossing: at the instant `E` passes, the newest status we hold predates it, and a clean
+        /// renewal looks identical to a failed one until we ask again. The `user_expiry` wake supplies that fetch.
         public func isRenewalOverdue(atTimestampSeconds nowSeconds: UInt64) -> Bool {
             guard
                 autoRenewing,

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -44,12 +44,25 @@ public extension SessionPro {
         /// both names exist to prevent, so they are named after the question they answer rather than after what they
         /// are: anything gating a *display* claim reads this one; anything rate-limiting a *request* reads that one.
         ///
-        /// **Sole consumer is `isRenewalOverdue(atTimestampSeconds:)`.** Dropping it and gating that on
-        /// `loadingState == .success` alone is what shipped before, and it fires the alarming "renewal unsuccessful"
-        /// copy off a **pre-crossing snapshot** the moment `E` passes — `.success` means "a fetch succeeded at some
-        /// point", which at that instant is necessarily a fetch from before the threshold. Removable only once
-        /// `loadingState` itself carries *when*; if that happens, delete this then and not before.
+        /// Read for *when* by `isRenewalOverdue(atTimestampSeconds:)` and for *whether* by
+        /// `hasConfirmedStatusFetch`. The `when` is the part that can't be recovered from `loadingState`: gating
+        /// `isRenewalOverdue` on `loadingState == .success` alone is what shipped before, and it fires the alarming
+        /// "renewal unsuccessful" copy off a **pre-crossing snapshot** the moment `E` passes — `.success` means "a
+        /// fetch succeeded at some point", which at that instant is necessarily a fetch from before the threshold.
+        /// Removable only once `loadingState` itself carries *when*; if that happens, delete this then and not before.
         public let lastConfirmedStatusFetchSeconds: UInt64
+
+        /// Whether a `get_pro_status` has confirmed this state at any point this process.
+        ///
+        /// **For anything that must not be rendered off unconfirmed status.** At cold launch the fields a
+        /// `get_pro_status` owns are simply absent, and `status` is inferred from the local proof — so a control that
+        /// keys off, say, `autoRenewing` would render its "not renewing" shape before we have asked anyone.
+        ///
+        /// 🔴 **Latched, not tracked — this is the difference from `loadingState == .success`.** Set once on the first
+        /// success and never cleared, so a later failure doesn't retract a control the user could already see. Use
+        /// `loadingState` where the question is "what is the request doing *now*" (spinner, retry copy); use this where
+        /// the question is "do we know enough to show this at all".
+        public var hasConfirmedStatusFetch: Bool { (lastConfirmedStatusFetchSeconds > 0) }
 
         /// The instant the renewal falls due — the account's paid-through end.
         ///

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -81,25 +81,16 @@ public extension SessionPro {
         /// same quantity expressed two ways and are now genuinely different instants.
         public var displayTimestampSeconds: UInt64? { accessExpiryTimestampSeconds }
 
-        /// The instant we stop being served — the end of coverage, `E + G`.
+        /// The instant we stop being served — the end of coverage, `E + G`. The backend judges `Active`/`Expired`
+        /// against exactly this instant. See `SessionPro.coverageEndSeconds` for why the addition saturates.
         ///
-        /// `G` is how much longer the backend keeps serving past the expiry it reported: the store's dunning
-        /// grace plus a latency allowance, and `0` whenever the subscription isn't auto-renewing, so `E + 0 == E`
-        /// there and no branching on provider or renewal state is needed. The backend judges `Active`/`Expired`
-        /// against exactly this instant.
-        ///
-        /// 🔴 **Read `G` from the response root, never from `latest_payment`.** Both carry a field of that name
-        /// and they are different quantities — the payment-level one is the raw store value and is *not* gated on
-        /// `auto_renewing`, so a cancelled subscriber keeps a multi-week value there and coverage would run weeks
-        /// late. See `GetProStatusResponse`.
-        ///
-        /// `E` and `G` are only comparable as a pair from one response — libsession enforces that by erasing `G`
-        /// when `E` is cleared, so a stranded `G` can't pair with a later, unrelated `E`. Clamps rather than
-        /// traps: both arrive from **synced config**, so a corrupt value is reachable from another device, and an
-        /// unsigned overflow would crash on every launch — worse than any wrong date.
+        /// 🔴 **`G` here must be the response's ROOT `grace_period_duration`, never `latest_payment`'s.** Both carry
+        /// a field of that name and they are different quantities: the payment-level one is the raw store value and
+        /// is *not* gated on `auto_renewing`, so a cancelled subscriber keeps a multi-week value there and coverage
+        /// would run weeks late. See `GetProStatusResponse`.
         public var coverageEndTimestampSeconds: UInt64? {
             accessExpiryTimestampSeconds.map { expiry in
-                (expiry > (UInt64.max - gracePeriodSeconds) ? UInt64.max : expiry + gracePeriodSeconds)
+                SessionPro.coverageEndSeconds(expirySeconds: expiry, gracePeriodSeconds: gracePeriodSeconds)
             }
         }
 

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -30,12 +30,83 @@ public extension SessionPro {
         public let originatingPlatform: SessionProUI.ClientPlatform
         public let originatingAccount: SessionPro.OriginatingAccount
         public let refundingStatus: SessionPro.RefundingStatus
-        
-        /// Both the renewal countdown and the grace trigger key off the ACCOUNT paid-through end
-        /// (`get_pro_status` `expiry_ts`), never the latest payment's expiry — those differ when vouchers
-        /// or overlapping payments are involved. Matches Android/desktop.
+
+        /// Unix seconds at which the last `get_pro_status` **completed successfully**, or `0` if none has this
+        /// process. `loadingState == .success` only says a fetch succeeded at *some* point; this says *when*, which is
+        /// what a warning needs before it can claim the status behind it is post-threshold rather than a pre-crossing
+        /// snapshot. Not persisted — a warning should re-confirm after a cold launch.
+        ///
+        /// **This is the "have we CONFIRMED?" value. Its counterpart is the "have we ASKED?" value**, the persisted
+        /// `proStatusLastFetchAttemptTimestamp` backing the refresh floor. Substituting one for the other is the bug
+        /// both names exist to prevent, so they are named after the question they answer rather than after what they
+        /// are: anything gating a *display* claim reads this one; anything rate-limiting a *request* reads that one.
+        ///
+        /// **Sole consumer is `isRenewalOverdue(atTimestampSeconds:)`.** Dropping it and gating that on
+        /// `loadingState == .success` alone is what shipped before, and it fires the alarming "renewal unsuccessful"
+        /// copy off a **pre-crossing snapshot** the moment `E` passes — `.success` means "a fetch succeeded at some
+        /// point", which at that instant is necessarily a fetch from before the threshold. Removable only once
+        /// `loadingState` itself carries *when*; if that happens, delete this then and not before.
+        public let lastConfirmedStatusFetchSeconds: UInt64
+
+        /// 🔴 **The comment below asserts a premise that is WRONG, and the fix is deliberately not here.**
+        /// `get_pro_status`'s `expiry_ts` is **grace-INCLUSIVE**: verified against `Session-Pro-Backend`
+        /// @ `a5efbf9`, the backend folds grace in at *write* time
+        /// (`payment_expiry_at = expiry_at + grace if auto_renewing`) and judges `Active`/`Expired` against
+        /// that same value — its own test subtracts grace to recover the store's paid-through date. So this
+        /// is **`coverage_end`**, not paid-through: `now ≥ E` is the grace **exit**, and the real grace
+        /// window is `E − grace ≤ now < E`.
+        ///
+        /// Two consequences. The first is severe everywhere; the second's magnitude depends on the **payment
+        /// provider**, which is *not* the same thing as the platform doing the displaying:
+        /// - 🔴 **The real defect, provider-independent:** a grace indicator written as `now ≥ E` *inside* an
+        ///   Active branch is **dead code**. Active requires `now ≤ E`, so the two meet only at a single
+        ///   instant, and the "renewal overdue, still covered" state is therefore **unreachable** — which is
+        ///   the entire state this refresh redesign exists to surface.
+        /// - **A renewal date rendered as `E` is late by one grace period.** For an **App Store** payment
+        ///   that is ~1 hour (Apple configures no grace period, so the backend's is entirely its own) and
+        ///   effectively cosmetic. For a **Play Store** payment it is the base plan's operator-configured
+        ///   grace — *days* — and the backend stores the real value at the moment the user **enters** grace,
+        ///   i.e. exactly when this screen is the one they are looking at.
+        ///
+        /// **That second case reaches this client.** `latestPaymentItem.paymentProvider` can be `.playStore`
+        /// (see `originatingPlatform`, which the grace modal interpolates as the store name), so a user who
+        /// subscribed on Android and views on iOS gets the multi-day error here. Do not simplify this to
+        /// "iOS is Apple, therefore an hour" — the purchase path is Apple-only, the *display* path is not.
+        ///
+        /// Not corrected here because all three clients wrote the same wrong premise in three different
+        /// wordings — which is why it read as corroboration rather than one mistake — so the correction is
+        /// one uniform change that must land on all three together. With the architect.
+        ///
+        /// Original text kept verbatim below, superseded, so it stays greppable alongside the Android and
+        /// desktop copies it echoes:
+        ///
+        /// > Both the renewal countdown and the grace trigger key off the ACCOUNT paid-through end
+        /// > (`get_pro_status` `expiry_ts`), never the latest payment's expiry — those differ when vouchers
+        /// > or overlapping payments are involved. Matches Android/desktop.
         public var displayTimestampSeconds: UInt64? {
             accessExpiryTimestampSeconds
+        }
+
+        /// Whether we are past the account's paid-through end while still auto-renewing — i.e. the renewal is
+        /// overdue but the account is still covered by the backend's grace period.
+        ///
+        /// **Debounced against the crossing**, which is the point: at the instant `E` passes, the newest
+        /// status we hold was fetched *before* it, and a subscription that renewed cleanly looks identical to
+        /// one that failed until we ask again. Requiring a fetch that completed at or after `E` is what stops
+        /// the warning firing off that stale snapshot. The `E+30s` `user_expiry` wake is what supplies that
+        /// fetch promptly; without it this would stay false for as long as nothing else went to the network.
+        ///
+        /// 🔴 **The THRESHOLD here inherits the wrong premise flagged on `displayTimestampSeconds` above.**
+        /// `E` is grace-*inclusive*, so `now ≥ E` is the grace **exit** — on a correct reading this can only
+        /// become true once coverage has fully lapsed, and the real window is `E − grace ≤ now < E`. The
+        /// *debounce* (requiring a confirmed fetch past the threshold) is correct wherever the threshold
+        /// sits; it is the comparison that moves. Left for the one uniform cross-client correction.
+        public func isRenewalOverdue(atTimestampSeconds nowSeconds: UInt64) -> Bool {
+            guard autoRenewing, let expirySeconds: UInt64 = accessExpiryTimestampSeconds, expirySeconds > 0 else {
+                return false
+            }
+
+            return (nowSeconds >= expirySeconds && lastConfirmedStatusFetchSeconds >= expirySeconds)
         }
     }
 }
@@ -56,7 +127,8 @@ public extension SessionPro.State {
         latestPaymentItem: nil,
         originatingPlatform: .iOS,
         originatingAccount: .originatingAccount,
-        refundingStatus: .notRefunding
+        refundingStatus: .notRefunding,
+        lastConfirmedStatusFetchSeconds: 0
     )
 }
 
@@ -73,6 +145,7 @@ internal extension SessionPro.State {
         accessExpiryTimestampSeconds: Update<UInt64?> = .useExisting,
         refundRequestedTimestampSeconds: Update<UInt64> = .useExisting,
         latestPaymentItem: Update<Network.SessionPro.PaymentItem?> = .useExisting,
+        lastConfirmedStatusFetchSeconds: Update<UInt64> = .useExisting,
         using dependencies: Dependencies
     ) -> SessionPro.State {
         let finalBuildVariant: BuildVariant = {
@@ -154,7 +227,9 @@ internal extension SessionPro.State {
             latestPaymentItem: finalLatestPaymentItem,
             originatingPlatform: finalOriginatingPlatform,
             originatingAccount: finalOriginatingAccount,
-            refundingStatus: finalRefundingStatus
+            refundingStatus: finalRefundingStatus,
+            lastConfirmedStatusFetchSeconds: lastConfirmedStatusFetchSeconds
+                .or(self.lastConfirmedStatusFetchSeconds)
         )
     }
 }

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -62,6 +62,10 @@ public extension SessionPro {
         ///
         /// `E` and `G` are only comparable as a pair from one response — libsession enforces that by erasing
         /// `G` when `E` is cleared, so a stranded `G` can't pair with a later, unrelated `E`.
+        /// **The `min` is an underflow guard.** These are `UInt64`, so a bare `$0 - gracePeriodSeconds` traps
+        /// when grace exceeds expiry, and `max(0, …)` — the signed-arithmetic reflex — is a no-op here. It
+        /// clamps to `0`, which `isRenewalOverdue` and every other consumer treat as "no meaningful
+        /// paid-through instant"; it only arises for an unset or garbage `E`.
         public var displayTimestampSeconds: UInt64? {
             accessExpiryTimestampSeconds.map { $0 - min($0, gracePeriodSeconds) }
         }

--- a/SessionMessagingKit/Utilities/Preferences.swift
+++ b/SessionMessagingKit/Utilities/Preferences.swift
@@ -110,20 +110,16 @@ public extension KeyValueStore.IntKey {
     /// This is the ticket number for the pro revocations request (it's used to to track the version of pro revocations the current device has)
     static let proRevocationsTicket: KeyValueStore.IntKey = "proRevocationsTicket"
 
-    /// Unix seconds at which we last **started** a `get_pro_status`, backing the status-refresh floor
+    /// Unix seconds at which we last started a `get_pro_status`, backing the status floor. Stamped on the attempt,
+    /// not on success, so a failing network can't turn every trigger into an unthrottled retry.
     ///
-    /// **This is the "have we ASKED?" value.** Its counterpart is the "have we CONFIRMED?" value,
-    /// `SessionPro.State.lastConfirmedStatusFetchSeconds`, which is stamped on *completion*. Both are named after the
-    /// question they answer because substituting one for the other is the bug: rate-limiting a request off a
-    /// confirmation lets failures retry unbounded, and gating a *display* claim off an attempt asserts something we
-    /// never actually learned
+    /// Persisted because the triggers that generate load — launch, foregrounding — run across process death.
     ///
-    /// **Note:** persisted rather than in-memory on purpose — `get_pro_status` fires on paths that run across process
-    /// death (startup, the `user_expiry` wake), and a per-process timestamp would reset and defeat the floor exactly
-    /// where the load actually comes from
+    /// Its counterpart is `SessionPro.State.lastConfirmedStatusFetchSeconds`, stamped on completion: this one
+    /// rate-limits requests, that one gates display claims.
     static let proStatusLastFetchAttemptTimestamp: KeyValueStore.IntKey = "proStatusLastFetchAttemptTimestamp"
 
-    /// Unix seconds of the last `get_pro_status` fetch the **startup gate** started, backing its own (much longer)
+    /// Unix seconds of the last `get_pro_status` fetch the startup gate started, backing its own (much longer)
     /// min-interval — mobile cold starts are frequent, so the gate needs a rate limit of its own rather than the 60s floor
     static let proStatusLastStartupFetchAttemptTimestamp: KeyValueStore.IntKey = "proStatusLastStartupFetchAttemptTimestamp"
 }

--- a/SessionMessagingKit/Utilities/Preferences.swift
+++ b/SessionMessagingKit/Utilities/Preferences.swift
@@ -109,6 +109,23 @@ public extension KeyValueStore.IntKey {
     
     /// This is the ticket number for the pro revocations request (it's used to to track the version of pro revocations the current device has)
     static let proRevocationsTicket: KeyValueStore.IntKey = "proRevocationsTicket"
+
+    /// Unix seconds at which we last **started** a `get_pro_status`, backing the status-refresh floor
+    ///
+    /// **This is the "have we ASKED?" value.** Its counterpart is the "have we CONFIRMED?" value,
+    /// `SessionPro.State.lastConfirmedStatusFetchSeconds`, which is stamped on *completion*. Both are named after the
+    /// question they answer because substituting one for the other is the bug: rate-limiting a request off a
+    /// confirmation lets failures retry unbounded, and gating a *display* claim off an attempt asserts something we
+    /// never actually learned
+    ///
+    /// **Note:** persisted rather than in-memory on purpose — `get_pro_status` fires on paths that run across process
+    /// death (startup, the `user_expiry` wake), and a per-process timestamp would reset and defeat the floor exactly
+    /// where the load actually comes from
+    static let proStatusLastFetchAttemptTimestamp: KeyValueStore.IntKey = "proStatusLastFetchAttemptTimestamp"
+
+    /// Unix seconds of the last `get_pro_status` fetch the **startup gate** started, backing its own (much longer)
+    /// min-interval — mobile cold starts are frequent, so the gate needs a rate limit of its own rather than the 60s floor
+    static let proStatusLastStartupFetchAttemptTimestamp: KeyValueStore.IntKey = "proStatusLastStartupFetchAttemptTimestamp"
 }
 
 // stringlint:ignore_contents

--- a/SessionMessagingKit/Utilities/Profile+Updating.swift
+++ b/SessionMessagingKit/Utilities/Profile+Updating.swift
@@ -525,10 +525,10 @@ public extension Profile {
             /// We don't automatically update the current users profile data when changed in the database so need to manually
             /// trigger the update
             if isCurrentUser {
-                /// **`suppressUserProfileConfigUpdate` gates the write-back ONLY.** Its purpose is to prevent a
-                /// write-back *loop*: its single caller is the user-profile config **merge** handler, where the
-                /// values we're about to store came *from* the config, so pushing them back would be circular.
-                /// That is a statement about the *write*, not about a *read-and-project*, and gating both on it
+                /// `suppressUserProfileConfigUpdate` gates the write-back ONLY. Its purpose is to prevent a
+                /// write-back loop: its single caller is the user-profile config merge handler, where the
+                /// values we're about to store came from the config, so pushing them back would be circular.
+                /// That is a statement about the write, not about a read-and-project, and gating both on it
                 /// meant a merge never told `SessionProManager` anything had changed.
                 if !suppressUserProfileConfigUpdate {
                     let userSessionId: SessionId = dependencies[cache: .general].sessionId
@@ -551,16 +551,11 @@ public extension Profile {
                     }
                 }
 
-                /// After the commit completes we need to update the SessionProManager to ensure it has the latest state.
+                /// After the commit, re-project so the manager's state matches config. Outside the
+                /// `suppressUserProfileConfigUpdate` branch: that flag exists to stop a config write-back, and a
+                /// merge still has to re-project — otherwise a remote change to `E` or `I` never reaches the status trigger.
                 ///
-                /// **Outside the suppress check on purpose** — the current user's profile has changed either way, so
-                /// the manager needs to re-read it either way. This is the *only* thing that re-projects config into
-                /// `SessionProManager`, so before it moved out here a synced `E`/`I` change from another device
-                /// produced no status refresh at all: the manager's own change detection existed but nothing on the
-                /// merge path reached it.
-                ///
-                /// It does not loop back: the fetch this can trigger writes config through `performAndPushChange`
-                /// directly rather than through `Profile.updateIfNeeded`, and libsession de-dupes an unchanged write.
+                /// `afterCommit` so the read sees committed data, detached so it doesn't extend the write.
                 db.afterCommit {
                     Task.detached(priority: .userInitiated) {
                         await dependencies[singleton: .sessionProManager].updateWithLatestFromUserConfig()

--- a/SessionMessagingKit/Utilities/Profile+Updating.swift
+++ b/SessionMessagingKit/Utilities/Profile+Updating.swift
@@ -524,27 +524,43 @@ public extension Profile {
             
             /// We don't automatically update the current users profile data when changed in the database so need to manually
             /// trigger the update
-            if !suppressUserProfileConfigUpdate, isCurrentUser {
-                let userSessionId: SessionId = dependencies[cache: .general].sessionId
-                
-                try dependencies.mutate(cache: .libSession) { cache in
-                    try cache.performAndPushChange(db, for: .userProfile, sessionId: userSessionId) { _ in
-                        try cache.updateProfile(
-                            displayName: .set(to: updatedProfile.name),
-                            displayPictureUrl: .set(to: updatedProfile.displayPictureUrl),
-                            displayPictureEncryptionKey: .set(to: updatedProfile.displayPictureEncryptionKey),
-                            proProfileFeatures: .set(to: updatedProState.profileFeatures),
-                            isReuploadProfilePicture: {
-                                switch displayPictureUpdate {
-                                    case .currentUserUpdateTo(_, _, let type): return (type == .reupload)
-                                    default: return false
-                                }
-                            }()
-                        )
+            if isCurrentUser {
+                /// **`suppressUserProfileConfigUpdate` gates the write-back ONLY.** Its purpose is to prevent a
+                /// write-back *loop*: its single caller is the user-profile config **merge** handler, where the
+                /// values we're about to store came *from* the config, so pushing them back would be circular.
+                /// That is a statement about the *write*, not about a *read-and-project*, and gating both on it
+                /// meant a merge never told `SessionProManager` anything had changed.
+                if !suppressUserProfileConfigUpdate {
+                    let userSessionId: SessionId = dependencies[cache: .general].sessionId
+
+                    try dependencies.mutate(cache: .libSession) { cache in
+                        try cache.performAndPushChange(db, for: .userProfile, sessionId: userSessionId) { _ in
+                            try cache.updateProfile(
+                                displayName: .set(to: updatedProfile.name),
+                                displayPictureUrl: .set(to: updatedProfile.displayPictureUrl),
+                                displayPictureEncryptionKey: .set(to: updatedProfile.displayPictureEncryptionKey),
+                                proProfileFeatures: .set(to: updatedProState.profileFeatures),
+                                isReuploadProfilePicture: {
+                                    switch displayPictureUpdate {
+                                        case .currentUserUpdateTo(_, _, let type): return (type == .reupload)
+                                        default: return false
+                                    }
+                                }()
+                            )
+                        }
                     }
                 }
-                
-                /// After the commit completes we need to update the SessionProManager to ensure it has the latest state
+
+                /// After the commit completes we need to update the SessionProManager to ensure it has the latest state.
+                ///
+                /// **Outside the suppress check on purpose** — the current user's profile has changed either way, so
+                /// the manager needs to re-read it either way. This is the *only* thing that re-projects config into
+                /// `SessionProManager`, so before it moved out here a synced `E`/`I` change from another device
+                /// produced no status refresh at all: the manager's own change detection existed but nothing on the
+                /// merge path reached it.
+                ///
+                /// It does not loop back: the fetch this can trigger writes config through `performAndPushChange`
+                /// directly rather than through `Profile.updateIfNeeded`, and libsession de-dupes an unchanged write.
                 db.afterCommit {
                     Task.detached(priority: .userInitiated) {
                         await dependencies[singleton: .sessionProManager].updateWithLatestFromUserConfig()

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -26,6 +26,7 @@ class MockLibSessionCache: LibSessionCacheType, Mockable {
     var proConfig: SessionPro.ProConfig? { handler.mock() }
     var proAccessExpiryTimestampSeconds: UInt64 { handler.mock() }
     var proAutoRenewing: Bool { handler.mock() }
+    var proGracePeriodSeconds: UInt64 { handler.mock() }
 
     // MARK: - State Management
     
@@ -207,6 +208,10 @@ class MockLibSessionCache: LibSessionCacheType, Mockable {
 
     func updateProAutoRenewing(_ proAutoRenewing: Bool) {
         handler.mockNoReturn(args: [proAutoRenewing])
+    }
+
+    func updateProGracePeriodSeconds(_ proGracePeriodSeconds: UInt64) {
+        handler.mockNoReturn(args: [proGracePeriodSeconds])
     }
 
     var refundRequestedTimestampSeconds: UInt64 { handler.mock() }
@@ -504,6 +509,7 @@ extension MockLibSessionCache {
         try await self.when { $0.proConfig }.thenReturn(nil)
         try await self.when { $0.proAccessExpiryTimestampSeconds }.thenReturn(0)
         try await self.when { $0.proAutoRenewing }.thenReturn(false)
+        try await self.when { $0.proGracePeriodSeconds }.thenReturn(0)
         try await self.when { $0.proPrepaidTimestampSeconds }.thenReturn(0)
         try await self.when { $0.refundRequestedTimestampSeconds }.thenReturn(0)
         try await self

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -25,7 +25,8 @@ class MockLibSessionCache: LibSessionCacheType, Mockable {
     var allDumpSessionIds: Set<SessionId> { handler.mock() }
     var proConfig: SessionPro.ProConfig? { handler.mock() }
     var proAccessExpiryTimestampSeconds: UInt64 { handler.mock() }
-    
+    var proAutoRenewing: Bool { handler.mock() }
+
     // MARK: - State Management
     
     func loadState(_ db: ObservingDatabase, userEd25519SecretKey: [UInt8]) throws {
@@ -202,6 +203,10 @@ class MockLibSessionCache: LibSessionCacheType, Mockable {
     
     func updateProAccessExpiryTimestampSeconds(_ proAccessExpiryTimestampSeconds: UInt64) {
         handler.mockNoReturn(args: [proAccessExpiryTimestampSeconds])
+    }
+
+    func updateProAutoRenewing(_ proAutoRenewing: Bool) {
+        handler.mockNoReturn(args: [proAutoRenewing])
     }
 
     var refundRequestedTimestampSeconds: UInt64 { handler.mock() }
@@ -485,6 +490,22 @@ extension MockLibSessionCache {
         try await self
             .when { $0.isMessageRequest(threadId: .any, threadVariant: .any) }
             .thenReturn(false)
+
+        /// The Pro read-set, defaulted to "this user has never been Pro".
+        ///
+        /// These are needed by specs that have nothing to do with Pro, because the real `SessionProManager`'s
+        /// initialisation reads **all** of them in a single `dependencies.mutate(cache: .libSession)` — so any spec
+        /// that stands up a libSession cache and lets the manager initialise needs the whole set stubbed, not one of
+        /// them. Defaulting them here rather than per-spec keeps that from being rediscovered each time a spec
+        /// incidentally touches the manager.
+        ///
+        /// Until `SessionPro.ProConfig` gained its `Mocked` conformance the first of these reads was a `fatalError`
+        /// that took the whole process down, which is why the others were never reached and this was never needed.
+        try await self.when { $0.proConfig }.thenReturn(nil)
+        try await self.when { $0.proAccessExpiryTimestampSeconds }.thenReturn(0)
+        try await self.when { $0.proAutoRenewing }.thenReturn(false)
+        try await self.when { $0.proPrepaidTimestampSeconds }.thenReturn(0)
+        try await self.when { $0.refundRequestedTimestampSeconds }.thenReturn(0)
         try await self
             .when { $0.pinnedPriority(threadId: .any, threadVariant: .any, openGroupUrlInfo: .any) }
             .thenReturn(LibSession.defaultNewThreadPriority)

--- a/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockLibSessionCache.swift
@@ -498,14 +498,8 @@ extension MockLibSessionCache {
 
         /// The Pro read-set, defaulted to "this user has never been Pro".
         ///
-        /// These are needed by specs that have nothing to do with Pro, because the real `SessionProManager`'s
-        /// initialisation reads **all** of them in a single `dependencies.mutate(cache: .libSession)` — so any spec
-        /// that stands up a libSession cache and lets the manager initialise needs the whole set stubbed, not one of
-        /// them. Defaulting them here rather than per-spec keeps that from being rediscovered each time a spec
-        /// incidentally touches the manager.
-        ///
-        /// Until `SessionPro.ProConfig` gained its `Mocked` conformance the first of these reads was a `fatalError`
-        /// that took the whole process down, which is why the others were never reached and this was never needed.
+        /// `SessionProManager` initialisation reads all of them in a single `mutate(cache:)`, so any spec that stands up
+        /// a libSession cache and lets the manager initialise needs the whole set stubbed — one at a time is not enough.
         try await self.when { $0.proConfig }.thenReturn(nil)
         try await self.when { $0.proAccessExpiryTimestampSeconds }.thenReturn(0)
         try await self.when { $0.proAutoRenewing }.thenReturn(false)

--- a/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
+++ b/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
@@ -16,9 +16,9 @@ import TestUtilities
 /// every spec merging a userProfile config hit it, and both suites reported **`0 failed` while exiting 65**:
 /// `SessionMessagingKitTests` with 18 restarts, `SessionTests` with 32.
 ///
-/// **Note:** `Optional: Mocked where Wrapped: Mocked` makes `.mock` a **non-nil** config, so an unstubbed read now
-/// reports "there is a Pro config, holding an empty/zero proof" rather than "there is none". A spec wanting the absent
-/// case should stub `nil` explicitly — which it now can, because the read no longer takes the process down first.
+/// **Note:** `Optional: Mocked where Wrapped: Mocked` makes `.mock` a **non-nil** config, so an unstubbed read
+/// reports "there is a Pro config, holding an empty/zero proof" rather than "there is none". A spec that wants the
+/// absent case must stub `nil` explicitly.
 extension SessionPro.ProConfig: Mocked {
     /// Deliberately distinctive so it cannot collide with a real value during argument matching.
     public static var any: SessionPro.ProConfig {

--- a/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
+++ b/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
@@ -3,10 +3,38 @@
 import Foundation
 import SessionUtil
 import SessionUIKit
+import SessionNetworkingKit
 import SessionUtilitiesKit
 import TestUtilities
 
 @testable import SessionMessagingKit
+
+/// Without this, an unstubbed read of `MockLibSessionCache.proConfig` (`SessionPro.ProConfig?`) is a **process crash
+/// rather than a test failure**: `MockHandler` cannot synthesise a value for a non-`Mocked` return type, so it raises a
+/// `fatalError`. That masked far more than it looks — the read sits on the pre-existing
+/// `LibSessionCacheType.handleUserProfileUpdate` path (`LibSession+UserProfile.swift`, the `proUpdate:` argument), so
+/// every spec merging a userProfile config hit it, and both suites reported **`0 failed` while exiting 65**:
+/// `SessionMessagingKitTests` with 18 restarts, `SessionTests` with 32.
+///
+/// **Note:** `Optional: Mocked where Wrapped: Mocked` makes `.mock` a **non-nil** config, so an unstubbed read now
+/// reports "there is a Pro config, holding an empty/zero proof" rather than "there is none". A spec wanting the absent
+/// case should stub `nil` explicitly — which it now can, because the read no longer takes the process down first.
+extension SessionPro.ProConfig: Mocked {
+    /// Deliberately distinctive so it cannot collide with a real value during argument matching.
+    public static var any: SessionPro.ProConfig {
+        SessionPro.ProConfig(
+            rotatingPrivateKey: [.any],
+            proProof: Network.SessionPro.ProProof(version: .any)
+        )
+    }
+
+    public static var mock: SessionPro.ProConfig {
+        SessionPro.ProConfig(
+            rotatingPrivateKey: [],
+            proProof: Network.SessionPro.ProProof()
+        )
+    }
+}
 
 extension Message.Destination: @retroactive Mocked {
     public static var any: Message.Destination = .contact(publicKey: String.any)

--- a/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
+++ b/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
@@ -9,16 +9,12 @@ import TestUtilities
 
 @testable import SessionMessagingKit
 
-/// Without this, an unstubbed read of `MockLibSessionCache.proConfig` (`SessionPro.ProConfig?`) is a **process crash
-/// rather than a test failure**: `MockHandler` cannot synthesise a value for a non-`Mocked` return type, so it raises a
-/// `fatalError`. That masked far more than it looks — the read sits on the pre-existing
-/// `LibSessionCacheType.handleUserProfileUpdate` path (`LibSession+UserProfile.swift`, the `proUpdate:` argument), so
-/// every spec merging a userProfile config hit it, and both suites reported **`0 failed` while exiting 65**:
-/// `SessionMessagingKitTests` with 18 restarts, `SessionTests` with 32.
+/// Without this, an unstubbed read of `MockLibSessionCache.proConfig` hits `Mocked`'s `fatalError`. It sits on
+/// the pre-existing `handleUserProfileUpdate` path, so every spec merging a userProfile config hit it and both
+/// suites reported `0 failed` while exiting 65.
 ///
-/// **Note:** `Optional: Mocked where Wrapped: Mocked` makes `.mock` a **non-nil** config, so an unstubbed read
-/// reports "there is a Pro config, holding an empty/zero proof" rather than "there is none". A spec that wants the
-/// absent case must stub `nil` explicitly.
+/// `Optional: Mocked where Wrapped: Mocked` makes `.mock` non-nil, so an unstubbed read reports a Pro config
+/// holding an empty proof rather than none; a spec wanting the absent case must stub `nil` explicitly.
 extension SessionPro.ProConfig: Mocked {
     /// Deliberately distinctive so it cannot collide with a real value during argument matching.
     public static var any: SessionPro.ProConfig {

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -23,11 +23,13 @@ public extension Network.SessionPro {
 
         /// Not public — read them through `accountRenewalInfo`.
         ///
-        /// Only meaningful on a successful parse: on any non-OK outcome the struct carries its zero defaults, `0` and
-        /// `false`, which are indistinguishable from a backend saying "no grace, not renewing". That is not inert —
-        /// the config keys are presence-only, so writing that `false` erases a flag `get_pro_status` had learned.
+        /// Trustworthy only when `outcome == .success`. On a transport or protocol failure nothing was parsed, so
+        /// these hold `0`/`false` — indistinguishable from an account that genuinely has no grace and is not
+        /// renewing. That is not inert: the config keys are presence-only, so writing that `false` erases a flag
+        /// `get_pro_status` had learned.
         ///
-        /// The type cannot express the absent case, so the scope does.
+        /// The type cannot express "not parsed", so the scope does — hence private, behind a success-gated accessor.
+        /// A `0`/`false` that *was* parsed is a real answer; the gate exists for the values that were not.
         private let rawAccountGracePeriodSeconds: UInt64
         private let rawAccountAutoRenewing: Bool
 
@@ -90,8 +92,8 @@ public extension Network.SessionPro {
             /// Whole unix seconds; `0` = absent.
             self.accountExpiryTimestampSeconds = UInt64(max(0, result.account_expiry_ts))
 
-            /// Stored raw and gated on the outcome by `accountRenewalInfo` — on a non-OK parse these are the
-            /// C struct's zero-initialised defaults rather than anything the backend said.
+            /// Stored raw and gated on the outcome by `accountRenewalInfo`: read them through that, since a
+            /// failure that parsed nothing leaves these at `0`/`false` rather than at anything the backend said.
             self.rawAccountGracePeriodSeconds = UInt64(max(0, result.account_grace_period_duration))
             self.rawAccountAutoRenewing = result.account_auto_renewing
         }

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -11,19 +11,23 @@ public extension Network.SessionPro {
     struct GenerateProProofResponse: Equatable {
         public let header: ResponseHeader
         public let proof: ProProof
-        /// The account's true, grace-inclusive entitlement end (unix seconds), or `0` if this response
-        /// carries no horizon. Advisory + unsigned (not an entitlement authority, not in the proof sig) —
-        /// used only to refresh the cached access expiry `E` for display / preemptive-renewal timing.
-        /// Present on a successful proof and on `subscription_expired` (a now-past value); `0` otherwise.
+        /// The account's expiry — the end of the paid term (unix seconds) — or `0` if this response carries no
+        /// horizon. Advisory + unsigned (not an entitlement authority, not in the proof sig): used only to refresh
+        /// the cached access expiry `E` for display / preemptive-renewal timing. Present on a successful proof and
+        /// on `subscription_expired` (a now-past value); `0` otherwise.
+        ///
+        /// **The account's own expiry, not a proof horizon, and not grace-inclusive** — it is the same quantity
+        /// `get_pro_status` reports as `expiry_ts`, so it is directly comparable with it and with config `E`.
+        /// Coverage end is `E + G`, derived by the caller; this value never has grace folded into it.
         public let accountExpiryTimestampSeconds: UInt64
 
         /// 🔴 **Deliberately not public — read them through `accountRenewalInfo`.**
         ///
-        /// libsession's parser returns *before* filling these on any non-OK outcome, so what the C struct
-        /// carries then is its zero-initialised default: `0` and `false`, with no presence flag and nothing
-        /// nullable left to trip over. That is **indistinguishable from a backend that genuinely said "no
-        /// grace, not renewing"** — and it is not inert, because the config keys are presence-only, so writing
-        /// that `false` *erases* a flag `get_pro_status` had learned.
+        /// **These are only meaningful on a successful parse.** On any non-OK outcome the struct carries its
+        /// zero-initialised defaults — `0` and `false`, with no presence flag and nothing nullable left to trip
+        /// over — which are **indistinguishable from a backend that genuinely said "no grace, not renewing"**.
+        /// And that is not inert: the config keys are presence-only, so writing that `false` *erases* a flag
+        /// `get_pro_status` had learned.
         ///
         /// The failure modes aren't symmetric either: `false` happens to be truthful for
         /// `subscription_expired` / `not_subscribed` / `revoked`, and is a **lie** for a protocol error, a
@@ -37,9 +41,8 @@ public extension Network.SessionPro {
         /// The account's grace period and renewal flag — **`nil` unless this response carried a proof.**
         ///
         /// They exist so a proof outcome can keep `E`, `G` and `A` coherent: this response writes `E`, and
-        /// without them a proof would move the access expiry while leaving a grace period and renewal flag
-        /// paired with the *previous* one, which makes `E - G` — the paid-through instant — silently
-        /// meaningless.
+        /// without them a proof would move the access expiry while leaving a grace period and renewal flag paired
+        /// with the *previous* one, which makes `E + G` — the coverage end — silently meaningless.
         public var accountRenewalInfo: AccountRenewalInfo? {
             guard outcome == .success else { return nil }
 

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -17,6 +17,22 @@ public extension Network.SessionPro {
         /// Present on a successful proof and on `subscription_expired` (a now-past value); `0` otherwise.
         public let accountExpiryTimestampSeconds: UInt64
 
+        /// The account's grace period (seconds) and auto-renewing flag, as advisory extras on the proof
+        /// response — `nil` when the backend didn't say, which is **not** the same as `0`/`false`.
+        ///
+        /// They exist so a proof outcome can keep `E`, `G` and `A` coherent: this response writes `E`, and
+        /// without them a proof would move the access expiry while leaving a grace period and renewal flag
+        /// that were paired with the *previous* one.
+        ///
+        /// **Modelled as `Optional` deliberately.** libsession reports each as a value plus a `has_` flag, and
+        /// collapsing that to a plain value with `?? false` / `?? 0` would be actively destructive rather than
+        /// merely lossy: config stores both presence-only, so writing `false`/`0` **erases** them — against a
+        /// backend predating these fields, every proof fetch would wipe values correctly learned from
+        /// `get_pro_status`. Absent must mean "leave alone", and the type is what enforces that at the
+        /// boundary rather than leaving `has_` for call sites to remember.
+        public let accountGracePeriodSeconds: UInt64?
+        public let accountAutoRenewing: Bool?
+
         /// The Rev 2 §4 ON_COMPLETE outcome, derived from the header. Success carries a fresh proof +
         /// account expiry; the failure slugs drive config clears; anything unrecognised — including a
         /// backend fault (`status == ERROR`) — is `transient`, i.e. fail closed non-destructively (the
@@ -56,6 +72,19 @@ public extension Network.SessionPro {
             self.proof = ProProof(result.proof)
             /// Whole unix seconds; `0` = absent.
             self.accountExpiryTimestampSeconds = UInt64(max(0, result.account_expiry_ts))
+
+            /// Fold each `value` + `has_` pair into an `Optional` here, so absence can't be mistaken for a
+            /// zero/false value anywhere downstream.
+            self.accountGracePeriodSeconds = (
+                result.has_account_grace_period_duration ?
+                    UInt64(max(0, result.account_grace_period_duration)) :
+                    nil
+            )
+            self.accountAutoRenewing = (
+                result.has_account_auto_renewing ?
+                    result.account_auto_renewing :
+                    nil
+            )
         }
     }
 }

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -16,33 +16,26 @@ public extension Network.SessionPro {
         /// the cached access expiry `E` for display / preemptive-renewal timing. Present on a successful proof and
         /// on `subscription_expired` (a now-past value); `0` otherwise.
         ///
-        /// **The account's own expiry, not a proof horizon, and not grace-inclusive** — it is the same quantity
+        /// The account's own expiry, not a proof horizon, and not grace-inclusive — it is the same quantity
         /// `get_pro_status` reports as `expiry_ts`, so it is directly comparable with it and with config `E`.
         /// Coverage end is `E + G`, derived by the caller; this value never has grace folded into it.
         public let accountExpiryTimestampSeconds: UInt64
 
-        /// 🔴 **Deliberately not public — read them through `accountRenewalInfo`.**
+        /// Not public — read them through `accountRenewalInfo`.
         ///
-        /// **These are only meaningful on a successful parse.** On any non-OK outcome the struct carries its
-        /// zero-initialised defaults — `0` and `false`, with no presence flag and nothing nullable left to trip
-        /// over — which are **indistinguishable from a backend that genuinely said "no grace, not renewing"**.
-        /// And that is not inert: the config keys are presence-only, so writing that `false` *erases* a flag
-        /// `get_pro_status` had learned.
+        /// Only meaningful on a successful parse: on any non-OK outcome the struct carries its zero defaults, `0` and
+        /// `false`, which are indistinguishable from a backend saying "no grace, not renewing". That is not inert —
+        /// the config keys are presence-only, so writing that `false` erases a flag `get_pro_status` had learned.
         ///
-        /// The failure modes aren't symmetric either: `false` happens to be truthful for
-        /// `subscription_expired` / `not_subscribed` / `revoked`, and is a **lie** for a protocol error, a
-        /// stale request or a transport failure — where the response said nothing about the account at all.
-        ///
-        /// The type cannot express the absent case, so the *scope* has to: these are private and reachable only
-        /// through a success-shaped accessor.
+        /// The type cannot express the absent case, so the scope does.
         private let rawAccountGracePeriodSeconds: UInt64
         private let rawAccountAutoRenewing: Bool
 
-        /// The account's grace period and renewal flag — **`nil` unless this response carried a proof.**
+        /// The account's grace period and renewal flag — `nil` unless this response carried a proof.
         ///
         /// They exist so a proof outcome can keep `E`, `G` and `A` coherent: this response writes `E`, and
         /// without them a proof would move the access expiry while leaving a grace period and renewal flag paired
-        /// with the *previous* one, which makes `E + G` — the coverage end — silently meaningless.
+        /// with the previous one, which makes `E + G` — the coverage end — silently meaningless.
         public var accountRenewalInfo: AccountRenewalInfo? {
             guard outcome == .success else { return nil }
 

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -17,21 +17,19 @@ public extension Network.SessionPro {
         /// Present on a successful proof and on `subscription_expired` (a now-past value); `0` otherwise.
         public let accountExpiryTimestampSeconds: UInt64
 
-        /// The account's grace period (seconds) and auto-renewing flag, as advisory extras on the proof
-        /// response — `nil` when the backend didn't say, which is **not** the same as `0`/`false`.
+        /// The account's grace period (seconds) and auto-renewing flag, carried alongside the account expiry.
         ///
         /// They exist so a proof outcome can keep `E`, `G` and `A` coherent: this response writes `E`, and
         /// without them a proof would move the access expiry while leaving a grace period and renewal flag
-        /// that were paired with the *previous* one.
+        /// paired with the *previous* one — which makes `E - G`, the paid-through instant, silently meaningless.
         ///
-        /// **Modelled as `Optional` deliberately.** libsession reports each as a value plus a `has_` flag, and
-        /// collapsing that to a plain value with `?? false` / `?? 0` would be actively destructive rather than
-        /// merely lossy: config stores both presence-only, so writing `false`/`0` **erases** them — against a
-        /// backend predating these fields, every proof fetch would wipe values correctly learned from
-        /// `get_pro_status`. Absent must mean "leave alone", and the type is what enforces that at the
-        /// boundary rather than leaving `has_` for call sites to remember.
-        public let accountGracePeriodSeconds: UInt64?
-        public let accountAutoRenewing: Bool?
+        /// **Required on a successful proof**, like `accountExpiryTimestampSeconds`, rather than defaulted:
+        /// libsession fails the parse if either is missing. That is the safer shape, because a default here
+        /// would not be inert — writing `false`/`0` to the config keys *erases* them, so a defaulted value
+        /// would destroy state learned from `get_pro_status`. Failing the parse keeps what we already have.
+        /// Zero/false on the failure outcomes, which carry no proof and for which that is the truthful value.
+        public let accountGracePeriodSeconds: UInt64
+        public let accountAutoRenewing: Bool
 
         /// The Rev 2 §4 ON_COMPLETE outcome, derived from the header. Success carries a fresh proof +
         /// account expiry; the failure slugs drive config clears; anything unrecognised — including a
@@ -73,18 +71,8 @@ public extension Network.SessionPro {
             /// Whole unix seconds; `0` = absent.
             self.accountExpiryTimestampSeconds = UInt64(max(0, result.account_expiry_ts))
 
-            /// Fold each `value` + `has_` pair into an `Optional` here, so absence can't be mistaken for a
-            /// zero/false value anywhere downstream.
-            self.accountGracePeriodSeconds = (
-                result.has_account_grace_period_duration ?
-                    UInt64(max(0, result.account_grace_period_duration)) :
-                    nil
-            )
-            self.accountAutoRenewing = (
-                result.has_account_auto_renewing ?
-                    result.account_auto_renewing :
-                    nil
-            )
+            self.accountGracePeriodSeconds = UInt64(max(0, result.account_grace_period_duration))
+            self.accountAutoRenewing = result.account_auto_renewing
         }
     }
 }

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -17,19 +17,42 @@ public extension Network.SessionPro {
         /// Present on a successful proof and on `subscription_expired` (a now-past value); `0` otherwise.
         public let accountExpiryTimestampSeconds: UInt64
 
-        /// The account's grace period (seconds) and auto-renewing flag, carried alongside the account expiry.
+        /// 🔴 **Deliberately not public — read them through `accountRenewalInfo`.**
+        ///
+        /// libsession's parser returns *before* filling these on any non-OK outcome, so what the C struct
+        /// carries then is its zero-initialised default: `0` and `false`, with no presence flag and nothing
+        /// nullable left to trip over. That is **indistinguishable from a backend that genuinely said "no
+        /// grace, not renewing"** — and it is not inert, because the config keys are presence-only, so writing
+        /// that `false` *erases* a flag `get_pro_status` had learned.
+        ///
+        /// The failure modes aren't symmetric either: `false` happens to be truthful for
+        /// `subscription_expired` / `not_subscribed` / `revoked`, and is a **lie** for a protocol error, a
+        /// stale request or a transport failure — where the response said nothing about the account at all.
+        ///
+        /// Since the type can no longer express the absent case, the *scope* has to, which is why these are
+        /// private and reachable only through a success-shaped accessor.
+        private let rawAccountGracePeriodSeconds: UInt64
+        private let rawAccountAutoRenewing: Bool
+
+        /// The account's grace period and renewal flag — **`nil` unless this response carried a proof.**
         ///
         /// They exist so a proof outcome can keep `E`, `G` and `A` coherent: this response writes `E`, and
         /// without them a proof would move the access expiry while leaving a grace period and renewal flag
-        /// paired with the *previous* one — which makes `E - G`, the paid-through instant, silently meaningless.
-        ///
-        /// **Required on a successful proof**, like `accountExpiryTimestampSeconds`, rather than defaulted:
-        /// libsession fails the parse if either is missing. That is the safer shape, because a default here
-        /// would not be inert — writing `false`/`0` to the config keys *erases* them, so a defaulted value
-        /// would destroy state learned from `get_pro_status`. Failing the parse keeps what we already have.
-        /// Zero/false on the failure outcomes, which carry no proof and for which that is the truthful value.
-        public let accountGracePeriodSeconds: UInt64
-        public let accountAutoRenewing: Bool
+        /// paired with the *previous* one, which makes `E - G` — the paid-through instant — silently
+        /// meaningless.
+        public var accountRenewalInfo: AccountRenewalInfo? {
+            guard outcome == .success else { return nil }
+
+            return AccountRenewalInfo(
+                gracePeriodSeconds: rawAccountGracePeriodSeconds,
+                autoRenewing: rawAccountAutoRenewing
+            )
+        }
+
+        public struct AccountRenewalInfo: Equatable {
+            public let gracePeriodSeconds: UInt64
+            public let autoRenewing: Bool
+        }
 
         /// The Rev 2 §4 ON_COMPLETE outcome, derived from the header. Success carries a fresh proof +
         /// account expiry; the failure slugs drive config clears; anything unrecognised — including a
@@ -71,8 +94,10 @@ public extension Network.SessionPro {
             /// Whole unix seconds; `0` = absent.
             self.accountExpiryTimestampSeconds = UInt64(max(0, result.account_expiry_ts))
 
-            self.accountGracePeriodSeconds = UInt64(max(0, result.account_grace_period_duration))
-            self.accountAutoRenewing = result.account_auto_renewing
+            /// Stored raw and gated on the outcome by `accountRenewalInfo` — on a non-OK parse these are the
+            /// C struct's zero-initialised defaults rather than anything the backend said.
+            self.rawAccountGracePeriodSeconds = UInt64(max(0, result.account_grace_period_duration))
+            self.rawAccountAutoRenewing = result.account_auto_renewing
         }
     }
 }

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -33,8 +33,8 @@ public extension Network.SessionPro {
         /// `subscription_expired` / `not_subscribed` / `revoked`, and is a **lie** for a protocol error, a
         /// stale request or a transport failure — where the response said nothing about the account at all.
         ///
-        /// Since the type can no longer express the absent case, the *scope* has to, which is why these are
-        /// private and reachable only through a success-shaped accessor.
+        /// The type cannot express the absent case, so the *scope* has to: these are private and reachable only
+        /// through a success-shaped accessor.
         private let rawAccountGracePeriodSeconds: UInt64
         private let rawAccountAutoRenewing: Bool
 

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -35,6 +35,17 @@ public extension Network.SessionPro {
             self.autoRenewing = result.auto_renewing
             /// Whole unix seconds on the wire and in our domain — direct assigns, no conversion.
             self.expiryTimestampSeconds = UInt64(max(0, result.expiry_ts))
+            /// 🔴 **The ROOT `grace_period_duration`, not `latest_payment.grace_period_duration`.** Both exist on
+            /// this response and they are different quantities:
+            ///
+            /// | field | meaning |
+            /// |---|---|
+            /// | root (this one) | `coverage_end - user.expiry_at` — how much longer the ACCOUNT is served |
+            /// | `latest_payment` | the raw value a store declared about one transaction |
+            ///
+            /// The payment-level one is **not** gated on `auto_renewing`, so a cancelled subscriber keeps a
+            /// multi-week value in it; reading that would put coverage weeks late for an account that is about to
+            /// lapse. Verified against `Session-Pro-Backend@1b22202` (`server.py`, `backend.py:523`).
             self.gracePeriodDurationSeconds = UInt64(max(0, result.grace_period_duration))
             /// `refund_requested_ts` is gone from the response — refund-pending is config-synced state now.
             self.latestPaymentItem = (result.has_latest_payment ? PaymentItem(result.latest_payment) : nil)

--- a/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GetProStatusResponse.swift
@@ -35,17 +35,10 @@ public extension Network.SessionPro {
             self.autoRenewing = result.auto_renewing
             /// Whole unix seconds on the wire and in our domain — direct assigns, no conversion.
             self.expiryTimestampSeconds = UInt64(max(0, result.expiry_ts))
-            /// 🔴 **The ROOT `grace_period_duration`, not `latest_payment.grace_period_duration`.** Both exist on
-            /// this response and they are different quantities:
-            ///
-            /// | field | meaning |
-            /// |---|---|
-            /// | root (this one) | `coverage_end - user.expiry_at` — how much longer the ACCOUNT is served |
-            /// | `latest_payment` | the raw value a store declared about one transaction |
-            ///
-            /// The payment-level one is **not** gated on `auto_renewing`, so a cancelled subscriber keeps a
-            /// multi-week value in it; reading that would put coverage weeks late for an account that is about to
-            /// lapse. Verified against `Session-Pro-Backend@1b22202` (`server.py`, `backend.py:523`).
+            /// The root `grace_period_duration`, not `latest_payment`'s. Both exist and are different quantities: this one
+            /// is `coverage_end - user.expiry_at` for the account, while the payment-level field is the raw store value and
+            /// is not gated on `auto_renewing` — a cancelled subscriber keeps a multi-week value there, which would put
+            /// coverage weeks late.
             self.gracePeriodDurationSeconds = UInt64(max(0, result.grace_period_duration))
             /// `refund_requested_ts` is gone from the response — refund-pending is config-synced state now.
             self.latestPaymentItem = (result.has_latest_payment ? PaymentItem(result.latest_payment) : nil)

--- a/SessionNetworkingKit/Utilities/Dependencies+Network.swift
+++ b/SessionNetworkingKit/Utilities/Dependencies+Network.swift
@@ -57,6 +57,32 @@ public extension Dependencies {
         )
     }
     
+    nonisolated func networkOffsetDateNow() -> Date {
+        /// If we don't currently have a network instance then we don't want to create it because we may not want the instance (eg. the
+        /// `NotificationServiceExtension` shouldn't start up the network unless it's actually going to send an `endCall`
+        /// message which should be rare)
+        guard has(singleton: .network) else { return dateNow }
+        
+        let timestampMs: Int64 = timestampNowMsWithOffset(
+            offsetMs: self[singleton: .network].syncState.networkTimeOffsetMs
+        )
+        
+        return Date(timeIntervalSince1970: TimeInterval(timestampMs / 1000))
+    }
+    
+    func networkOffsetDateNow() async -> Date {
+        /// If we don't currently have a network instance then we don't want to create it because we may not want the instance (eg. the
+        /// `NotificationServiceExtension` shouldn't start up the network unless it's actually going to send an `endCall`
+        /// message which should be rare)
+        guard has(singleton: .network) else { return dateNow }
+        
+        let timestampMs: Int64 = await timestampNowMsWithOffset(
+            offsetMs: self[singleton: .network].networkTimeOffsetMs
+        )
+        
+        return Date(timeIntervalSince1970: TimeInterval(timestampMs / 1000))
+    }
+    
     func networkTimeOffsetMs<T: Numeric>() async -> T {
         /// If we don't currently have a network instance then we don't want to create it because we may not want the instance (eg. the
         /// `NotificationServiceExtension` shouldn't start up the network unless it's actually going to send an `endCall`

--- a/SessionTests/Conversations/Settings/ThreadSettingsViewModelSpec.swift
+++ b/SessionTests/Conversations/Settings/ThreadSettingsViewModelSpec.swift
@@ -138,8 +138,17 @@ class ThreadSettingsViewModelSpec: AsyncSpec {
                     using: dependencies
                 )
             }
+
+            /// Needed even though this spec has nothing to do with the network: the real `SessionProManager`
+            /// initialises alongside the view model and its revocation-list task waits on a network connection, which
+            /// reads this. It went unnoticed until `SessionPro.ProConfig` gained its `Mocked` conformance, because
+            /// before that the manager's initialisation crashed the process on an earlier unstubbed read instead of
+            /// getting this far.
+            try await mockNetwork
+                .when { $0.networkStatus }
+                .thenReturn(.singleValue(value: .connected))
         }
-        
+
         // MARK: - a ThreadSettingsViewModel
         describe("a ThreadSettingsViewModel") {
             beforeEach {


### PR DESCRIPTION
# Pro: unify the `get_pro_status` refresh design (iOS)

Implements the iOS half of the cross-platform Pro status-refresh unification. Android and Desktop are
landing the same design under their own PRs; the constants and the trigger set are a deliberate
cross-client contract, not iOS tuning.

## ⚠️ Merge dependencies — this cannot merge alone

1. **libSession [libsession-util#124](https://github.com/session-foundation/libsession-util/pull/124), at `b066ba27`** — the branch this client is
   built and verified against. It adds the grace period in config (`user_profile_get_pro_grace_period`,
   key `G`) **and contains #121's `8e5634b8`**, so it is the only dependency you need: `E + G` is the
   coverage end that the startup gate, the Expired CTA and the `user_expiry` wake all derive.
   - **#121 alone is not sufficient.** It carries `user_profile_{get,set}_pro_auto_renewing` (key `A`) but
     **no `pro_grace_period` symbols at all**, and this branch calls the grace accessors — so it does not
     compile against #121.
   - **Not** `jagerman/pro-auto-renewing-config-pfs` — identical commit subject, different sha, rebased onto
     the PFS track. Picking it by name would silently put this client on a different libSession.
2. **A `libsession-util-spm` release containing `b066ba27`**, then re-pinning the SPM dependency here. Until
   then the default `Session` scheme cannot build this branch; use `Session_CompileLibSession`.
3. The equivalent Android and Desktop PRs, for the behaviour to be consistent across clients — not a
   build dependency, but they should not ship far apart.

### A second libSession dependency: the grace period in config ([libsession-util#124](https://github.com/session-foundation/libsession-util/pull/124))

**This branch reads config key `G`** (`user_profile_get_pro_grace_period`), plus the grace period and
renewal flag the *proof* response now carries. Both are **build dependencies** — the startup gate, the
renewal-date display and the `user_expiry` wake all need the coverage end, `E + G`.

Built and verified from source via `Session_CompileLibSession` against **`b066ba27`**, which contains both
this and the `auto_renewing` work above. The two proof-response
fields are plain values there rather than optionals — which means **absence is no longer expressible in the
type, only in the scope**: libSession's parser returns before filling them on any non-OK outcome, so what
the struct carries then is `0`/`false`, indistinguishable from a backend that genuinely said "no grace, not
renewing". Since the config keys are presence-only, writing that `false` would *erase* state learned from
`get_pro_status`. This client therefore keeps the raw values private and exposes them only through a
success-gated accessor. The `G` config accessors are confirmed present as
`T` in the built framework and the app bundle, alongside the shipping control symbol.

## The expiry/grace model

Stated up front because the whole PR turns on it. Verified against `Session-Pro-Backend@1b22202`
(`server.py`: `expiry_ts = user.expiry_at`, `grace_period_duration = coverage_end − user.expiry_at`, with
Active judged against `coverage_end`):

```
E              the account expires here     -> this is the date to show the user
[E, E + G)     expired but still served     -> the grace window
>= E + G       lapsed
```

So the display carries no arithmetic at all — the date shown is `E`. Only *coverage* questions add `G`.
`SessionPro.State` names the two separately (`displayTimestampSeconds` vs `coverageEndTimestampSeconds`) so a
coverage test can't be written against the display value.

⚠️ **An intermediate commit on this branch has the sign the other way** — `8e3f8db566 derive the paid-through
instant as E - G, not E` — and is superseded, not reverted, by `Pro: correct the expiry/grace model`. The
final state above is the correct one.

## What changed

### The status refresh floor — new on iOS

There was none. `refreshProState` guarded only on an in-flight bool, so nothing limited how often
`get_pro_status` could be called. Added a **60s drop-on-fresh** floor with a **persisted** timestamp
(`proStatusLastFetchAttemptTimestamp`), since the triggers that generate the load run across process
death.

Two exemptions: `immediate` callers, and the **first attempt of a process**.

The second is load-bearing rather than a shortcut. Because the timestamp persists, a relaunch shortly after
a previous fetch would otherwise have the floor drop the startup fetch — leaving `loadingState` on its
initial value with nothing to resolve it, which means a permanent spinner on the Pro screen and no CTA,
since both gate on a confirmed fetch. It is keyed on having *attempted*, not succeeded: after a failure the
state is `.error` and the UI offers a retry, so the spinner problem is gone and there is no reason to keep
bypassing. Cold-start load stays bounded by the startup gate's own 24h interval, which is the stronger limit
anyway.

### `immediate`, replacing an unbounded refresh

`refreshProState(immediate:forceLoadingState:)`. `immediate` means exactly one thing — bypass the floor —
and is reserved to the callers that genuinely need it: manual refresh/recover, the bounded post-purchase
poll, the bounded while-open grace poll, and developer-only mock paths. `forceLoadingState` (the spinner)
is deliberately kept orthogonal; conflating the two is how the equivalent flag on Android ended up dead.

### Startup gate

Startup previously fetched unconditionally, including for users who have never been Pro. It is now gated
on CTA-worthiness computed from synced config, plus a persisted ~24h min-interval. A user who is
comfortably active and auto-renewing, or who has never been Pro, no longer fetches on launch.

The test is against `E`, the date the renewal falls due — not against the coverage end `E + G`. Gating on
`now ≥ E + G` would put the entire grace window in the no-fetch branch, which is the one state this design
exists to surface. Both halves are synced, so the decision stays config-derivable, and no caller branches on
provider or renewal state: the backend's `account_coverage_end` folds the `auto_renewing` test into its own
arithmetic and returns the bare expiry when the subscription isn't renewing, giving `E + 0 == E`.

**Why a non-renewing subscription outside the CTA window doesn't fetch.** `auto_renewing` is stored
presence-only — libSession's setter *erases* the key on false — so the key is present iff its value is 1,
and "not auto-renewing" and "never written" are the same stored state. That makes the branch sound only if
absent really does mean not-renewing, which in turn depends on every writer of the access expiry also
writing the flag. Both do: the `get_pro_status` success path, and the proof-success path. Note that the
encoding is why a companion "has it ever been written" predicate wouldn't help — the distinction isn't
recoverable from storage, so it has to be maintained on the write side.

### The single `user_expiry` wake

New. The proof is clamped to expire well short of the account horizon, so the proof reconcile's wake was
the next thing to touch the network after a renewal fell due — and the renewal lands somewhere in between.
Without this, an overdue renewal showed a stale "active" for that whole interval.

**Two instants**, each answering a different question:

| instant | question |
|---|---|
| `E + 30s` | the renewal has just fallen due — did the charge succeed or fail? |
| `E + 30s` | coverage has just ended — did grace run out without a recovery? |

The second is armed **only when `E + G != E`**; with no grace period (every non-auto-renewing account)
the two coincide and one wake is right. It isn't redundant with the proof loop landing near `E`: that
chain only reaches a status refresh via the config-change trigger, which fires on `E` *changing* — and a
renewal that **failed** leaves `E` untouched, which is the case most worth waking for.

Fires once per instant, and catches up on `willEnterForeground` for a crossing slept through.

### `auto_renewing` in config, and the cancel-access row

Written on every successful `get_pro_status`, in the same mutation as `E`. No client-side churn guard:
libSession's `assign_if_changed`/`erase` already short-circuit when nothing changed, which is what the
existing unconditional `E` write relies on.

The renewal flag is read for two things, and only one of them was gated. The Pro screen's cancel-access row
keys off it directly, outside any loading gate — so before a `get_pro_status` has succeeded it read the
"not renewing" shape for everyone, including a renewing subscriber, who was then shown no way to cancel.
The design has that row wait for the status rather than guess at it, so it is now gated on a confirmed
fetch and simply absent until one lands. This matches the Android and Desktop clients, whose equivalent
starts in a loading state.

The gate is **latched** — "a fetch has succeeded at some point this process" — rather than
`loadingState == .success`. A later failed refresh should not retract a control the user could already see;
the last confirmed answer is still the best one available. `loadingState` stays the signal for "what is the
request doing *now*" (spinner, retry copy).

### Which source owns the displayed expiry, grace period and renewal flag

Config and a `get_pro_status` response both wrote the display copies of `E`, `G` and `A`, so whichever ran
last won — and a config merge carrying an older renewal flag could overwrite a fresher fetched one.

A response wins now, and the rule is *whichever response last spoke*, not *`get_pro_status`*. A response is
the only snapshot carrying the rest of the picture that has to agree with those three: `latest_payment`
(provider, plan, refund window) has no config representation at all, so sourcing one field from config would
leave the screen showing a mix of two different moments. Config keeps the same three values for the two jobs
it is genuinely good for — the fetch trigger, and carrying state between devices.

So all three response paths write display state, not just the status fetch:

- **Proof success** already wrote `E`/`G`/`A` to config; it now writes the display copies too, under the same
  two conditions, so a response carrying no account expiry isn't read as "expires at 0" and the
  zero-initialised grace/renewal defaults aren't read as "no grace, not renewing".
- **Proof clear / revoked** — a cleared outcome is a response too, and it says "you have nothing". Without an
  explicit display write these would clear config and leave the screen showing a subscription that exists
  nowhere else. The clear path writes only when its downgrade guard actually let the clear through: on a veto,
  config describes another device's fresher proof, and clearing the display would discard a newer answer.

### A related fix: the post-purchase poll's baseline

The poll asked "has the expiry advanced since I started", taking its baseline from display state with `?? 0`.
The proof generation is an unawaited task, so the poll starts before any response has landed — and reading an
absent expiry as `0` made the first response look like an advance from nothing, including when it was carrying
the *pre-purchase* expiry because the payment hadn't registered. That ended the poll on its first attempt at
exactly the moment it exists to keep chasing. The baseline is now optional: with none, the first response
supplies one.

**Known, pre-existing, and not addressed here:** the purchase-confirmation screen
(`SessionProPaymentScreenContent.swift:32`) reads the displayed expiry immediately after `purchasePro`
returns, which — for the same unawaited-task reason — is before any post-purchase response has landed. It
shows the pre-purchase date. That behaviour is unchanged by this PR; fixing it means having the confirmation
await a refresh rather than reading state nothing has updated yet.

### Change detection no longer reads display state

`updateWithLatestFromUserConfig` decided "did config change" by diffing two `SessionPro.State` snapshots of
the access expiry — the same field the UI renders. That tied the config trigger to a display concern: any
change making the displayed expiry response-sourced rather than config-sourced would have silently stopped
the trigger firing at all, taking the remote-merge path below with it. It now diffs against config values
held for the purpose, the way the prepaid marker `I` already did.

`G` is deliberately not watched. A grace-period change *is* the information rather than a signal that the
server moved, so fetching to confirm what we were just told is a wasted round trip — the same reason the
renewal flag isn't watched either.

### Config-change trigger now watches `I`, and fires for *remote* changes at all

Two separate gaps. `proPrepaidTimestampSeconds` was being read and then discarded, so a purchase started on
another device — which sets only `I` — had no status refresh even locally.

And the trigger never fired for a **merge**. `updateWithLatestFromUserConfig` is the only thing that
re-projects config into `SessionProManager`, and its `db.afterCommit` hook sat inside
`Profile.updateIfNeeded`'s `!suppressUserProfileConfigUpdate` branch — so the merge handler, the single
caller that passes `suppress: true`, never reached it. The manager's own `E`/`I` change detection existed
with no path to it.

That flag exists to prevent a write-back *loop*: the values came from the config, so pushing them back
would be circular. That is a statement about the write, not about a read-and-project, so only the write
stays gated and the re-projection moved out alongside it, both still inside `isCurrentUser`.

Effect: a purchase on another device now pulls the entitlement through rather than stranding if the
purchasing device goes offline before redeeming, and a cancellation or refund the sender learned about
surfaces without waiting for a proof to lapse. It cannot loop — the resulting fetch writes config through
`performAndPushChange` rather than back through `Profile.updateIfNeeded`, libSession de-dupes an unchanged
write, and the first projection of a process is already excluded from counting as a change.

Also: the **first** config projection of a process no longer counts as a change. It previously read as
`0 → E` and fired an ungated refresh *before* the startup gate ran, which would have walked straight past
the gate on every cold launch. (It also means iOS was doing two status fetches per launch.)

### The Expired CTA is anchored at coverage end, and its window was never bounded

Two separate defects, both in `sessionProExpiringCTAInfo`'s `.expired` branch.

**The 30-day bound never bounded anything.** It compared "time until `E`", which is *negative* once `E` is
past, against thirty days — and any negative value satisfies that. So the only thing limiting the Expired CTA
was the shown-once flag, and an account that lapsed years ago got the CTA the first time it was seen.

**It now measures from coverage end, `E + G`.** The backend reports `Expired` only once it has stopped
serving, so measuring a window from `E` shortens it by exactly `G`. That also puts the CTA's deadline on the
same instant as the startup gate's own bound, so the two agree about when an account is too stale to chase.

**Who this affects.** `G` is multi-day on **both** providers once a real dunning window is known, so the
re-anchor bites on both:

| provider | how `G` is populated |
|---|---|
| Apple | states its dunning window directly → `G` is that window (plus a ~1h latency allowance) |
| Google Play | extends the expiry it reports; the backend keeps the paid term as `E` and stores the extension as `G` |

The clearest example is an **Apple subscription whose renewal failed and whose dunning window then elapsed**.

Two cases where it is genuinely inert:

- **Cancellations** — `subscription_coverage_end` returns the bare expiry when `auto_renewing` is false, so
  coverage really does end at `E`.
- **A Play row whose *first* notification already carries the grace extension** — there is no earlier paid
  term to measure against, so that expiry is stored as-is and `G` reads zero.

**There is no lower bound, deliberately.** The backend forces `Expired` on revocation *after* computing the
expiry and grace period, so a refunded or charged-back account reports `Expired` with its coverage end still
in the future. Requiring coverage to have elapsed suppressed the CTA for exactly those accounts. Reaching that
branch already means the backend called it expired, and it is revocation-aware, so re-deriving the verdict
locally can only disagree with it.

Signed arithmetic on both sides: `E + G` can sit ahead of `now` on clock skew or a config from another device,
and an unsigned subtraction underflows to a value that satisfies any upper bound. An absent coverage end
yields no CTA rather than a zero interval, since an account can report `Expired` with no expiry at all once
the backend has pruned its history.

The **Expiring** window is untouched. It is anchored at `E` because "your payment is due soon" is a statement
about the payment date, not about how long we keep serving.

### A revocation-list match now validates with the server

When the user's own proof appears on the revocation list, the credential is cleared — and the client now
**fetches `get_pro_status`** rather than deciding the consequences locally. `E` is deliberately left alone: a
tag on that list says the *credential* is dead, not that the *account* has lapsed, and only the server can say
which.

The fetch is what makes leaving `E` safe. Nothing else on that path reaches the network — the config
projection is not a fetch, and its change trigger needs `E` or `I` to move, neither of which this path touches
— so without it the account holds a stale future `E` with no proof and nothing scheduled to correct it, which
is the `pro_renewal_target` spin that clearing `E` elsewhere exists to avoid. Routine floored path, since
nobody is waiting on a screen.

**The subtlest part is a lock-scope guard.** `remove_pro_config` wipes whatever proof is stored,
unconditionally, and the read that identified it as revoked happens in a *separate* cache-lock acquisition. An
incoming config merge mutates the libSession config object directly, so between the two a device can land a
**new, unrevoked** proof that would then be deleted. Actor isolation does not help: the storage write suspends
and the merge does not run on that actor. The tag is therefore re-read under the lock, inside the write, and
the projection and the refresh are both gated on the clear having actually applied. `applyProofClear` already
guarded the same window this way.

`applyProofRevoked` is deliberately *not* the same: there a proof response said `revoked`, which is terminal
and about the account, so that path clears `E` and asks nothing further. Its docstring previously claimed to
mirror the revocation-list path; it doesn't, and neither should be changed to match the other.

### Smaller things

- **`E + G` has one definition.** `SessionPro.coverageEndSeconds` replaces the same saturating add
  open-coded at three sites. Saturating rather than trapping because both operands come from synced config, so
  a corrupt value is reachable from another device and `+` on `UInt64` would crash at launch; safe because
  entitlement comes from the signed proof.
- **Comment volume reduced by ~45%** across the branch's own commits, with no code lines changed.

### Grace warning debounced against the crossing

The in-settings label showed the alarming "renewal unsuccessful" copy as soon as the displayed expiry
passed, gated only on `loadingState == .success` — which means "a fetch succeeded at some point", not
"since the crossing". At the instant the threshold passes that is necessarily a pre-crossing snapshot, and
a clean renewal is indistinguishable from a failed one until we ask again.

Now requires a fetch that *completed* at or after the threshold, and the threshold is `E` rather than the
coverage end `E + G` — keyed off `E + G` it could only have become true once coverage had fully lapsed,
making the grace state unreachable. The `user_expiry` wake is what makes that fetch arrive promptly.

**Only the mechanism changed; the copy is untouched and already correct.** The shipped strings read
*"Pro renewal unsuccessful, retrying soon"* and *"Your Pro access will remain active … while the
{platform_store} retries your payment"* — one calm message covering the whole grace window, which is what
the design wants. What was missing was that it could never *appear* at the right time.

### Network time everywhere

Every `E`-vs-now comparison uses network time rather than the device clock, including two view-model grace
checks that were on `dateNow`.

### Test infrastructure: 50 process crashes → 0

`SessionPro.ProConfig` had no `Mocked` conformance, so an unstubbed read of `MockLibSessionCache.proConfig`
was a `fatalError` — a **process crash rather than a test failure**. The read sits on the pre-existing
`handleUserProfileUpdate` path, so it hit every spec that merges a userProfile config, and two of CI's four
suites exited 65 while reporting `0 failed`.

Fixing it exposed three further layers, each masked by the one before: the whole Pro read-set needed
defaults (the manager's init reads five properties in one `mutate`), then one spec needed `networkStatus`
(that manager's revocation task waits on a connection).

| | before | after |
|---|---|---|
| `SessionMessagingKitTests` + `SessionTests` | 50 crashes, `0 failed`, `EXIT=65` | 1834 passed, 0 failed, **0 crashes** |

Note the suite is not reliably 0-failure: `ThreadNotificationSettingsViewModelSpec` carries a pre-existing
2–8% data race whose fix (`68d3fc69a4`) is **not** an ancestor of `dev` — the un-isolated
`lazy var footerButtonInfo` is still at `ThreadNotificationSettingsViewModel.swift:136`. It did not fire in
the runs above; expect roughly one failure per full `SessionTests` run on any branch cut from `dev`.

## 🔴 Known flaws and deliberate omissions

Each is a deliberate choice that could reasonably be read as an oversight.

1. **The while-open grace poll is bounded at both ends, and gated on `autoRenewing` as well.** The window
   is `[E, E + G)`. The `autoRenewing` gate is not redundant with it: without the gate, a non-renewing
   subscription lapsing with the Pro screen open fired at least one floor-exempt request and kept firing
   every 60s. The upper bound is what terminates the poll — previously teardown depended on `status`
   leaving `.active`, which arrives from a different source and may not.
2. **Both floor timestamps are stamped on the attempt, not on success.** A failed request costs the
   backend the same as a successful one, and stamping on success lets a failing network retry on every
   trigger. The cost is that a launch with no connectivity burns its 24h gate slot.
   *This is not free*: it is precisely what makes the floored path's proof reconcile necessary (a failed
   fetch arms the floor without reaching its own reconcile), which is why `refreshProState` reconciles on
   the way out of a dropped refresh.
3. **No new unit tests.** There are no Pro specs in the repo to extend, and `Session.xcodeproj` has no
   synchronised file groups, so a new spec file needs hand-editing `project.pbxproj`.
   `SessionPro.State.isRenewalOverdue(atTimestampSeconds:)` and the gate's CTA-worthiness test are pure
   functions and would be the cheap things to pin first.
4. **Not exercised on device.** StoreKit purchase flows cannot run on a simulator (the
   `targetEnvironment(simulator)` branch returns an empty product list), so the post-purchase poll changes
   — the `immediate` reclassification and the named constants — are unchanged in logic but unverified at
   runtime.

## Testing

- Built from libSession source against **`b066ba27`** (`feature/pro-auto-renewing-tristate`, carrying `A`,
  `G`, and the proof-response parse of both) — `** BUILD SUCCEEDED **`, 0 errors, no new warnings in any changed file. Both new `G`
  accessors verified as `T` in the built framework and the app bundle's embedded copy, alongside the
  shipping `user_profile_get_pro_access_expiry` as a control.
- `SessionMessagingKitTests` + `SessionTests`: **1834 passed, 0 failed, 0 restarts, 0 fatals**, against a
  clean-`dev` baseline of 50 process crashes reporting `0 failed` while exiting 65. Crash count read
  separately from the failure count, since that is the number that moved.
  `SessionUtilitiesKitTests`/`SessionNetworkingKitTests` sit below `SessionMessagingKit` in the dependency
  graph and are unaffected.
- **The Appium regression suite should be run** (`Session_Appium`, `pnpm test-ios`) — this changes
  user-visible Pro screen behaviour (the grace label's timing, and when the expiry CTAs appear), which the
  in-repo Quick/Nimble suites do not cover.
