### PR TITLE
Pro: do not raise the expiry CTA over the Pro settings screen

### DIFF
--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -588,7 +588,32 @@ public class HomeViewModel: NavigatableStateHolder {
         }
     }
 
+    /// Whether the Pro settings screen is the front-most screen.
+    ///
+    /// That screen already states the plan and offers the same action, so a CTA raised over it talks over a better
+    /// answer. Session Desktop declines for the same reason (`aProSettingsScreenIsOpen` in `SessionCTA.tsx`).
+    ///
+    /// `frontMostViewController` descends presented controllers AND navigation stacks, so this sees the screen while
+    /// it is pushed inside the settings stack rather than only when it is presented.
+    @MainActor private var aProSettingsScreenIsOpen: Bool {
+        dependencies[singleton: .appContext].frontMostViewController
+            is SessionListHostingViewController<SessionProSettingsViewModel>
+    }
+
     @MainActor func showSessionProCTAIfNeeded() async {
+        /// Declining here rather than after the info is fetched is what makes it a DEFERRAL rather than a loss: the
+        /// `hasShownProExpiring/ExpiredCTA` latch is written when the modal is presented, so reaching the presentation
+        /// while this screen is open would consume a once-per-cycle warning the user never saw.
+        ///
+        /// Reachable only because the check is no longer tied to this screen appearing - `retryProCTAOnConfirmedStatus`
+        /// fires on a status confirmation, and the fetch that confirms it is the one the Pro settings screen makes on
+        /// open. Before that retry existed the check only ran on appearance, so being in settings was impossible by
+        /// construction and no guard was needed.
+        ///
+        /// Nothing re-arms afterwards, and nothing needs to: leaving the screen puts Home back on screen, and this runs
+        /// on that appearance.
+        guard !aProSettingsScreenIsOpen else { return }
+
         guard let info = await dependencies[singleton: .sessionProManager].sessionProExpiringCTAInfo() else {
             /// Nothing to show *yet* is not the same as nothing to show. Park until a status fetch confirms the state,
             /// then look once more - see `retryProCTAOnConfirmedStatus`


### PR DESCRIPTION
> **Draft — part of the Pro revocation set, for review alongside session-appium#138.**

The Pro settings screen already states the plan and offers the same action, so an expiry CTA raised over it talks over a better answer. Session Desktop declines for exactly this reason (`aProSettingsScreenIsOpen` in `SessionCTA.tsx`); iOS had no equivalent.

**The cost was not cosmetic.** `hasShownProExpiring/ExpiredCTA` is written when the modal is **presented**, so reaching presentation while that screen is open consumes a once-per-cycle warning the user never saw. Android does not have this exposure at all — it writes its latch on dismissal.

### Only reachable since the status-confirmation retry

Before `retryProCTAOnConfirmedStatus`, the check ran solely on the home screen appearing, so being inside Pro settings was impossible by construction and the missing guard was harmless. Adding a status-driven trigger removed that accidental protection without replacing it — and the fetch that confirms the status is the one the Pro settings screen makes on open, so the new trigger fires precisely where the guard was needed.

This restores the protection without giving up the retry, which was fixing a real one-shot race.

### Details

- Declining **before** the info is fetched is what makes it a deferral rather than a loss.
- Nothing needs to re-arm: leaving the screen puts Home back on screen and the check runs on that appearance.
- `frontMostViewController` descends navigation stacks as well as presented controllers, so it sees the screen while it is *pushed* inside the settings stack rather than only when presented.

### Verification

Found by the overhang spec, which had never passed on iOS. It passes on both platforms with this, and the CTA is observed absent while in settings and present on the return.
