### PR TITLE
Pro: show hero copy in every Pro status, not just never-subscribed and the sheet

### DIFF
--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -399,16 +399,20 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 }
                             }(),
                             description: {
-                                switch (state.proState.status, state.isInBottomSheet) {
-                                    case (.expired, true):
+                                switch state.proState.status {
+                                    case .expired:
                                         return "proAccessRenewStart"
                                             .localizedFormatted()
-                                        
-                                    case (.never, _):
+
+                                    case .never:
                                         return "proFullestPotential"
                                             .localizedFormatted()
-                                        
-                                    default: return nil
+
+                                    case .active:
+                                        return "proThanksForSupporting"
+                                            .localizedFormatted()
+
+                                    case .unknown: return nil
                                 }
                             }()
                         )


### PR DESCRIPTION
The Pro settings hero rendered a description only for never-subscribed users, and for expired users when the screen was presented in the bottom sheet. Expired users reaching it from anywhere else, and active subscribers, saw the image with nothing under it.

Key off the status alone: expired always gets proAccessRenewStart, and active gets the new proThanksForSupporting. isInBottomSheet still drives the disabled theme style above, which is unchanged.