### PR TITLE
Notifications: stop extension messages being discarded on import

### DIFF
--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -1053,17 +1053,14 @@ public extension LibSession {
                 
                 Task.detached(priority: .medium) { [dependencies] in
                     /// Replicate any dumps
+                    ///
+                    /// A result with no dump changed no config, so its replica is left untouched - the replica's modification date is the
+                    /// "config last changed" timestamp the notification extension reads, and advancing it for a merge which changed
+                    /// nothing would make already-received messages look outdated
                     for result in results {
-                        switch result.dump {
-                            case .some(let dump):
-                                dependencies[singleton: .extensionHelper].replicate(dump: dump)
-                            
-                            case .none:
-                                dependencies[singleton: .extensionHelper].refreshDumpModifiedDate(
-                                    sessionId: result.sessionId,
-                                    variant: result.variant
-                                )
-                        }
+                        guard case .some(let dump) = result.dump else { continue }
+
+                        dependencies[singleton: .extensionHelper].replicate(dump: dump)
                     }
                 }
             }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -199,6 +199,7 @@ public enum MessageReceiver {
         serverExpirationTimestamp: TimeInterval?,
         suppressNotifications: Bool,
         currentUserSessionIds: Set<String>,
+        wasValidatedOnReceipt: Bool = false,
         using dependencies: Dependencies
     ) throws -> InsertedInteractionInfo? {
         /// Throw if the message is outdated and shouldn't be processed (this is based on pretty flaky logic which checks if the config
@@ -210,6 +211,7 @@ public enum MessageReceiver {
             openGroupUrlInfo: (threadVariant != .community ? nil :
                 try? LibSession.OpenGroupUrlInfo.fetchOne(db, id: threadId)
             ),
+            wasValidatedOnReceipt: wasValidatedOnReceipt,
             using: dependencies
         )
         
@@ -479,11 +481,23 @@ public enum MessageReceiver {
         }
     }
     
+    /// - Parameter wasValidatedOnReceipt: Set for messages the notification extension already validated when it received them (ie.
+    /// the import path). It skips **only** the trailing hidden-conversation check, which is the one whose answer drifts after receipt:
+    /// its baseline moves forwards with every config change, including ones unrelated to the conversation, and a conversation which
+    /// has never been in the config cannot be told apart from one the user deleted (see the `deleted_contacts` TODO above) - so by
+    /// import time it discards messages the user has already been shown a notification for.
+    ///
+    /// The group checks are deliberately **still** applied, because their answers remain meaningful (and are recoverable if they were
+    /// wrong): being kicked removes the group's messages, so a message inserted afterwards would be an orphan the user cannot get
+    /// rid of, and a message predating `deleteBefore` must not reappear after the history was cleared. A group check which fails
+    /// because the main app has not caught up yet is not a permanent loss either - the caller removes the deduplication record on
+    /// failure, so a later poll can reprocess the message once the state is in place.
     public static func throwIfMessageOutdated(
         message: Message,
         threadId: String,
         threadVariant: SessionThread.Variant,
         openGroupUrlInfo: LibSession.OpenGroupUrlInfo?,
+        wasValidatedOnReceipt: Bool = false,
         using dependencies: Dependencies
     ) throws {
         // TODO: [Database Relocation] Need the "deleted_contacts" logic to handle the 'throwIfMessageOutdated' case
@@ -546,6 +560,8 @@ public enum MessageReceiver {
                 }
         }
         
