### PR TITLE
Notifications: stop a cold background fetch waiting on the home screen

### DIFF
--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -23,7 +23,11 @@ private extension Log.Category {
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     private static let backgroundFetchId: String = "com.loki-project.loki-messenger.background-fetch" // stringlint:ignore
     fileprivate static let maxRootViewControllerInitialQueryDuration: Int = 10
-    
+
+    /// Kept well inside the time the OS allows a `BGAppRefreshTask`, so a fetch which can't get started still leaves enough of its
+    /// budget to be worth waiting for the next one
+    fileprivate static let maxBackgroundPollPrerequisiteDuration: Int = 10
+
     /// The AppDelete is initialised by the OS so we should init an instance of `Dependencies` to be used throughout
     let dependencies: Dependencies = Dependencies.createEmpty()
     @MainActor var hasInitialRootViewController: Bool = false
@@ -198,6 +202,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
     }
     
+    /// Wait for the state a background poll actually needs - a usable database and a loaded `libSession` cache.
+    ///
+    /// This deliberately does **not** wait on `appReadiness`: that is only set once the home screen has rendered its conversation list
+    /// (so the app can swap away from the `LoadingVC` with data already in place), which requires a scene. A launch iOS started purely
+    /// to run this task has none, so waiting on it means the poll never runs at all and the fetch is spent doing nothing.
+    ///
+    /// - Returns: whether the prerequisites became available before `timeout`.
+    fileprivate static func awaitBackgroundPollPrerequisites(
+        timeout: DispatchTimeInterval = .seconds(AppDelegate.maxBackgroundPollPrerequisiteDuration),
+        using dependencies: Dependencies
+    ) async -> Bool {
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                _ = await dependencies[singleton: .storage].state.first(where: { $0 == .readyForUse })
+                await dependencies.untilInitialised(cache: .libSession)
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+
+            let result: Bool = (await group.next() ?? false)
+            group.cancelAll()
+            return result
+        }
+    }
+
     private func handleBackgroundRefresh(task: BGAppRefreshTask) {
         /// Immediately reschedule the next refresh so we don't miss future opportunities even if this one gets cancelled or fails
         scheduleBackgroundRefresh()
@@ -205,8 +237,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let fetchTask: Task<Void, Never> = Task(priority: .userInitiated) { [dependencies] in
             Log.appResumedExecution()
             Log.info(.backgroundPoller, "Starting background fetch.")
-            await dependencies[singleton: .appReadiness].isReady()
-            
+
             guard
                 !Task.isCancelled,
                 dependencies[singleton: .appContext].isInBackground
@@ -214,11 +245,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 task.setTaskCompleted(success: false)
                 return
             }
-            
+
             /// Resume database and network access
+            ///
+            /// **Note:** This has to happen before waiting on the prerequisites below because a suspended database only reaches
+            /// `readyForUse` once it has been resumed
             await dependencies[singleton: .storage].resumeDatabaseAccess()
             await dependencies[singleton: .network].resumeNetworkAccess(autoReconnect: false)
-            
+
+            guard await AppDelegate.awaitBackgroundPollPrerequisites(using: dependencies) else {
+                Log.warn(.backgroundPoller, "Aborting background fetch as the database and libSession state didn't become available in time.")
+                task.setTaskCompleted(success: false)
+                return
+            }
+
             /// Perform the polling
             let poller: BackgroundPoller = BackgroundPoller()
             let hadValidMessages: Bool = await poller.poll(using: dependencies)


### PR DESCRIPTION
Found while reviewing user logs for push-notification complaints. Independent of #741.

## The bug

`handleBackgroundRefresh` waits on `appReadiness.isReady()` before doing anything, and readiness is only set once the home screen has rendered its conversation list — that gate exists so the app can swap away from the `LoadingVC` with data already in place, which needs a scene. A launch the OS starts purely to run a `BGAppRefreshTask` has no scene, so the wait never completes and the fetch spends its entire budget polling nothing.

The chain:

```
handleBackgroundRefresh          AppDelegate:208   await appReadiness.isReady()
  ← setAppReady()                AppDelegate:301   only reached after…
  ← setupComplete(viewController) AppDelegate:826
  ← HomeVC.afterInitialConversationsLoaded         AppDelegate:937-941
  ← HomeVC.render(state:)        HomeVC:494-501    fires on the FIRST rendered state
```

Across four user logs from two unrelated accounts, **every background fetch that followed a cold launch (13) failed this way** — 12 of them logging the 10s root-view-controller timeout — while fetches on an already-running process polled in about a second. The same startup work completes in 284ms in a foreground launch on the same device, so this is a hang rather than slowness.

Effect: once iOS evicts the app process, background polling stops entirely until the user next opens the app. For Slow Mode users that is the whole delivery path.

## The change

The fetch now waits for what the poll actually uses — the database reaching `readyForUse` and the libSession cache being loaded — raced against a timeout so a fetch that can't get started gives up instead of burning its budget. Readiness is deliberately left alone: `setAppReady()` also runs every deferred `runNowOrWhenAppDidBecomeReady` block (call handling, notification-response handling), and firing those during a scene-less launch is a much wider change than this bug warrants.

Two details worth a reviewer's attention, both of which would fail silently:

- The wait **must** come after `resumeDatabaseAccess()`. A suspended database only reaches `readyForUse` once resumed, so waiting first would deadlock the warm fetches that work today.
- It relies on `Storage.state` replaying its current value to a new consumer (`CurrentValueAsyncStream._makeTrackedStream` yields `currentValue`), so the wait returns immediately when storage is already ready rather than waiting for a transition that already happened.

## Testing

`SessionTests`: 1273 passed, 0 failed, 0 restarts.

⚠️ **The end-to-end path is unverified.** A cold `BGAppRefreshTask` launch can't be exercised headlessly in the simulator, so confirmation has to come from a device log showing a poll result after a cold-launch fetch. The failing signature to look for is `Starting background fetch` followed by `Showing startup alert due to error: Startup timeout` with no poll in between.