### PR TITLE
Pro: identify each message-info feature row

### DIFF
--- a/Session/Media Viewing & Editing/MessageInfoScreen.swift
+++ b/Session/Media Viewing & Editing/MessageInfoScreen.swift
@@ -60,6 +60,21 @@ struct MessageInfoScreen: View {
             }
         }
         
+        /// Lets a test assert *which* features a message was sent with, rather than how many
+        ///
+        /// **Note:** A cross-platform contract - Android defines the same strings in its `content-descriptions`
+        /// module, so one Appium locator serves both platforms
+        var accessibilityIdentifier: String {
+            switch self {
+                case .proBadge: return SessionProUI.AccessibilityIdentifier.messageFeatureBadges
+                case .increasedMessageLength:
+                    return SessionProUI.AccessibilityIdentifier.messageFeatureLongerMessages
+                    
+                case .animatedDisplayPicture:
+                    return SessionProUI.AccessibilityIdentifier.messageFeatureAnimatedDisplayPicture
+            }
+        }
+        
         static func from(
             messageFeatures: SessionPro.MessageFeatures,
             profileFeatures: SessionPro.ProfileFeatures
@@ -398,6 +413,11 @@ struct MessageInfoScreen: View {
                                                 Text(feature.title)
                                                     .font(.Body.largeRegular)
                                                     .foregroundColor(themeColor: .textPrimary)
+                                                    .accessibility(
+                                                        Accessibility(
+                                                            identifier: feature.accessibilityIdentifier
+                                                        )
+                                                    )
                                             }
                                         }
                                     }

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProUI.swift
@@ -40,6 +40,17 @@ public extension SessionProUI {
         /// The "Pro Beta Features" section header
         public static let featuresHeader: String = "pro-settings-features-header"
 
+        /// The rows of the "This message used the following Session Pro features" list on the message info screen
+        ///
+        /// **Note:** One identifier per feature rather than an indexed set, so a test can assert *which* features a
+        /// message was sent with. These sit on the row's text, so the label is the localized feature name
+        ///
+        /// **Note:** The names are the per-message subset of the shared Pro feature vocabulary (Desktop derives its
+        /// equivalents from that full list), so one feature is named the same wherever it appears
+        public static let messageFeatureBadges: String = "pro-message-feature-badges"
+        public static let messageFeatureLongerMessages: String = "pro-message-feature-longer-messages"
+        public static let messageFeatureAnimatedDisplayPicture: String = "pro-message-feature-animated-display-picture"
+
         /// The "Update Pro Access" row
         ///
         /// **Note:** `ListItemCell` is a `Button`, so its title and subtitle merge into this one element rather


### PR DESCRIPTION
The message info screen lists the Session Pro features a message was sent with, but the rows carried no accessibility identifier — so an automated test can only match them by their localized text. That breaks on any wording or translation change, and it cannot distinguish *which* feature a row is without hard-coding three strings.

This gives each row a per-feature identifier, declared alongside the other Pro identifiers in `SessionProUI.AccessibilityIdentifier` and applied with the existing `.accessibility(Accessibility(identifier:))` helper:

| Feature | Identifier |
|---|---|
| `.proBadge` | `pro-message-feature-badges` |
| `.increasedMessageLength` | `pro-message-feature-longer-messages` |
| `.animatedDisplayPicture` | `pro-message-feature-animated-display-picture` |

The names are the **per-message subset of the shared Pro feature vocabulary** (the same words the Pro settings surface uses), so one feature is called the same thing wherever it appears rather than gaining a second name per screen.

These strings are a **cross-platform contract**, as that enum's doc comment already notes: the matching PRs give Android the same values in its `content-descriptions` module and Desktop derives them from its own `ProFeatureItems` list, so one Appium locator serves all three clients.

No behaviour change — the identifier takes over the element's `name`, leaving the feature title in its accessibility `label`.

**Not built locally** (Linux box); relying on CI.