+        guard !wasValidatedOnReceipt else { return }
+
         /// If the conversation is not visible in the config and the message was sent before the last config update (minus a buffer period)
         /// then we can assume that the user has hidden/deleted the conversation and it shouldn't be reshown by this (old) message
         try dependencies.mutate(cache: .libSession) { cache in

--- a/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/SwarmPoller.swift
@@ -362,8 +362,20 @@ public enum SwarmPoller {
                     }
                     catch {
                         /// If we deferred the dedupe inserts then the savepoint rolled them back so cancel their pending file writes too
+                        ///
+                        /// Cancelling the pending write only discards the record *this* run would have created - the extension saved its
+                        /// own dedupe file when it received the message, so that has to be removed separately or the config message is
+                        /// dropped as a duplicate on every future poll and never merges (for `groupKeys` that leaves the extension's
+                        /// replica able to decrypt messages the main app cannot, which is the divergence behind #700)
                         if forceSynchronousProcessing {
-                            processedMessages.forEach { MessageDeduplication.removePendingWrite($0, using: dependencies) }
+                            processedMessages.forEach { processedMessage in
+                                MessageDeduplication.removePendingWrite(processedMessage, using: dependencies)
+
+                                try? dependencies[singleton: .extensionHelper].removeDedupeRecord(
+                                    threadId: processedMessage.threadId,
+                                    uniqueIdentifier: processedMessage.uniqueIdentifier
+                                )
+                            }
                         }
 
                         invalidMessageCount += 1
@@ -401,6 +413,7 @@ public enum SwarmPoller {
                                     serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                                     suppressNotifications: (source == .pushNotification),    /// Have already shown
                                     currentUserSessionIds: [currentUserSessionId.hexString], /// Swarm poller only has one
+                                    wasValidatedOnReceipt: (source == .pushNotification),
                                     using: dependencies
                                 )
 

--- a/SessionMessagingKit/Utilities/ExtensionHelper.swift
+++ b/SessionMessagingKit/Utilities/ExtensionHelper.swift
@@ -44,7 +44,13 @@ public class ExtensionHelper: ExtensionHelperType {
     // stringlint:ignore_stop
     
     private let dependencies: Dependencies
-    
+
+    /// Several entry points can start a load at once - the app launching, the scene becoming active, and a notification tap going through
+    /// `waitUntilMessagesAreLoaded` (which bypasses `SceneDelegate.scheduleLoadMessages` entirely, so its task cancellation
+    /// cannot serialise them). Concurrent runs enumerate, decrypt and import the same files, which doubles the work and makes the
+    /// import logs read as though twice as many messages arrived
+    @ThreadSafeObject private var currentLoadMessagesTask: Task<Void, Error>?
+
     // MARK: - Initialization
     
     init(using dependencies: Dependencies) {
@@ -66,7 +72,7 @@ public class ExtensionHelper: ExtensionHelperType {
             .path
     }
     
-    private func write(data: Data, to path: String) throws {
+    private func write(data: Data, to path: String, modifiedDate: Date? = nil) throws {
         /// Load in the data and `encKey` and reset the `encKey` as soon as the function ends
         guard
             var encKey: [UInt8] = (try? dependencies[singleton: .keychain]
@@ -118,6 +124,15 @@ public class ExtensionHelper: ExtensionHelperType {
         /// from the original storage directory instead if inheriting the setting of the current directory (and since we write to a temporary
         /// directory it defaults to having `complete` protection instead of `completeUntilFirstUserAuthentication`)
         try? dependencies[singleton: .fileManager].protectFileOrFolder(at: path)
+
+        /// Moving the temporary file into place gives it a fresh modification date, so a caller-supplied date **must** be applied after
+        /// the move rather than to the temporary file - applying it earlier is silently overwritten with the time of the write
+        if let modifiedDate: Date = modifiedDate {
+            try dependencies[singleton: .fileManager].setAttributes(
+                [.modificationDate: modifiedDate],
+                ofItemAtPath: path
+            )
+        }
     }
     
     private func read(from path: String, usingKey encKey: [UInt8]) throws -> Data {
@@ -158,15 +173,6 @@ public class ExtensionHelper: ExtensionHelperType {
             .attributesOfItem(atPath: path)
             .getting(.modificationDate) as? Date)?
             .timeIntervalSince1970)
-    }
-    
-    private func refreshModifiedDate(at path: String) throws {
-        guard dependencies[singleton: .fileManager].fileExists(atPath: path) else { return }
-        
-        try dependencies[singleton: .fileManager].setAttributes(
-            [.modificationDate: dependencies.dateNow],
-            ofItemAtPath: path
-        )
     }
     
     public func deleteCache() {
@@ -358,15 +364,27 @@ public class ExtensionHelper: ExtensionHelperType {
             !dependencies[singleton: .fileManager].fileExists(atPath: path)
         else { return }
         
+        /// The replica's modification date is how both this process and the notification extension recover *when the config last
+        /// changed* - the extension has no database access so `ConfigDump.timestampMs` is unreachable there, and
+        /// `seedDumpTimestampsFromDisk` reads the date back in its place. `throwIfMessageOutdated` then discards messages
+        /// sent before it, so the date has to carry the dump's own timestamp rather than the time we happen to write the file:
+        /// stamping the write time makes a rewrite which changes no config (eg. the self-healing replication) retroactively
+        /// classify already-received messages as outdated and silently drop them
+        let dumpTimestamp: TimeInterval = (TimeInterval(dump.timestampMs) / 1000)
+
         /// Write the dump data to disk
         do {
-            try write(data: dump.data, to: path)
-            
+            try write(
+                data: dump.data,
+                to: path,
+                modifiedDate: Date(timeIntervalSince1970: dumpTimestamp)
+            )
+
             dependencies.mutate(cache: .libSession) { cache in
                 cache.updateCachedDumpTimestamp(
                     sessionId: dump.sessionId,
                     variant: dump.variant,
-                    timestamp: dependencies.dateNow.timeIntervalSince1970
+                    timestamp: dumpTimestamp
                 )
             }
         }
@@ -458,9 +476,44 @@ public class ExtensionHelper: ExtensionHelperType {
         /// No need to read from the database if there are no missing dumps
         guard !missingReplicatedDumpInfo.isEmpty else { return }
         
+        /// Load the config dumps from the database
+        let missingDumpIds: Set<String> = Set(missingReplicatedDumpInfo.map { $0.sessionId.hexString })
+        let dumps: [ConfigDump] = ((try? await dependencies[singleton: .storage].read { db in
+            try ConfigDump
+                .filter(missingDumpIds.contains(ConfigDump.Columns.publicKey))
+                .fetchAll(db)
+        }) ?? [])
+
+        /// A variant with no dump in the database has nothing to replicate, and that is a normal state rather than a fault - a config which
+        /// has never been modified never produces one (eg. `userGroups` for a user who has never had a group or community). Those
+        /// have to be excluded before anything below, because they can never be resolved: they would be reported as missing on every
+        /// launch forever and, since one missing dump re-replicates the whole set, would rewrite every dump for that conversation each
+        /// time
+        let storedVariants: [String: Set<ConfigDump.Variant>] = dumps.reduce(into: [:]) { result, dump in
+            result[dump.sessionId.hexString, default: []].insert(dump.variant)
+        }
+        let replicableDumpInfo: [ReplicatedDumpInfo] = missingReplicatedDumpInfo
+            .map { info in
+                ReplicatedDumpInfo(
+                    sessionId: info.sessionId,
+                    states: info.states.filter {
+                        storedVariants[info.sessionId.hexString]?.contains($0.variant) == true
+                    }
+                )
+            }
+            .filter { info in
+                info.states.contains(where: {
+                    !$0.filePathGenerated ||
+                    !$0.fileExists ||
+                    !$0.correctFileProtectionType
+                })
+            }
+
+        guard !replicableDumpInfo.isEmpty else { return }
+
         /// Add logs indicating the failures
         let formatter: ListFormatter = ListFormatter()
-        missingReplicatedDumpInfo.forEach { info in
+        replicableDumpInfo.forEach { info in
             if info.states.contains(where: { !$0.filePathGenerated }) {
                 Log.warn(.cat, "Will replicate dumps for \(info.sessionId.hexString) due to failure to generate dump a file path.")
                 return
@@ -481,38 +534,30 @@ public class ExtensionHelper: ExtensionHelperType {
             }
         }
         
-        /// Load the config dumps from the database
-        let fetchTimestamp: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-        let missingDumpIds: Set<String> = Set(missingReplicatedDumpInfo.map { $0.sessionId.hexString })
-        let dumps: [ConfigDump] = ((try? await dependencies[singleton: .storage].read { db in
-            try ConfigDump
-                .filter(missingDumpIds.contains(ConfigDump.Columns.publicKey))
-                .fetchAll(db)
-        }) ?? [])
-        
-        /// Persist each dump to disk (if there isn't already one there, or it was updated before the dump was fetched from
-        /// the database)
+        /// Persist each dump to disk
         ///
         /// **Note:** Because it's likely that this function runs in the background it's possible that another thread could trigger
         /// a config update which would result in the dump getting replicated - if that occurs then we don't want to override what
         /// is likely a newer dump, but do need to replace what might be an invalid dump file (hence the timestamp check)
-        dumps.forEach { dump in
-            let dumpLastUpdated: TimeInterval = lastUpdatedTimestamp(
-                for: dump.sessionId,
-                variant: dump.variant
-            )
-            
-            replicate(
-                dump: dump,
-                replaceExisting: (dumpLastUpdated < fetchTimestamp)
-            )
-        }
-    }
-    
-    public func refreshDumpModifiedDate(sessionId: SessionId, variant: ConfigDump.Variant) {
-        guard let path: String = dumpFilePath(for: sessionId, variant: variant) else { return }
-        
-        try? refreshModifiedDate(at: path)
+        ///
+        /// A replica's modification date holds the timestamp of the dump it was written from, so comparing it against the timestamp
+        /// of the row just fetched is what identifies a newer replica - an **equal** date must still be replaced, because that is how
+        /// a dump with a missing file or the wrong `fileProtectionType` presents
+        let sessionIdsToReplicate: Set<String> = Set(replicableDumpInfo.map { $0.sessionId.hexString })
+
+        dumps
+            .filter { sessionIdsToReplicate.contains($0.sessionId.hexString) }
+            .forEach { dump in
+                let dumpLastUpdated: TimeInterval = lastUpdatedTimestamp(
+                    for: dump.sessionId,
+                    variant: dump.variant
+                )
+
+                replicate(
+                    dump: dump,
+                    replaceExisting: (dumpLastUpdated <= (TimeInterval(dump.timestampMs) / 1000))
+                )
+            }
     }
     
     public func loadUserConfigState(
@@ -535,6 +580,10 @@ public class ExtensionHelper: ExtensionHelperType {
             .forEach { variant in
                 guard
                     let path: String = dumpFilePath(for: userSessionId, variant: variant),
+                    /// A variant with no replica has simply never been dumped (eg. `userGroups` for a user with no groups or
+                    /// communities) which the default state below handles - attempting the read would log a file-not-found error on
+                    /// every notification for something whose absence is expected
+                    dependencies[singleton: .fileManager].fileExists(atPath: path),
                     let dump: Data = try? read(from: path, usingKey: encKey),
                     let config: LibSession.Config = try? cache.loadState(
                         for: variant,
@@ -827,6 +876,27 @@ public class ExtensionHelper: ExtensionHelperType {
     }
     
     public func loadMessages() async throws {
+        /// Join the run already in flight rather than starting a second one over the same files - a caller which awaits this needs the
+        /// messages to actually be loaded when it returns (`waitUntilMessagesAreLoaded` gates opening a tapped notification on
+        /// it), so this cannot just return early
+        let task: Task<Void, Error> = _currentLoadMessagesTask.performUpdateAndMap { existingTask in
+            switch existingTask {
+                case .some(let existingTask): return (existingTask, existingTask)
+                case .none:
+                    let newTask: Task<Void, Error> = Task { [weak self] in
+                        defer { self?._currentLoadMessagesTask.set(to: nil) }
+
+                        try await self?.performLoadMessages()
+                    }
+
+                    return (newTask, newTask)
+            }
+        }
+
+        try await task.value
+    }
+
+    private func performLoadMessages() async throws {
         typealias MessageData = (namespace: Network.StorageServer.Namespace, messages: [Network.StorageServer.Message], lastHash: String?)
         typealias ConversationMessages = (
             swarmPublicKey: String,
@@ -1162,7 +1232,6 @@ public protocol ExtensionHelperType {
     func replicate(dump: ConfigDump?, replaceExisting: Bool)
     func replicateAllConfigDumpsIfNeeded(userSessionId: SessionId, allDumpSessionIds: Set<SessionId>) async
     func removeConfigDumps(for sessionId: SessionId)
-    func refreshDumpModifiedDate(sessionId: SessionId, variant: ConfigDump.Variant)
     func loadUserConfigState(
         into cache: LibSessionCacheType,
         userSessionId: SessionId,

--- a/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageReceiverGroupsSpec.swift
@@ -3542,6 +3542,93 @@ class MessageReceiverGroupsSpec: AsyncSpec {
                     expect(groupMember.invited).to(equal(0))
                 }
             }
+
+            // MARK: -- when checking whether a message is outdated
+            context("when checking whether a message is outdated") {
+                @TestState var message: VisibleMessage! = VisibleMessage(
+                    sender: "051111111111111111111111111111111111111111111111111111111111111112",
+                    sentTimestampMs: 1234567890000,
+                    text: "Test"
+                )
+
+                // MARK: ---- rejects a message for a group the user was kicked from even when validated on receipt
+                it("rejects a message for a group the user was kicked from even when validated on receipt") {
+                    try await fixture.mockLibSessionCache
+                        .when { $0.wasKickedFromGroup(groupSessionId: .any) }
+                        .thenReturn(true)
+
+                    /// Being kicked removes the group's messages, so inserting one afterwards would leave an orphan the user
+                    /// cannot remove - the extension having validated the message at receipt must not bypass this
+                    await expect {
+                        try MessageReceiver.throwIfMessageOutdated(
+                            message: message,
+                            threadId: fixture.groupId.hexString,
+                            threadVariant: .group,
+                            openGroupUrlInfo: nil,
+                            wasValidatedOnReceipt: true,
+                            using: fixture.dependencies
+                        )
+                    }.to(throwError(MessageError.outdatedMessage))
+                }
+
+                // MARK: ---- rejects a message sent before the group history was cleared even when validated on receipt
+                it("rejects a message sent before the group history was cleared even when validated on receipt") {
+                    try await fixture.mockLibSessionCache
+                        .when { $0.groupDeleteBefore(groupSessionId: .any) }
+                        .thenReturn(1234567890)
+
+                    await expect {
+                        try MessageReceiver.throwIfMessageOutdated(
+                            message: message,
+                            threadId: fixture.groupId.hexString,
+                            threadVariant: .group,
+                            openGroupUrlInfo: nil,
+                            wasValidatedOnReceipt: true,
+                            using: fixture.dependencies
+                        )
+                    }.to(throwError(MessageError.outdatedMessage))
+                }
+
+                // MARK: ---- ignores the hidden conversation check when validated on receipt
+                it("ignores the hidden conversation check when validated on receipt") {
+                    try await fixture.mockLibSessionCache
+                        .when {
+                            $0.conversationInConfig(
+                                threadId: .any,
+                                threadVariant: .any,
+                                visibleOnly: .any,
+                                openGroupUrlInfo: .any
+                            )
+                        }
+                        .thenReturn(false)
+                    try await fixture.mockLibSessionCache
+                        .when { $0.canPerformChange(threadId: .any, threadVariant: .any, changeTimestampMs: .any) }
+                        .thenReturn(false)
+
+                    /// This is the combination which discards a message request the extension has already shown a notification for
+                    await expect {
+                        try MessageReceiver.throwIfMessageOutdated(
+                            message: message,
+                            threadId: "051111111111111111111111111111111111111111111111111111111111111112",
+                            threadVariant: .contact,
+                            openGroupUrlInfo: nil,
+                            wasValidatedOnReceipt: true,
+                            using: fixture.dependencies
+                        )
+                    }.toNot(throwError())
+
+                    await expect {
+                        try MessageReceiver.throwIfMessageOutdated(
+                            message: message,
+                            threadId: "051111111111111111111111111111111111111111111111111111111111111112",
+                            threadVariant: .contact,
+                            openGroupUrlInfo: nil,
+                            wasValidatedOnReceipt: false,
+                            using: fixture.dependencies
+                        )
+                    }.to(throwError(MessageError.outdatedMessage))
+                }
+            }
         }
     }
 }

--- a/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/Pollers/SwarmPollerSpec.swift
@@ -54,6 +54,69 @@ class SwarmPollerSpec: AsyncSpec {
                 }
             }
 
+            // MARK: -- when a config message fails to merge on the notification extension import path
+            context("when a config message fails to merge on the notification extension import path") {
+                // MARK: ---- removes the orphan dedupe record so the config message can be reprocessed by a later poll
+                it("removes the orphan dedupe record so the config message can be reprocessed by a later poll") {
+                    _ = try await fixture.mockStorage.write { db in
+                        SwarmPoller.processPollResponse(
+                            db,
+                            cat: .poller,
+                            source: .pushNotification,
+                            swarmPublicKey: fixture.userSessionId.hexString,
+                            shouldStoreMessages: true,
+                            ignoreDedupeFiles: true,
+                            forceSynchronousProcessing: true,
+                            sortedMessages: [(
+                                namespace: .configUserGroups,
+                                messages: [fixture.configMessage(hash: "TestConfigHash")],
+                                lastHash: nil
+                            )],
+                            using: fixture.dependencies
+                        )
+                    }
+
+                    /// The extension created a dedupe file for this config message when it received it, so without removing it the
+                    /// message would be dropped as a duplicate on every future poll and the config change would never apply
+                    await fixture.mockExtensionHelper
+                        .verify {
+                            try $0.removeDedupeRecord(
+                                threadId: fixture.userSessionId.hexString,
+                                uniqueIdentifier: "TestConfigHash"
+                            )
+                        }
+                        .wasCalled(exactly: 1, timeout: .milliseconds(100))
+                }
+            }
+
+            // MARK: -- when a config message fails to merge on the normal (non-synchronous) poll path
+            context("when a config message fails to merge on the normal (non-synchronous) poll path") {
+                // MARK: ---- does not remove the dedupe record
+                it("does not remove the dedupe record") {
+                    _ = try await fixture.mockStorage.write { db in
+                        SwarmPoller.processPollResponse(
+                            db,
+                            cat: .poller,
+                            source: .snode(fixture.snode),
+                            swarmPublicKey: fixture.userSessionId.hexString,
+                            shouldStoreMessages: true,
+                            ignoreDedupeFiles: false,
+                            forceSynchronousProcessing: false,
+                            sortedMessages: [(
+                                namespace: .configUserGroups,
+                                messages: [fixture.configMessage(hash: "TestConfigHash")],
+                                lastHash: nil
+                            )],
+                            using: fixture.dependencies
+                        )
+                    }
+
+                    await fixture.mockExtensionHelper
+                        .verify { try $0.removeDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
+                        .wasNotCalled(timeout: .milliseconds(100))
+                }
+            }
+
             // MARK: -- when a message fails to process on the normal (non-synchronous) poll path
             context("when a message fails to process on the normal (non-synchronous) poll path") {
                 // MARK: ---- does not remove the dedupe record
@@ -96,10 +159,20 @@ private class SwarmPollerTestFixture: FixtureBase {
     var mockCrypto: MockCrypto { mock(for: .crypto) }
     var mockExtensionHelper: MockExtensionHelper { mock(for: .extensionHelper) }
     var mockGeneralCache: MockGeneralCache { mock(cache: .general) }
+    var mockLibSessionCache: MockLibSessionCache { mock(cache: .libSession) }
 
     let groupId: SessionId = SessionId(
         .group,
         hex: "03cbd569f56fb13ea95a3f0c05c331cc24139c0090feb412069dc49fab34406ece"
+    )
+    let userSessionId: SessionId = SessionId(.standard, hex: TestConstants.publicKey)
+    let snode: LibSession.Snode = LibSession.Snode(
+        ed25519PubkeyHex: TestConstants.edPublicKey,
+        ip: "1.1.1.1",
+        httpsPort: 10,
+        quicPort: 1,
+        version: "2.11.0",
+        swarmId: 1
     )
 
     static func create() async throws -> SwarmPollerTestFixture {
@@ -110,6 +183,20 @@ private class SwarmPollerTestFixture: FixtureBase {
     }
 
     // MARK: - Convenience
+
+    func configMessage(hash: String) -> Network.StorageServer.Message {
+        return Network.StorageServer.Message(
+            snode: nil,
+            publicKey: userSessionId.hexString,
+            namespace: .configUserGroups,
+            rawMessage: Network.StorageServer.GetMessagesResponse.RawMessage(
+                base64EncodedDataString: Data([1, 2, 3]).base64EncodedString(),
+                expirationMs: nil,
+                hash: hash,
+                timestampMs: 1234567890
+            )
+        )!
+    }
 
     func message(hash: String) -> Network.StorageServer.Message {
         return Network.StorageServer.Message(
@@ -162,5 +249,17 @@ private class SwarmPollerTestFixture: FixtureBase {
         try await mockExtensionHelper
             .when { try $0.removeDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
             .thenReturn(())
+        try await mockExtensionHelper
+            .when { try $0.createDedupeRecord(threadId: .any, uniqueIdentifier: .any) }
+            .thenReturn(())
+        try await mockExtensionHelper
+            .when { $0.dedupeRecordExists(threadId: .any, uniqueIdentifier: .any) }
+            .thenReturn(false)
+
+        /// Force the config merge to fail (as it would when the config data can't be applied)
+        try await mockLibSessionCache.defaultInitialSetup()
+        try await mockLibSessionCache
+            .when { try $0.handleConfigMessages(.any, swarmPublicKey: .any, messages: .any) }
+            .thenThrow(TestError.mock)
     }
 }

--- a/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
+++ b/SessionMessagingKitTests/Utilities/ExtensionHelperSpec.swift
@@ -724,6 +724,77 @@ class ExtensionHelperSpec: AsyncSpec {
                         .wasCalled(exactly: 1)
                 }
                 
+                // MARK: ---- stamps the dump timestamp on the file instead of the time it was written
+                it("stamps the dump timestamp on the file instead of the time it was written") {
+                    extensionHelper.replicate(
+                        dump: ConfigDump(
+                            variant: .userProfile,
+                            sessionId: "05\(TestConstants.publicKey)",
+                            data: Data([1, 2, 3]),
+                            timestampMs: 1234567890
+                        ),
+                        replaceExisting: true
+                    )
+
+                    /// The modification date is what both processes read back as "when the config last changed", so it must be
+                    /// the dump's own timestamp - `dependencies.dateNow` is 1234567890 **seconds**, so stamping the write
+                    /// time would give a date a million times further into the future than the correct one
+                    await mockFileManager
+                        .verify {
+                            try $0.setAttributes(
+                                [.modificationDate: Date(timeIntervalSince1970: 1234567.89)],
+                                ofItemAtPath: "/test/extensionCache/conversations/010203/dumps/010203"
+                            )
+                        }
+                        .wasCalled(exactly: 1)
+                }
+
+                // MARK: ---- stamps the date after moving the file into place
+                it("stamps the date after moving the file into place") {
+                    try await mockFileManager
+                        .when { _ = try $0.replaceItem(atPath: .any, withItemAtPath: .any) }
+                        .thenThrow(TestError.mock)
+
+                    extensionHelper.replicate(
+                        dump: ConfigDump(
+                            variant: .userProfile,
+                            sessionId: "05\(TestConstants.publicKey)",
+                            data: Data([1, 2, 3]),
+                            timestampMs: 1234567890
+                        ),
+                        replaceExisting: true
+                    )
+
+                    /// Moving the file resets its modification date, so a date applied before the move would be silently discarded -
+                    /// if the move never happens there is nothing to stamp
+                    await mockFileManager
+                        .verify { try $0.setAttributes(.any, ofItemAtPath: .any) }
+                        .wasNotCalled()
+                }
+
+                // MARK: ---- updates the cached dump timestamp with the dump timestamp
+                it("updates the cached dump timestamp with the dump timestamp") {
+                    extensionHelper.replicate(
+                        dump: ConfigDump(
+                            variant: .userProfile,
+                            sessionId: "05\(TestConstants.publicKey)",
+                            data: Data([1, 2, 3]),
+                            timestampMs: 1234567890
+                        ),
+                        replaceExisting: true
+                    )
+
+                    await mockLibSessionCache
+                        .verify {
+                            $0.updateCachedDumpTimestamp(
+                                sessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
+                                variant: .userProfile,
+                                timestamp: 1234567.89
+                            )
+                        }
+                        .wasCalled(exactly: 1)
+                }
+
                 // MARK: ---- does nothing when given a null dump
                 it("does nothing when given a null dump") {
                     extensionHelper.replicate(dump: nil, replaceExisting: true)
@@ -1011,6 +1082,86 @@ class ExtensionHelperSpec: AsyncSpec {
                         ]))
                 }
                 
+                // MARK: ---- does nothing when the only missing variant has no dump in the database
+                it("does nothing when the only missing variant has no dump in the database") {
+                    try await mockStorage.write { db in
+                        try ConfigDump
+                            .filter(ConfigDump.Columns.variant == ConfigDump.Variant.userGroups)
+                            .deleteAll(db)
+                    }
+
+                    for value in mockValues {
+                        guard
+                            let variant: ConfigDump.Variant = value.variant,
+                            ConfigDump.Variant.userVariants.contains(variant)
+                        else { continue }
+
+                        try await mockFileManager
+                            .when {
+                                $0.fileExists(
+                                    atPath: "/test/extensionCache/conversations/010203/dumps/" +
+                                        value.hashValue.toHexString()
+                                )
+                            }
+                            .thenReturn(variant != .userGroups)
+                    }
+
+                    await extensionHelper.replicateAllConfigDumpsIfNeeded(
+                        userSessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
+                        allDumpSessionIds: [SessionId(.standard, hex: "05\(TestConstants.publicKey)")]
+                    )
+
+                    /// A config which has never been modified never produces a dump, so there is nothing to replicate and nothing is
+                    /// wrong - without this the whole set would be rewritten (and a warning logged) on every single launch
+                    await mockFileManager
+                        .verify { try $0.write(data: .any, toPath: .any) }
+                        .wasNotCalled()
+                    await mockFileManager
+                        .verify { _ = try $0.replaceItem(atPath: .any, withItemAtPath: .any) }
+                        .wasNotCalled()
+                    await expect { await mockLogger.logs.filter { $0.level == .warn } }
+                        .toEventually(beEmpty(), timeout: .milliseconds(100))
+                }
+
+                // MARK: ---- only replaces replicas which are not newer than the dumps it fetched
+                it("only replaces replicas which are not newer than the dumps it fetched") {
+                    for value in mockValues {
+                        guard
+                            let variant: ConfigDump.Variant = value.variant,
+                            ConfigDump.Variant.userVariants.contains(variant)
+                        else { continue }
+
+                        try await mockFileManager
+                            .when {
+                                $0.fileExists(
+                                    atPath: "/test/extensionCache/conversations/010203/dumps/" +
+                                        value.hashValue.toHexString()
+                                )
+                            }
+                            .thenReturn(variant != .userGroups)
+                    }
+
+                    await extensionHelper.replicateAllConfigDumpsIfNeeded(
+                        userSessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
+                        allDumpSessionIds: [SessionId(.standard, hex: "05\(TestConstants.publicKey)")]
+                    )
+
+                    /// A single missing dump re-fetches the whole set for that `SessionId`, but the replicas already on disk carry a
+                    /// modification date newer than the database rows just fetched (ie. another thread replicated a newer dump), so
+                    /// only the missing one should be written - rewriting the others would replace newer config state with older
+                    await mockFileManager
+                        .verify {
+                            _ = try $0.replaceItem(
+                                atPath: "/test/extensionCache/conversations/010203/dumps/050607",
+                                withItemAtPath: "tmpFile"
+                            )
+                        }
+                        .wasCalled(exactly: 1)
+                    await mockFileManager
+                        .verify { _ = try $0.replaceItem(atPath: .any, withItemAtPath: .any) }
+                        .wasCalled(exactly: 1)
+                }
+
                 // MARK: ---- does nothing when failing to generate a hash
                 it("does nothing when failing to generate a hash") {
                     for value in mockValues {
@@ -1018,7 +1169,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             .when { $0.generate(.hash(message: Array(value.key.data(using: .utf8)!))) }
                             .thenReturn(nil)
                     }
-                    
+
                     await extensionHelper.replicateAllConfigDumpsIfNeeded(
                         userSessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
                         allDumpSessionIds: [SessionId(.standard, hex: "05\(TestConstants.publicKey)")]
@@ -1112,61 +1263,10 @@ class ExtensionHelperSpec: AsyncSpec {
                 }
             }
 
-            // MARK: -- when refreshing the dump modified date
-            context("when refreshing the dump modified date") {
-                beforeEach {
-                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(true)
-                }
-                
-                // MARK: ---- updates the modified date
-                it("updates the modified date") {
-                    extensionHelper.refreshDumpModifiedDate(
-                        sessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
-                        variant: .userProfile
-                    )
-                    
-                    await mockFileManager
-                        .verify {
-                            try $0.setAttributes(
-                                [.modificationDate: Date(timeIntervalSince1970: 1234567890)],
-                                ofItemAtPath: "/test/extensionCache/conversations/010203/dumps/010203"
-                            )
-                        }
-                        .wasCalled(exactly: 1)
-                }
-                
-                // MARK: ---- does nothing when it fails to generate a hash
-                it("does nothing when it fails to generate a hash") {
-                    try await mockCrypto.when { $0.generate(.hash(message: .any)) }.thenReturn(nil)
-                    
-                    extensionHelper.refreshDumpModifiedDate(
-                        sessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
-                        variant: .userProfile
-                    )
-                    
-                    await mockFileManager
-                        .verify { try $0.setAttributes(.any, ofItemAtPath: .any) }
-                        .wasNotCalled()
-                }
-                
-                // MARK: ---- does nothing if the file does not exist
-                it("does nothing if the file does not exist") {
-                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(false)
-                    
-                    extensionHelper.refreshDumpModifiedDate(
-                        sessionId: SessionId(.standard, hex: "05\(TestConstants.publicKey)"),
-                        variant: .userProfile
-                    )
-                    
-                    await mockFileManager
-                        .verify { try $0.setAttributes(.any, ofItemAtPath: .any) }
-                        .wasNotCalled()
-                }
-            }
-            
             // MARK: -- when loading user configs
             context("when loading user configs") {
                 beforeEach {
+                    try await mockFileManager.when { $0.fileExists(atPath: .any) }.thenReturn(true)
                     try await mockCrypto
                         .when { $0.generate(.plaintextWithXChaCha20(ciphertext: .any, encKey: .any)) }
                         .thenReturn(Data([1, 2, 3]))
@@ -2455,7 +2555,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             ],
                             message: "Finished: Successfully processed 1/1 standard messages, 0/0 config messages.",
                             file: "SessionMessagingKit/ExtensionHelper.swift",
-                            function: "loadMessages()"
+                            function: "performLoadMessages()"
                         )
                     ))
                 }
@@ -2492,7 +2592,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             ],
                             message: "Discarding some config message changes due to error: Failed to read from file.",
                             file: "SessionMessagingKit/ExtensionHelper.swift",
-                            function: "loadMessages()"
+                            function: "performLoadMessages()"
                         )
                     ))
                     await expect { await mockLogger.logs }.toEventually(contain(
@@ -2508,7 +2608,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             ],
                             message: "Finished: Successfully processed 0/0 standard messages, 0/1 config messages.",
                             file: "SessionMessagingKit/ExtensionHelper.swift",
-                            function: "loadMessages()"
+                            function: "performLoadMessages()"
                         )
                     ))
                 }
@@ -2545,7 +2645,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             ],
                             message: "Discarding standard message due to error: Failed to read from file.",
                             file: "SessionMessagingKit/ExtensionHelper.swift",
-                            function: "loadMessages()"
+                            function: "performLoadMessages()"
                         )
                     ))
                     await expect { await mockLogger.logs }.toEventually(contain(
@@ -2561,7 +2661,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             ],
                             message: "Finished: Successfully processed 0/1 standard messages, 0/0 config messages.",
                             file: "SessionMessagingKit/ExtensionHelper.swift",
-                            function: "loadMessages()"
+                            function: "performLoadMessages()"
                         )
                     ))
                 }
@@ -2603,7 +2703,7 @@ class ExtensionHelperSpec: AsyncSpec {
                             ],
                             message: "Finished: Successfully processed 1/1 standard messages, 0/0 config messages.",
                             file: "SessionMessagingKit/ExtensionHelper.swift",
-                            function: "loadMessages()"
+                            function: "performLoadMessages()"
                         )
                     ))
                 }

