### PR TITLE
Pass the file server port through to the download url

### DIFF
--- a/SessionNetworkingKit/LibSession/LibSession+Networking.swift
+++ b/SessionNetworkingKit/LibSession/LibSession+Networking.swift
@@ -598,11 +598,18 @@ public actor LibSessionNetwork: NetworkType {
         
         var url: [CChar] = [CChar](repeating: 0, count: 1024)
         
-        let result = try LibSessionNetwork.withCustomFileServer(dependencies[feature: .customFileServer]) { schemePtr, hostPtr, _, pubkeyPtr in
+        /// The port is passed through rather than discarded: a download url that omits it sends every
+        /// recipient to the scheme's default port, which for a self-hosted file server is not the file
+        /// server. `withCustomFileServer` has always parsed it - there was simply nowhere to put it until
+        /// `session_file_server_generate_download_url` took one.
+        ///
+        /// 0 means "the scheme already implies it", which is also what an absent port means here.
+        let result = try LibSessionNetwork.withCustomFileServer(dependencies[feature: .customFileServer]) { schemePtr, hostPtr, port, pubkeyPtr in
             session_file_server_generate_download_url(
                 cFileId,
                 schemePtr,
                 hostPtr,
+                (port ?? 0),
                 pubkeyPtr,
                 dependencies[feature: .useStreamEncryptionForAttachments],
                 &url,


### PR DESCRIPTION
`withCustomFileServer` has always parsed the port out of the configured file server url and handed it to its callback. `generateDownloadUrl` took it as `_` and threw it away, because `session_file_server_generate_download_url` had no parameter to put it in.

The result was a download url with no port, so every recipient fetched the scheme's default port instead of the file server. That returns *a* response rather than an error, so it surfaced as an **undecryptable attachment** — a long way from the cause. Invisible for the default file server, where the scheme's port is already correct.

One line, now that libSession takes a port.

## ⚠️ Blocked — do not merge yet

The `port` argument this passes **does not exist in the C API iOS currently builds against**. It is added by libsession-util#134:

```
include/session/network/backends/session_file_server.h  (#134)
+    uint16_t port,
```

iOS pins `libsession-util-spm` **1.8.0** (revision `9aa4acf8`), and this PR does not bump `Package.resolved` — it touches one Swift file. Required order:

1. libsession-util#134 merges
2. a `libsession-util-spm` release carries it
3. iOS's pin moves to that release
4. **then** this PR

Nothing is staged as of 2026-08-25: there is no `libsession-util-spm` release after 1.8.0, and v1.8.0 is byte-identical to `upstream/dev` over `session_file_server.h`/`.cpp`, which #134 modifies. CI builds `App_Store_Release` against the pin, so merging before the pin moves would fail the build.

## Conflicts with #756 — keep both

Both PRs edit the same call in `generateDownloadUrl`. They compose (separate arguments) but conflict textually:

- this PR adds `(port ?? 0)`, and widens the closure from `{ schemePtr, hostPtr, _, pubkeyPtr in }` to bind the port
- #756 replaces the `use_stream_encryption` argument with a literal `true`

Merged call:

```swift
let result = try LibSessionNetwork.withCustomFileServer(dependencies[feature: .customFileServer]) { schemePtr, hostPtr, port, pubkeyPtr in
    session_file_server_generate_download_url(
        cFileId, schemePtr, hostPtr, (port ?? 0), pubkeyPtr, true, &url, url.count)
}
```

**#756 should land first** — it compiles against the current pin; this one cannot until the chain above completes.

## Verification, and its limits

End-to-end through the Session Appium suite: the url in the receiving client's log went from `http://192.168.139.2/file/…` to `http://192.168.139.2:8000/file/…` across the change, and the attachment then downloaded and rendered. All six directions of the cross-client attachment matrix pass with this plus libsession-util#135.

That was measured on a `Debug_Compile_LibSession` build, which compiles libSession from a local checkout. **That is a behavioural result, not a build result** — it is structurally incapable of catching the pin dependency above, which is why the blocker was found by review rather than by testing.
