### PR TITLE
feat: add accessibility identifiers to the "Open URL" confirmation

### DIFF
--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -1599,17 +1599,8 @@ extension ConversationVC:
         
         let modal: ConfirmationModal = ConfirmationModal(
             targetView: self.view,
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: url.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize))
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                url,
                 hasCloseButton: true,
                 onConfirm:  { modal in
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -711,17 +711,8 @@ public class HomeViewModel: NavigatableStateHolder {
         ])
         
         let modal: ConfirmationModal = ConfirmationModal(
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: surveyUrl.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize))
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                surveyUrl,
                 hasCloseButton: true,
                 onConfirm: { modal in
                     UIApplication.shared.open(surveyUrl, options: [:], completionHandler: nil)

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -1228,17 +1228,8 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
         guard let url: URL = URL(string: Constants.urls.token) else { return }
         
         let modal: ConfirmationModal = ConfirmationModal(
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: url.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize))
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                url,
                 hasCloseButton: true,
                 onConfirm: { modal in
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/Session/Utilities/DonationsManager.swift
+++ b/Session/Utilities/DonationsManager.swift
@@ -127,17 +127,8 @@ public class DonationsManager {
         guard let url: URL = URL(string: Constants.urls.donations) else { return nil }
         
         return ConfirmationModal(
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: url.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize))
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                url,
                 hasCloseButton: true,
                 dismissType: .single,
                 onConfirm: { [dependencies] modal in

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -1252,17 +1252,8 @@ extension SessionProSettingsViewModel {
         guard let url: URL = URL(string: urlString) else { return }
         
         let modal: ConfirmationModal = ConfirmationModal(
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: url.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize))
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                url,
                 hasCloseButton: true,
                 onConfirm:  { [dependencies] modal in
                     dependencies[singleton: .appContext].openUrl(url)

--- a/SessionUIKit/Components/Modals & Toast/ConfirmationModal.swift
+++ b/SessionUIKit/Components/Modals & Toast/ConfirmationModal.swift
@@ -8,6 +8,34 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
     nonisolated public static let explanationFont: UIFont = .systemFont(ofSize: Values.smallFontSize)
     private static let closeSize: CGFloat = 24
     
+    /// Accessibility identifiers for the shared "Open URL" confirmation
+    ///
+    /// **Note:** That confirmation is raised from a number of places (the conversation, the settings and
+    /// Session Network screens, the Pro screens, the donations prompt) which all build it through
+    /// `ConfirmationModal.Info.openUrl`, so it is tagged there - once - rather than at each call site
+    ///
+    /// **Note:** These exact strings are a cross-platform contract with Desktop (which already uses
+    /// `open-url-confirm-button`) so a single Appium locator serves both platforms - renaming one means
+    /// renaming it in the other repos too
+    // stringlint:ignore_contents
+    public enum AccessibilityIdentifier {
+        /// The confirmation modal itself
+        ///
+        /// **Note:** This sits on the modal's `contentView`, which is deliberately left out of the
+        /// accessibility hierarchy as an element of its own - making it one would hide the description and
+        /// the buttons below it
+        public static let openUrlDialog: String = "open-url-dialog"
+
+        /// The explanatory copy, which is the element carrying the interpolated url
+        ///
+        /// **Note:** The identifier takes over the element's `name`, so an assertion on *which* url the
+        /// confirmation offers reads the accessibility **label**
+        public static let openUrlDescription: String = "open-url-description"
+
+        /// The "Open" button - **not** the "Copy URL" action, which is still addressed by its display string
+        public static let openUrlConfirmButton: String = "open-url-confirm-button"
+    }
+    
     public private(set) var info: Info
     private var internalOnConfirm: ((ConfirmationModal) -> ())? = nil
     private var internalOnCancel: ((ConfirmationModal) -> ())? = nil
@@ -605,7 +633,8 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
                 textToConfirmContainer.isHidden = false
             }
         
-        confirmButton.accessibilityIdentifier = info.confirmTitle
+        confirmButton.accessibilityIdentifier = (info.confirmAccessibility?.identifier ?? info.confirmTitle)
+        confirmButton.accessibilityLabel = (info.confirmAccessibility?.label ?? info.confirmTitle)
         confirmButton.isAccessibilityElement = true
         confirmButton.setTitle(info.confirmTitle, for: .normal)
         confirmButton.setThemeTitleColor(info.confirmStyle, for: .normal)
@@ -627,8 +656,16 @@ public class ConfirmationModal: Modal, UITextFieldDelegate, UITextViewDelegate {
         titleLabel.accessibilityLabel = titleLabel.text
         
         explanationLabel.isAccessibilityElement = true
-        explanationLabel.accessibilityIdentifier = "Modal description"
-        explanationLabel.accessibilityLabel = explanationLabel.text?.deformatted()
+        explanationLabel.accessibilityIdentifier = (info.bodyAccessibility?.identifier ?? "Modal description")
+        explanationLabel.accessibilityLabel = (
+            info.bodyAccessibility?.label ??
+            explanationLabel.text?.deformatted()
+        )
+        
+        /// Deliberately **not** made an accessibility element of its own - that would flatten the modal into a
+        /// single element and hide the description and the buttons within it
+        contentView.accessibilityIdentifier = info.accessibility?.identifier
+        contentView.accessibilityLabel = info.accessibility?.label
     }
     
     // MARK: - Error Handling
@@ -775,16 +812,19 @@ public extension ConfirmationModal {
     struct Info: Equatable, Hashable {
         internal let title: String
         public let body: Body
+        let bodyAccessibility: Accessibility?
         public let showCondition: ShowCondition
         internal let confirmTitle: String?
         let confirmStyle: ThemeValue
         let confirmEnabled: ButtonValidator
+        let confirmAccessibility: Accessibility?
         internal let cancelTitle: String
         let cancelStyle: ThemeValue
         let cancelEnabled: ButtonValidator
         let hasCloseButton: Bool
         let dismissOnConfirm: Bool
         let dismissType: Modal.DismissType
+        let accessibility: Accessibility?
         public let onConfirm: (@MainActor (ConfirmationModal) -> ())?
         let onCancel: (@MainActor (ConfirmationModal) -> ())?
         let afterClosed: (() -> ())?
@@ -794,32 +834,38 @@ public extension ConfirmationModal {
         public init(
             title: String,
             body: Body = .none,
+            bodyAccessibility: Accessibility? = nil,
             showCondition: ShowCondition = .none,
             confirmTitle: String? = nil,
             confirmStyle: ThemeValue = .alert_text,
             confirmEnabled: ButtonValidator = true,
+            confirmAccessibility: Accessibility? = nil,
             cancelTitle: String = "cancel".localized(),
             cancelStyle: ThemeValue = .danger,
             cancelEnabled: ButtonValidator = true,
             hasCloseButton: Bool = false,
             dismissOnConfirm: Bool = true,
             dismissType: Modal.DismissType = .recursive,
+            accessibility: Accessibility? = nil,
             onConfirm: (@MainActor (ConfirmationModal) -> ())? = nil,
             onCancel: (@MainActor (ConfirmationModal) -> ())? = nil,
             afterClosed: (() -> ())? = nil
         ) {
             self.title = title
             self.body = body
+            self.bodyAccessibility = bodyAccessibility
             self.showCondition = showCondition
             self.confirmTitle = confirmTitle
             self.confirmStyle = confirmStyle
             self.confirmEnabled = confirmEnabled
+            self.confirmAccessibility = confirmAccessibility
             self.cancelTitle = cancelTitle
             self.cancelStyle = cancelStyle
             self.cancelEnabled = cancelEnabled
             self.hasCloseButton = hasCloseButton
             self.dismissOnConfirm = dismissOnConfirm
             self.dismissType = dismissType
+            self.accessibility = accessibility
             self.onConfirm = onConfirm
             self.onCancel = onCancel
             self.afterClosed = afterClosed
@@ -837,16 +883,19 @@ public extension ConfirmationModal {
             return Info(
                 title: self.title,
                 body: (body ?? self.body),
+                bodyAccessibility: self.bodyAccessibility,
                 showCondition: self.showCondition,
                 confirmTitle: self.confirmTitle,
                 confirmStyle: self.confirmStyle,
                 confirmEnabled: self.confirmEnabled,
+                confirmAccessibility: self.confirmAccessibility,
                 cancelTitle: (cancelTitle ?? self.cancelTitle),
                 cancelStyle: self.cancelStyle,
                 cancelEnabled: self.cancelEnabled,
                 hasCloseButton: self.hasCloseButton,
                 dismissOnConfirm: self.dismissOnConfirm,
                 dismissType: self.dismissType,
+                accessibility: self.accessibility,
                 onConfirm: (onConfirm ?? self.onConfirm),
                 onCancel: (onCancel ?? self.onCancel),
                 afterClosed: (afterClosed ?? self.afterClosed)
@@ -868,7 +917,10 @@ public extension ConfirmationModal {
                 lhs.cancelEnabled.isValid(with: lhs) == rhs.cancelEnabled.isValid(with: rhs) &&
                 lhs.hasCloseButton == rhs.hasCloseButton &&
                 lhs.dismissOnConfirm == rhs.dismissOnConfirm &&
-                lhs.dismissType == rhs.dismissType
+                lhs.dismissType == rhs.dismissType &&
+                lhs.bodyAccessibility == rhs.bodyAccessibility &&
+                lhs.confirmAccessibility == rhs.confirmAccessibility &&
+                lhs.accessibility == rhs.accessibility
             )
         }
         
@@ -885,6 +937,9 @@ public extension ConfirmationModal {
             hasCloseButton.hash(into: &hasher)
             dismissOnConfirm.hash(into: &hasher)
             dismissType.hash(into: &hasher)
+            bodyAccessibility?.hash(into: &hasher)
+            confirmAccessibility?.hash(into: &hasher)
+            accessibility?.hash(into: &hasher)
         }
     }
 }
@@ -1153,6 +1208,51 @@ public extension ConfirmationModal.Info {
                     textToConfirm.hash(into: &hasher)
                 }
         }
+    }
+}
+
+// MARK: - Open URL Confirmation
+
+public extension ConfirmationModal.Info {
+    /// The shared "Open URL" confirmation, offering to open the given `url` or copy it to the clipboard
+    ///
+    /// **Note:** This exists so the accessibility identifiers in
+    /// `ConfirmationModal.AccessibilityIdentifier` are applied once, rather than being repeated at each of
+    /// the places which raise this confirmation
+    static func openUrl(
+        _ url: URL,
+        bodyScrollMode: ScrollableLabel.ScrollMode = .automatic,
+        hasCloseButton: Bool = false,
+        dismissType: Modal.DismissType = .recursive,
+        onConfirm: @escaping @MainActor (ConfirmationModal) -> (),
+        onCancel: @escaping @MainActor (ConfirmationModal) -> ()
+    ) -> ConfirmationModal.Info {
+        return ConfirmationModal.Info(
+            title: "urlOpen".localized(),
+            body: .attributedText(
+                "urlOpenDescription"
+                    .put(key: "url", value: url.absoluteString)
+                    .localizedFormatted(baseFont: ConfirmationModal.explanationFont),
+                scrollMode: bodyScrollMode
+            ),
+            bodyAccessibility: Accessibility(
+                identifier: ConfirmationModal.AccessibilityIdentifier.openUrlDescription
+            ),
+            confirmTitle: "open".localized(),
+            confirmStyle: .danger,
+            confirmAccessibility: Accessibility(
+                identifier: ConfirmationModal.AccessibilityIdentifier.openUrlConfirmButton
+            ),
+            cancelTitle: "urlCopy".localized(),
+            cancelStyle: .alert_text,
+            hasCloseButton: hasCloseButton,
+            dismissType: dismissType,
+            accessibility: Accessibility(
+                identifier: ConfirmationModal.AccessibilityIdentifier.openUrlDialog
+            ),
+            onConfirm: onConfirm,
+            onCancel: onCancel
+        )
     }
 }
 

--- a/SessionUIKit/Screens/Settings/SessionNetworkScreen/SessionNetworkScreen.swift
+++ b/SessionUIKit/Screens/Settings/SessionNetworkScreen/SessionNetworkScreen.swift
@@ -112,18 +112,8 @@ public struct SessionNetworkScreen<ViewModel: SessionNetworkScreenContent.ViewMo
         guard let url: URL = URL(string: urlString) else { return }
         
         let modal: ConfirmationModal = ConfirmationModal(
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: url.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize)),
-                    scrollMode: .automatic
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                url,
                 onConfirm:  { _ in viewModel.openURL(url) },
                 onCancel: { modal in
                     UIPasteboard.general.string = url.absoluteString

--- a/SessionUIKit/Screens/Settings/SessionProSettings/SessionProPaymentScreen.swift
+++ b/SessionUIKit/Screens/Settings/SessionProSettings/SessionProPaymentScreen.swift
@@ -486,18 +486,8 @@ public struct SessionProPaymentScreen<ViewModel: SessionProPaymentScreenContent.
         guard let url: URL = URL(string: urlString) else { return }
         
         let modal: ConfirmationModal = ConfirmationModal(
-            info: ConfirmationModal.Info(
-                title: "urlOpen".localized(),
-                body: .attributedText(
-                    "urlOpenDescription"
-                        .put(key: "url", value: url.absoluteString)
-                        .localizedFormatted(baseFont: .systemFont(ofSize: Values.smallFontSize)),
-                    scrollMode: .automatic
-                ),
-                confirmTitle: "open".localized(),
-                confirmStyle: .danger,
-                cancelTitle: "urlCopy".localized(),
-                cancelStyle: .alert_text,
+            info: .openUrl(
+                url,
                 onConfirm:  { [weak viewModel] _ in
                     viewModel?.openURL(url)
                 },


### PR DESCRIPTION
The e2e suite (session-appium) cannot assert anything about the "Open URL" confirmation — it carries no accessibility identifiers, so a spec cannot check that it appeared, read which url it offers, or confirm it by anything more stable than the localized button title.

Adds:

- `open-url-dialog` — the modal's content view
- `open-url-description` — the explanation label, which carries the interpolated url
- `open-url-confirm-button` — the confirm button (the same id session-desktop already uses, so the harness needs one locator rather than one per platform)

The confirmation was hand-built in **seven** places, so rather than repeat the identifiers seven times this adds a shared `ConfirmationModal.Info.openUrl` factory that every caller now goes through — tagged once, and seven copies of the same construction removed. `Info` gained three optional accessibility fields to make that possible, each defaulted to the existing behaviour so no other modal changes.

Tagging `ConfirmationModal` itself was not an option: it renders every confirmation in the app, so the identifiers would have landed on all of them.

`contentView` deliberately stays a container rather than becoming an accessibility element, so the description and buttons inside remain queryable. The url-bearing text is readable on `label` (the identifier takes over `name`), and the confirm button gained an explicit `accessibilityLabel` so its title stays readable too.

The "Copy URL" action is left untagged on purpose: an existing harness locator finds it by its display string.

Verified by building the `SessionUIKit` scheme (BUILD SUCCEEDED), which covers the new API and two of the seven call sites. The five in `SessionMessagingKit` / `Session` are parse-checked only — the worktree used to prepare this has no `LibSession-Util` submodule — though their call shapes match the factory signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)