### PR TITLE
Apple developer account transfer preparation changes

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -684,6 +684,7 @@
 		FD37EA0D28AB2A45003AE748 /* _013_FixDeletedMessageReadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37EA0C28AB2A45003AE748 /* _013_FixDeletedMessageReadState.swift */; };
 		FD37EA0F28AB3330003AE748 /* _014_FixHiddenModAdminSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37EA0E28AB3330003AE748 /* _014_FixHiddenModAdminSupport.swift */; };
 		FD37EA1528AB42CB003AE748 /* IdentitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37EA1428AB42CB003AE748 /* IdentitySpec.swift */; };
+		FDA10000202608130000005B /* StorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA10000202608130000005A /* StorageSpec.swift */; };
 		FD37EA1728AC5605003AE748 /* NotificationContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37EA1628AC5605003AE748 /* NotificationContentViewModel.swift */; };
 		FD37EA1928AC5CCA003AE748 /* NotificationSoundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37EA1828AC5CCA003AE748 /* NotificationSoundViewModel.swift */; };
 		FD39352C28F382920084DADA /* VersionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD39352B28F382920084DADA /* VersionFooterView.swift */; };
@@ -2424,6 +2425,7 @@
 		FD37EA0C28AB2A45003AE748 /* _013_FixDeletedMessageReadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _013_FixDeletedMessageReadState.swift; sourceTree = "<group>"; };
 		FD37EA0E28AB3330003AE748 /* _014_FixHiddenModAdminSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _014_FixHiddenModAdminSupport.swift; sourceTree = "<group>"; };
 		FD37EA1428AB42CB003AE748 /* IdentitySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentitySpec.swift; sourceTree = "<group>"; };
+		FDA10000202608130000005A /* StorageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSpec.swift; sourceTree = "<group>"; };
 		FD37EA1628AC5605003AE748 /* NotificationContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentViewModel.swift; sourceTree = "<group>"; };
 		FD37EA1828AC5CCA003AE748 /* NotificationSoundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundViewModel.swift; sourceTree = "<group>"; };
 		FD39352B28F382920084DADA /* VersionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionFooterView.swift; sourceTree = "<group>"; };
@@ -4951,6 +4953,7 @@
 		FD37EA1228AB3F60003AE748 /* Database */ = {
 			isa = PBXGroup;
 			children = (
+				FDA10000202608130000005A /* StorageSpec.swift */,
 				FD37EA1328AB42C1003AE748 /* Models */,
 			);
 			path = Database;
@@ -8264,6 +8267,7 @@
 				FDEF30942F2973340004C5BD /* MockJobRunner.swift in Sources */,
 				FD5973202F760DBA00DB345A /* _051_AddUniqueJobConstraintBack.swift in Sources */,
 				FD37EA1528AB42CB003AE748 /* IdentitySpec.swift in Sources */,
+				FDA10000202608130000005B /* StorageSpec.swift in Sources */,
 				FDEF309B2F2974220004C5BD /* MockKeychain.swift in Sources */,
 				FD0B77B229B82B7A009169BA /* ArrayUtilitiesSpec.swift in Sources */,
 				FD23CE262A676B5B0000B97C /* DependenciesSpec.swift in Sources */,

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		FD17D7E527F6A09900122BE0 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD17D7E427F6A09900122BE0 /* Identity.swift */; };
 		FD184C232EF2100D001089EB /* SessionProError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD184C222EF2100A001089EB /* SessionProError.swift */; };
 		FD19363F2ACA66DE004BCF0F /* DatabaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19363E2ACA66DE004BCF0F /* DatabaseSpec.swift */; };
+		FDA10000202608130000004B /* KeychainStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA10000202608130000004A /* KeychainStorageSpec.swift */; };
 		FD1A553E2E14BE11003761E4 /* PagedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1A553D2E14BE0E003761E4 /* PagedData.swift */; };
 		FD1A55412E161AF6003761E4 /* Combine+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1A55402E161AF3003761E4 /* Combine+Utilities.swift */; };
 		FD1A94FB2900D1C2000D73D3 /* PersistableRecord+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1A94FA2900D1C2000D73D3 /* PersistableRecord+Utilities.swift */; };
@@ -764,6 +765,7 @@
 		FD6A38EC2C2A63B500762359 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FD6A38EB2C2A63B500762359 /* KeychainSwift */; };
 		FD6A38EF2C2A641200762359 /* DifferenceKit in Frameworks */ = {isa = PBXBuildFile; productRef = FD6A38EE2C2A641200762359 /* DifferenceKit */; };
 		FD6A38F12C2A66B100762359 /* KeychainStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6A38F02C2A66B100762359 /* KeychainStorage.swift */; };
+		FDA10000202608120000001B /* KeychainAccessGroupMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA10000202608120000001A /* KeychainAccessGroupMigration.swift */; };
 		FD6A39132C2A946A00762359 /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = FD6A39122C2A946A00762359 /* SwiftProtobuf */; };
 		FD6A39222C2AA91D00762359 /* NVActivityIndicatorView in Frameworks */ = {isa = PBXBuildFile; productRef = FD6A39212C2AA91D00762359 /* NVActivityIndicatorView */; };
 		FD6A39322C2AD33E00762359 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = FD6A39312C2AD33E00762359 /* Quick */; };
@@ -972,6 +974,7 @@
 		FD99A3BA2EC58DE300E59F94 /* _048_SessionProChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD99A3B92EC58DD500E59F94 /* _048_SessionProChanges.swift */; };
 		FD99D0872D0FA731005D2E15 /* ThreadSafe.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD99D0862D0FA72E005D2E15 /* ThreadSafe.swift */; };
 		FD99D0922D10F5EE005D2E15 /* ThreadSafeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD99D0912D10F5EB005D2E15 /* ThreadSafeSpec.swift */; };
+		FDA10000202608120000002B /* KeychainAccessGroupMigrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA10000202608120000002A /* KeychainAccessGroupMigrationSpec.swift */; };
 		FD9AECA52AAA9609009B3406 /* NotificationResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9AECA42AAA9609009B3406 /* NotificationResolution.swift */; };
 		FD9BDE012A5D24EA005F1EBC /* SessionUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C331FF1B2558F9D300070591 /* SessionUIKit.framework */; };
 		FD9E26AF2EA5DC7D00404C7F /* _046_RemoveQuoteUnusedColumnsAndForeignKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9E26AE2EA5DC7100404C7F /* _046_RemoveQuoteUnusedColumnsAndForeignKeys.swift */; };
@@ -2280,6 +2283,7 @@
 		FD17D7E627F6A16700122BE0 /* _003_SUK_YDBToGRDBMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _003_SUK_YDBToGRDBMigration.swift; sourceTree = "<group>"; };
 		FD184C222EF2100A001089EB /* SessionProError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionProError.swift; sourceTree = "<group>"; };
 		FD19363E2ACA66DE004BCF0F /* DatabaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSpec.swift; sourceTree = "<group>"; };
+		FDA10000202608130000004A /* KeychainStorageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStorageSpec.swift; sourceTree = "<group>"; };
 		FD1A553D2E14BE0E003761E4 /* PagedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedData.swift; sourceTree = "<group>"; };
 		FD1A55402E161AF3003761E4 /* Combine+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Utilities.swift"; sourceTree = "<group>"; };
 		FD1A55422E179AE6003761E4 /* ObservableKeyEvent+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableKeyEvent+Utilities.swift"; sourceTree = "<group>"; };
@@ -2486,6 +2490,7 @@
 		FD66CB272BF3449B00268FAB /* SessionNetworkingKit.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SessionNetworkingKit.xctestplan; sourceTree = "<group>"; };
 		FD66CB2B2BF344C600268FAB /* SessionMessageKit.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SessionMessageKit.xctestplan; sourceTree = "<group>"; };
 		FD6A38F02C2A66B100762359 /* KeychainStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStorage.swift; sourceTree = "<group>"; };
+		FDA10000202608120000001A /* KeychainAccessGroupMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessGroupMigration.swift; sourceTree = "<group>"; };
 		FD6B927B2E6F8BAC004463B5 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		FD6B928B2E779DC8004463B5 /* FileServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileServer.swift; sourceTree = "<group>"; };
 		FD6B928D2E779E95004463B5 /* FileServerEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileServerEndpoint.swift; sourceTree = "<group>"; };
@@ -2627,6 +2632,7 @@
 		FD99A3B92EC58DD500E59F94 /* _048_SessionProChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _048_SessionProChanges.swift; sourceTree = "<group>"; };
 		FD99D0862D0FA72E005D2E15 /* ThreadSafe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafe.swift; sourceTree = "<group>"; };
 		FD99D0912D10F5EB005D2E15 /* ThreadSafeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeSpec.swift; sourceTree = "<group>"; };
+		FDA10000202608120000002A /* KeychainAccessGroupMigrationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessGroupMigrationSpec.swift; sourceTree = "<group>"; };
 		FD9AECA42AAA9609009B3406 /* NotificationResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationResolution.swift; sourceTree = "<group>"; };
 		FD9E26AE2EA5DC7100404C7F /* _046_RemoveQuoteUnusedColumnsAndForeignKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _046_RemoveQuoteUnusedColumnsAndForeignKeys.swift; sourceTree = "<group>"; };
 		FD9E26B82EA72D3E00404C7F /* SessionUIKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SessionUIKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4801,6 +4807,7 @@
 			isa = PBXGroup;
 			children = (
 				FD19363E2ACA66DE004BCF0F /* DatabaseSpec.swift */,
+				FDA10000202608130000004A /* KeychainStorageSpec.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -4856,6 +4863,7 @@
 				FDF0DF702F4D69EC000D6041 /* FileHandleType.swift */,
 				FD3FAB682AF1ADCA00DC5421 /* FileManagerType.swift */,
 				FDF0DF6E2F4D3457000D6041 /* FlatMapLatestActor.swift */,
+				FDA10000202608120000001A /* KeychainAccessGroupMigration.swift */,
 				FD6A38F02C2A66B100762359 /* KeychainStorage.swift */,
 				FD78EA032DDEC3C000D55B50 /* MultiTaskManager.swift */,
 				FDB3486D2BE8457F00B716C2 /* SessionBackgroundTask.swift */,
@@ -6086,6 +6094,7 @@
 			children = (
 				FD01503D2CA2433D005B08A1 /* BencodeDecoderSpec.swift */,
 				FD01503E2CA2433D005B08A1 /* BencodeEncoderSpec.swift */,
+				FDA10000202608120000002A /* KeychainAccessGroupMigrationSpec.swift */,
 				FD99D0912D10F5EB005D2E15 /* ThreadSafeSpec.swift */,
 				FD01503F2CA2433D005B08A1 /* VersionSpec.swift */,
 			);
@@ -7600,6 +7609,7 @@
 				FDE521A02E0D230000061B8E /* ObservationManager.swift in Sources */,
 				FDE754DF2C9BAF8A002A2623 /* KeyPair.swift in Sources */,
 				FD2272D12C34EBD6004D8A6C /* JSONDecoder+Utilities.swift in Sources */,
+				FDA10000202608120000001B /* KeychainAccessGroupMigration.swift in Sources */,
 				FD6A38F12C2A66B100762359 /* KeychainStorage.swift in Sources */,
 				FD2272EA2C351CA7004D8A6C /* Threading.swift in Sources */,
 				FD0E353C2AB9880B006A81F7 /* AppVersion.swift in Sources */,
@@ -8199,6 +8209,7 @@
 				FDF0DF7A2F4D6DC6000D6041 /* TestFileHandle.swift in Sources */,
 				FDEF307F2F2971920004C5BD /* MockAppContext.swift in Sources */,
 				FD19363F2ACA66DE004BCF0F /* DatabaseSpec.swift in Sources */,
