### PR TITLE
Pro: revocation-path conformance fixes

### DIFF
--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -51,6 +51,7 @@ public class HomeViewModel: NavigatableStateHolder {
     /// This value is the current state of the view
     @MainActor @Published private(set) var state: State
     private var observationTask: Task<Void, Never>?
+    private var proCTARetryTask: Task<Void, Never>?
     
     // MARK: - Initialization
     @MainActor init(using dependencies: Dependencies) {
@@ -76,6 +77,7 @@ public class HomeViewModel: NavigatableStateHolder {
     
     deinit {
         observationTask?.cancel()
+        proCTARetryTask?.cancel()
         NotificationCenter.default.removeObserver(self)
     }
     
@@ -563,10 +565,41 @@ public class HomeViewModel: NavigatableStateHolder {
             .addingTimeInterval(2 * 7 * 24 * 60 * 60)
     }
     
+    /// Re-run the CTA check when a `get_pro_status` first confirms the state
+    ///
+    /// `sessionProExpiringCTAInfo()` declines on an unconfirmed status, and the fetch that would confirm it hangs off
+    /// `didBecomeActive` rather than off this screen appearing - so the two are unordered and this check can sample
+    /// before the answer exists. Without a retry that is permanent for the launch: the check runs once per appearance
+    /// and a lapse that the fetch would have revealed is simply never shown.
+    ///
+    /// **Note:** Waits for the transition into `.success` rather than polling, and only ever re-runs once. The fetch is
+    /// allowed not to happen - the startup gate declines inside its own interval - so this must not assume one is
+    /// coming, which is why it holds no timeout and simply stays parked until the screen goes away.
+    @MainActor private func retryProCTAOnConfirmedStatus() {
+        proCTARetryTask?.cancel()
+        proCTARetryTask = Task { [weak self, dependencies] in
+            for await state in dependencies[singleton: .sessionProManager].state {
+                guard !Task.isCancelled else { return }
+                guard state.loadingState == .success else { continue }
+
+                await self?.showSessionProCTAIfNeeded()
+                return
+            }
+        }
+    }
+
     @MainActor func showSessionProCTAIfNeeded() async {
         guard let info = await dependencies[singleton: .sessionProManager].sessionProExpiringCTAInfo() else {
+            /// Nothing to show *yet* is not the same as nothing to show. Park until a status fetch confirms the state,
+            /// then look once more - see `retryProCTAOnConfirmedStatus`
+            if await dependencies[singleton: .sessionProManager].currentUserCurrentProState.loadingState != .success {
+                retryProCTAOnConfirmedStatus()
+            }
+
             return
         }
+
+        proCTARetryTask?.cancel()
         
         try? await Task.sleep(for: .seconds(1)) /// Cooperative suspension, so safe to call on main thread
         

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel+Testing.swift
@@ -54,6 +54,15 @@ extension DeveloperSettingsViewModel {
             /// **Value:** `true`/`false` (default: `false`)
             case forceOffline
             
+            /// Forces the next Pro revocation-list poll to be due at launch, by backdating the persisted instant the
+            /// polling gate reads. The gate itself is unmodified and still decides.
+            ///
+            /// Needed because the QA backend serves a `retry_in` of a day, so after the first poll no revocation
+            /// behaviour is observable in a test run.
+            ///
+            /// **Value:** `true`/`1` enables; absent, empty or anything else disables (default: disabled)
+            case forceProRevocationRefresh
+            
             /// Specifies the maximum number of files that can be uploaded/downloaded at the same time
             ///
             /// **Value:** `0-9,223,372,036,854,775,807` (default: `2`)
@@ -306,6 +315,10 @@ extension DeveloperSettingsViewModel {
                     
                 case .forceOffline:
                     dependencies.set(feature: .forceOffline, to: (value == "true"))
+                    
+                case .forceProRevocationRefresh:
+                    /// Explicitly parsed rather than treated as present-means-on, so passing `0` disables it as it reads
+                    dependencies.set(feature: .forceProRevocationRefresh, to: (value == "true" || value == "1"))
                     
                 case .maxConcurrentFiles:
                     guard let intValue: Int = Int(value, radix: 10) else { continue }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -739,10 +739,25 @@ extension MessageReceiver {
         /// only risk diverging from that (see `session_protocol.h` `session_protocol_decode_envelope`)
         let proStatus: SessionPro.DecodedStatus? = decodedMessage.decodedPro?.status
 
+        /// A verified proof is not the same as an entitled one: `libSession` checks the backend's signature and the proof's expiry,
+        /// but it has no knowledge of the revocation list, so a revoked proof still decodes as `.valid`. libsession's own contract is
+        /// that incoming messages carrying a revoked proof "will not be entitled to Pro features" (`pro_backend.hpp`), which is this
+        /// check - the profile-derived features already honour it elsewhere.
+        ///
+        /// **Note:** Judged against network time, and against the list as it stands at receipt. That makes the outcome depend on when
+        /// the message is processed, and truncation here is destructive - the shortened body is what is persisted. That is deliberate:
+        /// the sender was not entitled, so a recipient must not be able to recover the full "fake Pro" content later by switching to a
+        /// modified client.
+        let proofIsRevoked: Bool = dependencies[singleton: .sessionProManager].proofIsRevoked(
+            decodedMessage.decodedPro?.proProof,
+            atTimestampMs: dependencies.networkOffsetTimestampMs()
+        )
+        let proIsEntitled: Bool = (proStatus == .valid && !proofIsRevoked)
+
         /// Check if the message is too long
         guard
             info.status == .exceedsCharacterLimit || (
-                proStatus != .valid &&
+                !proIsEntitled &&
                 info.features.contains(.largerCharacterLimit)
             )
         else { return text }
@@ -750,7 +765,7 @@ extension MessageReceiver {
         // FIXME: Replace this with a libSession-based truncation solution
         let utf16View = text.utf16
         let characterLimit: Int = (
-            proStatus == .valid ?
+            proIsEntitled ?
                 SessionPro.ProCharacterLimit :
                 SessionPro.CharacterLimit
         )

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1976,15 +1976,27 @@ public actor SessionProManager: SessionProManagerType {
                     }
 
                     
-                    /// Written in the same transaction as the response it came from: a ticket that advanced without
-                    /// its matching next-poll instant would re-poll on the next pass and defeat the cadence.
+                    /// A ticket that is already current comes back with an EMPTY item list rather than the list we
+                    /// hold, so replacing unconditionally erased every revocation we knew about - and a recipient then
+                    /// went back to honouring a proof it had already learnt was revoked. Only a response that advanced
+                    /// the ticket carries a list worth storing. Session Desktop guards the same way.
+                    let ticketAdvanced: Bool = (response.ticket > ticket)
+
+                    /// The next-poll instant is written unconditionally: it is the cadence the backend asked for, and it
+                    /// applies whether or not there was anything new. Written in the same transaction as the response it
+                    /// came from, since a ticket that advanced without its matching instant would re-poll on the next
+                    /// pass and defeat that cadence.
                     try await dependencies[singleton: .storage].write { db in
-                        db[.proRevocationsTicket] = Int(response.ticket)
-                        db[.proRevocationList] = response.items
+                        if ticketAdvanced {
+                            db[.proRevocationsTicket] = Int(response.ticket)
+                            db[.proRevocationList] = response.items
+                        }
                         db[.proRevocationsNextPollTimestamp] = Int(nowSeconds + UInt64(max(0, response.retryInSeconds)))
                     }
                     
-                    syncState.update(revocationList: .set(to:response.items))
+                    if ticketAdvanced {
+                        syncState.update(revocationList: .set(to:response.items))
+                    }
 
                     /// §6.4: the revocation-list path is authoritative — if the current user's OWN proof is
                     /// now revoked, clear the credential (regardless of expiry/validity). Otherwise a

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1871,6 +1871,20 @@ public actor SessionProManager: SessionProManagerType {
             
             while true {
                 do {
+                    /// The server owns this cadence, so honour the instant it implied even across a relaunch. Waiting
+                    /// here rather than sleeping after the fetch means there is exactly one place that decides when the
+                    /// next poll happens, and it reads persisted state - so a restart resumes the remainder of the
+                    /// interval instead of starting a fresh one.
+                    let nowSeconds: UInt64 = (await dependencies.networkOffsetTimestampMs() / 1000)
+                    let nextPollSeconds: UInt64 = ((try? await dependencies[singleton: .storage].read { db in
+                        db[.proRevocationsNextPollTimestamp].map { UInt64(max(0, $0)) }
+                    }) ?? nil) ?? 0
+
+                    if nextPollSeconds > nowSeconds {
+                        try? await Task.sleep(for: .seconds(Int(nextPollSeconds - nowSeconds)))
+                        continue
+                    }
+
                     let ticket: Int64 = try await Result(
                         catching: {
                             try await dependencies[singleton: .storage].read { db in
@@ -1894,9 +1908,12 @@ public actor SessionProManager: SessionProManagerType {
                     }
 
                     
+                    /// Written in the same transaction as the response it came from: a ticket that advanced without
+                    /// its matching next-poll instant would re-poll on the next pass and defeat the cadence.
                     try await dependencies[singleton: .storage].write { db in
                         db[.proRevocationsTicket] = Int(response.ticket)
                         db[.proRevocationList] = response.items
+                        db[.proRevocationsNextPollTimestamp] = Int(nowSeconds + UInt64(max(0, response.retryInSeconds)))
                     }
                     
                     syncState.update(revocationList: .set(to:response.items))
@@ -1917,9 +1934,8 @@ public actor SessionProManager: SessionProManagerType {
                     
                     Log.info(.sessionPro, (response.ticket != ticket ? "Successfully updated revocation list to \(response.ticket)." : "Revocation list already up-to-date."))
 
-                    /// Wait the server-recommended interval before polling again; libSession clamps
-                    /// `retry_in`/`retain_for` to sane bounds in its revocations parser, so we use it as-is.
-                    try? await Task.sleep(for: .seconds(Int(response.retryInSeconds)))
+                    /// No sleep here - the persisted instant above is what the next iteration waits on. libSession
+                    /// clamps `retry_in`/`retain_for` to sane bounds in its revocations parser, so we use it as-is.
                 }
                 catch {
                     Log.warn(.sessionPro, "\(error), will retry in 10s.")

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -289,6 +289,25 @@ public actor SessionProManager: SessionProManagerType {
         return !isRevoked
     }
     
+    /// Whether `proof` is revoked as of `timestampMs`, honouring each item's effective instant
+    ///
+    /// Separate from `currentUserProofIsValid(atTimestampMs:)` because that one answers the question for our OWN proof and folds in
+    /// expiry; this answers only "is this proof revoked", for a proof that arrived on a message.
+    nonisolated public func proofIsRevoked(
+        _ proof: Network.SessionPro.ProProof?,
+        atTimestampMs timestampMs: UInt64
+    ) -> Bool {
+        guard let proof: Network.SessionPro.ProProof = proof else { return false }
+
+        let nowSeconds: TimeInterval = TimeInterval(timestampMs / 1000)
+        let proofRevocationTagHex: String = proof.revocationTag.toHexString()
+
+        return syncState.revocationList.contains { item in
+            TimeInterval(item.effectiveTimestampSeconds) <= nowSeconds &&
+            item.revocationTag.toHexString() == proofRevocationTagHex
+        }
+    }
+
     nonisolated public func messageFeatures(for message: String) -> SessionPro.FeaturesForMessage {
         /// libsession no longer inspects the text — we pass the natively-counted codepoint count
         /// (`unicodeScalars.count`) and it returns the required feature bitset + limit status.
@@ -2159,6 +2178,10 @@ public protocol SessionProManagerType: SessionProUIManagerType {
     
     nonisolated func proProofIsActive(
         for proof: Network.SessionPro.ProProof?,
+        atTimestampMs timestampMs: UInt64
+    ) -> Bool
+    nonisolated func proofIsRevoked(
+        _ proof: Network.SessionPro.ProProof?,
         atTimestampMs timestampMs: UInt64
     ) -> Bool
     nonisolated func messageFeatures(for message: String) -> SessionPro.FeaturesForMessage

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1746,11 +1746,47 @@ public actor SessionProManager: SessionProManagerType {
 
         guard let affectedProfiles: [Profile], !affectedProfiles.isEmpty else { return }
 
-        /// Send the profile's **stored** values - the row genuinely hasn't changed, and the direct-cache-update path writes these
-        /// straight into the cached profile, so anything else here would corrupt it. The events exist to force the requery which
-        /// re-derives `profileFeatures(for:)` against the current time.
+        await notifyProStateRederivationNeeded(for: affectedProfiles)
+
+        Log.info(.sessionPro, "Invalidated pro state for \(affectedProfiles.count) profile(s).")
+    }
+
+    /// Force a requery for profiles whose proof is revoked as of now, regardless of when it became effective
+    ///
+    /// `emitProInvalidationEvents(since:until:)` only covers instants that fall inside its window, which is the right rule for the
+    /// passage of time but the wrong one for a list arriving: a revocation that was **already** effective when we fetched it has no
+    /// instant left in the future to wake on, and its `effective_at` is usually behind the window's lower bound as well. Without this
+    /// such a revocation is cached and correctly honoured while the badge stays on screen until something unrelated rebuilds the view.
+    private func emitAlreadyEffectiveRevocationEvents() async {
+        let nowSeconds: TimeInterval = await dependencies.networkOffsetDateNow().timeIntervalSince1970
+        let effectiveTags: Set<String> = Set(
+            syncState.revocationList
+                .filter { TimeInterval($0.effectiveTimestampSeconds) <= nowSeconds }
+                .map { $0.revocationTag.toHexString() }
+        )
+
+        guard !effectiveTags.isEmpty else { return }
+
+        /// The window bounds are irrelevant here - passing an empty one leaves `revocationTagsHex` as the only clause that can match,
+        /// which is exactly the "is this profile's proof revoked" question
+        let revokedProfiles: [Profile]? = try? await dependencies[singleton: .storage].read { db in
+            try Profile.withProStateInvalidated(db, since: 0, until: 0, revocationTagsHex: effectiveTags)
+        }
+
+        guard let revokedProfiles: [Profile], !revokedProfiles.isEmpty else { return }
+
+        await notifyProStateRederivationNeeded(for: revokedProfiles)
+
+        Log.info(.sessionPro, "Re-derived pro state for \(revokedProfiles.count) revoked profile(s).")
+    }
+
+    /// Emit the profile events that force a requery, which is what re-derives `profileFeatures(for:)` against the current time
+    ///
+    /// **Note:** Sends the profile's **stored** values - the row genuinely hasn't changed, and the direct-cache-update path writes
+    /// these straight into the cached profile, so anything else here would corrupt it.
+    private func notifyProStateRederivationNeeded(for profiles: [Profile]) async {
         await dependencies.notify(
-            events: affectedProfiles.map { profile in
+            events: profiles.map { profile in
                 ObservedEvent(
                     key: .profile(profile.id),
                     value: ProfileEvent(
@@ -1769,8 +1805,6 @@ public actor SessionProManager: SessionProManagerType {
                 )
             }
         )
-
-        Log.info(.sessionPro, "Invalidated pro state for \(affectedProfiles.count) profile(s).")
     }
 
     /// Re-evaluate the invalidation schedule when the app returns to the foreground, or when any profile's pro status changes
@@ -1946,6 +1980,9 @@ public actor SessionProManager: SessionProManagerType {
 
                     /// The list we schedule against just changed, so the next `effective_at` may have moved
                     await scheduleNextProInvalidation()
+
+                    /// ...and anything already effective when it arrived has no upcoming instant for that to wake on
+                    await emitAlreadyEffectiveRevocationEvents()
                     
                     Log.info(.sessionPro, (response.ticket != ticket ? "Successfully updated revocation list to \(response.ticket)." : "Revocation list already up-to-date."))
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1868,6 +1868,21 @@ public actor SessionProManager: SessionProManagerType {
             } catch {
                 Log.warn(.sessionPro, "Failed to load revocation list from db: \(error)")
             }
+
+            /// Automated tests only: backdate the stored instant so the gate below finds a poll due. The QA backend
+            /// serves a `retry_in` of a day, which is inside libSession's clamp, so without this nothing after the
+            /// first poll is observable in a test run.
+            ///
+            /// **Note:** This moves the gate's *input* and then leaves the gate alone, deliberately - a test-only fetch
+            /// path could pass while the production one was broken. Applied once here rather than per iteration, so the
+            /// server's cadence still governs every subsequent poll.
+            if dependencies[feature: .forceProRevocationRefresh] {
+                Log.warn(.sessionPro, "forceProRevocationRefresh is set; treating a revocation poll as due.")
+
+                try? await dependencies[singleton: .storage].write { db in
+                    db[.proRevocationsNextPollTimestamp] = 0
+                }
+            }
             
             while true {
                 do {

--- a/SessionMessagingKit/Utilities/Preferences.swift
+++ b/SessionMessagingKit/Utilities/Preferences.swift
@@ -122,6 +122,15 @@ public extension KeyValueStore.IntKey {
     /// Unix seconds of the last `get_pro_status` fetch the startup gate started, backing its own (much longer)
     /// min-interval — mobile cold starts are frequent, so the gate needs a rate limit of its own rather than the 60s floor
     static let proStatusLastStartupFetchAttemptTimestamp: KeyValueStore.IntKey = "proStatusLastStartupFetchAttemptTimestamp"
+
+    /// Unix seconds at which the next revocation-list poll is due — `now + retry_in` of the last successful fetch.
+    ///
+    /// Persisted because the server owns this cadence and it is measured in hours: holding it only in the polling
+    /// task made every relaunch fetch immediately, so the interval was honoured within a process lifetime and
+    /// nowhere else. Reading it is what makes a restart respect the server's answer.
+    ///
+    /// Absent or `0` means "due now", which is what a first launch wants.
+    static let proRevocationsNextPollTimestamp: KeyValueStore.IntKey = "proRevocationsNextPollTimestamp"
 }
 
 // stringlint:ignore_contents

--- a/SessionUtilitiesKit/General/Feature.swift
+++ b/SessionUtilitiesKit/General/Feature.swift
@@ -41,6 +41,17 @@ public extension FeatureStorage {
         identifier: "forceOffline"
     )
     
+    /// Set only by the automated-test launch environment: backdates the persisted revocation next-poll instant once at
+    /// launch so the polling gate, unmodified, decides a poll is due.
+    ///
+    /// It exists because the QA backend serves a `retry_in` of a day, which is inside libSession's clamp, so nothing
+    /// else shortens it and no revocation behaviour is reachable in a test run. It moves the input the gate reads -
+    /// it is deliberately not a fetch trigger, so a spec exercises the production polling path rather than one that
+    /// can pass while that path is broken.
+    static let forceProRevocationRefresh: FeatureConfig<Bool> = Dependencies.create(
+        identifier: "forceProRevocationRefresh"
+    )
+    
     static let debugDisappearingMessageDurations: FeatureConfig<Bool> = Dependencies.create(
         identifier: "debugDisappearingMessageDurations"
     )


### PR DESCRIPTION
Five behaviour changes and one test hook, all in the Pro revocation path. Each commit stands alone and carries its own reasoning; the summary below is the shape of the set.

### The bugs

- **The cached revocation list was erased on every poll that found nothing new.** `get_pro_revocations` answers a ticket that is already current with an *empty* item list rather than the list we hold, so replacing unconditionally threw away every revocation already known. A recipient that had fetched a pending revocation went back to honouring the proof once the effective instant passed, because by then it no longer held the entry. Both the stored list and the in-memory copy are now gated on the ticket advancing; the next-poll instant stays unconditional, since it is the cadence the backend asked for either way. Desktop guards the same way, and Android is immune by construction (it skips an empty response and upserts rather than replaces).
- **The next-poll instant was not persisted**, so the interval — measured in hours — was honoured within a process lifetime and nowhere else, and every relaunch polled immediately. It is now written in the same transaction as the ticket and list it came from, and the wait happens at the top of the loop against the stored value, so a restart resumes the remainder of an interval rather than starting a fresh one. Desktop and Android both persist it; iOS was the deviation.
- **An already-effective revocation did not refresh the badge.** The windowed emission wakes on instants passing while we run, which is right for the passage of time and wrong for a list arriving: a revocation already effective when fetched has no future instant to wake on. It was cached and honoured, but the badge stayed on screen until something unrelated rebuilt the view. Each fetch now also sweeps for profiles whose stored tag is revoked as of now, alongside the windowed path rather than replacing it.
- **Message-carried features survived revocation.** libSession checks the backend signature and the proof's expiry but knows nothing of the revocation list, so a revoked proof decodes as `.valid` and kept earning the larger character limit — the profile-derived features already honoured the list, the message-carried ones did not. Verified and entitled are now separate values, and both the guard and the limit read entitlement. `largerCharacterLimit` is the only message-carried feature today, so this closes the surface rather than one case of it.
- **The expiring-Pro CTA fired or did not depending on a race.** It declines on an unconfirmed status, and the fetch that would confirm it hangs off `didBecomeActive` rather than off the home screen appearing — unordered, and the check ran exactly once per appearance, so whichever landed first decided. It now observes the transition into success and looks once more. Deliberately no timeout, and armed only when the status is genuinely unconfirmed, so the other reasons for declining a CTA are not retried.

### Test hook

`forceProRevocationRefresh` (simulator-scoped, like the surrounding hooks) backdates the persisted next-poll instant once at launch and then leaves the gate alone. The QA backend serves a `retry_in` of a day, which is inside libSession's clamp, so without it no revocation behaviour is reachable after a client's first poll. Backdating rather than adding a fetch path means a spec exercises the production polling path rather than a parallel one that could pass while that path was broken.

### Notes for review

- Truncation stays destructive at receipt, deliberately: the sender was not entitled, so a recipient must not be able to recover the full content later on a modified client. The cost is that a recipient offline while the sender was legitimately Pro sees the message truncated.
- The revocation-list cache bug was found by an end-to-end spec, which now covers it as a regression test.
