### PR TITLE
Network: disable QUIC path-MTU discovery

### DIFF
--- a/SessionNetworkingKit/LibSession/LibSession+Networking.swift
+++ b/SessionNetworkingKit/LibSession/LibSession+Networking.swift
@@ -809,6 +809,11 @@ public actor LibSessionNetwork: NetworkType {
             case .direct: config.router = SESSION_NETWORK_ROUTER_DIRECT
         }
         
+        /// QUIC path-MTU discovery probes with oversized datagrams, which some mobile networks black-hole
+        /// rather than reject - so sending appears to fail on cellular while it succeeds on Wi-Fi. libSession
+        /// leaves discovery on by default, so it has to be switched off here.
+        config.quic_disable_mtu_discovery = true
+        
         /// If it's not the main app then we want to run in "Single Path Mode" (no use creating extra paths in the extensions)
         if !dependencies[singleton: .appContext].isMainApp {
             config.onionreq_single_path_mode = true


### PR DESCRIPTION
### The symptom

Sending fails on mobile data while Wi-Fi works. MTU discovery probes with oversized datagrams, which
reduced-MTU cellular paths (tunnelled and IPv6-transition carriers, commonly 1400–1428) black-hole
rather than reject — so the client sees sends time out on cellular and behave normally on Wi-Fi.

iOS is the client this hits: libSession's only transport is QUIC over UDP, which has to do its own path
MTU probing. Android reaches storage servers over its own OkHttp/TCP stack, where MSS clamping and
kernel black-hole detection handle this.

### History

libSession disabled MTU discovery unconditionally from April 2025 (795b47a8, *"caused issues with some
networks"*) until the old network code was deleted in September 2025 (3f681767). The config option that
replaced that call site is now the only way to get the behaviour back, so the client has to ask for it.

### 🔴 Ordering — this is inert on its own

libSession ignored the flag: both arms of its ternary produced an empty `std::optional`, which its QUIC
layer treats as "no option given". Fixed in session-foundation/libsession-util#133.

**This change does nothing until that lands in a libSession release and the SPM pin moves past 1.8.0.**
It is opened now so the client side isn't the piece left behind — merging it alone will look like MTU
was not the cause.

### Testing

Not runtime-tested, because the pinned libSession still ignores the flag. Verified that the field exists
in the currently pinned 1.8.0 xcframework header (`session_network.h`), so this compiles against the
current pin.