### PR TITLE
Pro: compare revocation instants against network time

### DIFF
--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -319,7 +319,8 @@ public actor SessionProManager: SessionProManagerType {
             case (.some(let proRevocationTagHex), let expiryUnixTimestampSeconds, _) where expiryUnixTimestampSeconds > 0:
                 /// **Note:** A revocation item only takes effect once our clock reaches its `effectiveTimestampSeconds`, the backend
                 /// can publish a revocation ahead of time so we need to keep honouring the proof until that instant passes
-                let nowTimestampSeconds: TimeInterval = syncState.dependencies.dateNow.timeIntervalSince1970
+                let nowTimestampSeconds: TimeInterval = syncState.dependencies.networkOffsetDateNow()
+                    .timeIntervalSince1970
                 let proWasRevoked: Bool = syncState.revocationList.contains { item in
                     TimeInterval(item.effectiveTimestampSeconds) <= nowTimestampSeconds &&
                     item.revocationTag.toHexString() == proRevocationTagHex
@@ -1665,7 +1666,7 @@ public actor SessionProManager: SessionProManagerType {
     /// is built fresh and evaluates `profileFeatures(for:)` against the current time anyway, so re-emitting for profiles which lapsed
     /// while the app was closed would be pure noise.
     private func catchUpProInvalidation() async {
-        let now: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+        let now: TimeInterval = await dependencies.networkOffsetDateNow().timeIntervalSince1970
 
         if lastProInvalidationCheck > 0 {
             await emitProInvalidationEvents(since: lastProInvalidationCheck, until: now)
@@ -1679,7 +1680,7 @@ public actor SessionProManager: SessionProManagerType {
 
     /// How long to wait before the next instant, or `nil` if there's nothing upcoming
     private func nextProInvalidationDelay() async -> Int? {
-        let now: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+        let now: TimeInterval = await dependencies.networkOffsetDateNow().timeIntervalSince1970
 
         guard let nextInstant: TimeInterval = await nextProInvalidationInstant(after: now) else { return nil }
 
@@ -1996,7 +1997,7 @@ public actor SessionProManager: SessionProManagerType {
     /// regardless of expiry — then refresh the account status so the server settles what the state now is.
     /// No-op when we hold no proof or it isn't revoked, so the refresh only happens on an actual revocation.
     private func clearOwnCredentialIfRevoked() async {
-        let nowSeconds: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+        let nowSeconds: TimeInterval = await dependencies.networkOffsetDateNow().timeIntervalSince1970
 
         let ownProofRevocationTagHex: String? = dependencies.mutate(cache: .libSession) {
             $0.proConfig?.proProof.revocationTag.toHexString()


### PR DESCRIPTION
Found while auditing all three clients against the latest Pro protocol changes. Desktop and Android both
compare the revocation list's effective timestamp against network time; iOS was the only one that did not,
and only at some of its call sites.

### The bug

`SessionProManager` read `effectiveTimestampSeconds` — a backend-supplied instant — against four different
device-clock reads via `dependencies.dateNow`, which returns a bare `Date()` with no network offset
(`Dependencies.swift:36-43`). One other site already used network time.

**Mixed is worse than uniformly wrong.** The same instant was compared against different clocks depending
on the path, so under clock skew `currentUserHasProAccess` and the profile-badge path could disagree about
the same proof. A uniform offset would at least have been consistent.

The site that matters most clears the user's *own* credential, so a fast device clock discarded a
still-valid proof early.

### The change

All four now use the existing `networkOffsetDateNow()`, the same source the correct site already used, so
every reader of `effectiveTimestampSeconds` compares against one clock. One file, five lines.

`retain_for` is parsed and never read on iOS, so the memory-only aging it drives is unimplemented. Out of
scope here and flagged separately.

### What this does not do

This makes the clock **consistent, not correct**. `networkOffsetDateNow()` falls back to the device clock
when there is no network singleton — which is deliberate, since forcing the network up would be wrong in
the extensions. In that state all four sites are still on device time, just the *same* time as
`currentUserHasProAccess`. The disagreement is what is removed; this should not be read as making
revocation timing skew-proof.

### Testing

Simulator `Debug` build, green. No test run: the Session Pro end-to-end suite has no revocation coverage
yet — that is the next batch, and these are the call sites it will exercise.

Comparison for context — Desktop uses `NetworkTime.now()` at both its readers, Android uses `SnodeClock`
at all five of its.