--- a/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
+++ b/SessionMessagingKitTests/_TestUtilities/MockExtensionHelper.swift
@@ -76,10 +76,6 @@ class MockExtensionHelper: ExtensionHelperType, Mockable {
         handler.mockNoReturn(args: [sessionId])
     }
 
-    func refreshDumpModifiedDate(sessionId: SessionId, variant: ConfigDump.Variant) {
-        handler.mockNoReturn(args: [sessionId, variant])
-    }
-    
     func loadUserConfigState(
         into cache: LibSessionCacheType,
         userSessionId: SessionId,

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -363,12 +363,10 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
         sessionId: SessionId,
         timestampMs: Int64
     ) throws {
-        guard cache.configNeedsDump(config) else {
-            return dependencies[singleton: .extensionHelper].refreshDumpModifiedDate(
-                sessionId: sessionId,
-                variant: variant
-            )
-        }
+        /// A merge which produced no dump changed no config, so the replica (and the "config last changed" date its modification
+        /// date carries) must be left alone - advancing it would make messages already received by this extension look outdated
+        /// to the main app when it imports them
+        guard cache.configNeedsDump(config) else { return }
         
         /// Update the replicated extension config dump (this way any subsequent push notifications will use the correct
         /// data - eg. group encryption keys)


### PR DESCRIPTION
Root-caused from a user log (notification shows, message gone — reported for message requests and 1-1 conversations). Six messages were provably discarded at a cold launch, hours after their notifications had been shown.

## The bug

`throwIfMessageOutdated` drops a message when the conversation isn't visible in the config **and** the message was sent before the last config change. That second half is compared against a baseline which, since the extensions were de-databased, has been the **modification date of the replicated config dump** — i.e. when the file was last written, not when the config last changed. `replicate(dump:)` stamped `dateNow`, and the launch-time self-heal rewrites dumps for integrity reasons, so the baseline jumped to "now" on every launch. Every message the extension had saved while the app was closed then looked outdated and was thrown away.

For the reporting user it fired at *every* launch, because a `userGroups` dump that had never existed (they're in no groups) was treated as a lost replica, forcing a full re-replication each time.

## Changes

- The replica now carries the dump's own timestamp, applied after the file is moved into place (the move resets it). `refreshDumpModifiedDate` is deleted rather than fixed — a merge which produces no dump changed no config, so it must not move the baseline at all.
- The self-heal's `replaceExisting` guard now compares like with like; against `dateNow` it would have become always-true and silently stopped guarding.
- Messages imported from the extension skip only the hidden-conversation check, which the extension already evaluated at receipt. All group checks still run, so a message can't land in a group the user has since been kicked from (which removes that group's messages) or predate a cleared history.
- A config message that fails to merge on the import path now has the extension's dedupe record removed, as the standard-message path already does. Previously it was dropped as a duplicate on every future poll and never merged — for `groupKeys` that leaves the extension able to decrypt messages the main app cannot.
- Config dumps are only replicated if they exist in the database, so a never-dumped variant is no longer reported missing on every launch, and an absent replica no longer logs an error on every notification.
- Concurrent extension-message imports (a notification tap during launch runs two) now await the one in flight.

## Testing

`SessionMessagingKitTests`: 568 passed, 0 failed, 0 restarts. 13 new cases across `ExtensionHelperSpec`, `SwarmPollerSpec` and `MessageReceiverGroupsSpec`, each mutation-verified — reverting the corresponding fix fails exactly the intended tests and nothing else.