### PR TITLE
Input: name the character-limit countdown and hide it when it is hidden

### DIFF
--- a/SessionUIKit/Components/Input View/InputView.swift
+++ b/SessionUIKit/Components/Input View/InputView.swift
@@ -279,6 +279,9 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
         result.alignment = .center
         result.addGestureRecognizer(characterLimitLabelTapGestureRecognizer)
         result.alpha = 0
+        /// Matches the `alpha` above: `updateNumberOfCharactersLeft` only runs once the text changes, so without this
+        /// a composer which has not been typed in yet would expose an invisible, textless countdown
+        result.accessibilityElementsHidden = true
         
         return result
     }()
@@ -296,6 +299,10 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
         label.font = .systemFont(ofSize: Values.smallFontSize)
         label.themeTextColor = .textPrimary
         label.textAlignment = .center
+        /// Identifier only, unlike the other controls in this file which set `accessibilityLabel` to the same string -
+        /// a `UILabel`'s `accessibilityLabel` defaults to its text, so assigning one here would overwrite the
+        /// remaining-character count with a constant and leave the number unreadable
+        label.accessibilityIdentifier = "character-limit-text"
         
         return label
     }()
@@ -441,7 +448,11 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
         let numberOfCharactersLeft: Int = SNUIKit.numberOfCharactersLeft(for: text)
         characterLimitLabel.text = "\(numberOfCharactersLeft.formatted(format: .abbreviated(decimalPlaces: 1)))"
         characterLimitLabel.themeTextColor = (numberOfCharactersLeft < 0) ? .danger : .textPrimary
-        proStackView.alpha = (numberOfCharactersLeft <= Self.thresholdForCharacterLimit) ? 1 : 0
+        let showCharacterLimit: Bool = (numberOfCharactersLeft <= Self.thresholdForCharacterLimit)
+        proStackView.alpha = (showCharacterLimit ? 1 : 0)
+        /// An `alpha` of `0` leaves the view in the accessibility tree, where it reads as present-but-blank; hiding it
+        /// here keeps the tree agreeing with the screen, which is what lets absence be asserted at all
+        proStackView.accessibilityElementsHidden = !showCharacterLimit
         characterLimitLabelTapGestureRecognizer.isEnabled = (numberOfCharactersLeft < Self.thresholdForCharacterLimit)
     }
 


### PR DESCRIPTION
Gives the composer's character-limit countdown a stable identity, so the regression suite can address
it properly.

### Why

The countdown had no accessibility identifier, so the suite matched it with an unscoped xpath built by
interpolating the expected number:

```
//XCUIElementTypeStaticText[@name="200"]
```

That is loose when a number is supplied — it matches *any* static text reading `200` — and useless
when one is not. The "no countdown shows" cases construct the locator with no number, so the selector
became `[@name="undefined"]`, which can never match. **Two specs were therefore passing without
asserting anything**: `Message length limit (1799 chars non Pro)` and `(9799 chars Pro)`.

### What changed

- `characterLimitLabel` gains `accessibilityIdentifier = "character-limit-text"`
- `proStackView.accessibilityElementsHidden` now tracks the same condition as its `alpha`, in both the
  update path and the initialiser

Two details worth calling out, both of which would have broken this if done the obvious way:

**The identifier is set alone.** Every other control in this file assigns `accessibilityLabel` the same
string as its identifier. A `UILabel`'s `accessibilityLabel` defaults to its text, so following that
convention here would overwrite the remaining-character count with a constant and leave the number
unreadable — which is the one value a test needs.

**The initialiser needs the flag too.** `updateNumberOfCharactersLeft` only runs on a text change, so a
composer nobody has typed in yet would have `alpha = 0` with the subtree still in the accessibility
tree — precisely the at-rest state the "no countdown" assertion inspects.

### Behaviour

Unchanged. Layout, threshold and copy are untouched — the countdown still appears with 200 characters
left, and `accessibilityElementsHidden` affects only the accessibility tree, not layout or the tap
gesture.

Verified in a running app: identifier present, the number readable on the element's `label`, and the
subtree absent from the tree when the countdown is hidden. With the matching harness change, all eight
message-length specs pass on iOS, including the two that previously asserted nothing.
