### PR TITLE
Pro: split access from display, and stop upselling an active plan

### DIFF
--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -575,7 +575,7 @@ extension ConversationVC:
     
     @MainActor func handleCharacterLimitLabelTapped() {
         let manager: SessionProManagerType = viewModel.dependencies[singleton: .sessionProManager]
-        let didShowCTAModal: Bool = manager.showSessionProCTAIfNeeded(
+        let ctaOutcome: ProCTAOutcome = manager.showSessionProCTAIfNeeded(
             .longerMessages(renew: (manager.currentUserCurrentProState.status == .expired)),
             onConfirm: { [weak self, manager] in
                 manager.showSessionProBottomSheetIfNeeded(
@@ -595,7 +595,7 @@ extension ConversationVC:
             }
         )
         
-        guard !didShowCTAModal else { return }
+        guard ctaOutcome != .shown else { return }
         
         let numberOfCharactersLeft: Int = viewModel.dependencies[singleton: .sessionProManager].numberOfCharactersLeft(
             for: snInputView.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -715,7 +715,7 @@ extension ConversationVC:
     
     @MainActor func showModalForMessagesExceedingCharacterLimit() {
         let manager: SessionProManagerType = viewModel.dependencies[singleton: .sessionProManager]
-        let didShowCTAModal: Bool = manager.showSessionProCTAIfNeeded(
+        let ctaOutcome: ProCTAOutcome = manager.showSessionProCTAIfNeeded(
             .longerMessages(renew: (manager.currentUserCurrentProState.status == .expired)),
             onConfirm: { [weak self, manager] in
                 manager.showSessionProBottomSheetIfNeeded(
@@ -735,7 +735,7 @@ extension ConversationVC:
             }
         )
         
-        guard !didShowCTAModal else { return }
+        guard ctaOutcome != .shown else { return }
         
         let confirmationModal: ConfirmationModal = ConfirmationModal(
             info: ConfirmationModal.Info(

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -422,7 +422,12 @@ class ThreadSettingsViewModel: SessionListScreenContent.ViewModelType, Navigatio
                                 viewModel?.transitionToScreen(ConfirmationModal(info: info), transitionType: .present)
                             },
                             onImageTap: { [weak viewModel, dependencies = viewModel.dependencies] in
-                                guard !dependencies[singleton: .sessionProManager].currentUserIsCurrentlyPro else {
+                                /// **The gate reads ACCESS.** Note the prompt below is NOT covered by the DISPLAY guard in
+                                /// `showSessionProCTAIfNeeded` on the group path: `.groupLimit` is on that function's exempt
+                                /// list, so a user whose plan reads active still sees it. That is plausibly correct - the
+                                /// variant is about whether the GROUP has Pro rather than the user - but it is the one place
+                                /// on this client where an access gate reaches an exempt variant
+                                guard !dependencies[singleton: .sessionProManager].currentUserHasProAccess else {
                                     guard let info: ConfirmationModal.Info = viewModel?.updateDisplayNameModal(state: state) else {
                                         return
                                     }

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -424,9 +424,8 @@ class ThreadSettingsViewModel: SessionListScreenContent.ViewModelType, Navigatio
                             onImageTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                                 /// **The gate reads ACCESS.** Note the prompt below is NOT covered by the DISPLAY guard in
                                 /// `showSessionProCTAIfNeeded` on the group path: `.groupLimit` is on that function's exempt
-                                /// list, so a user whose plan reads active still sees it. That is plausibly correct - the
-                                /// variant is about whether the GROUP has Pro rather than the user - but it is the one place
-                                /// on this client where an access gate reaches an exempt variant
+                                /// list, so a user whose plan reads active still sees it. That is correct here: the variant
+                                /// asks whether the GROUP has Pro, which is independent of the user's own plan
                                 guard !dependencies[singleton: .sessionProManager].currentUserHasProAccess else {
                                     guard let info: ConfirmationModal.Info = viewModel?.updateDisplayNameModal(state: state) else {
                                         return

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
@@ -174,6 +174,16 @@ extension DeveloperSettingsViewModel {
             /// behaviour should use `"never"`
             case mockCurrentUserSessionProBackendStatus
 
+            /// Simulates whether this device holds a usable Pro **proof**, which is what grants access to Pro features -
+            /// separately from `mockCurrentUserSessionProBackendStatus`, which only says what the backend *reports*
+            ///
+            /// **Note:** A mocked run holds no real proof, so a spec wanting a fully Pro client must set BOTH this and the
+            /// backend status. Setting only the status yields display-Active-without-access, which is a real state (a plan
+            /// is active but no proof has arrived yet) and the one the message-truncation behaviour lives in
+            ///
+            /// **Value:** `"valid"`/`"none"`/`"useActual"` (default: `"useActual"`)
+            case mockCurrentUserSessionProProof
+
             /// Simulates the loading state of the Session Pro status request, letting a test reach the loading and
             /// backend-unavailable screens without having to take the backend down
             ///
@@ -475,6 +485,20 @@ extension DeveloperSettingsViewModel {
                     else { continue }
 
                     dependencies.set(feature: .mockCurrentUserSessionProBackendStatus, to: mock)
+
+                case .mockCurrentUserSessionProProof:
+                    guard
+                        let mock: MockableFeature<SessionPro.MockProofValidity> = mockedProFeature(
+                            value,
+                            for: key,
+                            options: [
+                                "valid": .valid,
+                                "none": .none
+                            ]
+                        )
+                    else { continue }
+
+                    dependencies.set(feature: .mockCurrentUserSessionProProof, to: mock)
 
                 case .mockCurrentUserSessionProLoadingState:
                     guard

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -494,7 +494,10 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                                     }
                                 }(),
                                 font: .Headings.H8,
-                                color: .sessionButton_text
+                                color: .sessionButton_text,
+                                accessibility: Accessibility(
+                                    identifier: SessionProUI.AccessibilityIdentifier.menuItemTitle
+                                )
                             )
                         )
                     ),

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -1033,10 +1033,10 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                         switch modal.info.body {
                             case .image(.some(let source), _, _, _, let style, _, _, _, _, _):
                                 let isAnimatedImage: Bool = ImageDataManager.isAnimatedImage(source)
-                                var didShowCTAModal: Bool = false
+                                var ctaOutcome: ProCTAOutcome = .suppressedPlanActive
                                 
                                 if isAnimatedImage && proState.status != .active {
-                                    didShowCTAModal = dependencies[singleton: .sessionProManager].showSessionProCTAIfNeeded(
+                                    ctaOutcome = dependencies[singleton: .sessionProManager].showSessionProCTAIfNeeded(
                                         .animatedProfileImage(
                                             isSessionProActivated: (proState.status == .active),
                                             renew: (proState.status == .expired)
@@ -1056,7 +1056,7 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                                 
                                 /// If we showed the CTA modal then the user doesn't have Session Pro so can't use the
                                 /// selected image as their display picture
-                                guard !didShowCTAModal else { return }
+                                guard ctaOutcome != .shown else { return }
                                 
                                 self?.updateProfile(
                                     displayPictureUpdateGenerator: { [weak self] in

--- a/Session/Shared/BaseVC.swift
+++ b/Session/Shared/BaseVC.swift
@@ -99,7 +99,14 @@ public class BaseVC: UIViewController {
         headingImageView.set(.height, to: Values.mediumFontSize)
         
         let sessionProBadge: SessionProBadge = SessionProBadge(size: .medium)
-        sessionProBadge.isHidden = !sessionProUIManager.currentUserIsCurrentlyPro
+        /// **An entitlement indicator, so it reads ACCESS** - it says "you have this", and it has one while the proof
+        /// is live even if the plan has lapsed.
+        ///
+        /// Deliberately the opposite source to the composer's badge (`InputView`), which is the same widget class and
+        /// the same property in the opposite role - an upsell, reading DISPLAY. Do not reconcile the two: making this
+        /// one read DISPLAY would take a subscriber's badge away during the overhang, which is the inverse of the bug
+        /// that split them
+        sessionProBadge.isHidden = !sessionProUIManager.currentUserHasProAccess
         
         let stackView: UIStackView = UIStackView(arrangedSubviews: [ headingImageView, sessionProBadge ])
         stackView.semanticContentAttribute = .forceLeftToRight
@@ -109,7 +116,7 @@ public class BaseVC: UIViewController {
         
         proObservationTask?.cancel()
         proObservationTask = Task.detached(priority: .userInitiated) { [weak sessionProBadge] in
-            for await isPro in sessionProUIManager.currentUserIsPro {
+            for await isPro in sessionProUIManager.currentUserHasProAccessStream {
                 await MainActor.run { [weak sessionProBadge] in
                     sessionProBadge?.isHidden = !isPro
                 }

--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -261,7 +261,10 @@ public extension UIContextualAction {
                         ) { _, _, completionHandler in
                             if
                                 !isCurrentlyPinned,
-                                !dependencies[singleton: .sessionProManager].currentUserIsCurrentlyPro,
+                                /// **The gate reads ACCESS**; the prompt it raises below reads DISPLAY, and that split is enforced
+                                /// inside `showSessionProCTAIfNeeded` rather than here - so this one read doing both jobs is
+                                /// safe only because `.morePinnedConvos` is not on that function's exempt list
+                                !dependencies[singleton: .sessionProManager].currentUserHasProAccess,
                                 currentPinnedConversationCount >= SessionPro.PinnedConversationLimit
                             {
                                 dependencies[singleton: .sessionProManager].showSessionProCTAIfNeeded(

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -569,15 +569,34 @@ public actor SessionProManager: SessionProManagerType {
         }
         
         /// Infer the `proStatus` based on the config state (since we don't sync the status)
+        ///
+        /// `E` is consulted before the proof because they are evidence about different things: `E` arrived by config
+        /// sync and is the backend's view of the ACCOUNT's plan, whereas a proof is this DEVICE's credential. A device
+        /// restored from seed receives `E` before it acquires a proof, and reading the proof first tells such a user
+        /// they have never subscribed.
+        ///
+        /// It is also the only ordering which can express a lapsed plan that is still being served: past `E` with a
+        /// live proof displays as expired while access continues until the proof itself does. Reading the proof first
+        /// collapses that to active.
+        let nowMs: UInt64 = await dependencies.networkOffsetTimestampMs()
         let proStatus: Network.SessionPro.BackendUserProStatus = {
+            let expirySeconds: UInt64 = proInfo.accessExpiryTimestampSeconds
+
+            if expirySeconds > 0 {
+                return ((nowMs / 1000) < expirySeconds ? .active : .expired)
+            }
+
+            /// The only rung which reads the proof, and it reads it through `proProofIsActive` - expiry alone. Not
+            /// `currentUserProofIsValid`, which additionally consults the revocation list, and not
+            /// `currentUserHasProAccess`, which is the access answer and is mockable. A revoked-but-unexpired
+            /// credential therefore still seeds a display of active, which is correct: revocation withdraws what this
+            /// device may DO, while what the plan SAYS is the backend's to state and arrives with a response.
             guard let proof: Network.SessionPro.ProProof = proInfo.proConfig?.proProof else {
                 return .never
             }
-            
-            let proofIsActive: Bool = proProofIsActive(
-                for: proof,
-                atTimestampMs: dependencies.networkOffsetTimestampMs()
-            )
+
+            let proofIsActive: Bool = proProofIsActive(for: proof, atTimestampMs: nowMs)
+
             return (proofIsActive ? .active : .expired)
         }()
         let oldState: SessionPro.State = await stateStream.getCurrent()
@@ -585,6 +604,10 @@ public actor SessionProManager: SessionProManagerType {
         /// `E`, `G` and `A` are not projected here — their display copies are owned by whichever response last spoke,
         /// since only a response carries `latest_payment` and the rest that has to agree with them. Config keeps the
         /// three as the fetch trigger and the cross-device carrier, so every proof outcome writes the display itself.
+        ///
+        /// `E` deciding the status above is not in tension with that: a status is a claim the config alone can support,
+        /// whereas a rendered DATE has to agree with `G` and `A`, which only a response carries. So `E` is read to
+        /// choose active-vs-expired and still not projected as a value to show.
         let updatedState: SessionPro.State = oldState.with(
             status: .set(to: proStatus),
             proof: .set(to: proInfo.proConfig?.proProof),

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -221,7 +221,14 @@ public actor SessionProManager: SessionProManagerType {
             
             /// Kick off a refresh so we know we have the latest state (if it's the main app), but only when
             /// the config we just projected says it's warranted — see `startupStatusFetchIsNeeded`.
-            if dependencies[singleton: .appContext].isMainApp, await self?.startupStatusFetchIsNeeded() == true {
+            /// Foreground-ness rather than `isMainApp`: the main app is launched with no UI for background fetches,
+            /// silent pushes and VoIP wakes, and a launch which cannot show a CTA must not evaluate whether one is
+            /// warranted. The budget is stamped on the attempt, so spending it where nothing can consume the result
+            /// leaves the following foreground - the moment someone could actually see it - declining on the interval.
+            if
+                await dependencies[singleton: .appContext].isMainAppAndForeground,
+                await self?.startupStatusFetchIsNeeded() == true
+            {
                 try? await self?.refreshProState()
             }
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -142,7 +142,7 @@ public actor SessionProManager: SessionProManagerType {
     ///
     /// A dedicated carrier rather than a projection of `stateStream`, because the second of those is not a state change -
     /// nothing is written when an instant simply passes. Feeding it from ONE observer of `stateStream` rather than from
-    /// each of its ten send sites is deliberate: a send site added later is covered without anyone remembering to.
+    /// each site which sends state is deliberate: a send site added later is covered without anyone remembering to.
     ///
     /// **Note:** `profileFeatures(for:)` needs none of this - the same wake already emits profile events, and that
     /// derivation re-runs against the current time, so the badge path is covered by a different route.
@@ -191,11 +191,10 @@ public actor SessionProManager: SessionProManagerType {
     /// The distinction a caller has to make: a gate ("may I use this?") reads ACCESS, and anything explaining a gate
     /// to the user ("upgrade to send longer messages") reads DISPLAY. An upsell shown on ACCESS would offer Pro to
     /// someone whose plan is active but whose proof has not arrived - inviting them to buy what they already pay for.
-    /// **Note:** The same predicate is spelled inline wherever a caller already holds a `SessionPro.State` snapshot
-    /// rather than this manager - the Pro settings screens, `SettingsViewModel` and `ThreadSettingsViewModel` between
-    /// them do so about nine times. Those cannot call this accessor, so a change to what "active" MEANS - the obvious
-    /// candidate being it coming to include the grace window, since `coverageEndTimestampSeconds` already exists - has
-    /// to find them too. Grep `status == .active` rather than this symbol.
+    /// **Note:** A caller holding a `SessionPro.State` snapshot rather than this manager cannot reach this accessor and
+    /// spells the predicate inline instead, so a change to what "active" MEANS - the obvious candidate being it coming
+    /// to include the grace window, since `coverageEndTimestampSeconds` already exists - has to find those too. Grep
+    /// `status == .active` rather than this symbol.
     nonisolated public var currentUserProPlanIsActive: Bool { syncState.state.status == .active }
 
     nonisolated public var currentUserProPlanIsActiveStream: AsyncStream<Bool> {
@@ -416,7 +415,7 @@ public actor SessionProManager: SessionProManagerType {
             /// **Why the guard below must not apply to these:** it exists to stop us inviting a user to buy Pro when
             /// their plan already reads active. These three are not that invitation - `groupLimit` asks whether the
             /// GROUP has Pro rather than the user, and `expiring`/`animatedProfileImage` are shown *because* of the
-            /// user's own state rather than in spite of it. Confirmed as deliberate 2026-08-14
+            /// user's own state rather than in spite of it.
             case .groupLimit, .animatedProfileImage, .expiring: break
             default:
                 guard !currentUserProPlanIsActive else { return .suppressedPlanActive }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -219,18 +219,9 @@ public actor SessionProManager: SessionProManagerType {
             await self?.startProInvalidationRescheduleObservations()
             await self?.scheduleNextProInvalidation()
             
-            /// Kick off a refresh so we know we have the latest state (if it's the main app), but only when
-            /// the config we just projected says it's warranted — see `startupStatusFetchIsNeeded`.
-            /// Foreground-ness rather than `isMainApp`: the main app is launched with no UI for background fetches,
-            /// silent pushes and VoIP wakes, and a launch which cannot show a CTA must not evaluate whether one is
-            /// warranted. The budget is stamped on the attempt, so spending it where nothing can consume the result
-            /// leaves the following foreground - the moment someone could actually see it - declining on the interval.
-            if
-                await dependencies[singleton: .appContext].isMainAppAndForeground,
-                await self?.startupStatusFetchIsNeeded() == true
-            {
-                try? await self?.refreshProState()
-            }
+            /// **Note:** No gated status fetch here. It hangs off `didBecomeActive` instead - see
+            /// `startProInvalidationRescheduleObservations` - because a launch is not evidence of a foreground, and
+            /// evaluating the gate without one spends an attempt-stamped budget where no CTA can be shown.
 
             /// Kick the foreground-anchored proof-renewal reconcile (main-app-gated inside)
             await self?.reconcileProofRenewal()
@@ -1790,6 +1781,7 @@ public actor SessionProManager: SessionProManagerType {
             await withTaskGroup(of: Void.self) { group in
                 let keys: [ObservableKey] = [
                     .appLifecycle(.willEnterForeground),
+                    .appLifecycle(.didBecomeActive),
                     .anyProfileProStatusChanged
                 ]
 
@@ -1814,21 +1806,25 @@ public actor SessionProManager: SessionProManagerType {
                                 /// Same reasoning for the `user_expiry` wake: a `Task.sleep` doesn't survive
                                 /// suspension, so this is what catches up an `E` crossing we slept through.
                                 await self?.evaluateUserExpiryStatusWake()
+                            }
 
-                                /// The same gate as at launch, at a second moment. The expiring CTA arms seven days
-                                /// before `E`, but the wakes which survive suspension fire AT `E` and at coverage
-                                /// end - after that window opens rather than before it. So a subscriber who enters
-                                /// it while merely backgrounded could not be warned until the process next started.
-                                ///
-                                /// Safe to run on every foreground because the predicate is unchanged: its own 24h
-                                /// interval declines before any request is made, so this costs a state read on the
-                                /// overwhelming majority of returns.
-                                if
-                                    dependencies[singleton: .appContext].isMainApp,
-                                    await self?.startupStatusFetchIsNeeded() == true
-                                {
-                                    try? await self?.refreshProState()
-                                }
+                            /// The gated status fetch hangs off *becoming active* rather than off launch or off
+                            /// entering the foreground, because that is the only signal which covers both moments
+                            /// without assuming anything about startup ordering: it fires on a cold launch into the
+                            /// foreground AND on returning from the background, and it only fires when the app is
+                            /// actually active, so the foreground-ness is inherent rather than asserted.
+                            ///
+                            /// Both moments are needed. The expiring CTA arms seven days before `E`, while the wakes
+                            /// which survive suspension fire AT `E` and at coverage end - after that window has
+                            /// opened - so a subscriber entering it while merely backgrounded would otherwise not be
+                            /// warned until the process next started.
+                            ///
+                            /// It fires more often than a foreground transition does - dismissing a system alert,
+                            /// returning from control centre, every activation - and that is affordable because the
+                            /// gate checks its own 24h interval first: a fire inside the window costs one comparison
+                            /// and reads nothing further.
+                            if key == .appLifecycle(.didBecomeActive), await self?.startupStatusFetchIsNeeded() == true {
+                                try? await self?.refreshProState()
                             }
                         }
                     }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1807,6 +1807,21 @@ public actor SessionProManager: SessionProManagerType {
                                 /// Same reasoning for the `user_expiry` wake: a `Task.sleep` doesn't survive
                                 /// suspension, so this is what catches up an `E` crossing we slept through.
                                 await self?.evaluateUserExpiryStatusWake()
+
+                                /// The same gate as at launch, at a second moment. The expiring CTA arms seven days
+                                /// before `E`, but the wakes which survive suspension fire AT `E` and at coverage
+                                /// end - after that window opens rather than before it. So a subscriber who enters
+                                /// it while merely backgrounded could not be warned until the process next started.
+                                ///
+                                /// Safe to run on every foreground because the predicate is unchanged: its own 24h
+                                /// interval declines before any request is made, so this costs a state read on the
+                                /// overwhelming majority of returns.
+                                if
+                                    dependencies[singleton: .appContext].isMainApp,
+                                    await self?.startupStatusFetchIsNeeded() == true
+                                {
+                                    try? await self?.refreshProState()
+                                }
                             }
                         }
                     }

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -409,12 +409,17 @@ public actor SessionProManager: SessionProManagerType {
         onCancel: (() -> Void)?,
         afterClosed: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool {
+    ) -> ProCTAOutcome {
         switch variant {
             /// The `groupLimit`, `animatedProfileImage`, and `expiring` CTA can be shown for Session Pro users as well
+            ///
+            /// **Why the guard below must not apply to these:** it exists to stop us inviting a user to buy Pro when
+            /// their plan already reads active. These three are not that invitation - `groupLimit` asks whether the
+            /// GROUP has Pro rather than the user, and `expiring`/`animatedProfileImage` are shown *because* of the
+            /// user's own state rather than in spite of it. Confirmed as deliberate 2026-08-14
             case .groupLimit, .animatedProfileImage, .expiring: break
             default:
-                guard syncState.state.status != .active else { return false }
+                guard !currentUserProPlanIsActive else { return .suppressedPlanActive }
                 
                 break
         }
@@ -432,7 +437,7 @@ public actor SessionProManager: SessionProManagerType {
         )
         presenting?(sessionProModal)
         
-        return true
+        return .shown
     }
     
     @MainActor public func showSessionProBottomSheetIfNeeded(

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -93,6 +93,7 @@ public actor SessionProManager: SessionProManagerType {
     private var entitlementsObservingTask: Task<Void, Never>?
     private var proMockingObservationTask: Task<Void, Never>?
     private var proInvalidationTask: Task<Void, Never>?
+    private var accessObservationTask: Task<Void, Never>?
     private var appLifecycleObservingTask: Task<Void, Never>?
 
     /// Proof-renewal reconcile loop (Rev 2). `proofRenewalWakeTask` is the advisory in-foreground wake;
@@ -134,22 +135,70 @@ public actor SessionProManager: SessionProManagerType {
     
     nonisolated private let stateStream: CurrentValueAsyncStream<SessionPro.State> = CurrentValueAsyncStream(.invalid)
     nonisolated private let hasCompletedInitialization: CurrentValueAsyncStream<Bool> = CurrentValueAsyncStream(false)
+
+    /// The observable half of the access answer, fed from the two things which can change it: any state change (config
+    /// projection, a response, a credential clear) and the invalidation wake (a proof reaching its expiry, a revocation
+    /// reaching its `effective_at`).
+    ///
+    /// A dedicated carrier rather than a projection of `stateStream`, because the second of those is not a state change -
+    /// nothing is written when an instant simply passes. Feeding it from ONE observer of `stateStream` rather than from
+    /// each of its ten send sites is deliberate: a send site added later is covered without anyone remembering to.
+    ///
+    /// **Note:** `profileFeatures(for:)` needs none of this - the same wake already emits profile events, and that
+    /// derivation re-runs against the current time, so the badge path is covered by a different route.
+    nonisolated private let accessStream: CurrentValueAsyncStream<Bool> = CurrentValueAsyncStream(false)
     
     nonisolated public var currentUserCurrentRotatingKeyPair: KeyPair? { syncState.rotatingKeyPair }
     nonisolated public var currentUserCurrentProState: SessionPro.State { syncState.state }
-    nonisolated public var currentUserIsCurrentlyPro: Bool { syncState.state.status == .active }
+    /// Whether this device may currently *use* Pro features - the **access** question, as distinct from `state.status`,
+    /// which is the **display** question ("what state is the plan in", driving the settings row and the expiry CTAs).
+    ///
+    /// The two are meant to disagree. A subscription that has lapsed shows as expired while its proof is still live, and
+    /// the features keep working until the proof itself does not - so a display value can never stand in for this one.
+    ///
+    /// Derived from the proof and **recomputed on every read**, never snapshotted: a proof expires, and a revocation
+    /// becomes effective, at an instant no cached copy of this answer would notice.
+    nonisolated public var currentUserHasProAccess: Bool {
+        /// The proof mock, never the status mock: a mocked run holds no real proof, so if this consulted
+        /// `mockCurrentUserSessionProBackendStatus` then "the plan is Active" would grant access as a side effect and
+        /// display-Active-without-access - the state the message-truncation bug lives in - could not be reached by a test
+        switch syncState.dependencies[feature: .mockCurrentUserSessionProProof] {
+            case .simulate(let validity): return (validity == .valid)
+            case .useActual:
+                return currentUserProofIsValid(atTimestampMs: syncState.dependencies.networkOffsetTimestampMs())
+        }
+    }
 
     nonisolated public var pinnedConversationLimit: Int { SessionPro.PinnedConversationLimit }
     nonisolated public var characterLimit: Int {
         (
-            currentUserIsCurrentlyPro ?
+            currentUserHasProAccess ?
                 SessionPro.ProCharacterLimit :
                 SessionPro.CharacterLimit
         )
     }
     
     nonisolated public var state: AsyncStream<SessionPro.State> { stateStream.stream }
-    nonisolated public var currentUserIsPro: AsyncStream<Bool> {
+    /// **Note:** Emits the access answer recomputed at each state change rather than a projection of the emitted state -
+    /// the state is the trigger, not the source. A revocation reaches this by clearing the proof, which is itself a state
+    /// change; a bare `revocationList` update is not one, and does not need to be, since it cannot grant or remove access
+    /// without that clear.
+    nonisolated public var currentUserHasProAccessStream: AsyncStream<Bool> { accessStream.stream }
+
+    /// Whether the user's PLAN reads active - the **display** question, and deliberately not
+    /// `currentUserHasProAccess`.
+    ///
+    /// The distinction a caller has to make: a gate ("may I use this?") reads ACCESS, and anything explaining a gate
+    /// to the user ("upgrade to send longer messages") reads DISPLAY. An upsell shown on ACCESS would offer Pro to
+    /// someone whose plan is active but whose proof has not arrived - inviting them to buy what they already pay for.
+    /// **Note:** The same predicate is spelled inline wherever a caller already holds a `SessionPro.State` snapshot
+    /// rather than this manager - the Pro settings screens, `SettingsViewModel` and `ThreadSettingsViewModel` between
+    /// them do so about nine times. Those cannot call this accessor, so a change to what "active" MEANS - the obvious
+    /// candidate being it coming to include the grace window, since `coverageEndTimestampSeconds` already exists - has
+    /// to find them too. Grep `status == .active` rather than this symbol.
+    nonisolated public var currentUserProPlanIsActive: Bool { syncState.state.status == .active }
+
+    nonisolated public var currentUserProPlanIsActiveStream: AsyncStream<Bool> {
         stateStream.stream
             .map { $0.status == .active }
             .asAsyncStream()
@@ -166,6 +215,7 @@ public actor SessionProManager: SessionProManagerType {
 
             await self?.updateWithLatestFromUserConfig()
             await self?.startRevocationListTask()
+            await self?.startAccessObservation()
             await self?.startStoreKitObservations()
             await self?.startProInvalidationRescheduleObservations()
             await self?.scheduleNextProInvalidation()
@@ -189,6 +239,7 @@ public actor SessionProManager: SessionProManagerType {
         entitlementsObservingTask?.cancel()
         proMockingObservationTask?.cancel()
         proInvalidationTask?.cancel()
+        accessObservationTask?.cancel()
         appLifecycleObservingTask?.cancel()
         proofRenewalWakeTask?.cancel()
         proofGenerationTask?.cancel()
@@ -265,7 +316,7 @@ public actor SessionProManager: SessionProManagerType {
         /// Check if the pro status on the profile has expired (if so clear the features)
         switch (profile.proRevocationTagHex, profile.proExpiryUnixTimestampSeconds, profile.id == currentUserSessionId.hexString) {
             case (_, _, true):
-                if !currentUserIsCurrentlyPro {
+                if !currentUserHasProAccess {
                     result = .none
                 }
             case (.some(let proRevocationTagHex), let expiryUnixTimestampSeconds, _) where expiryUnixTimestampSeconds > 0:
@@ -1591,6 +1642,9 @@ public actor SessionProManager: SessionProManagerType {
             await emitProInvalidationEvents(since: lastProInvalidationCheck, until: now)
         }
 
+        /// An instant passing is not a state change, so this is the only thing that tells the access stream about it
+        await emitAccessChange()
+
         lastProInvalidationCheck = now
     }
 
@@ -1616,6 +1670,13 @@ public actor SessionProManager: SessionProManagerType {
             .filter { $0 > now }
             .min()
 
+        /// Our OWN proof's expiry, named separately from the profile scan below rather than relied upon through it. The
+        /// current user's profile row carries a copy of this instant, so the scan would usually find it - but "usually"
+        /// is not a basis for the instant at which this device stops being allowed to use Pro
+        let ownProofExpiry: TimeInterval? = syncState.state.proof
+            .map { TimeInterval($0.expiryUnixTimestampSeconds) }
+            .flatMap { $0 > now ? $0 : nil }
+
         /// Profiles need a query - there's no global in-memory profile cache to consult (`ConversationDataCache` is a
         /// per-observation snapshot). This runs on reschedule rather than per-frame, so a `MIN()` scan is fine.
         let nextExpiry: TimeInterval? = (try? await dependencies[singleton: .storage].read { db in
@@ -1623,7 +1684,7 @@ public actor SessionProManager: SessionProManagerType {
         })
         .map { TimeInterval($0) }
 
-        return [nextEffective, nextExpiry].compactMap { $0 }.min()
+        return [nextEffective, ownProofExpiry, nextExpiry].compactMap { $0 }.min()
     }
 
     /// Emit a profile event for every profile whose pro state went stale within `(since, until]`
@@ -1725,6 +1786,21 @@ public actor SessionProManager: SessionProManagerType {
                 }
             }
         }
+    }
+
+    private func startAccessObservation() {
+        accessObservationTask?.cancel()
+        accessObservationTask = Task { [weak self, stateStream] in
+            for await _ in stateStream.stream {
+                guard !Task.isCancelled else { return }
+
+                await self?.emitAccessChange()
+            }
+        }
+    }
+
+    private func emitAccessChange() async {
+        await accessStream.send(currentUserHasProAccess)
     }
 
     private func startRevocationListTask() {

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -833,7 +833,7 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                         .localized(),
                                     font: .Headings.H8
                                 ),
-                                description: {
+                                description: { () -> SessionListScreenContent.TextInfo? in
                                     /// Every state of this line is the same slot, so they share the one identifier
                                     /// and the state is distinguished by the text
                                     let accessibility: Accessibility = Accessibility(
@@ -859,7 +859,6 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                             )
 
                                         case .success:
-                                            let expirationTimestamp: TimeInterval = Double(state.proState.displayTimestampSeconds ?? 0)
                                             let isInAutoRenewingGracePeriod: Bool = state.proState.isRenewalOverdue(
                                                 atTimestampSeconds: (
                                                     viewModel.dependencies.networkOffsetTimestampMs() / 1000
@@ -875,6 +874,17 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                                 )
                                             }
                                             
+                                            /// Render nothing rather than a date we do not have: `E` is owned by whichever
+                                            /// response last spoke, so it is absent before the first one and again after a
+                                            /// terminal clear. The clamp below floors the value at *now*, so a missing `E`
+                                            /// would not read as 1970 - it would read as "expires in 0 minutes", which is
+                                            /// a plausible-looking lie rather than an obvious one
+                                            guard
+                                                let expirySeconds: UInt64 = state.proState.displayTimestampSeconds,
+                                                expirySeconds > 0
+                                            else { return nil }
+                                            
+                                            let expirationTimestamp: TimeInterval = Double(expirySeconds)
                                             let expirationDate: Date = Date(timeIntervalSince1970: floor(max(expirationTimestamp, viewModel.dependencies.dateNow.timeIntervalSince1970)))
                                             let expirationString: String = expirationDate
                                                 .timeIntervalSince(viewModel.dependencies.dateNow)

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -414,7 +414,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
 
                                     case .unknown: return nil
                                 }
-                            }()
+                            }(),
+                            descriptionAccessibility: Accessibility(
+                                identifier: SessionProUI.AccessibilityIdentifier.heroDescription
+                            )
                         )
                     ),
                     onTap: { [weak viewModel] in

--- a/SessionMessagingKit/SessionPro/Types/SessionProState.swift
+++ b/SessionMessagingKit/SessionPro/Types/SessionProState.swift
@@ -331,6 +331,56 @@ extension SessionPro.LoadingState: MockableFeatureValue {
     }
 }
 
+// MARK: - SessionPro.MockProofValidity
+
+public extension FeatureStorage {
+    /// Mocks the **access** half of Pro - whether this device holds a usable proof - independently of
+    /// `mockCurrentUserSessionProBackendStatus`, which mocks the **display** half.
+    ///
+    /// The two are separate levers on purpose. A mocked run holds no real proof, so before this existed the status
+    /// mock was the only thing a test could set and it necessarily had to grant both - which made
+    /// display-Active-without-access, the state the message-truncation bug lives in, unreachable by mock.
+    static let mockCurrentUserSessionProProof: FeatureConfig<MockableFeature<SessionPro.MockProofValidity>> = Dependencies.create(
+        identifier: "mockCurrentUserSessionProProof"
+    )
+}
+
+public extension SessionPro {
+    /// **Note:** Deliberately not an expiry or a revocation state - it answers only "does a valid proof exist", which is
+    /// the whole of what the access check asks. Extend it rather than overloading `none` if a test ever needs to
+    /// distinguish *why* a proof is unusable
+    enum MockProofValidity: Sendable, Hashable, CaseIterable {
+        case valid
+        case none
+    }
+}
+
+extension SessionPro.MockProofValidity: MockableFeatureValue {
+    public var rawValue: Int {
+        switch self {
+            case .valid: return 1
+            case .none: return 2
+        }
+    }
+
+    public init?(rawValue: Int) {
+        switch rawValue {
+            case 1: self = .valid
+            case 2: self = .none
+            default: return nil
+        }
+    }
+
+    public var title: String { "\(self)" }
+
+    public var subtitle: String {
+        switch self {
+            case .valid: return "Behave as though a valid, unrevoked proof is held (grants Pro features)."
+            case .none: return "Behave as though no usable proof is held (Pro features are withheld)."
+        }
+    }
+}
+
 // MARK: - Network.SessionPro.BackendUserProStatus
 
 public extension FeatureStorage {

--- a/SessionMessagingKit/Utilities/ProfilePictureView+Convenience.swift
+++ b/SessionMessagingKit/Utilities/ProfilePictureView+Convenience.swift
@@ -209,7 +209,9 @@ public extension ProfilePictureView {
             case .none: return false
             
             case .some(let profile) where profile.id == dependencies[cache: .general].sessionId.hexString:
-                return dependencies[singleton: .sessionProManager].currentUserIsCurrentlyPro
+                /// **A capability gate, so it reads ACCESS** - it answers "may this avatar animate", not "should we sell
+                /// Pro". The upsell for this feature lives elsewhere and reads DISPLAY
+                return dependencies[singleton: .sessionProManager].currentUserHasProAccess
                 
             case .some(let profile):
                 return dependencies[singleton: .sessionProManager]

--- a/SessionUIKit/Components/Input View/InputView.swift
+++ b/SessionUIKit/Components/Input View/InputView.swift
@@ -66,6 +66,7 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
     public var quoteViewModel: QuoteViewModel? { didSet { handleQuoteDraftChanged() } }
     public var linkPreviewViewModel: LinkPreviewViewModel?
     private var proStatusObservationTask: Task<Void, Never>?
+    private var proPlanObservationTask: Task<Void, Never>?
     private var linkPreviewLoadTask: Task<Void, Never>?
     private var voiceMessageRecordingView: VoiceMessageRecordingView?
     private lazy var mentionsViewHeightConstraint = mentionsView.set(.height, to: 0)
@@ -309,7 +310,11 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
     
     private lazy var sessionProBadge: SessionProBadge = {
         let result: SessionProBadge = SessionProBadge(size: .medium)
-        result.isHidden = (sessionProManager?.currentUserIsCurrentlyPro == true)
+        /// **The gate reads ACCESS; the thing explaining the gate reads DISPLAY.** This badge is a prompt to buy Pro -
+        /// tapping its stack opens the `longerMessages` CTA - so it follows the plan, not the entitlement. Read on
+        /// ACCESS it would offer Pro to someone whose plan is active but whose proof has not arrived yet, four pixels
+        /// from a modal that (correctly) declines to make that same offer
+        result.isHidden = (sessionProManager?.currentUserProPlanIsActive == true)
         
         return result
     }()
@@ -364,14 +369,25 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
         
         setUpViewHierarchy()
         
+        /// The character limit is an ACCESS question, so it follows the entitlement
         self.proStatusObservationTask = Task(priority: .userInitiated) { [weak self] in
             guard let sessionProManager else { return }
             
-            for await isPro in sessionProManager.currentUserIsPro {
+            for await _ in sessionProManager.currentUserHasProAccessStream {
                 await MainActor.run { [weak self] in
-                    /// The pro badge is a button to prompt a pro upgrade so hide it when already pro
-                    self?.sessionProBadge.isHidden = isPro
                     self?.updateNumberOfCharactersLeft((self?.inputTextView.text ?? ""))
+                }
+            }
+        }
+        
+        /// The badge is an upgrade prompt, so it follows the PLAN - see its initialiser. Separate from the task above
+        /// because the two values change independently: a proof can lapse while the plan stays active, and vice versa
+        self.proPlanObservationTask = Task(priority: .userInitiated) { [weak self] in
+            guard let sessionProManager else { return }
+            
+            for await planIsActive in sessionProManager.currentUserProPlanIsActiveStream {
+                await MainActor.run { [weak self] in
+                    self?.sessionProBadge.isHidden = planIsActive
                 }
             }
         }
@@ -388,6 +404,7 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
     deinit {
         linkPreviewLoadTask?.cancel()
         proStatusObservationTask?.cancel()
+        proPlanObservationTask?.cancel()
     }
 
     private func setUpViewHierarchy() {

--- a/SessionUIKit/Components/SwiftUI/ProCTAModal+Type.swift
+++ b/SessionUIKit/Components/SwiftUI/ProCTAModal+Type.swift
@@ -3,6 +3,29 @@
 import UIKit
 import SwiftUI
 
+// MARK: - ProCTAOutcome
+
+/// Why a Pro CTA was or was not shown.
+///
+/// Replaces a `Bool`, which collapsed the two "not shown" reasons into one and left every caller to
+/// re-derive what to do next - which is how five call sites reached five different answers about the same
+/// state.
+public enum ProCTAOutcome: Equatable {
+    /// The CTA was presented.
+    case shown
+
+    /// Suppressed because the user's PLAN reads active, so an upsell would offer them what they already pay
+    /// for. The caller must still refuse whatever was gated - it is `ACCESS` that was missing, not the plan -
+    /// but must refuse **without selling**.
+    ///
+    /// **TODO: [PRO] surfaces reaching this state with no neutral copy currently refuse in silence.**
+    /// Accepted deliberately rather than overlooked: the alternative was blocking the access/display split on
+    /// a translation round for an edge case (active plan, no usable proof). `ConversationVC`'s send gate shows
+    /// what the fix looks like - it explains the refusal without offering a purchase. Do NOT "fix" this by
+    /// reinstating the upsell; that is the bug this state exists to prevent.
+    case suppressedPlanActive
+}
+
 // MARK: - SessionProCTAManagerType
 
 public protocol SessionProCTAManagerType: AnyObject {
@@ -13,7 +36,7 @@ public protocol SessionProCTAManagerType: AnyObject {
         onCancel: (() -> Void)?,
         afterClosed: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool
+    ) -> ProCTAOutcome
     
     @MainActor func showSessionProBottomSheetIfNeeded(
         afterClosed: (() -> Void)?,
@@ -30,7 +53,7 @@ public extension SessionProCTAManagerType {
         onCancel: (() -> Void)?,
         afterClosed: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool {
+    ) -> ProCTAOutcome {
         showSessionProCTAIfNeeded(
             variant,
             dismissType: .recursive,
@@ -46,7 +69,7 @@ public extension SessionProCTAManagerType {
         onConfirm: (() -> Void)?,
         onCancel: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool {
+    ) -> ProCTAOutcome {
         showSessionProCTAIfNeeded(
             variant,
             dismissType: .recursive,
@@ -61,7 +84,7 @@ public extension SessionProCTAManagerType {
         _ variant: ProCTAModal.Variant,
         onConfirm: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool {
+    ) -> ProCTAOutcome {
         showSessionProCTAIfNeeded(
             variant,
             dismissType: .recursive,

--- a/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
+++ b/SessionUIKit/Screens/SessionListScreen/ListItemViews/SessionListScreen+ListItemLogoWithPro.swift
@@ -84,17 +84,23 @@ public struct ListItemLogoWithPro: View {
         public let glowingBackgroundStyle: GlowingBackgroundStyle
         public let state: State
         public let description: ThemedAttributedString?
-        
+
+        /// Identifies the description for a caller which needs to address it, since this component is shared by
+        /// screens whose hero copy answers different questions
+        public let descriptionAccessibility: Accessibility?
+
         public init(
             themeStyle: ThemeStyle,
             glowingBackgroundStyle: GlowingBackgroundStyle,
             state: State,
-            description: ThemedAttributedString? = nil
+            description: ThemedAttributedString? = nil,
+            descriptionAccessibility: Accessibility? = nil
         ) {
             self.themeStyle = themeStyle
             self.glowingBackgroundStyle = glowingBackgroundStyle
             self.state = state
             self.description = description
+            self.descriptionAccessibility = descriptionAccessibility
         }
     }
     
@@ -172,6 +178,10 @@ public struct ListItemLogoWithPro: View {
                     )
                 }
                 
+                /// **Note:** No `accessibilityElement(children: .combine)` here, unlike the banners above: those are
+                /// an `HStack` of genuinely separate views, whereas `AttributedText` resolves its runs through
+                /// `ThemedText`, which concatenates them into a single `Text`. So this is already one element whose
+                /// label is the whole string, and combining would only flatten something that is not split
                 if let description = info.description {
                     AttributedText(description)
                         .font(.Body.baseRegular)
@@ -179,6 +189,7 @@ public struct ListItemLogoWithPro: View {
                         .multilineTextAlignment(.center)
                         .padding(.top, Values.mediumSpacing)
                         .padding(.bottom, Values.largeSpacing)
+                        .accessibility(info.descriptionAccessibility)
                 }
             }
             .padding(.vertical, info.glowingBackgroundStyle.verticalPaddings)

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
@@ -17,6 +17,15 @@ public extension SessionProUI {
         /// The Pro entry in the main settings list, which opens this screen
         public static let menuItem: String = "pro-menu-item"
 
+        /// The state-bearing line within that entry - "Upgrade Session", "Session Pro Beta" or "Renew Pro Beta"
+        ///
+        /// **Note:** `menuItem` sits on the tap target, which carries no text of its own, so the row's *state* is
+        /// only readable through this. A flat identifier rather than the generic
+        /// `ListItemCell.AccessibilityIdentifier.title`, so a locator can address it without a parent traversal -
+        /// and, one element carrying one identifier, this replaces `action-item-title` on this row rather than
+        /// sitting alongside it
+        public static let menuItemTitle: String = "pro-menu-item-title"
+
         /// The loading/error banner under the logo - one identifier for the slot, with the individual states
         /// distinguished by their text (`checkingProStatus`, `proStatusLoading`, `errorCheckingProStatus`,
         /// `proErrorRefreshingStatus`) rather than by separate identifiers

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
@@ -31,6 +31,15 @@ public extension SessionProUI {
         /// `proErrorRefreshingStatus`) rather than by separate identifiers
         public static let statusBanner: String = "pro-settings-status-banner"
 
+        /// The hero copy under the logo - one identifier for the slot, with the statuses distinguished by their
+        /// text (`proAccessRenewStart`, `proFullestPotential`, `proThanksForSupporting`) rather than by separate
+        /// identifiers. The `unknown` status renders no element at all, so absence is a meaningful assertion
+        ///
+        /// **Note:** Supplied by the caller rather than hard-coded into `ListItemLogoWithPro`, because the payment
+        /// screen renders the same component with a description of its own - tagging it inside the component would
+        /// put this identifier on two different screens' copy
+        public static let heroDescription: String = "pro-settings-description"
+
         /// The "Your Pro Stats" section header
         public static let statsHeader: String = "pro-settings-stats-header"
 

--- a/SessionUIKit/Types/SessionProUIManagerType.swift
+++ b/SessionUIKit/Types/SessionProUIManagerType.swift
@@ -5,8 +5,10 @@ import UIKit
 public protocol SessionProUIManagerType: Actor {
     nonisolated var characterLimit: Int { get }
     nonisolated var pinnedConversationLimit: Int { get }
-    nonisolated var currentUserIsCurrentlyPro: Bool { get }
-    nonisolated var currentUserIsPro: AsyncStream<Bool> { get }
+    nonisolated var currentUserHasProAccess: Bool { get }
+    nonisolated var currentUserProPlanIsActive: Bool { get }
+    nonisolated var currentUserHasProAccessStream: AsyncStream<Bool> { get }
+    nonisolated var currentUserProPlanIsActiveStream: AsyncStream<Bool> { get }
     
     nonisolated func numberOfCharactersLeft(for content: String) -> Int
     
@@ -62,8 +64,12 @@ internal actor NoopSessionProUIManager: SessionProUIManagerType {
     private let isPro: Bool
     nonisolated public let characterLimit: Int
     nonisolated public let pinnedConversationLimit: Int
-    nonisolated public let currentUserIsCurrentlyPro: Bool
-    nonisolated public var currentUserIsPro: AsyncStream<Bool> {
+    nonisolated public let currentUserHasProAccess: Bool
+    nonisolated public let currentUserProPlanIsActive: Bool
+    nonisolated public var currentUserHasProAccessStream: AsyncStream<Bool> {
+        AsyncStream(unfolding: { return self.isPro })
+    }
+    nonisolated public var currentUserProPlanIsActiveStream: AsyncStream<Bool> {
         AsyncStream(unfolding: { return self.isPro })
     }
     
@@ -75,7 +81,8 @@ internal actor NoopSessionProUIManager: SessionProUIManagerType {
         self.isPro = isPro
         self.characterLimit = characterLimit
         self.pinnedConversationLimit = pinnedConversationLimit
-        self.currentUserIsCurrentlyPro = isPro
+        self.currentUserHasProAccess = isPro
+        self.currentUserProPlanIsActive = isPro
     }
     
     nonisolated public func numberOfCharactersLeft(for content: String) -> Int { 0 }

--- a/SessionUIKit/Types/SessionProUIManagerType.swift
+++ b/SessionUIKit/Types/SessionProUIManagerType.swift
@@ -19,7 +19,7 @@ public protocol SessionProUIManagerType: Actor {
         onCancel: (() -> Void)?,
         afterClosed: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool
+    ) -> ProCTAOutcome
     
     @MainActor func showSessionProBottomSheetIfNeeded(
         afterClosed: (() -> Void)?,
@@ -39,7 +39,7 @@ public extension SessionProUIManagerType {
         onCancel: (() -> Void)? = nil,
         afterClosed: (() -> Void)? = nil,
         presenting: ((UIViewController) -> Void)? = nil
-    ) -> Bool {
+    ) -> ProCTAOutcome {
         showSessionProCTAIfNeeded(
             variant,
             dismissType: dismissType,
@@ -92,8 +92,8 @@ internal actor NoopSessionProUIManager: SessionProUIManagerType {
         dismissType: Modal.DismissType,
         afterClosed: (() -> Void)?,
         presenting: ((UIViewController) -> Void)?
-    ) -> Bool {
-        return false
+    ) -> ProCTAOutcome {
+        return .suppressedPlanActive
     }
     
     @MainActor func showSessionProBottomSheetIfNeeded(

--- a/SignalUtilitiesKit/Media Viewing & Editing/Attachment Approval/AttachmentApprovalViewController.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/Attachment Approval/AttachmentApprovalViewController.swift
@@ -702,7 +702,7 @@ public class AttachmentApprovalViewController: UIPageViewController, UIPageViewC
     
     @MainActor func showModalForMessagesExceedingCharacterLimit() {
         let manager: SessionProManagerType = dependencies[singleton: .sessionProManager]
-        let didShowCTAModal: Bool = manager.showSessionProCTAIfNeeded(
+        let ctaOutcome: ProCTAOutcome = manager.showSessionProCTAIfNeeded(
             .longerMessages(renew: (manager.currentUserCurrentProState.status == .expired)),
             onConfirm: { [weak self, manager] in
                 manager.showSessionProBottomSheetIfNeeded(
@@ -722,7 +722,7 @@ public class AttachmentApprovalViewController: UIPageViewController, UIPageViewC
             }
         )
         
-        guard !didShowCTAModal else { return }
+        guard ctaOutcome != .shown else { return }
         
         let confirmationModal: ConfirmationModal = ConfirmationModal(
             info: ConfirmationModal.Info(
@@ -756,7 +756,7 @@ extension AttachmentApprovalViewController: InputViewDelegate {
     
     public func handleCharacterLimitLabelTapped() {
         let manager: SessionProManagerType = dependencies[singleton: .sessionProManager]
-        let didShowCTAModal: Bool = manager.showSessionProCTAIfNeeded(
+        let ctaOutcome: ProCTAOutcome = manager.showSessionProCTAIfNeeded(
             .longerMessages(renew: (manager.currentUserCurrentProState.status == .expired)),
             onConfirm: { [weak self, manager] in
                 manager.showSessionProBottomSheetIfNeeded(
@@ -776,7 +776,7 @@ extension AttachmentApprovalViewController: InputViewDelegate {
             }
         )
         
-        guard !didShowCTAModal else { return }
+        guard ctaOutcome != .shown else { return }
         
         let numberOfCharactersLeft: Int = manager.numberOfCharactersLeft(
             for: snInputView.text.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
Draft — parked for review, not ready to merge.

Splits Pro into two values: **ACCESS** (the proof in config, validated on every read against expiry and the revocation list) and **DISPLAY** (the backend status, seeded from the proof at launch with no date). They are meant to disagree — a lapsed plan whose proof still has time left displays as expired while the features keep working.

Also here: upsell affordances read DISPLAY rather than inverted ACCESS, so a user whose plan reads active is not invited to buy Pro they already have; and a test mock for the proof, separate from the status mock, which is what makes an active-plan-with-no-proof client reachable at all.

**Deliberately not done** — held items and accepted trades are recorded in the code comments, including a refusal that is currently silent because no copy exists for "your plan is active but we cannot verify it yet".

Client-side counterpart to session-appium#128.