+				FDA10000202608130000004B /* KeychainStorageSpec.swift in Sources */,
 				FD23CE332A67C4D90000B97C /* MockNetwork.swift in Sources */,
 				FDEF30872F29719F0004C5BD /* MockCrypto.swift in Sources */,
 				FD71161528D00D6700B47552 /* ThreadDisappearingMessagesViewModelSpec.swift in Sources */,
@@ -8231,6 +8242,7 @@
 				FDEF307A2F2971230004C5BD /* Mocked+SUK.swift in Sources */,
 				FD01504E2CA243E7005B08A1 /* TypeConversionUtilitiesSpec.swift in Sources */,
 				FD65318D2AA025C500DFEEAA /* TestDependencies.swift in Sources */,
+				FDA10000202608120000002B /* KeychainAccessGroupMigrationSpec.swift in Sources */,
 				FD99D0922D10F5EE005D2E15 /* ThreadSafeSpec.swift in Sources */,
 				FDD23AF02E459EDD0057E853 /* _020_AddJobUniqueHash.swift in Sources */,
 				FDEF30812F2971920004C5BD /* MockAppContext.swift in Sources */,

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -379,10 +379,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         switch error {
             // Don't offer the 'Restore' option if it was a 'startupFailed' error as a restore is unlikely to
-            // resolve it (most likely the database is locked or the key was somehow lost - safer to get them
-            // to restart and manually reinstall/restore)
+            // resolve it (most likely the database is locked, so a restart is the safer suggestion)
+            //
+            // 'databaseKeyMissingWithActiveDatabase' is deliberately not in this list: resetting is the only way
+            // forward there, so it must keep falling through to the branch below
             case .databaseError(StorageError.startupFailed), .databaseError(DatabaseError.SQLITE_LOCKED): break
-                
+
             // Offer the 'Restore' option if it was a migration error
             case .databaseError:
                 alert.addAction(UIAlertAction(title: "clearDeviceRestore".localized(), style: .destructive) { [weak self, dependencies] _ in

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -378,11 +378,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         })
         
         switch error {
-            // Don't offer the 'Restore' option if it was a 'startupFailed' error as a restore is unlikely to
-            // resolve it (most likely the database is locked, so a restart is the safer suggestion)
+            // Every branch offers 'Clear Data', which is added unconditionally above - what differs is whether
+            // 'Clear Data & Restore' is offered in addition. Withheld here because a restore replays migrations
+            // against a fresh database, which does not address a database that is locked or that failed to start
+            // for a reason we could not identify
             //
-            // 'databaseKeyMissingWithActiveDatabase' is deliberately not in this list: resetting is the only way
-            // forward there, so it must keep falling through to the branch below
+            // 'databaseKeyMissingWithActiveDatabase' is deliberately not in this list: the data is unreachable, so
+            // restoring is the only thing that recovers the account, and it must keep falling through below
             case .databaseError(StorageError.startupFailed), .databaseError(DatabaseError.SQLITE_LOCKED): break
 
             // Offer the 'Restore' option if it was a migration error

--- a/Session/Meta/StartupError.swift
+++ b/Session/Meta/StartupError.swift
@@ -17,6 +17,7 @@ internal enum StartupError: Error, CustomStringConvertible {
             case .databaseError(StorageError.startupFailed), .databaseError(DatabaseError.SQLITE_LOCKED), .databaseError(StorageError.databaseSuspended):
                 return "Database startup failed"
             case .databaseError(StorageError.migrationNoLongerSupported): return "Unsupported version"
+            case .databaseError(StorageError.databaseKeyMissingWithActiveDatabase): return "Database key missing"
             case .failedToRestore: return "Failed to restore"
             case .databaseError: return "Database error"
             case .startupTimeout: return "Startup timeout"

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -1061,13 +1061,20 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
             .extensionEncryptionKey,
             .pushNotificationEncryptionKey
         ]
-        let status: [KeychainStorage.DataKey: Bool] = KeychainAccessGroupMigration.verify(
-            keys: keys,
-            using: dependencies
-        )
-        let presentCount: Int = status.filter { _, isPresent in isPresent }.count
+        let status: [KeychainStorage.DataKey: KeychainAccessGroupMigration.KeyState] = KeychainAccessGroupMigration
+            .verify(keys: keys, using: dependencies)
+        let presentCount: Int = status.filter { _, state in state == .present }.count
+        /// "absent" and "could not be read" are deliberately distinguished - this screen is the only field
+        /// signal there is, and a check which learned nothing must not look like a check which found nothing
         let detail: String = keys
-            .map { key in "\(status[key] == true ? "✓" : "✗") \(key.rawValue)" }
+            .map { key in
+                switch status[key] {
+                    case .present: return "✓ \(key.rawValue)"
+                    case .absent: return "✗ \(key.rawValue) (not created yet)"
+                    case .unreadable(let reason): return "⚠️ \(key.rawValue) (unreadable: \(reason))"
+                    case .none: return "⚠️ \(key.rawValue) (not checked)"
+                }
+            }
             .joined(separator: "\n")
 
         self.transitionToScreen(

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -126,6 +126,7 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
         
         case createMockContacts
         case forceSlowDatabaseQueries
+        case appGroupKeychainStatus
         case exportDatabase
         case importDatabase
         
@@ -165,6 +166,7 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
 
                 case .createMockContacts: return "createMockContacts"
                 case .forceSlowDatabaseQueries: return "forceSlowDatabaseQueries"
+                case .appGroupKeychainStatus: return "appGroupKeychainStatus"
                 case .exportDatabase: return "exportDatabase"
                 case .importDatabase: return "importDatabase"
             }
@@ -208,6 +210,7 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
                 
                 case .createMockContacts: result.append(.createMockContacts); fallthrough
                 case .forceSlowDatabaseQueries: result.append(.forceSlowDatabaseQueries); fallthrough
+                case .appGroupKeychainStatus: result.append(.appGroupKeychainStatus); fallthrough
                 case .exportDatabase: result.append(.exportDatabase); fallthrough
                 case .importDatabase: result.append(.importDatabase)
             }
@@ -823,6 +826,29 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
                     }
                 ),
                 SessionListScreenContent.ListItemInfo(
+                    id: .appGroupKeychainStatus,
+                    variant: .cell(
+                        info: ListItemCell.Info(
+                            title: SessionListScreenContent.TextInfo(
+                                "App Group Keychain Items",
+                                font: .Body.largeBold
+                            ),
+                            description: .htmlTagged("""
+                            Checks how many keychain items are readable from the app group's access group, which is \
+                            the copy that survives a change of team ID when the app is transferred between \
+                            developer accounts.
+
+                            <b>Note:</b> Keys are created lazily, so a fresh install can legitimately report fewer \
+                            than the full count until push registration and the extensions have each run once.
+                            """),
+                            trailingAccessory: .highlightingBackgroundLabel(title: "Check")
+                        )
+                    ),
+                    onTap: { [weak self] in
+                        self?.checkAppGroupKeychainStatus()
+                    }
+                ),
+                SessionListScreenContent.ListItemInfo(
                     id: .exportDatabase,
                     variant: .cell(
                         info: ListItemCell.Info(
@@ -937,7 +963,7 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
             switch item {
                 case .developerMode, .versionBlindedID, .customDateTime, .scheduleLocalNotification,
                     .copyDocumentsPath, .copyAppGroupPath, .resetSnodeCache, .createMockContacts,
-                    .exportDatabase, .importDatabase, .advancedLogging:
+                    .appGroupKeychainStatus, .exportDatabase, .importDatabase, .advancedLogging:
                     break   /// These are actions rather than values stored as "features" so no need to do anything
                     
                 case .networkConfig:
@@ -1029,6 +1055,34 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
         refreshScreen()
     }
     
+    private func checkAppGroupKeychainStatus() {
+        let keys: [KeychainStorage.DataKey] = [
+            .dbCipherKeySpec,
+            .extensionEncryptionKey,
+            .pushNotificationEncryptionKey
+        ]
+        let status: [KeychainStorage.DataKey: Bool] = KeychainAccessGroupMigration.verify(
+            keys: keys,
+            using: dependencies
+        )
+        let presentCount: Int = status.filter { _, isPresent in isPresent }.count
+        let detail: String = keys
+            .map { key in "\(status[key] == true ? "✓" : "✗") \(key.rawValue)" }
+            .joined(separator: "\n")
+
+        self.transitionToScreen(
+            ConfirmationModal(
+                info: ConfirmationModal.Info(
+                    title: "App Group Keychain Items",
+                    body: .text("\(presentCount)/\(keys.count) readable from \(dependencies[singleton: .keychain].appGroupAccessGroup)\n\n\(detail)"),
+                    cancelTitle: "Done",
+                    cancelStyle: .alert_text
+                )
+            ),
+            transitionType: .present
+        )
+    }
+
     private func resetServiceNodeCache() {
         self.transitionToScreen(
             ConfirmationModal(

--- a/SessionMessagingKit/Utilities/AppSetup.swift
+++ b/SessionMessagingKit/Utilities/AppSetup.swift
@@ -116,5 +116,23 @@ public enum AppSetup {
         
         /// Load community data into memory
         await dependencies[singleton: .communityManager].loadCacheIfNeeded()
+
+        /// Copy keychain items into the app group's access group so they survive a change of team ID
+        ///
+        /// This runs on every launch rather than once, because the keys are created lazily at different times -
+        /// `dbCipherKeySpec` when the database is first opened, the others on first use - so a single run would
+        /// permanently miss whichever keys did not exist yet. The migration is idempotent, so repeating it is
+        /// only the cost of a few keychain operations
+        ///
+        /// It has to run **after** the database is set up: on a fresh install `dbCipherKeySpec` does not exist
+        /// until then, and a migration that ran earlier would find nothing to copy
+        KeychainAccessGroupMigration.run(
+            keys: [
+                .dbCipherKeySpec,
+                .extensionEncryptionKey,
+                .pushNotificationEncryptionKey
+            ],
+            using: dependencies
+        )
     }
 }

--- a/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
+++ b/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
@@ -785,7 +785,8 @@ class ExtensionHelperSpec: AsyncSpec {
                     try await mockFileManager
                         .when { _ = try $0.replaceItem(atPath: .any, withItemAtPath: .any) }
                         .thenThrow(TestError.mock)
-                    
+                    await mockLogger.clearLogs()    // Clear logs first to make it easier to debug
+
                     extensionHelper.replicate(
                         dump: ConfigDump(
                             variant: .userProfile,
@@ -795,9 +796,12 @@ class ExtensionHelperSpec: AsyncSpec {
                         ),
                         replaceExisting: true
                     )
-                    
+
+                    /// Assert that the log was emitted rather than that it was the *only* log emitted - background work
+                    /// unrelated to this spec (eg. `SessionProManager`'s revocation list task) writes to the same logger,
+                    /// so an exact match on the whole array fails on whichever lines happen to arrive alongside it
                     await expect { await mockLogger.logs }.toEventually(
-                        equal([
+                        contain(
                             MockLogger.LogOutput(
                                 level: .error,
                                 categories: [
@@ -812,7 +816,7 @@ class ExtensionHelperSpec: AsyncSpec {
                                 file: "SessionMessagingKit/ExtensionHelper.swift",
                                 function: "replicate(dump:replaceExisting:)"
                             )
-                        ]),
+                        ),
                         timeout: .milliseconds(100)
                     )
                 }

--- a/SessionTests/Database/KeychainStorageSpec.swift
+++ b/SessionTests/Database/KeychainStorageSpec.swift
@@ -107,11 +107,57 @@ class KeychainStorageSpec: AsyncSpec {
                 // MARK: ---- does not return an item written to the default group
                 ///
                 /// **This is the assumption the app transfer plan rests on.** An item written without an explicit
-                /// group lands in the app's first access group - the team-prefixed application identifier - so a
+                /// group lands in the app's first access group - here the team-prefixed `keychain-access-groups`
+                /// entry - so a
                 /// read scoped to the app group must not see it. Were scoping unenforced, a migration that
                 /// silently did nothing would still verify as successful.
+                /// **Written through the Security framework directly, not `KeychainStorage`.** The unscoped setter
+                /// mirrors into the app group by design, so going through it would put the item in both groups and
+                /// this could never fail. The property under test belongs to iOS rather than to our wrapper, so the
+                /// spec asserts it against iOS
                 it("does not return an item written to the default group") {
+                    let status: OSStatus = SecItemAdd(
+                        [
+                            kSecClass: kSecClassGenericPassword,
+                            kSecAttrAccount: dataKey.rawValue,
+                            kSecValueData: otherValue,
+                            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+                        ] as CFDictionary,
+                        nil
+                    )
+                    expect(status).to(equal(errSecSuccess))
+
+                    expect { try storage.data(forKey: dataKey, accessGroup: storage.appGroupAccessGroup) }
+                        .to(throwError())
+                }
+
+                // MARK: ------ accepts a write when the same key already exists in the default group
+                ///
+                /// **This is the only sequence that runs on a device**, and every other spec here starts from an
+                /// empty keychain, so nothing else reaches it. `migrate` reads the existing default-group item and
+                /// then writes the same account into the app group — if the access group were not part of the
+                /// uniqueness tuple for a generic password, that write would fail with `errSecDuplicateItem` and
+                /// the migration would fail for every existing user while the rest of this file stayed green
+                it("accepts a write when the same key already exists in the default group") {
                     try storage.set(data: otherValue, forKey: dataKey)
+
+                    expect {
+                        try storage.set(data: value, forKey: dataKey, accessGroup: storage.appGroupAccessGroup)
+                    }.toNot(throwError())
+                    expect(try storage.data(forKey: dataKey, accessGroup: storage.appGroupAccessGroup))
+                        .to(equal(value))
+                }
+
+                // MARK: ------ is removed by an unscoped delete
+                ///
+                /// Whether an unscoped `SecItemDelete` spans every access group decides two things the app relies
+                /// on: that "Clear all data" really removes the app-group copy, and that an ordinary unscoped
+                /// write — which deletes before it adds — transiently un-migrates a key. Apple documents that the
+                /// search, update and delete calls default to every access group the app belongs to; this asserts
+                /// it rather than inheriting it
+                it("is removed by an unscoped delete") {
+                    try storage.set(data: value, forKey: dataKey, accessGroup: storage.appGroupAccessGroup)
+                    try storage.remove(key: dataKey)
 
                     expect { try storage.data(forKey: dataKey, accessGroup: storage.appGroupAccessGroup) }
                         .to(throwError())

--- a/SessionTests/Database/KeychainStorageSpec.swift
+++ b/SessionTests/Database/KeychainStorageSpec.swift
@@ -27,7 +27,6 @@ class KeychainStorageSpec: AsyncSpec {
 
         /// Distinctive so a leaked item is obvious, and so these can never collide with a real key
         let dataKey: KeychainStorage.DataKey = "__KeychainStorageSpec_data__"
-        let stringKey: KeychainStorage.StringKey = "__KeychainStorageSpec_string__"
         let value: Data = Data([0xDE, 0xAD, 0xBE, 0xEF])
         let otherValue: Data = Data([0x01, 0x02, 0x03, 0x04])
 
@@ -38,7 +37,6 @@ class KeychainStorageSpec: AsyncSpec {
         /// leaks into every later run on the same device or simulator
         func cleanUp() {
             try? storage.remove(key: dataKey)
-            try? storage.remove(key: stringKey)
         }
 
         beforeEach { cleanUp() }
@@ -56,12 +54,6 @@ class KeychainStorageSpec: AsyncSpec {
             it("round-trips data") {
                 expect { try storage.set(data: value, forKey: dataKey) }.toNot(throwError())
                 expect(try storage.data(forKey: dataKey)).to(equal(value))
-            }
-
-            // MARK: -- round-trips a string
-            it("round-trips a string") {
-                expect { try storage.set(string: "testValue", forKey: stringKey) }.toNot(throwError())
-                expect(try storage.string(forKey: stringKey)).to(equal("testValue"))
             }
 
             // MARK: -- reports an absent item as not found rather than as another failure

--- a/SessionTests/Database/KeychainStorageSpec.swift
+++ b/SessionTests/Database/KeychainStorageSpec.swift
@@ -1,0 +1,122 @@
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
+
+import Foundation
+import TestUtilities
+
+import Quick
+import Nimble
+
+@testable import SessionUtilitiesKit
+
+/// Exercises the **real** keychain via `KeychainStorage` rather than a mock, so the access group scoping that the
+/// app transfer depends on is asserted against the Security framework instead of against our own call shape.
+/// `KeychainAccessGroupMigrationSpec` covers the migration's logic; this covers the storage it stands on.
+///
+/// 🔴 **This spec lives in `SessionTests` specifically, and must stay there.** Keychain access is granted by
+/// entitlements, so it needs a test target with a host application. `SessionUtilitiesKitTests` - where
+/// `KeychainStorage` itself lives - has no `TEST_HOST` and is a logic-test bundle, which means no entitlements on
+/// any platform (every write returns `errSecMissingEntitlement`, `-34018`) and no ability to run on a device at
+/// all ("Logic Testing on iOS devices is not supported"). Only `SessionTests` and `SessionUIKitTests` have a host
+/// app.
+///
+/// Given a host app, the simulator applies entitlements and enforces access group scoping just as a device does,
+/// so these expectations hold in both environments and nothing here needs to be conditional.
+class KeychainStorageSpec: AsyncSpec {
+    override class func spec() {
+        // MARK: Configuration
+
+        /// Distinctive so a leaked item is obvious, and so these can never collide with a real key
+        let dataKey: KeychainStorage.DataKey = "__KeychainStorageSpec_data__"
+        let stringKey: KeychainStorage.StringKey = "__KeychainStorageSpec_string__"
+        let value: Data = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        let otherValue: Data = Data([0x01, 0x02, 0x03, 0x04])
+
+        @TestState var dependencies: TestDependencies! = TestDependencies()
+        @TestState var storage: KeychainStorage! = KeychainStorage(using: dependencies)
+
+        /// The keychain outlives the test process, so anything written here has to be cleaned up explicitly or it
+        /// leaks into every later run on the same device or simulator
+        func cleanUp() {
+            try? storage.remove(key: dataKey)
+            try? storage.remove(key: stringKey)
+        }
+
+        beforeEach { cleanUp() }
+        afterEach { cleanUp() }
+
+        // MARK: - Keychain Storage
+        describe("Keychain Storage") {
+            // MARK: -- exposes the app group as an access group
+            it("exposes the app group as an access group") {
+                expect(storage.appGroupAccessGroup).to(equal(UserDefaults.applicationGroup))
+                expect(storage.appGroupAccessGroup).to(beginWith("group."))
+            }
+
+            // MARK: -- round-trips data
+            it("round-trips data") {
+                expect { try storage.set(data: value, forKey: dataKey) }.toNot(throwError())
+                expect(try storage.data(forKey: dataKey)).to(equal(value))
+            }
+
+            // MARK: -- round-trips a string
+            it("round-trips a string") {
+                expect { try storage.set(string: "testValue", forKey: stringKey) }.toNot(throwError())
+                expect(try storage.string(forKey: stringKey)).to(equal("testValue"))
+            }
+
+            // MARK: -- reports an absent item as not found rather than as another failure
+            ///
+            /// Asserting the specific code matters: a bare "it throws" would also be satisfied by a missing
+            /// entitlement, so it would pass on a host that cannot reach the keychain at all
+            it("reports an absent item as not found rather than as another failure") {
+                expect { try storage.data(forKey: dataKey) }
+                    .to(throwError { error in
+                        expect((error as? KeychainStorageError)?.code).to(equal(errSecItemNotFound))
+                    })
+            }
+
+            // MARK: -- removes an item
+            it("removes an item") {
+                try storage.set(data: value, forKey: dataKey)
+                expect { try storage.remove(key: dataKey) }.toNot(throwError())
+                expect { try storage.data(forKey: dataKey) }.to(throwError())
+            }
+
+            // MARK: -- the app group access group
+            context("the app group access group") {
+                // MARK: ---- round-trips data written to it
+                it("round-trips data written to it") {
+                    expect {
+                        try storage.set(data: value, forKey: dataKey, accessGroup: storage.appGroupAccessGroup)
+                    }.toNot(throwError())
+                    expect(try storage.data(forKey: dataKey, accessGroup: storage.appGroupAccessGroup))
+                        .to(equal(value))
+                }
+
+                // MARK: ---- is visible to an unscoped read
+                ///
+                /// Apple documents that an unscoped read searches every access group the app belongs to, and the
+                /// migration relies on it: afterwards the app keeps reading keys without naming a group and still
+                /// finds them. If this stopped holding the app would lose its keys silently
+                it("is visible to an unscoped read") {
+                    try storage.set(data: value, forKey: dataKey, accessGroup: storage.appGroupAccessGroup)
+
+                    expect(try storage.data(forKey: dataKey)).to(equal(value))
+                }
+
+                // MARK: ---- does not return an item written to the default group
+                ///
+                /// **This is the assumption the app transfer plan rests on.** An item written without an explicit
+                /// group lands in the app's first access group - the team-prefixed application identifier - so a
+                /// read scoped to the app group must not see it. Were scoping unenforced, a migration that
+                /// silently did nothing would still verify as successful.
+                it("does not return an item written to the default group") {
+                    try storage.set(data: otherValue, forKey: dataKey)
+
+                    expect { try storage.data(forKey: dataKey, accessGroup: storage.appGroupAccessGroup) }
+                        .to(throwError())
+                }
+            }
+        }
+    }
+}

--- a/SessionUtilitiesKit/Database/Storage.swift
+++ b/SessionUtilitiesKit/Database/Storage.swift
@@ -149,7 +149,8 @@ public actor Storage {
         /// `getOrGenerateEncryptionKey` below - which is the exact behaviour this exists to prevent
         if dependencies[singleton: .fileManager].fileExists(atPath: Storage.databasePath) {
             do {
-                let existingKeySpec: Data = try getDatabaseCipherKeySpec()
+                var existingKeySpec: Data = try getDatabaseCipherKeySpec()
+                defer { existingKeySpec.resetBytes(in: 0..<existingKeySpec.count) }
 
                 guard existingKeySpec.count == Storage.SQLCipherKeySpecLength else {
                     throw KeychainStorageError.keySpecInvalid

--- a/SessionUtilitiesKit/Database/Storage.swift
+++ b/SessionUtilitiesKit/Database/Storage.swift
@@ -135,6 +135,37 @@ public actor Storage {
         try? dependencies[singleton: .fileManager].protectFileOrFolder(at: Storage.databasePathShm)
         try? dependencies[singleton: .fileManager].protectFileOrFolder(at: Storage.databasePathWal)
         
+        /// If a database exists but its key does not then it can never be opened, and generating a replacement would
+        /// make that worse: the new key cannot decrypt the existing file, and it overwrites the evidence, so
+        /// afterwards "the key was lost" is indistinguishable from "the database was corrupted" - including in a
+        /// user-supplied report. Fail with a specific error instead, which lets the app offer to reset the database
+        /// rather than presenting a dead end
+        ///
+        /// **Only** a genuinely absent key counts. The keychain is also unreadable before the device's first
+        /// unlock, and treating that as a lost key would offer to destroy the data of a user whose key is fine
+        if dependencies[singleton: .fileManager].fileExists(atPath: Storage.databasePath) {
+            do { _ = try getDatabaseCipherKeySpec() }
+            catch {
+                let isAbsent: Bool = {
+                    switch (error, (error as? KeychainStorageError)?.code) {
+                        case (KeychainStorageError.keySpecInvalid, _), (_, errSecItemNotFound): return true
+                        default: return false
+                    }
+                }()
+
+                if isAbsent {
+                    Log.critical(.storage, "Database exists but its encryption key is missing; cannot open it.")
+                    startupError = StorageError.databaseKeyMissingWithActiveDatabase
+                    syncState.update(
+                        hasValidDatabaseConnection: .set(to: false),
+                        state: .set(to: .noDatabaseConnection)
+                    )
+                    await _state.send(.noDatabaseConnection)
+                    return
+                }
+            }
+        }
+
         /// Generate the database KeySpec if needed (this MUST be done before we try to access the database as a different thread
         /// might attempt to access the database before the key is successfully created)
         ///

--- a/SessionUtilitiesKit/Database/Storage.swift
+++ b/SessionUtilitiesKit/Database/Storage.swift
@@ -141,10 +141,20 @@ public actor Storage {
         /// user-supplied report. Fail with a specific error instead, which lets the app offer to reset the database
         /// rather than presenting a dead end
         ///
-        /// **Only** a genuinely absent key counts. The keychain is also unreadable before the device's first
+        /// **Only** an absent or unusable key counts. The keychain is also unreadable before the device's first
         /// unlock, and treating that as a lost key would offer to destroy the data of a user whose key is fine
+        ///
+        /// The length check has to happen here rather than being inherited from the read: a key of the wrong
+        /// length reads back without error, so it would slip past this and be silently replaced by
+        /// `getOrGenerateEncryptionKey` below - which is the exact behaviour this exists to prevent
         if dependencies[singleton: .fileManager].fileExists(atPath: Storage.databasePath) {
-            do { _ = try getDatabaseCipherKeySpec() }
+            do {
+                let existingKeySpec: Data = try getDatabaseCipherKeySpec()
+
+                guard existingKeySpec.count == Storage.SQLCipherKeySpecLength else {
+                    throw KeychainStorageError.keySpecInvalid
+                }
+            }
             catch {
                 let isAbsent: Bool = {
                     switch (error, (error as? KeychainStorageError)?.code) {
@@ -154,7 +164,7 @@ public actor Storage {
                 }()
 
                 if isAbsent {
-                    Log.critical(.storage, "Database exists but its encryption key is missing; cannot open it.")
+                    Log.critical(.storage, "Database exists but its encryption key is missing or unusable (\(error)); cannot open it.")
                     startupError = StorageError.databaseKeyMissingWithActiveDatabase
                     syncState.update(
                         hasValidDatabaseConnection: .set(to: false),
@@ -468,6 +478,7 @@ public actor Storage {
             legacyService: "TSKeyChainService",
             toKey: .dbCipherKeySpec
         )
+
         return try dependencies[singleton: .keychain].data(forKey: .dbCipherKeySpec)
     }
     

--- a/SessionUtilitiesKit/Database/StorageError.swift
+++ b/SessionUtilitiesKit/Database/StorageError.swift
@@ -7,6 +7,13 @@ public enum StorageError: Error {
     case databaseInvalid
     case databaseSuspended
     case startupFailed
+
+    /// A database file exists but its encryption key does not, so it can never be opened
+    ///
+    /// Distinct from `startupFailed` because it is the one startup failure that is definitely unrecoverable in
+    /// place, which makes offering to reset the database the correct remedy rather than a destructive guess. A
+    /// missing key with **no** database is an ordinary fresh install and is not this case
+    case databaseKeyMissingWithActiveDatabase
     case migrationFailed
     case migrationNoLongerSupported
     case decodingFailed

--- a/SessionUtilitiesKit/Types/KeychainAccessGroupMigration.swift
+++ b/SessionUtilitiesKit/Types/KeychainAccessGroupMigration.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
+//
+// stringlint:ignore
+
+import Foundation
+
+// MARK: - KeychainAccessGroupMigration
+
+/// Copies keychain items into the app group's access group so they survive a change of team ID.
+///
+/// A keychain item belongs to exactly one access group. Items written without an explicit group land in the
+/// app's default group, which is the team-prefixed application identifier - so a change of team makes them
+/// unreachable. An app group identifier carries no team prefix on iOS and doubles as an access group, so an
+/// item written there is addressed by a string that the team change does not alter.
+///
+/// Items are **copied, not moved**. The values involved are never rotated, so leaving the original in place
+/// costs a duplicate and removes a failure mode; the original simply becomes unreachable once the team
+/// changes.
+public enum KeychainAccessGroupMigration {
+    public enum KeyOutcome: Equatable {
+        /// Written to the app group's access group and read back with a matching value
+        case migrated
+
+        /// The app has never created this item - not a failure, several keys are created lazily
+        case sourceMissing
+
+        /// The item could not be written to, or could not be read back from, the app group
+        case failed(String)
+    }
+
+    public struct Result: Equatable {
+        public let outcomes: [KeychainStorage.DataKey: KeyOutcome]
+
+        /// Keys confirmed to be readable from the app group's access group
+        public var verifiedKeys: [KeychainStorage.DataKey] {
+            outcomes
+                .filter { _, outcome in outcome == .migrated }
+                .map { key, _ in key }
+        }
+
+        public var failedKeys: [KeychainStorage.DataKey] {
+            outcomes
+                .filter { _, outcome in
+                    switch outcome {
+                        case .failed: return true
+                        default: return false
+                    }
+                }
+                .map { key, _ in key }
+        }
+
+        public var isFullySucceeded: Bool { failedKeys.isEmpty }
+    }
+
+    /// Runs the migration for `keys` and verifies each result.
+    ///
+    /// Verification is not optional decoration. An unscoped keychain read searches **every** access group the
+    /// app belongs to, so an item left behind in the default group reads back exactly like one that was
+    /// migrated - a failed migration is indistinguishable from a successful one until the team ID changes, at
+    /// which point it can no longer be fixed. The read-back here is scoped to the app group specifically, which
+    /// is the only way to assert where an item actually lives.
+    ///
+    /// Access group membership derives from entitlements, so this only functions where entitlements are applied -
+    /// which means a host application. `KeychainStorageSpec` (in `SessionTests`, the target that has one) asserts
+    /// the scoping this depends on against the real Security framework.
+    @discardableResult public static func run(
+        keys: [KeychainStorage.DataKey],
+        using dependencies: Dependencies
+    ) -> Result {
+        let keychain: KeychainStorageType = dependencies[singleton: .keychain]
+        let accessGroup: String = keychain.appGroupAccessGroup
+        let outcomes: [KeychainStorage.DataKey: KeyOutcome] = keys.reduce(into: [:]) { result, key in
+            result[key] = migrate(key: key, into: accessGroup, using: keychain)
+        }
+        let result: Result = Result(outcomes: outcomes)
+
+        switch result.isFullySucceeded {
+            case true:
+                Log.info(.keychain, "Keychain access group migration verified \(result.verifiedKeys.count)/\(keys.count) key(s).")
+
+            case false:
+                /// There is no telemetry to report this through, so the log is the only signal that reaches a
+                /// human - keep it at `critical` so it survives log filtering in a user-supplied report
+                Log.critical(.keychain, "Keychain access group migration FAILED for \(result.failedKeys.count)/\(keys.count) key(s): \(result.failedKeys.map { $0.rawValue }.joined(separator: ", ")).")
+        }
+
+        return result
+    }
+
+    /// Reports which of `keys` is currently readable from the app group's access group, without writing anything.
+    ///
+    /// There is no telemetry, so a migration that fails in the field reports itself only to the log. This exists so
+    /// the state can be read back on demand instead.
+    public static func verify(
+        keys: [KeychainStorage.DataKey],
+        using dependencies: Dependencies
+    ) -> [KeychainStorage.DataKey: Bool] {
+        let keychain: KeychainStorageType = dependencies[singleton: .keychain]
+        let accessGroup: String = keychain.appGroupAccessGroup
+
+        return keys.reduce(into: [:]) { result, key in
+            result[key] = ((try? keychain.data(forKey: key, accessGroup: accessGroup)) != nil)
+        }
+    }
+
+    private static func migrate(
+        key: KeychainStorage.DataKey,
+        into accessGroup: String,
+        using keychain: KeychainStorageType
+    ) -> KeyOutcome {
+        /// Read the value as the app normally would, which searches every access group the app belongs to - so
+        /// this finds the item whether it is still in the default group or has already been migrated, and the
+        /// write below is idempotent in either case
+        guard var source: Data = try? keychain.data(forKey: key) else { return .sourceMissing }
+        defer { source.resetBytes(in: 0..<source.count) }
+
+        do { try keychain.set(data: source, forKey: key, accessGroup: accessGroup) }
+        catch { return .failed("write failed: \(error)") }
+
+        guard var verified: Data = try? keychain.data(forKey: key, accessGroup: accessGroup) else {
+            return .failed("could not be read back from the app group access group")
+        }
+        defer { verified.resetBytes(in: 0..<verified.count) }
+
+        guard verified == source else { return .failed("value read back from the app group access group differs") }
+
+        return .migrated
+    }
+}

--- a/SessionUtilitiesKit/Types/KeychainAccessGroupMigration.swift
+++ b/SessionUtilitiesKit/Types/KeychainAccessGroupMigration.swift
@@ -15,13 +15,20 @@ import Foundation
 /// carries no team prefix on iOS and doubles as an access group, so an item written there is addressed by a
 /// string that the team change does not alter.
 ///
-/// Items are **copied, not moved**. The values involved are never rotated, so leaving the original in place
-/// costs a duplicate and removes a failure mode; the original simply becomes unreachable once the team
-/// changes.
+/// Items are **copied, not moved**: leaving the original in place costs a duplicate and removes a failure mode,
+/// and it becomes unreachable of its own accord once the team changes. Where a value is rotated - only
+/// `replaceDatabaseKey` does this - the copies cannot diverge, because an unscoped write deletes across every
+/// access group before it adds.
 public enum KeychainAccessGroupMigration {
     public enum KeyOutcome: Equatable {
         /// Written to the app group's access group and read back with a matching value
         case migrated
+
+        /// Already in the app group with a matching value, so nothing was written
+        ///
+        /// This is the steady state after the first successful run, and keeping it distinct from `migrated` is
+        /// what stops the migration rewriting the key on every launch - see `migrate(key:into:using:)`
+        case alreadyPresent
 
         /// The app has never created this item - not a failure, several keys are created lazily
         case sourceMissing
@@ -36,7 +43,7 @@ public enum KeychainAccessGroupMigration {
         /// Keys confirmed to be readable from the app group's access group
         public var verifiedKeys: [KeychainStorage.DataKey] {
             outcomes
-                .filter { _, outcome in outcome == .migrated }
+                .filter { _, outcome in outcome == .migrated || outcome == .alreadyPresent }
                 .map { key, _ in key }
         }
 
@@ -147,6 +154,21 @@ public enum KeychainAccessGroupMigration {
             return .sourceMissing
         }
         defer { source.resetBytes(in: 0..<source.count) }
+
+        /// Do not rewrite a value the app group already holds
+        ///
+        /// The scoped setter deletes and then adds, which are two calls with nothing atomic between them. Before
+        /// the transfer that is harmless because the default-group copy survives it - but **after** the transfer the
+        /// app group holds the only reachable copy of the database key, so writing unconditionally would delete
+        /// that sole copy and re-add it on every single launch. A kill in that window loses the database with no
+        /// recovery path, and the post-transfer state is precisely the one this exists to produce.
+        ///
+        /// Comparing first makes the steady state a read
+        if var existing: Data = try? keychain.data(forKey: key, accessGroup: accessGroup) {
+            defer { existing.resetBytes(in: 0..<existing.count) }
+
+            if existing == source { return .alreadyPresent }
+        }
 
         do { try keychain.set(data: source, forKey: key, accessGroup: accessGroup) }
         catch { return .failed("write failed: \(error)") }

--- a/SessionUtilitiesKit/Types/KeychainAccessGroupMigration.swift
+++ b/SessionUtilitiesKit/Types/KeychainAccessGroupMigration.swift
@@ -9,9 +9,11 @@ import Foundation
 /// Copies keychain items into the app group's access group so they survive a change of team ID.
 ///
 /// A keychain item belongs to exactly one access group. Items written without an explicit group land in the
-/// app's default group, which is the team-prefixed application identifier - so a change of team makes them
-/// unreachable. An app group identifier carries no team prefix on iOS and doubles as an access group, so an
-/// item written there is addressed by a string that the team change does not alter.
+/// app's **first** access group, which is the first entry of its `keychain-access-groups` entitlement when it
+/// has one and the application identifier otherwise. Every target here declares that entitlement, and its
+/// value is team-prefixed, so a change of team ID makes those items unreachable. An app group identifier
+/// carries no team prefix on iOS and doubles as an access group, so an item written there is addressed by a
+/// string that the team change does not alter.
 ///
 /// Items are **copied, not moved**. The values involved are never rotated, so leaving the original in place
 /// costs a duplicate and removes a failure mode; the original simply becomes unreachable once the team
@@ -91,15 +93,35 @@ public enum KeychainAccessGroupMigration {
     ///
     /// There is no telemetry, so a migration that fails in the field reports itself only to the log. This exists so
     /// the state can be read back on demand instead.
+    public enum KeyState: Equatable {
+        case present
+
+        /// The app group holds no such item - expected for keys which have not been created yet
+        case absent
+
+        /// The read itself failed, which is **not** the same as the item being absent and must not be
+        /// presented as though it were: it means this check learned nothing about that key
+        case unreadable(String)
+    }
+
     public static func verify(
         keys: [KeychainStorage.DataKey],
         using dependencies: Dependencies
-    ) -> [KeychainStorage.DataKey: Bool] {
+    ) -> [KeychainStorage.DataKey: KeyState] {
         let keychain: KeychainStorageType = dependencies[singleton: .keychain]
         let accessGroup: String = keychain.appGroupAccessGroup
 
         return keys.reduce(into: [:]) { result, key in
-            result[key] = ((try? keychain.data(forKey: key, accessGroup: accessGroup)) != nil)
+            do {
+                _ = try keychain.data(forKey: key, accessGroup: accessGroup)
+                result[key] = .present
+            }
+            catch {
+                result[key] = ((error as? KeychainStorageError)?.code == errSecItemNotFound ?
+                    .absent :
+                    .unreadable("\(error)")
+                )
+            }
         }
     }
 
@@ -111,7 +133,19 @@ public enum KeychainAccessGroupMigration {
         /// Read the value as the app normally would, which searches every access group the app belongs to - so
         /// this finds the item whether it is still in the default group or has already been migrated, and the
         /// write below is idempotent in either case
-        guard var source: Data = try? keychain.data(forKey: key) else { return .sourceMissing }
+        ///
+        /// Only `errSecItemNotFound` means the app has never created this item. Every other failure - a locked
+        /// keychain, a missing entitlement - is a read that did not work, and reporting those as "missing" would
+        /// let a run that read nothing at all report itself as a success
+        var source: Data
+        do { source = try keychain.data(forKey: key) }
+        catch {
+            guard (error as? KeychainStorageError)?.code == errSecItemNotFound else {
+                return .failed("could not be read: \(error)")
+            }
+
+            return .sourceMissing
+        }
         defer { source.resetBytes(in: 0..<source.count) }
 
         do { try keychain.set(data: source, forKey: key, accessGroup: accessGroup) }

--- a/SessionUtilitiesKit/Types/KeychainStorage.swift
+++ b/SessionUtilitiesKit/Types/KeychainStorage.swift
@@ -352,6 +352,15 @@ public extension KeychainStorage {
         public init(extendedGraphemeClusterLiteral value: String) { self.init(value) }
     }
     
+    /// ⚠️ **Values stored under a `StringKey` do not survive a change of team ID.**
+    ///
+    /// The string half of this API has no access group support: there is no `set(string:forKey:accessGroup:)` or
+    /// `string(forKey:accessGroup:)`, and `set(string:forKey:)` does not mirror into the app group the way the
+    /// data setter does - so a string value cannot be written to the app group, cannot be verified there, and is
+    /// not carried by `KeychainAccessGroupMigration`. A keychain item's access group is team-prefixed unless it is
+    /// an app group, so anything left here is lost when the app moves between developer accounts.
+    ///
+    /// Nothing uses this today. Store secrets under a `DataKey`, or add the scoped pair before you add a key here.
     struct StringKey: RawRepresentable, ExpressibleByStringLiteral, Hashable {
         public let rawValue: String
         

--- a/SessionUtilitiesKit/Types/KeychainStorage.swift
+++ b/SessionUtilitiesKit/Types/KeychainStorage.swift
@@ -39,14 +39,28 @@ public enum KeychainStorageError: Error {
 // MARK: - KeychainStorageType
 
 public protocol KeychainStorageType: AnyObject {
+    /// The app group identifier, which doubles as a keychain access group
+    ///
+    /// Unlike `keychain-access-groups` and `application-identifier`, an app group identifier carries no team ID
+    /// prefix on iOS, so items written here remain reachable when the team ID changes
+    var appGroupAccessGroup: String { get }
+
     func string(forKey key: KeychainStorage.StringKey) throws -> String
     func set(string: String, forKey key: KeychainStorage.StringKey) throws
     func remove(key: KeychainStorage.StringKey) throws
-    
+
     func data(forKey key: KeychainStorage.DataKey) throws -> Data
     func set(data: Data, forKey key: KeychainStorage.DataKey) throws
     func remove(key: KeychainStorage.DataKey) throws
-    
+
+    /// Read scoped to a single access group
+    ///
+    /// An unscoped read searches **every** access group the app belongs to, so it cannot distinguish an item in
+    /// the app group from the same item in the team-prefixed default group - scoping is the only way to assert
+    /// which group an item actually occupies
+    func data(forKey key: KeychainStorage.DataKey, accessGroup: String) throws -> Data
+    func set(data: Data, forKey key: KeychainStorage.DataKey, accessGroup: String) throws
+
     func removeAll() throws
     
     func migrateLegacyKeyIfNeeded(legacyKey: String, legacyService: String?, toKey key: KeychainStorage.DataKey) throws
@@ -82,14 +96,35 @@ public class KeychainStorage: KeychainStorageType {
     private let keychain: KeychainSwift = {
         let result: KeychainSwift = KeychainSwift()
         result.synchronizable = false // This is the default but better to be explicit
-        
+
         return result
     }()
-    
+
+    /// `KeychainSwift` applies its `accessGroup` to every query it builds, so a scoped instance is the mechanism
+    /// for reading and writing a specific group rather than the app's whole access group list
+    @ThreadSafeObject private var scopedKeychains: [String: KeychainSwift] = [:]
+
+    public var appGroupAccessGroup: String { UserDefaults.applicationGroup }
+
     // MARK: - Initialization
-    
+
     init(using dependencies: Dependencies) {
         self.dependencies = dependencies
+    }
+
+    private func keychain(for accessGroup: String) -> KeychainSwift {
+        if let existing: KeychainSwift = scopedKeychains[accessGroup] { return existing }
+
+        let result: KeychainSwift = KeychainSwift()
+        result.synchronizable = false
+        result.accessGroup = accessGroup
+        _scopedKeychains.performUpdate { current in
+            var updated: [String: KeychainSwift] = current
+            updated[accessGroup] = result
+            return updated
+        }
+
+        return result
     }
     
     // MARK: - Functions
@@ -145,7 +180,33 @@ public class KeychainStorage: KeychainStorageType {
     public func remove(key: KeychainStorage.DataKey) throws {
         try remove(key: key.rawValue)
     }
-    
+
+    public func data(forKey key: KeychainStorage.DataKey, accessGroup: String) throws -> Data {
+        let scoped: KeychainSwift = keychain(for: accessGroup)
+
+        guard let result: Data = scoped.getData(key.rawValue) else {
+            throw KeychainStorageError.failure(
+                code: Int32(scoped.lastResultCode),
+                logCategory: .keychain,
+                description: "Error retrieving data for access group, OSStatusCode: \(scoped.lastResultCode)"
+            )
+        }
+
+        return result
+    }
+
+    public func set(data: Data, forKey key: KeychainStorage.DataKey, accessGroup: String) throws {
+        let scoped: KeychainSwift = keychain(for: accessGroup)
+
+        guard scoped.set(data, forKey: key.rawValue, withAccess: .accessibleAfterFirstUnlockThisDeviceOnly) else {
+            throw KeychainStorageError.failure(
+                code: Int32(scoped.lastResultCode),
+                logCategory: .keychain,
+                description: "Error setting data for access group, OSStatusCode: \(scoped.lastResultCode)"
+            )
+        }
+    }
+
     private func remove(key: String) throws {
         guard keychain.delete(key) else {
             throw KeychainStorageError.failure(

--- a/SessionUtilitiesKit/Types/KeychainStorage.swift
+++ b/SessionUtilitiesKit/Types/KeychainStorage.swift
@@ -175,6 +175,20 @@ public class KeychainStorage: KeychainStorageType {
                 description: "Error setting data, OSStatusCode: \(keychain.lastResultCode)"
             )
         }
+
+        /// Mirror into the app group's access group, because a write here removes the app group's copy first
+        ///
+        /// An unscoped write deletes before it adds, and an unscoped delete spans **every** access group the app belongs
+        /// to - so without this, any write silently un-migrates the key and leaves it reachable only from the
+        /// team-prefixed group, which is the group a change of team ID takes away. Mirroring at this level rather than at
+        /// each call site is deliberate: there are three unscoped writers today and this covers future ones too
+        ///
+        /// A failure here must not fail the write the caller asked for. The item is still readable, and
+        /// `KeychainAccessGroupMigration` re-mirrors it on the next launch
+        do { try set(data: data, forKey: key, accessGroup: appGroupAccessGroup) }
+        catch {
+            Log.warn(.keychain, "Failed to mirror \(key.rawValue) into the app group access group: \(error)")
+        }
     }
     
     public func remove(key: KeychainStorage.DataKey) throws {

--- a/SessionUtilitiesKit/Types/KeychainStorage.swift
+++ b/SessionUtilitiesKit/Types/KeychainStorage.swift
@@ -45,10 +45,6 @@ public protocol KeychainStorageType: AnyObject {
     /// prefix on iOS, so items written here remain reachable when the team ID changes
     var appGroupAccessGroup: String { get }
 
-    func string(forKey key: KeychainStorage.StringKey) throws -> String
-    func set(string: String, forKey key: KeychainStorage.StringKey) throws
-    func remove(key: KeychainStorage.StringKey) throws
-
     func data(forKey key: KeychainStorage.DataKey) throws -> Data
     func set(data: Data, forKey key: KeychainStorage.DataKey) throws
     func remove(key: KeychainStorage.DataKey) throws
@@ -129,32 +125,6 @@ public class KeychainStorage: KeychainStorageType {
     
     // MARK: - Functions
     
-    public func string(forKey key: KeychainStorage.StringKey) throws -> String {
-        guard let result: String = keychain.get(key.rawValue) else {
-            throw KeychainStorageError.failure(
-                code: Int32(keychain.lastResultCode),
-                logCategory: .keychain,
-                description: "Error retrieving string, OSStatusCode: \(keychain.lastResultCode)"
-            )
-        }
-        
-        return result
-    }
-
-    public func set(string: String, forKey key: KeychainStorage.StringKey) throws {
-        guard keychain.set(string, forKey: key.rawValue, withAccess: .accessibleAfterFirstUnlockThisDeviceOnly) else {
-            throw KeychainStorageError.failure(
-                code: Int32(keychain.lastResultCode),
-                logCategory: .keychain,
-                description: "Error setting string, OSStatusCode: \(keychain.lastResultCode)"
-            )
-        }
-    }
-    
-    public func remove(key: KeychainStorage.StringKey) throws {
-        try remove(key: key.rawValue)
-    }
-
     public func data(forKey key: KeychainStorage.DataKey) throws -> Data {
         guard let result: Data = keychain.getData(key.rawValue) else {
             throw KeychainStorageError.failure(
@@ -352,22 +322,4 @@ public extension KeychainStorage {
         public init(extendedGraphemeClusterLiteral value: String) { self.init(value) }
     }
     
-    /// ⚠️ **Values stored under a `StringKey` do not survive a change of team ID.**
-    ///
-    /// The string half of this API has no access group support: there is no `set(string:forKey:accessGroup:)` or
-    /// `string(forKey:accessGroup:)`, and `set(string:forKey:)` does not mirror into the app group the way the
-    /// data setter does - so a string value cannot be written to the app group, cannot be verified there, and is
-    /// not carried by `KeychainAccessGroupMigration`. A keychain item's access group is team-prefixed unless it is
-    /// an app group, so anything left here is lost when the app moves between developer accounts.
-    ///
-    /// Nothing uses this today. Store secrets under a `DataKey`, or add the scoped pair before you add a key here.
-    struct StringKey: RawRepresentable, ExpressibleByStringLiteral, Hashable {
-        public let rawValue: String
-        
-        public init(_ rawValue: String) { self.rawValue = rawValue }
-        public init?(rawValue: String) { self.rawValue = rawValue }
-        public init(stringLiteral value: String) { self.init(value) }
-        public init(unicodeScalarLiteral value: String) { self.init(value) }
-        public init(extendedGraphemeClusterLiteral value: String) { self.init(value) }
-    }
 }

--- a/SessionUtilitiesKitTests/Database/StorageSpec.swift
+++ b/SessionUtilitiesKitTests/Database/StorageSpec.swift
@@ -1,0 +1,170 @@
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
+
+import Foundation
+import TestUtilities
+
+import Quick
+import Nimble
+
+@testable import SessionUtilitiesKit
+
+class StorageSpec: AsyncSpec {
+    override class func spec() {
+        // MARK: Configuration
+
+        @TestState var dependencies: TestDependencies! = TestDependencies()
+        @TestState var mockFileManager: MockFileManager! = .create(using: dependencies)
+        @TestState var mockKeychain: MockKeychain! = .create(using: dependencies)
+
+        beforeEach {
+            dependencies.set(singleton: .fileManager, to: mockFileManager)
+            dependencies.set(singleton: .keychain, to: mockKeychain)
+            try await mockFileManager.defaultInitialSetup()
+            try await mockKeychain
+                .when { try $0.migrateLegacyKeyIfNeeded(legacyKey: .any, legacyService: .any, toKey: .dbCipherKeySpec) }
+                .thenReturn(())
+        }
+
+        // MARK: - Storage
+        describe("Storage") {
+            // MARK: -- when a database exists but its encryption key does not
+            context("when a database exists but its encryption key does not") {
+                beforeEach {
+                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(true)
+                    try await mockKeychain
+                        .when { try $0.data(forKey: .dbCipherKeySpec) }
+                        .thenThrow(
+                            KeychainStorageError.failure(
+                                code: errSecItemNotFound,
+                                logCategory: .keychain,
+                                description: "not found"
+                            )
+                        )
+                }
+
+                // MARK: ---- fails with databaseKeyMissingWithActiveDatabase
+                it("fails with databaseKeyMissingWithActiveDatabase") {
+                    let storage: Storage = Storage.create(using: dependencies)
+
+                    await expect { try await storage.perform(migrations: []) }
+                        .to(throwError { error in
+                            switch error {
+                                case StorageError.databaseKeyMissingWithActiveDatabase: break
+                                default: fail("Expected databaseKeyMissingWithActiveDatabase, got \(error)")
+                            }
+                        })
+                }
+
+                // MARK: ---- does not generate a replacement key
+                ///
+                /// Generating one cannot open the existing database and destroys the evidence, after which a lost
+                /// key is indistinguishable from a corrupt database
+                it("does not generate a replacement key") {
+                    let storage: Storage = Storage.create(using: dependencies)
+                    _ = try? await storage.perform(migrations: [])
+
+                    await mockKeychain
+                        .verify {
+                            try $0.getOrGenerateEncryptionKey(
+                                forKey: .dbCipherKeySpec,
+                                length: .any,
+                                cat: .any,
+                                legacyKey: .any,
+                                legacyService: .any
+                            )
+                        }
+                        .wasNotCalled()
+                }
+            }
+
+            // MARK: -- when the keychain is inaccessible rather than empty
+            ///
+            /// The keychain cannot be read before the device's first unlock, and the app can be launched in the
+            /// background. Treating that as a lost key would offer to destroy the data of a user whose key is fine
+            context("when the keychain is inaccessible rather than empty") {
+                beforeEach {
+                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(true)
+                    try await mockKeychain
+                        .when { try $0.data(forKey: .dbCipherKeySpec) }
+                        .thenThrow(
+                            KeychainStorageError.failure(
+                                code: errSecInteractionNotAllowed,
+                                logCategory: .keychain,
+                                description: "locked"
+                            )
+                        )
+                    try await mockKeychain
+                        .when {
+                            try $0.getOrGenerateEncryptionKey(
+                                forKey: .dbCipherKeySpec,
+                                length: .any,
+                                cat: .any,
+                                legacyKey: .any,
+                                legacyService: .any
+                            )
+                        }
+                        .thenThrow(KeychainStorageError.keySpecInaccessible)
+                }
+
+                // MARK: ---- does not report the key as missing
+                it("does not report the key as missing") {
+                    let storage: Storage = Storage.create(using: dependencies)
+
+                    await expect { try await storage.perform(migrations: []) }
+                        .to(throwError { error in
+                            switch error {
+                                case StorageError.databaseKeyMissingWithActiveDatabase:
+                                    fail("An inaccessible keychain must not be reported as a missing key")
+
+                                default: break
+                            }
+                        })
+                }
+            }
+
+            // MARK: -- when there is no database
+            context("when there is no database") {
+                beforeEach {
+                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(false)
+                    try await mockKeychain
+                        .when { try $0.data(forKey: .dbCipherKeySpec) }
+                        .thenThrow(
+                            KeychainStorageError.failure(
+                                code: errSecItemNotFound,
+                                logCategory: .keychain,
+                                description: "not found"
+                            )
+                        )
+                    try await mockKeychain
+                        .when {
+                            try $0.getOrGenerateEncryptionKey(
+                                forKey: .dbCipherKeySpec,
+                                length: .any,
+                                cat: .any,
+                                legacyKey: .any,
+                                legacyService: .any
+                            )
+                        }
+                        .thenThrow(KeychainStorageError.keySpecCreationFailed)
+                }
+
+                // MARK: ---- does not report the key as missing
+                ///
+                /// An absent key with no database is an ordinary fresh install, not a lost key
+                it("does not report the key as missing") {
+                    let storage: Storage = Storage.create(using: dependencies)
+
+                    await expect { try await storage.perform(migrations: []) }
+                        .to(throwError { error in
+                            switch error {
+                                case StorageError.databaseKeyMissingWithActiveDatabase:
+                                    fail("A fresh install must not be reported as a missing key")
+
+                                default: break
+                            }
+                        })
+                }
+            }
+        }
+    }
+}

--- a/SessionUtilitiesKitTests/Database/StorageSpec.swift
+++ b/SessionUtilitiesKitTests/Database/StorageSpec.swift
@@ -77,6 +77,51 @@ class StorageSpec: AsyncSpec {
                 }
             }
 
+            // MARK: -- when the key exists but is the wrong length
+            ///
+            /// A key of the wrong length cannot open the database, so it is as unusable as an absent one. Without this
+            /// the read succeeds, the guard does not fire, and `getOrGenerateEncryptionKey` replaces the key and
+            /// overwrites the evidence - the exact behaviour the guard exists to prevent
+            context("when the key exists but is the wrong length") {
+                beforeEach {
+                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(true)
+                    try await mockKeychain
+                        .when { try $0.data(forKey: .dbCipherKeySpec) }
+                        .thenReturn(Data([1, 2, 3]))
+                }
+
+                // MARK: ---- fails with databaseKeyMissingWithActiveDatabase
+                it("fails with databaseKeyMissingWithActiveDatabase") {
+                    let storage: Storage = Storage.create(using: dependencies)
+
+                    await expect { try await storage.perform(migrations: []) }
+                        .to(throwError { error in
+                            switch error {
+                                case StorageError.databaseKeyMissingWithActiveDatabase: break
+                                default: fail("Expected databaseKeyMissingWithActiveDatabase, got \(error)")
+                            }
+                        })
+                }
+
+                // MARK: ---- does not generate a replacement key
+                it("does not generate a replacement key") {
+                    let storage: Storage = Storage.create(using: dependencies)
+                    _ = try? await storage.perform(migrations: [])
+
+                    await mockKeychain
+                        .verify {
+                            try $0.getOrGenerateEncryptionKey(
+                                forKey: .dbCipherKeySpec,
+                                length: .any,
+                                cat: .any,
+                                legacyKey: .any,
+                                legacyService: .any
+                            )
+                        }
+                        .wasNotCalled()
+                }
+            }
+
             // MARK: -- when the keychain is inaccessible rather than empty
             ///
             /// The keychain cannot be read before the device's first unlock, and the app can be launched in the

--- a/SessionUtilitiesKitTests/Utilities/KeychainAccessGroupMigrationSpec.swift
+++ b/SessionUtilitiesKitTests/Utilities/KeychainAccessGroupMigrationSpec.swift
@@ -24,27 +24,39 @@ class KeychainAccessGroupMigrationSpec: AsyncSpec {
         let valueA: Data = Data([1, 2, 3, 4])
         let valueB: Data = Data([5, 6, 7, 8])
 
+        /// Stands in for the app group's access group so that the pre-check and the post-write read-back - which call
+        /// the same method - can differ the way they do on a device. A static stub would make the two
+        /// indistinguishable and would hide whether a write happened at all
+        ///
+        /// Empty is represented by a value that cannot match either key's contents rather than by a throw, because the
+        /// dynamic stub form cannot throw
+        var appGroupStore: [KeychainStorage.DataKey: Data] = [:]
+        let absent: Data = Data()
+
         @TestState var dependencies: TestDependencies! = TestDependencies()
         @TestState var mockKeychain: MockKeychain! = .create(using: dependencies)
 
         beforeEach {
             dependencies.set(singleton: .keychain, to: mockKeychain)
+            appGroupStore = [:]
 
             try await mockKeychain.when { $0.appGroupAccessGroup }.thenReturn(testAccessGroup)
             try await mockKeychain.when { try $0.data(forKey: keyA) }.thenReturn(valueA)
             try await mockKeychain.when { try $0.data(forKey: keyB) }.thenReturn(valueB)
             try await mockKeychain
                 .when { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                .then { _ in appGroupStore[keyA] = valueA }
                 .thenReturn(())
             try await mockKeychain
                 .when { try $0.set(data: valueB, forKey: keyB, accessGroup: testAccessGroup) }
+                .then { _ in appGroupStore[keyB] = valueB }
                 .thenReturn(())
             try await mockKeychain
                 .when { try $0.data(forKey: keyA, accessGroup: testAccessGroup) }
-                .thenReturn(valueA)
+                .thenReturn { _ in appGroupStore[keyA] ?? absent }
             try await mockKeychain
                 .when { try $0.data(forKey: keyB, accessGroup: testAccessGroup) }
-                .thenReturn(valueB)
+                .thenReturn { _ in appGroupStore[keyB] ?? absent }
         }
 
         // MARK: - a Keychain Access Group Migration
@@ -71,9 +83,11 @@ class KeychainAccessGroupMigrationSpec: AsyncSpec {
 
                 /// An unscoped read would search every access group the app belongs to and so could not tell a
                 /// migrated item from one left behind in the default group
+                ///
+                /// Twice: once to decide whether a write is needed at all, and once afterwards to verify it landed
                 await mockKeychain
                     .verify { try $0.data(forKey: keyA, accessGroup: testAccessGroup) }
-                    .wasCalled(exactly: 1)
+                    .wasCalled(exactly: 2)
             }
 
             // MARK: -- copies rather than moves, leaving the original in place
@@ -90,7 +104,24 @@ class KeychainAccessGroupMigrationSpec: AsyncSpec {
                 let second = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
 
                 expect(first.outcomes[keyA]).to(equal(.migrated))
-                expect(second.outcomes[keyA]).to(equal(.migrated))
+                expect(second.outcomes[keyA]).to(equal(.alreadyPresent))
+                expect(second.verifiedKeys).to(equal([keyA]))
+                expect(second.isFullySucceeded).to(beTrue())
+            }
+
+            // MARK: -- does not rewrite a value the app group already holds
+            ///
+            /// The scoped setter deletes and then adds, and after the transfer the app group holds the **only**
+            /// reachable copy of the database key - so a rewrite on every launch would repeatedly leave the device
+            /// with no usable key for the window between those two calls, and a kill there is unrecoverable
+            it("does not rewrite a value the app group already holds") {
+                KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+                KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+                KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                await mockKeychain
+                    .verify { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                    .wasCalled(exactly: 1)
             }
 
             // MARK: -- when a key does not exist
@@ -113,6 +144,15 @@ class KeychainAccessGroupMigrationSpec: AsyncSpec {
 
                     expect(result.outcomes[keyA]).to(equal(.sourceMissing))
                     expect(result.isFullySucceeded).to(beTrue())
+                }
+
+                // MARK: ---- does not write anything
+                it("does not write anything") {
+                    KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    await mockKeychain
+                        .verify { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                        .wasNotCalled()
                 }
             }
 

--- a/SessionUtilitiesKitTests/Utilities/KeychainAccessGroupMigrationSpec.swift
+++ b/SessionUtilitiesKitTests/Utilities/KeychainAccessGroupMigrationSpec.swift
@@ -1,0 +1,198 @@
+// Copyright © 2026 Session Technology Foundation. All rights reserved.
+
+import Foundation
+import TestUtilities
+
+import Quick
+import Nimble
+
+@testable import SessionUtilitiesKit
+
+/// **These specs exercise the migration's logic against a mocked keychain, not the Security framework.**
+///
+/// They prove which calls are made and how each outcome is derived; they cannot prove that iOS honours
+/// `kSecAttrAccessGroup`, because no real keychain is involved. That half is covered by `KeychainStorageSpec`,
+/// which has to live in `SessionTests` because keychain access needs a test target with a host application and
+/// this one has none.
+class KeychainAccessGroupMigrationSpec: AsyncSpec {
+    override class func spec() {
+        // MARK: Configuration
+
+        let testAccessGroup: String = "group.com.test.app"
+        let keyA: KeychainStorage.DataKey = "TestKeyA"
+        let keyB: KeychainStorage.DataKey = "TestKeyB"
+        let valueA: Data = Data([1, 2, 3, 4])
+        let valueB: Data = Data([5, 6, 7, 8])
+
+        @TestState var dependencies: TestDependencies! = TestDependencies()
+        @TestState var mockKeychain: MockKeychain! = .create(using: dependencies)
+
+        beforeEach {
+            dependencies.set(singleton: .keychain, to: mockKeychain)
+
+            try await mockKeychain.when { $0.appGroupAccessGroup }.thenReturn(testAccessGroup)
+            try await mockKeychain.when { try $0.data(forKey: keyA) }.thenReturn(valueA)
+            try await mockKeychain.when { try $0.data(forKey: keyB) }.thenReturn(valueB)
+            try await mockKeychain
+                .when { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                .thenReturn(())
+            try await mockKeychain
+                .when { try $0.set(data: valueB, forKey: keyB, accessGroup: testAccessGroup) }
+                .thenReturn(())
+            try await mockKeychain
+                .when { try $0.data(forKey: keyA, accessGroup: testAccessGroup) }
+                .thenReturn(valueA)
+            try await mockKeychain
+                .when { try $0.data(forKey: keyB, accessGroup: testAccessGroup) }
+                .thenReturn(valueB)
+        }
+
+        // MARK: - a Keychain Access Group Migration
+        describe("a Keychain Access Group Migration") {
+            // MARK: -- writes each key into the app group access group
+            it("writes each key into the app group access group") {
+                let result = KeychainAccessGroupMigration.run(keys: [keyA, keyB], using: dependencies)
+
+                expect(result.outcomes[keyA]).to(equal(.migrated))
+                expect(result.outcomes[keyB]).to(equal(.migrated))
+                expect(result.isFullySucceeded).to(beTrue())
+
+                await mockKeychain
+                    .verify { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                    .wasCalled(exactly: 1)
+                await mockKeychain
+                    .verify { try $0.set(data: valueB, forKey: keyB, accessGroup: testAccessGroup) }
+                    .wasCalled(exactly: 1)
+            }
+
+            // MARK: -- verifies each key by reading it back from the app group specifically
+            it("verifies each key by reading it back from the app group specifically") {
+                KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                /// An unscoped read would search every access group the app belongs to and so could not tell a
+                /// migrated item from one left behind in the default group
+                await mockKeychain
+                    .verify { try $0.data(forKey: keyA, accessGroup: testAccessGroup) }
+                    .wasCalled(exactly: 1)
+            }
+
+            // MARK: -- copies rather than moves, leaving the original in place
+            it("copies rather than moves, leaving the original in place") {
+                KeychainAccessGroupMigration.run(keys: [keyA, keyB], using: dependencies)
+
+                await mockKeychain.verify { try $0.remove(key: keyA) }.wasNotCalled()
+                await mockKeychain.verify { try $0.remove(key: keyB) }.wasNotCalled()
+            }
+
+            // MARK: -- is idempotent
+            it("is idempotent") {
+                let first = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+                let second = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                expect(first.outcomes[keyA]).to(equal(.migrated))
+                expect(second.outcomes[keyA]).to(equal(.migrated))
+            }
+
+            // MARK: -- when a key does not exist
+            context("when a key does not exist") {
+                beforeEach {
+                    try await mockKeychain
+                        .when { try $0.data(forKey: keyA) }
+                        .thenThrow(KeychainStorageError.keySpecInaccessible)
+                }
+
+                // MARK: ---- reports it as missing rather than failed
+                it("reports it as missing rather than failed") {
+                    let result = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    expect(result.outcomes[keyA]).to(equal(.sourceMissing))
+                    expect(result.isFullySucceeded).to(beTrue())
+                }
+
+                // MARK: ---- does not write anything
+                it("does not write anything") {
+                    KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    await mockKeychain
+                        .verify { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                        .wasNotCalled()
+                }
+            }
+
+            // MARK: -- when the write fails
+            context("when the write fails") {
+                beforeEach {
+                    try await mockKeychain
+                        .when { try $0.set(data: valueA, forKey: keyA, accessGroup: testAccessGroup) }
+                        .thenThrow(KeychainStorageError.keySpecCreationFailed)
+                }
+
+                // MARK: ---- reports the key as failed
+                it("reports the key as failed") {
+                    let result = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    expect(result.failedKeys).to(equal([keyA]))
+                    expect(result.isFullySucceeded).to(beFalse())
+                }
+            }
+
+            // MARK: -- when the item cannot be read back from the app group
+            context("when the item cannot be read back from the app group") {
+                beforeEach {
+                    try await mockKeychain
+                        .when { try $0.data(forKey: keyA, accessGroup: testAccessGroup) }
+                        .thenThrow(KeychainStorageError.keySpecInaccessible)
+                }
+
+                // MARK: ---- reports the key as failed
+                ///
+                /// This is the case the whole verification step exists for: the write reported success and an
+                /// unscoped read would still find the item, so without the scoped read-back this would look
+                /// exactly like a successful migration
+                it("reports the key as failed") {
+                    let result = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    expect(result.failedKeys).to(equal([keyA]))
+                    expect(result.verifiedKeys).to(beEmpty())
+                    expect(result.isFullySucceeded).to(beFalse())
+                }
+            }
+
+            // MARK: -- when the value read back differs
+            context("when the value read back differs") {
+                beforeEach {
+                    try await mockKeychain
+                        .when { try $0.data(forKey: keyA, accessGroup: testAccessGroup) }
+                        .thenReturn(Data([9, 9, 9, 9]))
+                }
+
+                // MARK: ---- reports the key as failed
+                it("reports the key as failed") {
+                    let result = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    expect(result.failedKeys).to(equal([keyA]))
+                    expect(result.isFullySucceeded).to(beFalse())
+                }
+            }
+
+            // MARK: -- when one key of several fails
+            context("when one key of several fails") {
+                beforeEach {
+                    try await mockKeychain
+                        .when { try $0.data(forKey: keyB, accessGroup: testAccessGroup) }
+                        .thenThrow(KeychainStorageError.keySpecInaccessible)
+                }
+
+                // MARK: ---- still migrates the others but reports overall failure
+                it("still migrates the others but reports overall failure") {
+                    let result = KeychainAccessGroupMigration.run(keys: [keyA, keyB], using: dependencies)
+
+                    expect(result.outcomes[keyA]).to(equal(.migrated))
+                    expect(result.verifiedKeys).to(equal([keyA]))
+                    expect(result.failedKeys).to(equal([keyB]))
+                    expect(result.isFullySucceeded).to(beFalse())
+                }
+            }
+        }
+    }
+}

--- a/SessionUtilitiesKitTests/Utilities/KeychainAccessGroupMigrationSpec.swift
+++ b/SessionUtilitiesKitTests/Utilities/KeychainAccessGroupMigrationSpec.swift
@@ -98,7 +98,13 @@ class KeychainAccessGroupMigrationSpec: AsyncSpec {
                 beforeEach {
                     try await mockKeychain
                         .when { try $0.data(forKey: keyA) }
-                        .thenThrow(KeychainStorageError.keySpecInaccessible)
+                        .thenThrow(
+                            KeychainStorageError.failure(
+                                code: errSecItemNotFound,
+                                logCategory: .keychain,
+                                description: "not found"
+                            )
+                        )
                 }
 
                 // MARK: ---- reports it as missing rather than failed
@@ -107,6 +113,28 @@ class KeychainAccessGroupMigrationSpec: AsyncSpec {
 
                     expect(result.outcomes[keyA]).to(equal(.sourceMissing))
                     expect(result.isFullySucceeded).to(beTrue())
+                }
+            }
+
+            // MARK: -- when a key cannot be read
+            ///
+            /// A read that failed for any other reason - a locked keychain, a missing entitlement - taught us nothing
+            /// about that key, and reporting it as the benign lazily-created case would let a run that read nothing at
+            /// all describe itself as a success. `dbCipherKeySpec` in particular provably exists by the time the
+            /// migration runs, so "missing" for it is always a read failure
+            context("when a key cannot be read") {
+                beforeEach {
+                    try await mockKeychain
+                        .when { try $0.data(forKey: keyA) }
+                        .thenThrow(KeychainStorageError.keySpecInaccessible)
+                }
+
+                // MARK: ---- reports it as failed rather than missing
+                it("reports it as failed rather than missing") {
+                    let result = KeychainAccessGroupMigration.run(keys: [keyA], using: dependencies)
+
+                    expect(result.failedKeys).to(equal([keyA]))
+                    expect(result.isFullySucceeded).to(beFalse())
                 }
 
                 // MARK: ---- does not write anything

--- a/SessionUtilitiesKitTests/_TestUtilities/MockKeychain.swift
+++ b/SessionUtilitiesKitTests/_TestUtilities/MockKeychain.swift
@@ -27,12 +27,22 @@ class MockKeychain: KeychainStorageType, Mockable {
         return try handler.mockThrowing(args: [key])
     }
     
+    var appGroupAccessGroup: String { return handler.mock() }
+
     func data(forKey key: KeychainStorage.DataKey) throws -> Data {
         return try handler.mockThrowing(args: [key])
     }
-    
+
     func set(data: Data, forKey key: KeychainStorage.DataKey) throws {
         return try handler.mockThrowing(args: [key])
+    }
+
+    func data(forKey key: KeychainStorage.DataKey, accessGroup: String) throws -> Data {
+        return try handler.mockThrowing(args: [key, accessGroup])
+    }
+
+    func set(data: Data, forKey key: KeychainStorage.DataKey, accessGroup: String) throws {
+        return try handler.mockThrowing(args: [key, accessGroup])
     }
     
     func remove(key: KeychainStorage.DataKey) throws {

--- a/SessionUtilitiesKitTests/_TestUtilities/MockKeychain.swift
+++ b/SessionUtilitiesKitTests/_TestUtilities/MockKeychain.swift
@@ -34,7 +34,7 @@ class MockKeychain: KeychainStorageType, Mockable {
     }
 
     func set(data: Data, forKey key: KeychainStorage.DataKey) throws {
-        return try handler.mockThrowing(args: [key])
+        return try handler.mockThrowing(args: [key, data])
     }
 
     func data(forKey key: KeychainStorage.DataKey, accessGroup: String) throws -> Data {
@@ -42,7 +42,7 @@ class MockKeychain: KeychainStorageType, Mockable {
     }
 
     func set(data: Data, forKey key: KeychainStorage.DataKey, accessGroup: String) throws {
-        return try handler.mockThrowing(args: [key, accessGroup])
+        return try handler.mockThrowing(args: [key, accessGroup, data])
     }
     
     func remove(key: KeychainStorage.DataKey) throws {

--- a/SessionUtilitiesKitTests/_TestUtilities/MockKeychain.swift
+++ b/SessionUtilitiesKitTests/_TestUtilities/MockKeychain.swift
@@ -15,18 +15,6 @@ class MockKeychain: KeychainStorageType, Mockable {
         self.handler = MockHandler(forwardingHandler: handlerForBuilder)
     }
     
-    func string(forKey key: KeychainStorage.StringKey) throws -> String {
-        return try handler.mockThrowing(args: [key])
-    }
-    
-    func set(string: String, forKey key: KeychainStorage.StringKey) throws {
-        return try handler.mockThrowing(args: [key])
-    }
-    
-    func remove(key: KeychainStorage.StringKey) throws {
-        return try handler.mockThrowing(args: [key])
-    }
-    
     var appGroupAccessGroup: String { return handler.mock() }
 
     func data(forKey key: KeychainStorage.DataKey) throws -> Data {


### PR DESCRIPTION
Prepares the app to survive being transferred between Apple Developer accounts, and fixes an
unrelated flaky spec found along the way.

**The problem.** A keychain item belongs to exactly one access group. Items written without an explicit
group land in the app's **first** access group — the first entry of its `keychain-access-groups`
entitlement when it has one, and the application identifier otherwise. All three targets declare that
entitlement and its value is team-prefixed, so a change of team ID makes those items unreachable. One of
them is the database cipher key: the database file itself survives a transfer, but without its key it can
never be opened again.

An app group identifier carries no team prefix on iOS and doubles as a keychain access group, so
items copied there are addressed by a string the transfer does not alter. All three targets already
declare the group, so no entitlement change is needed. This is Apple's documented approach — see
[forums thread 706128](https://developer.apple.com/forums/thread/706128), whose 2026-03-31 revision
describes it, and [thread 841686](https://developer.apple.com/forums/thread/841686) where DTS
confirmed the app group container's files survive too.

#### 1. `Keychain: keep items reachable across an app transfer`

- New `KeychainAccessGroupMigration`, run from `AppSetup.postMigrationSetup`, copying the three
  keychain items (`dbCipherKeySpec`, `extensionEncryptionKey`, `pushNotificationEncryptionKey`) into
  the app group's access group.
- **Copies rather than moves.** The values are never rotated, so leaving the original in place costs a
  duplicate and removes a failure mode; it becomes unreachable after the transfer regardless.
- **Runs on every launch rather than once**, because `extensionEncryptionKey` and
  `pushNotificationEncryptionKey` are created lazily and a one-shot run would permanently miss
  whichever keys did not exist yet. It runs *after* the database is set up, since `dbCipherKeySpec`
  does not exist until then on a fresh install.
- **Verifies each item with a scoped read-back**, which is the load-bearing part. An unscoped keychain
  read searches *every* access group the app belongs to, so an item left behind in the default group
  reads back exactly like a migrated one — without the scoped read, a failed migration is
  indistinguishable from a successful one until the team ID changes, at which point it can no longer
  be fixed.
- `KeychainStorageType` gains an access-group-aware read/write pair so the migration goes through the
  injected dependency rather than reaching for `SecItem*` directly, which is also what makes it
  testable.

#### 2. `Keychain: add a dev settings check for app group keychain items`

- A read-only row in Developer Settings → Database reporting how many keys are readable from the app
  group's access group. The migration logs its own failures, but there is no telemetry for them to
  reach, so this is the only way to confirm the state on a real device.

#### 3. `Storage: fail explicitly when a database exists without its key`

- Startup read the cipher key with `getOrGenerateEncryptionKey`, so an absent key silently produced a
  brand new one. That cannot open the existing database *and* it overwrites the evidence — after one
  launch there is a valid-looking keychain item beside an unreadable database, so a lost key becomes
  indistinguishable from a corrupt one, including in a user-supplied report.
- New `StorageError.databaseKeyMissingWithActiveDatabase` routes to the startup alert's existing reset
  branch rather than the one that only suggests restarting, because a database whose key is gone
  cannot be recovered in place.
- **Only a genuinely absent key counts.** The keychain is also unreadable before the device's first
  unlock and the app can be launched in the background, so anything other than
  `errSecItemNotFound`/`keySpecInvalid` falls through to the previous behaviour — reporting those
  would offer to destroy the data of a user whose key is perfectly fine.

#### 4. `Tests: stop ExtensionHelperSpec asserting on unrelated log output`

Unrelated to the above, found while verifying it. `"logs an error when failing to write the file"`
matched the *whole* captured log array, so it failed whenever anything else logged during the test —
in practice `SessionProManager`'s revocation list task. The entry the test is about was present on
every failure. Now clears the logs first and asserts the entry is *contained*, matching the pattern
already used twice elsewhere in the same spec.

### Review fixes (4 further commits)

- **`Storage: treat a wrong-length cipher key as unusable, not as readable`** — the guard only fired on an
  absent key, but a wrong-length key reads back cleanly, slipped past, and was silently replaced. Q3.
- **`Keychain: stop reporting an unreadable key as a missing one`** — `sourceMissing` came from `try?`, so a
  locked or unentitled keychain read logged as success. Now only `errSecItemNotFound` is missing, and
  `verify` distinguishes absent from unreadable so the Developer Settings row cannot quietly say the wrong
  thing. Q4.
- **`Keychain: mirror every unscoped write into the app group`** — an unscoped write deletes across all access
  groups first, so any ordinary write un-migrated the key until the next launch. Three writers today, one of
  which rotates `dbCipherKeySpec`; mirroring in the setter covers all of them. Q2.
- **`Tests: assert the keychain sequence that actually runs on a device`** — the read-default-then-write-app-group
  sequence had no spec, and it is the one the migration performs in the field. Q1 and Q6.
- **`Keychain: warn where a new key is added, not where the mirror is missing`** — two comment corrections: the
  startup alert's withheld branch still offers *Clear Data*, so saying it "only suggests restarting" was wrong
  (and this PR had rewritten that comment without fixing it).
- **`Keychain: remove the unused string API rather than warn about it`** — 🔴 **removes public API from
  `SessionUtilitiesKit`.** The string half had no access group support at all, so a value stored there would not
  survive a change of team ID. Nothing used it: every `KeychainStorage.StringKey` reference was a declaration,
  the mock, or this PR's own spec. Removing it supersedes the warning added in the commit above.
- 🔴 **`Keychain: stop rewriting a key the app group already holds`** — **the most serious defect found.** The
  migration wrote unconditionally, and the scoped setter deletes then adds. After the transfer the app group holds
  the *only* reachable copy of `dbCipherKeySpec`, so every launch deleted that sole copy and re-added it, leaving
  a window with no usable database key — recurring for every transferred user, in exactly the state this feature
  creates. A kill in that window loses the database with no recovery. Re-review R1, R2, R4.
- **`Storage: zero the cipher key read by the startup guard`** — the new binding wasn't cleared, against the
  file's unanimous convention. R3.

**Correction to an earlier commit message.** `Storage: fail explicitly when a database exists without its key`
says the new error "routes to the startup alert's existing reset branch rather than the one that only suggests
restarting". The `clearDevice` action is added unconditionally before that switch, so both branches already
offer a destructive reset; the real difference is whether **Clear Data & Restore** is offered *in addition*.
The routing is right, the reason given for it was not. Left in history rather than force-pushed under review.

### Testing

- **18 new specs:** `KeychainAccessGroupMigrationSpec` (6, against a mocked keychain),
  `KeychainStorageSpec` (8, against the real Security framework), `StorageSpec` (4).
- `KeychainStorageSpec` lives in `SessionTests` deliberately. Keychain access is entitlement-granted,
  and `SessionTests`/`SessionUIKitTests` are the only test targets with a host application — a
  logic-test bundle returns `errSecMissingEntitlement` on every write and cannot run on a device at
  all.
- **Access-group scoping is asserted against the real keychain**, including that a read scoped to the
  app group does *not* return an item written to the default group. That is the assumption the whole
  change rests on.
- **Each guard was mutation-tested.** Removing the scoped read-back fails exactly the four
  verification specs; removing the storage guard fails exactly the two positive specs and leaves the
  fresh-install and pre-first-unlock guards green.
- The flake fix measured **2/10 `-test-iterations` failures before, 0/10 after**; it was costing
  roughly one spurious failure per `SessionMessagingKitTests` run.
- Manually verified on a real device via the Developer Settings row.
- `SessionTests` + `SessionUtilitiesKitTests` + `SessionMessagingKitTests`: **1965 passed, 0 failed, 0
  restarts**, run against a clean tree matching these commits exactly.
- Note for anyone re-running: the known `ThreadNotificationSettingsViewModelSpec` data race (~2-8%, fix not yet
  on `dev`) is unrelated to this PR but can still surface on any given run. `JobRunnerSpec`'s
  *"when failing jobs, marks the job as failed"* also failed once during this work and is likewise unrelated —
  that spec builds its storage with `Storage.createForTesting`, which skips `configureDatabase()` entirely, so
  the new guard cannot execute in it, and it has no keychain references at all. It passed 10/10 in isolation and
  in every subsequent full run.
