### PR TITLE
Attachments: make stream encryption the default and drop the legacy encryptor

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -884,6 +884,7 @@
 		FD71B9B02EF25A1200379A99 /* GlobalSearchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD71B9AF2EF25A0E00379A99 /* GlobalSearchSpec.swift */; };
 		FD72BDA12BE368C800CF6CF6 /* UIWindowLevel+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD72BDA02BE368C800CF6CF6 /* UIWindowLevel+Utilities.swift */; };
 		FD72BDA42BE3690B00CF6CF6 /* CryptoSMKSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD72BDA32BE3690B00CF6CF6 /* CryptoSMKSpec.swift */; };
+		FDA1E0052F0A11B000A11B05 /* CryptoAttachmentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA1E0042F0A11B000A11B04 /* CryptoAttachmentsSpec.swift */; };
 		FD72BDA72BE369DC00CF6CF6 /* CryptoOpenGroupSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD72BDA62BE369DC00CF6CF6 /* CryptoOpenGroupSpec.swift */; };
 		FD7443402D07A25C00862443 /* PushRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD74433F2D07A25C00862443 /* PushRegistrationManager.swift */; };
 		FD7443422D07A27E00862443 /* SyncPushTokensJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7443412D07A27E00862443 /* SyncPushTokensJob.swift */; };
@@ -1164,6 +1165,7 @@
 		FDE754A92C9B964D002A2623 /* MessageSenderGroupsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A52C9B964D002A2623 /* MessageSenderGroupsSpec.swift */; };
 		FDE754AA2C9B964D002A2623 /* MessageSenderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A62C9B964D002A2623 /* MessageSenderSpec.swift */; };
 		FDE754AC2C9B967E002A2623 /* FileMetadataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754AB2C9B967D002A2623 /* FileMetadataSpec.swift */; };
+		FDA1E0022F0A11B000A11B02 /* FileServerParsedDownloadUrlSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA1E0012F0A11B000A11B01 /* FileServerParsedDownloadUrlSpec.swift */; };
 		FDE754B02C9B96B4002A2623 /* WebRTCSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754AD2C9B96B3002A2623 /* WebRTCSession.swift */; };
 		FDE754B12C9B96B4002A2623 /* TurnServerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754AE2C9B96B4002A2623 /* TurnServerInfo.swift */; };
 		FDE754B22C9B96B4002A2623 /* WebRTC+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754AF2C9B96B4002A2623 /* WebRTC+Utilities.swift */; };
@@ -2551,6 +2553,7 @@
 		FD71B9AF2EF25A0E00379A99 /* GlobalSearchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchSpec.swift; sourceTree = "<group>"; };
 		FD72BDA02BE368C800CF6CF6 /* UIWindowLevel+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindowLevel+Utilities.swift"; sourceTree = "<group>"; };
 		FD72BDA32BE3690B00CF6CF6 /* CryptoSMKSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoSMKSpec.swift; sourceTree = "<group>"; };
+		FDA1E0042F0A11B000A11B04 /* CryptoAttachmentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoAttachmentsSpec.swift; sourceTree = "<group>"; };
 		FD72BDA62BE369DC00CF6CF6 /* CryptoOpenGroupSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoOpenGroupSpec.swift; sourceTree = "<group>"; };
 		FD74433F2D07A25C00862443 /* PushRegistrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationManager.swift; sourceTree = "<group>"; };
 		FD7443412D07A27E00862443 /* SyncPushTokensJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPushTokensJob.swift; sourceTree = "<group>"; };
@@ -2821,6 +2824,7 @@
 		FDE754A52C9B964D002A2623 /* MessageSenderGroupsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSenderGroupsSpec.swift; sourceTree = "<group>"; };
 		FDE754A62C9B964D002A2623 /* MessageSenderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSenderSpec.swift; sourceTree = "<group>"; };
 		FDE754AB2C9B967D002A2623 /* FileMetadataSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileMetadataSpec.swift; sourceTree = "<group>"; };
+		FDA1E0012F0A11B000A11B01 /* FileServerParsedDownloadUrlSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileServerParsedDownloadUrlSpec.swift; sourceTree = "<group>"; };
 		FDE754AD2C9B96B3002A2623 /* WebRTCSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRTCSession.swift; sourceTree = "<group>"; };
 		FDE754AE2C9B96B4002A2623 /* TurnServerInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TurnServerInfo.swift; sourceTree = "<group>"; };
 		FDE754AF2C9B96B4002A2623 /* WebRTC+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WebRTC+Utilities.swift"; sourceTree = "<group>"; };
@@ -5360,6 +5364,7 @@
 			isa = PBXGroup;
 			children = (
 				FD72BDA32BE3690B00CF6CF6 /* CryptoSMKSpec.swift */,
+				FDA1E0042F0A11B000A11B04 /* CryptoAttachmentsSpec.swift */,
 			);
 			path = Crypto;
 			sourceTree = "<group>";
@@ -5617,6 +5622,14 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		FDA1E0032F0A11B000A11B03 /* FileServer */ = {
+			isa = PBXGroup;
+			children = (
+				FDA1E0012F0A11B000A11B01 /* FileServerParsedDownloadUrlSpec.swift */,
+			);
+			path = FileServer;
+			sourceTree = "<group>";
+		};
 		FDAA16792AC28E2200DDBF77 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -5696,6 +5709,7 @@
 				FD66CB272BF3449B00268FAB /* SessionNetworkingKit.xctestplan */,
 				FD3765DD2AD8F02300DC1489 /* _TestUtilities */,
 				FD6B92C92E77B1A7004463B5 /* SOGS */,
+				FDA1E0032F0A11B000A11B03 /* FileServer */,
 				FDAA16792AC28E2200DDBF77 /* Models */,
 				FD2272C52C34E9D1004D8A6C /* Types */,
 			);
@@ -8332,6 +8346,7 @@
 				FDEF30932F2973340004C5BD /* MockJobRunner.swift in Sources */,
 				FDEF30762F296D310004C5BD /* FixtureBase.swift in Sources */,
 				FDE754AC2C9B967E002A2623 /* FileMetadataSpec.swift in Sources */,
+				FDA1E0022F0A11B000A11B02 /* FileServerParsedDownloadUrlSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8381,6 +8396,7 @@
 				FDEF30852F29719F0004C5BD /* MockCrypto.swift in Sources */,
 				FD3FAB672AF0C47000DC5421 /* DisplayPictureDownloadJobSpec.swift in Sources */,
 				FD72BDA42BE3690B00CF6CF6 /* CryptoSMKSpec.swift in Sources */,
+				FDA1E0052F0A11B000A11B05 /* CryptoAttachmentsSpec.swift in Sources */,
 				FDC2908927D70656005DAE71 /* RoomPollInfoSpec.swift in Sources */,
 				FD481AA32CB889AE00ECC4CF /* RetrieveDefaultOpenGroupRoomsJobSpec.swift in Sources */,
 				FDC2908D27D70905005DAE71 /* UpdateMessageRequestSpec.swift in Sources */,

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -445,7 +445,6 @@ extension ConversationVC:
                             )
                             try convertedAttachment.ensureExpectedEncryptedSize(
                                 logCat: .media,
-                                domain: .attachment,
                                 maxFileSize: Network.maxFileSize,
                                 using: dependencies
                             )
@@ -467,7 +466,6 @@ extension ConversationVC:
                 do {
                     try pendingAttachment.ensureExpectedEncryptedSize(
                         logCat: .media,
-                        domain: .attachment,
                         maxFileSize: Network.maxFileSize,
                         using: dependencies
                     )
@@ -767,7 +765,6 @@ extension ConversationVC:
             try attachments.forEach { attachment in
                 try attachment.ensureExpectedEncryptedSize(
                     logCat: .media,
-                    domain: .attachment,
                     maxFileSize: Network.maxFileSize,
                     using: viewModel.dependencies
                 )

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsFileServerViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsFileServerViewModel.swift
@@ -72,7 +72,6 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
     
     public enum ListItem: Hashable, Differentiable, CaseIterable {
         case shortenFileTTL
-        case useStreamEncryptionForAttachments
         case shareDownloadedFile
         case customFileServerUrl
         case customFileServerPubkey
@@ -84,7 +83,6 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
         public var differenceIdentifier: String {
             switch self {
                 case .shortenFileTTL: return "shortenFileTTL"
-                case .useStreamEncryptionForAttachments: return "useStreamEncryptionForAttachments"
                 case .shareDownloadedFile: return "shareDownloadedFile"
                 case .customFileServerUrl: return "customFileServerUrl"
                 case .customFileServerPubkey: return "customFileServerPubkey"
@@ -99,7 +97,6 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
             var result: [ListItem] = []
             switch ListItem.shortenFileTTL {
                 case .shortenFileTTL: result.append(.shortenFileTTL); fallthrough
-                case .useStreamEncryptionForAttachments: result.append(.useStreamEncryptionForAttachments); fallthrough
                 case .shareDownloadedFile: result.append(.shareDownloadedFile); fallthrough
                 case .customFileServerUrl: result.append(.customFileServerUrl); fallthrough
                 case .customFileServerPubkey: result.append(.customFileServerPubkey)
@@ -114,17 +111,14 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
     public struct State: Equatable, ObservableKeyProvider {
         struct Info: Equatable, Hashable {
             let shortenFileTTL: Bool
-            let useStreamEncryptionForAttachments: Bool
             let customFileServer: Network.FileServer.Custom
             
             public func with(
                 shortenFileTTL: Bool? = nil,
-                useStreamEncryptionForAttachments: Bool? = nil,
                 customFileServer: Network.FileServer.Custom? = nil
             ) -> Info {
                 return Info(
                     shortenFileTTL: (shortenFileTTL ?? self.shortenFileTTL),
-                    useStreamEncryptionForAttachments: (useStreamEncryptionForAttachments ?? self.useStreamEncryptionForAttachments),
                     customFileServer: (customFileServer ?? self.customFileServer)
                 )
             }
@@ -144,14 +138,12 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
         public let observedKeys: Set<ObservableKey> = [
             .updateScreen(DeveloperSettingsFileServerViewModel.self),
             .feature(.shortenFileTTL),
-            .feature(.useStreamEncryptionForAttachments),
             .feature(.customFileServer)
         ]
         
         static func initialState(using dependencies: Dependencies) -> State {
             let initialInfo: Info = Info(
                 shortenFileTTL: dependencies[feature: .shortenFileTTL],
-                useStreamEncryptionForAttachments: dependencies[feature: .useStreamEncryptionForAttachments],
                 customFileServer: dependencies[feature: .customFileServer]
             )
             
@@ -238,31 +230,6 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
                             key: .updateScreen(DeveloperSettingsFileServerViewModel.self),
                             value: state.pendingState.with(
                                 shortenFileTTL: !state.pendingState.shortenFileTTL
-                            )
-                        )
-                    }
-                ),
-                SessionListScreenContent.ListItemInfo(
-                    id: .useStreamEncryptionForAttachments,
-                    variant: .cell(
-                        info: ListItemCell.Info(
-                            title: SessionListScreenContent.TextInfo("Use Stream Encryption for Attachments", font: .Body.largeBold),
-                            description: .htmlTagged("""
-                            Controls whether attachments and display pictures should use the new stream encryption when uploading
-                            
-                            <warn>Warning: Old clients won't be able to decrypt attachments sent while this is enabled</warn>
-                            """),
-                            trailingAccessory: .toggle(
-                                state.pendingState.useStreamEncryptionForAttachments,
-                                oldValue: previousState.pendingState.useStreamEncryptionForAttachments
-                            )
-                        )
-                    ),
-                    onTap: { [dependencies = viewModel.dependencies] in
-                        dependencies.notifyAsync(
-                            key: .updateScreen(DeveloperSettingsFileServerViewModel.self),
-                            value: state.pendingState.with(
-                                useStreamEncryptionForAttachments: !state.pendingState.useStreamEncryptionForAttachments
                             )
                         )
                     }
@@ -607,8 +574,7 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
     
     public static func disableDeveloperMode(using dependencies: Dependencies) {
         let features: [FeatureConfig<Bool>] = [
-            .shortenFileTTL,
-            .useStreamEncryptionForAttachments
+            .shortenFileTTL
         ]
         
         features.forEach { feature in
@@ -629,13 +595,6 @@ class DeveloperSettingsFileServerViewModel: SessionListScreenContent.ViewModelTy
         
         if internalState.initialState.shortenFileTTL != internalState.pendingState.shortenFileTTL {
             dependencies.set(feature: .shortenFileTTL, to: internalState.pendingState.shortenFileTTL)
-        }
-        
-        if internalState.initialState.useStreamEncryptionForAttachments != internalState.pendingState.useStreamEncryptionForAttachments {
-            dependencies.set(
-                feature: .useStreamEncryptionForAttachments,
-                to: internalState.pendingState.useStreamEncryptionForAttachments
-            )
         }
         
         if internalState.initialState.customFileServer != internalState.pendingState.customFileServer {

--- a/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
+++ b/Session/Settings/DeveloperSettings/DeveloperSettingsViewModel.swift
@@ -480,7 +480,6 @@ class DeveloperSettingsViewModel: SessionListScreenContent.ViewModelType, Naviga
                             Configure settings related to the File Server.
 
                             <b>File TTL:</b> <span>\(dependencies[feature: .shortenFileTTL] ? "60 Seconds" : "14 Days")</span>
-                            <b>Stream Encryption:</b> <span>\(dependencies[feature: .useStreamEncryptionForAttachments] ? "Enabled" : "Disabled")</span>
                             <b>File Server:</b> <span>\(Network.FileServer.server(using: dependencies))</span>
                             """),
                             trailingAccessory: .icon(.chevronRight)

--- a/SessionMessagingKit/Crypto/Crypto+Attachments.swift
+++ b/SessionMessagingKit/Crypto/Crypto+Attachments.swift
@@ -26,7 +26,6 @@ public extension Crypto {
 }
 
 public extension Crypto.Generator {
-    private static var hmac256KeyLength: Int { 32 }
     private static var hmac256OutputLength: Int { 32 }
     private static var aesCBCIvLength: Int { 16 }
     private static var aesKeySize: Int { 32 }
@@ -77,136 +76,6 @@ public extension Crypto.Generator {
             return (Data(cEncryptedData), Data(cEncryptionKey))
         }
     }
-    
-    @available(*, deprecated, message: "This encryption method is deprecated and will be removed in a future release.")
-    static func legacyExpectedEncryptedAttachmentSize(
-        plaintextSize: Int
-    ) -> Crypto.Generator<Int> {
-        return Crypto.Generator(
-            id: "legacyExpectedEncryptedAttachmentSize",
-            args: [plaintextSize]
-        ) { dependencies in
-            return max(541, Int(floor(pow(1.05, ceil(log(Double(plaintextSize)) / log(1.05))))))
-        }
-    }
-    
-    @available(*, deprecated, message: "This encryption method is deprecated and will be removed in a future release.")
-    static func legacyEncryptedAttachment(
-        plaintext: Data
-    ) -> Crypto.Generator<(ciphertext: Data, encryptionKey: Data, digest: Data)> {
-        return Crypto.Generator(
-            id: "legacyEncryptedAttachment",
-            args: [plaintext]
-        ) { dependencies in
-            // Due to paddedSize, we need to divide by two.
-            guard
-                plaintext.count < (UInt.max / 2),
-                var iv: [UInt8] = dependencies[singleton: .crypto].generate(.randomBytes(aesCBCIvLength)),
-                var encryptionKey: [UInt8] = dependencies[singleton: .crypto].generate(.randomBytes(aesKeySize)),
-                var hmacKey: [UInt8] = dependencies[singleton: .crypto].generate(.randomBytes(hmac256KeyLength))
-            else { throw AttachmentError.legacyEncryptionFailed }
-
-            // The concatenated key for storage
-            var outKey: Data = Data()
-            outKey.append(Data(encryptionKey))
-            outKey.append(Data(hmacKey))
-
-            // Apply any padding
-            let desiredSize: Int = max(541, min(Int(Network.maxFileSize), Int(floor(pow(1.05, ceil(log(Double(plaintext.count)) / log(1.05)))))))
-            var paddedAttachmentData: [UInt8] = Array(plaintext)
-            if desiredSize > plaintext.count {
-                paddedAttachmentData.append(contentsOf: [UInt8](repeating: 0, count: desiredSize - plaintext.count))
-            }
-            
-            var numBytesEncrypted: size_t = 0
-            var bufferData: [UInt8] = Array(Data(count: paddedAttachmentData.count + kCCBlockSizeAES128))
-            let cryptStatus: CCCryptorStatus = CCCrypt(
-                CCOperation(kCCEncrypt),
-                CCAlgorithm(kCCAlgorithmAES128),
-                CCOptions(kCCOptionPKCS7Padding),
-                &encryptionKey, encryptionKey.count,
-                &iv,
-                &paddedAttachmentData, paddedAttachmentData.count,
-                &bufferData, bufferData.count,
-                &numBytesEncrypted
-            )
-
-            guard
-                cryptStatus == kCCSuccess,
-                bufferData.count >= numBytesEncrypted
-            else { throw AttachmentError.legacyEncryptionFailed }
-            
-            let ciphertext: [UInt8] = Array(bufferData[0..<numBytesEncrypted])
-            var encryptedPaddedData: [UInt8] = (iv + ciphertext)
-
-            // compute hmac of: iv || encrypted data
-            guard
-                encryptedPaddedData.count < (UInt.max / 2),
-                hmacKey.count < (UInt.max / 2)
-            else { throw AttachmentError.legacyEncryptionFailed }
-            
-            var hmacDataBuffer: [UInt8] = Array(Data(count: Int(CC_SHA256_DIGEST_LENGTH)))
-            CCHmac(
-                CCHmacAlgorithm(kCCHmacAlgSHA256),
-                &hmacKey,
-                hmacKey.count,
-                &encryptedPaddedData,
-                encryptedPaddedData.count,
-                &hmacDataBuffer
-            )
-            let hmac: [UInt8] = Array(hmacDataBuffer[0..<hmac256OutputLength])
-            encryptedPaddedData.append(contentsOf: hmac)
-
-            // compute digest of: iv || encrypted data || hmac
-            guard encryptedPaddedData.count < UInt32.max else {
-                throw AttachmentError.legacyEncryptionFailed
-            }
-            
-            var digest: [UInt8] = Array(Data(count: Int(CC_SHA256_DIGEST_LENGTH)))
-            CC_SHA256(&encryptedPaddedData, UInt32(encryptedPaddedData.count), &digest)
-            
-            return (Data(encryptedPaddedData), outKey, Data(digest))
-        }
-    }
-    
-    @available(*, deprecated, message: "This encryption method is deprecated and will be removed in a future release.")
-    static func legacyEncryptedDisplayPictureSize(
-        plaintextSize: Int
-    ) -> Crypto.Generator<Int> {
-        return Crypto.Generator(
-            id: "legacyEncryptedDisplayPictureSize",
-            args: [plaintextSize]
-        ) { dependencies in
-            return (plaintextSize + DisplayPictureManager.nonceLength + DisplayPictureManager.tagLength)
-        }
-    }
-    
-    @available(*, deprecated, message: "This encryption method is deprecated and will be removed in a future release.")
-    static func legacyEncryptedDisplayPicture(
-        data: Data,
-        key: Data
-    ) -> Crypto.Generator<Data> {
-        return Crypto.Generator(
-            id: "legacyEncryptedDisplayPicture",
-            args: [data, key]
-        ) { dependencies in
-            // The key structure is: nonce || ciphertext || authTag
-            guard
-                key.count == DisplayPictureManager.encryptionKeySize,
-                let nonceData: Data = dependencies[singleton: .crypto]
-                    .generate(.randomBytes(DisplayPictureManager.nonceLength)),
-                let nonce: AES.GCM.Nonce = try? AES.GCM.Nonce(data: nonceData),
-                let sealedData: AES.GCM.SealedBox = try? AES.GCM.seal(
-                    data,
-                    using: SymmetricKey(data: key),
-                    nonce: nonce
-                ),
-                let encryptedContent: Data = sealedData.combined
-            else { throw CryptoError.failedToGenerateOutput }
-
-            return encryptedContent
-        }
-    }
 }
 
 // MARK: - Decryption
@@ -241,7 +110,9 @@ public extension Crypto.Generator {
                 throw CryptoError.decryptionFailed
             }
             
-            return Data(cDecryptedData)
+            /// Padding is stripped during decryption, so the buffer sized from `decrypted_max_size` is
+            /// generally longer than the result
+            return Data(cDecryptedData[0..<cDecryptedSize])
         }
     }
     

--- a/SessionMessagingKit/Jobs/AttachmentDownloadJob.swift
+++ b/SessionMessagingKit/Jobs/AttachmentDownloadJob.swift
@@ -216,8 +216,12 @@ public enum AttachmentDownloadJob: JobExecutor {
         try Task.checkCancellation()
         
         /// Decrypt the data if needed
-        switch (attachment.encryptionKey, attachment.digest, parsedDownloadUrl.wantsStreamDecryption) {
-            case (.some(let key), .some(let digest), false) where !key.isEmpty:
+        switch try AttachmentDownloadJob.decryptionFormat(
+            encryptionKey: attachment.encryptionKey,
+            digest: attachment.digest,
+            wantsStreamDecryption: parsedDownloadUrl.wantsStreamDecryption
+        ) {
+            case .legacy(let key, let digest):
                 let ciphertext: Data = try dependencies[singleton: .fileManager].contents(atPath: response.temporaryFilePath)
                 let plaintext: Data = try dependencies[singleton: .crypto].tryGenerate(
                     .legacyDecryptAttachment(
@@ -234,7 +238,7 @@ public enum AttachmentDownloadJob: JobExecutor {
                     throw AttachmentDownloadError.failedToSaveFile
                 }
                 
-            case (.some(let key), _, true) where !key.isEmpty:
+            case .stream(let key):
                 guard
                     let downloadUrl: String = attachment.downloadUrl,
                     let finalPath: String = try? dependencies[singleton: .attachmentManager]
@@ -249,8 +253,7 @@ public enum AttachmentDownloadJob: JobExecutor {
                     )
                 )
                 
-            default:
-                /// File is in plaintext so just move it to the destination
+            case .plaintext:
                 guard
                     let finalPath: String = try? dependencies[singleton: .attachmentManager]
                         .path(for: parsedDownloadUrl.originalUrlString)
@@ -316,13 +319,47 @@ extension AttachmentDownloadJob {
         }
     }
     
+    /// The download url is the only thing that records which encryption an attachment was uploaded
+    /// with, so a key that cannot be paired with a format means the url did not describe its own
+    /// content - treating that as plaintext would write the ciphertext to the attachment's path and
+    /// report the download as successful
+    enum DecryptionFormat: Equatable {
+        case legacy(key: Data, digest: Data)
+        case stream(key: Data)
+        case plaintext
+    }
+    
+    static func decryptionFormat(
+        encryptionKey: Data?,
+        digest: Data?,
+        wantsStreamDecryption: Bool
+    ) throws -> DecryptionFormat {
+        switch (encryptionKey, digest, wantsStreamDecryption) {
+            case (.some(let key), .some(let digest), false) where !key.isEmpty:
+                return .legacy(key: key, digest: digest)
+                
+            case (.some(let key), _, true) where !key.isEmpty:
+                return .stream(key: key)
+                
+            case (.some(let key), _, _) where !key.isEmpty:
+                throw AttachmentDownloadError.unknownEncryptionFormat
+                
+            /// Community attachments carry no key, so they really are in plaintext
+            default:
+                return .plaintext
+        }
+    }
+    
     public enum AttachmentDownloadError: LocalizedError {
         case failedToSaveFile
+        case unknownEncryptionFormat
 
         // stringlint:ignore_contents
         public var errorDescription: String? {
             switch self {
                 case .failedToSaveFile: return "Failed to save file"
+                case .unknownEncryptionFormat:
+                    return "Attachment has an encryption key but the download url did not indicate its format"
             }
         }
     }

--- a/SessionMessagingKit/Sending & Receiving/Errors/AttachmentError.swift
+++ b/SessionMessagingKit/Sending & Receiving/Errors/AttachmentError.swift
@@ -10,7 +10,6 @@ public enum AttachmentError: Error, CustomStringConvertible {
     case noAttachment
     case notUploaded
     case encryptionFailed
-    case legacyEncryptionFailed
     case legacyDecryptionFailed
     case notEncrypted
     case uploadFailed
@@ -46,7 +45,6 @@ public enum AttachmentError: Error, CustomStringConvertible {
             case .noAttachment: return "No such attachment."
             case .notUploaded: return "Attachment not uploaded."
             case .encryptionFailed: return "Couldn't encrypt file."
-            case .legacyEncryptionFailed: return "Couldn't encrypt file (legacy)."
             case .legacyDecryptionFailed: return "Couldn't decrypt file (legacy)."
             case .notEncrypted: return "File not encrypted."
             case .uploadFailed: return "Upload failed."

--- a/SessionMessagingKit/Utilities/AttachmentManager.swift
+++ b/SessionMessagingKit/Utilities/AttachmentManager.swift
@@ -886,30 +886,12 @@ public extension PendingAttachment {
     
     func ensureExpectedEncryptedSize(
         logCat: Log.Category,
-        domain: Crypto.AttachmentDomain,
         maxFileSize: UInt,
         using dependencies: Dependencies
     ) throws {
-        let encryptedSize: UInt
-        
-        if dependencies[feature: .useStreamEncryptionForAttachments] {
-            encryptedSize = UInt(try dependencies[singleton: .crypto].tryGenerate(
-                .expectedEncryptedAttachmentSize(plaintextSize: Int(fileSize))
-            ))
-        }
-        else {
-            switch domain {
-                case .attachment:
-                    encryptedSize = UInt(try dependencies[singleton: .crypto].tryGenerate(
-                        .legacyExpectedEncryptedAttachmentSize(plaintextSize: Int(fileSize))
-                    ))
-                    
-                case .profilePicture:
-                    encryptedSize = UInt(try dependencies[singleton: .crypto].tryGenerate(
-                        .legacyEncryptedDisplayPictureSize(plaintextSize: Int(fileSize))
-                    ))
-            }
-        }
+        let encryptedSize: UInt = UInt(try dependencies[singleton: .crypto].tryGenerate(
+            .expectedEncryptedAttachmentSize(plaintextSize: Int(fileSize))
+        ))
         
         /// May as well throw here if we know the attachment is too large to send
         guard encryptedSize <= maxFileSize else {
@@ -988,60 +970,23 @@ public extension PendingAttachment {
         /// May as well throw here if we know the attachment is too large to send
         try ensureExpectedEncryptedSize(
             logCat: logCat,
-            domain: encryptionDomain,
             maxFileSize: Network.maxFileSize,
             using: dependencies
         )
         
-        /// Encrypt the data using either the legacy or updated encryption
-        typealias EncryptionData = (ciphertext: Data, encryptionKey: Data, digest: Data)
+        typealias EncryptionData = (ciphertext: Data, encryptionKey: Data)
         let (encryptedData, finalByteCount): (EncryptionData, UInt) = try autoreleasepool {
             do {
-                let result: EncryptionData
-                let finalByteCount: UInt
                 let plaintext: Data = try dependencies[singleton: .fileManager].contents(atPath: filePath)
+                let encryptionResult = try dependencies[singleton: .crypto].tryGenerate(
+                    .encryptAttachment(plaintext: plaintext, domain: encryptionDomain)
+                )
+                let result: EncryptionData = (encryptionResult.ciphertext, encryptionResult.encryptionKey)
                 
-                if dependencies[feature: .useStreamEncryptionForAttachments] {
-                    let encryptionResult = try dependencies[singleton: .crypto].tryGenerate(
-                        .encryptAttachment(plaintext: plaintext, domain: encryptionDomain)
-                    )
-                    
-                    /// Ideally we would set this to the `ciphertext` size so that the "download file" UI is accurate but then we'd
-                    /// need to update it after the download to be the `plaintext` so the "message info" UI was accurate - this
-                    /// also (currently) causes issues on Desktop so for the time being just stick with the `plaintext` size
-                    finalByteCount = UInt(preparedFileSize ?? 0)
-                    result = (encryptionResult.ciphertext, encryptionResult.encryptionKey, Data())
-                }
-                else {
-                    switch encryptionDomain {
-                        case .attachment:
-                            result = try dependencies[singleton: .crypto].tryGenerate(
-                                .legacyEncryptedAttachment(plaintext: plaintext)
-                            )
-                            
-                            /// For legacy attachments we need to set `byteCount` to the size of the data prior to encryption in
-                            /// order to be able to strip the padding correctly
-                            finalByteCount = UInt(preparedFileSize ?? 0)
-                            
-                        case .profilePicture:
-                            let encryptionKey: Data = try dependencies[singleton: .crypto]
-                                .tryGenerate(.randomBytes(DisplayPictureManager.encryptionKeySize))
-                            let ciphertext: Data = try dependencies[singleton: .crypto].tryGenerate(
-                                .legacyEncryptedDisplayPicture(data: plaintext, key: encryptionKey)
-                            )
-                            
-                            /// Ideally we would set this to the `ciphertext` size so that the "download file" UI is accurate but then we'd
-                            /// need to update it after the download to be the `plaintext` so the "message info" UI was accurate - this
-                            /// also (currently) causes issues on Desktop so for the time being just stick with the `plaintext` size
-                            finalByteCount = UInt(preparedFileSize ?? 0)
-                            result = (ciphertext, encryptionKey, Data())
-                    }
-                    
-                    /// Since the legacy encryption is a little more questionable we should double check the ciphertext size
-                    guard result.ciphertext.count <= Network.maxFileSize else {
-                        throw AttachmentError.fileSizeTooLarge
-                    }
-                }
+                /// Ideally we would set this to the `ciphertext` size so that the "download file" UI is accurate but then we'd
+                /// need to update it after the download to be the `plaintext` so the "message info" UI was accurate - this
+                /// also (currently) causes issues on Desktop so for the time being just stick with the `plaintext` size
+                let finalByteCount: UInt = UInt(preparedFileSize ?? 0)
                 
                 /// Since we successfully encrypted the data we can remove the file with the unencrypted content and replace it with
                 /// the encrypted content
@@ -1066,7 +1011,7 @@ public extension PendingAttachment {
                 downloadUrl: filePath,
                 byteCount: finalByteCount,
                 encryptionKey: encryptedData.encryptionKey,
-                digest: encryptedData.digest,
+                digest: nil,
                 using: dependencies
             ),
             filePath: filePath

--- a/SessionMessagingKitTests/Crypto/CryptoAttachmentsSpec.swift
+++ b/SessionMessagingKitTests/Crypto/CryptoAttachmentsSpec.swift
@@ -1,0 +1,296 @@
+// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import SessionUtilitiesKit
+import TestUtilities
+
+import Quick
+import Nimble
+
+@testable import SessionMessagingKit
+
+/// Content encrypted the legacy way stays on the file server indefinitely, so both legacy formats have
+/// to keep decrypting long after nothing writes them. The legacy vectors here were produced externally
+/// rather than by a round trip, so they still describe the wire format now that the encrypting half is
+/// gone.
+class CryptoAttachmentsSpec: AsyncSpec {
+    override class func spec() {
+        @TestState var dependencies: TestDependencies! = TestDependencies()
+        @TestState var crypto: Crypto! = Crypto(using: dependencies)
+        @TestState var mockGeneralCache: MockGeneralCache! = .create(using: dependencies)
+        
+        beforeEach {
+            dependencies.set(singleton: .crypto, to: crypto)
+            dependencies.set(cache: .general, to: mockGeneralCache)
+            try await mockGeneralCache.defaultInitialSetup()
+        }
+        
+        /// 32-byte AES key ‖ 32-byte HMAC key
+        let legacyAttachmentKey: Data = Data(
+            hex: String(repeating: "11", count: 32) + String(repeating: "22", count: 32)
+        )
+        /// IV ‖ AES-256-CBC(PKCS7) ‖ HMAC-SHA256(IV ‖ ciphertext), over a 541-byte zero-padded plaintext
+        let legacyAttachmentCiphertext: Data = Data(hex: [
+            "333333333333333333333333333333330ee1ed4f89c70232caed52b8765365ff",
+            "e904557d3c61038c97bdb5bee3189fc6f53aac97422dc92d8693c0a72b3aa362",
+            "01d1bd3a6dd6164a09154ae87aa95888066a80449e211fc64a69c04b0f9ddce0",
+            "2f144fbea3a731ded616d0436b2fd6ec908f89ebf85d15bad69bdaa66827f0b3",
+            "484b7425d383f7136e3c911881731c043863f49f5ada6f85f8fa456efd08a2db",
+            "8c7b510cb04a225035db36e21660f5274939dc09639ffd30cc36ac9fc8776761",
+            "5a93ab017c028a8bdf2dd7ef48c245b846c7cd4942866d77b056a2a59924d426",
+            "4d1e1d23b8c5ed598f23ada8a905c5579383581203db2c5f60c434551992162f",
+            "b9f36105a91515c5472105c64f3c111a16c745bbca3e810460319b3124c430ca",
+            "3d87f4fd9400502cd62d7e782ee5eebf4656f4acd84a9ae964e0f40804dea71d",
+            "675eb620a2659094b52a3bdf9b36c8ac66ffcbbb129749e5394eabf4b8708249",
+            "12cf7966797621b0ca073baf66d500d5589649b89d5298855471178c724907d2",
+            "5e5812ea7cbf4d9fdf19319eeba03b491cf2857a388ef861ea11e83876d43751",
+            "fbbc80aaf205e5d937e9dcc046f9aaf3ee56b6a627a5a474e1ac5cde5a12e52a",
+            "fd23fcdadeb591aa06f374bd84edf8a5d61151df711ed8fbded86f0b23c28ef4",
+            "414b99d422c4bf95f30f1f18b274c42d9e61a48f63a754d100c7bf64fc88f469",
+            "407560f167919c9d5f10d5a343dff87e753ab281e57073fce95481d2b8c4da0e",
+            "5f0d13c67d802c1733c232e3d520f38a4f9d5a43c6ce60843288322b883d7d24",
+            "796efd75c676cb02a5b6148ea737534d"
+        ].joined())
+        let legacyAttachmentDigest: Data = Data(
+            hex: "ee65e6417b452d017a4d8e2ce984883c1f7dc8d920d7551f0e2d2af7606bd9a9"
+        )
+        let legacyAttachmentPlaintext: Data = "legacy attachment payload".data(using: .utf8)!
+        
+        /// nonce ‖ AES-GCM ciphertext ‖ tag
+        let legacyDisplayPictureKey: Data = Data(hex: String(repeating: "44", count: 32))
+        let legacyDisplayPictureCiphertext: Data = Data(
+            hex: "5555555555555555555555554478a06908c0ab29f4a320e4eb849d7b895486cb" +
+                 "6f84114414cc1ae0a9b6c0226544ba88d842ee49bc6de829c8c1"
+        )
+        let legacyDisplayPicturePlaintext: Data = "legacy display picture payload".data(using: .utf8)!
+        
+        // MARK: - Attachment Crypto
+        describe("Attachment Crypto") {
+            // MARK: -- when decrypting legacy attachments
+            context("when decrypting legacy attachments") {
+                // MARK: ---- strips the sender's padding using the unpadded size
+                it("strips the sender's padding using the unpadded size") {
+                    let result: Data = try crypto.tryGenerate(
+                        .legacyDecryptAttachment(
+                            ciphertext: legacyAttachmentCiphertext,
+                            key: legacyAttachmentKey,
+                            digest: legacyAttachmentDigest,
+                            unpaddedSize: UInt(legacyAttachmentPlaintext.count)
+                        )
+                    )
+                    
+                    expect(result).to(equal(legacyAttachmentPlaintext))
+                }
+                
+                // MARK: ---- keeps the padding when no unpadded size is known
+                it("keeps the padding when no unpadded size is known") {
+                    /// Clients from before the size was on the pointer sent `0`, and the padding is
+                    /// indistinguishable from content at that point, so it has to be kept
+                    let result: Data = try crypto.tryGenerate(
+                        .legacyDecryptAttachment(
+                            ciphertext: legacyAttachmentCiphertext,
+                            key: legacyAttachmentKey,
+                            digest: legacyAttachmentDigest,
+                            unpaddedSize: 0
+                        )
+                    )
+                    
+                    expect(result.count).to(equal(541))
+                    expect(result.prefix(legacyAttachmentPlaintext.count)).to(equal(legacyAttachmentPlaintext))
+                }
+                
+                // MARK: ---- fails on a tampered ciphertext
+                it("fails on a tampered ciphertext") {
+                    var tampered: Data = legacyAttachmentCiphertext
+                    tampered[20] = tampered[20] &+ 1
+                    
+                    expect {
+                        try crypto.tryGenerate(
+                            .legacyDecryptAttachment(
+                                ciphertext: tampered,
+                                key: legacyAttachmentKey,
+                                digest: legacyAttachmentDigest,
+                                unpaddedSize: UInt(legacyAttachmentPlaintext.count)
+                            )
+                        )
+                    }.to(throwError(AttachmentError.legacyDecryptionFailed))
+                }
+                
+                // MARK: ---- fails on a mismatched digest
+                it("fails on a mismatched digest") {
+                    expect {
+                        try crypto.tryGenerate(
+                            .legacyDecryptAttachment(
+                                ciphertext: legacyAttachmentCiphertext,
+                                key: legacyAttachmentKey,
+                                digest: Data(hex: String(repeating: "00", count: 32)),
+                                unpaddedSize: UInt(legacyAttachmentPlaintext.count)
+                            )
+                        )
+                    }.to(throwError(AttachmentError.legacyDecryptionFailed))
+                }
+            }
+            
+            // MARK: -- when decrypting legacy display pictures
+            context("when decrypting legacy display pictures") {
+                // MARK: ---- returns the original data
+                it("returns the original data") {
+                    let result: Data = try crypto.tryGenerate(
+                        .legacyDecryptedDisplayPicture(
+                            data: legacyDisplayPictureCiphertext,
+                            key: legacyDisplayPictureKey
+                        )
+                    )
+                    
+                    expect(result).to(equal(legacyDisplayPicturePlaintext))
+                }
+                
+                // MARK: ---- fails with the wrong key
+                it("fails with the wrong key") {
+                    expect {
+                        try crypto.tryGenerate(
+                            .legacyDecryptedDisplayPicture(
+                                data: legacyDisplayPictureCiphertext,
+                                key: Data(hex: String(repeating: "45", count: 32))
+                            )
+                        )
+                    }.to(throwError(CryptoError.failedToGenerateOutput))
+                }
+            }
+            
+            // MARK: -- when choosing a decryption format
+            context("when choosing a decryption format") {
+                // MARK: ---- picks legacy for a key and digest with no stream fragment
+                it("picks legacy for a key and digest with no stream fragment") {
+                    expect(
+                        try AttachmentDownloadJob.decryptionFormat(
+                            encryptionKey: legacyAttachmentKey,
+                            digest: legacyAttachmentDigest,
+                            wantsStreamDecryption: false
+                        )
+                    ).to(equal(.legacy(key: legacyAttachmentKey, digest: legacyAttachmentDigest)))
+                }
+                
+                // MARK: ---- picks stream when the url says so, with or without a digest
+                it("picks stream when the url says so, with or without a digest") {
+                    let key: Data = Data(hex: String(repeating: "66", count: 32))
+                    
+                    expect(
+                        try AttachmentDownloadJob.decryptionFormat(
+                            encryptionKey: key,
+                            digest: nil,
+                            wantsStreamDecryption: true
+                        )
+                    ).to(equal(.stream(key: key)))
+                    
+                    /// A digest is meaningless for this format, but older senders left an empty one on
+                    /// the pointer so it must not change the decision
+                    expect(
+                        try AttachmentDownloadJob.decryptionFormat(
+                            encryptionKey: key,
+                            digest: Data(),
+                            wantsStreamDecryption: true
+                        )
+                    ).to(equal(.stream(key: key)))
+                }
+                
+                // MARK: ---- picks plaintext when there is no key
+                it("picks plaintext when there is no key") {
+                    expect(
+                        try AttachmentDownloadJob.decryptionFormat(
+                            encryptionKey: nil,
+                            digest: nil,
+                            wantsStreamDecryption: false
+                        )
+                    ).to(equal(.plaintext))
+                    
+                    /// Community attachments come through with an empty key rather than a missing one
+                    expect(
+                        try AttachmentDownloadJob.decryptionFormat(
+                            encryptionKey: Data(),
+                            digest: nil,
+                            wantsStreamDecryption: false
+                        )
+                    ).to(equal(.plaintext))
+                }
+                
+                // MARK: ---- throws for a key it cannot pair with a format
+                it("throws for a key it cannot pair with a format") {
+                    /// This is what a url whose stream fragment we failed to recognise looks like, and
+                    /// storing it as plaintext would save the ciphertext and report success
+                    expect {
+                        try AttachmentDownloadJob.decryptionFormat(
+                            encryptionKey: Data(hex: String(repeating: "66", count: 32)),
+                            digest: nil,
+                            wantsStreamDecryption: false
+                        )
+                    }.to(throwError(AttachmentDownloadJob.AttachmentDownloadError.unknownEncryptionFormat))
+                }
+            }
+            
+            // MARK: -- when using stream encryption
+            context("when using stream encryption") {
+                // MARK: ---- round trips an attachment
+                it("round trips an attachment") {
+                    let plaintext: Data = "stream attachment payload".data(using: .utf8)!
+                    let encrypted = try crypto.tryGenerate(
+                        .encryptAttachment(plaintext: plaintext, domain: .attachment)
+                    )
+                    
+                    expect(encrypted.ciphertext.first).to(equal(0x53))     /// the 'S' identifier
+                    expect(encrypted.encryptionKey.count).to(equal(32))
+                    expect(encrypted.ciphertext.count).to(equal(
+                        try crypto.tryGenerate(.expectedEncryptedAttachmentSize(plaintextSize: plaintext.count))
+                    ))
+                    
+                    let decrypted: Data = try crypto.tryGenerate(
+                        .decryptAttachment(ciphertext: encrypted.ciphertext, key: encrypted.encryptionKey)
+                    )
+                    
+                    expect(decrypted).to(equal(plaintext))
+                }
+                
+                // MARK: ---- gives an attachment and a display picture unrelated keys
+                it("gives an attachment and a display picture unrelated keys") {
+                    /// The domain is the blake2b key, so identical bytes from one sender must not
+                    /// produce related ciphertext across the two uses
+                    let plaintext: Data = "the same bytes, two domains".data(using: .utf8)!
+                    let asAttachment = try crypto.tryGenerate(
+                        .encryptAttachment(plaintext: plaintext, domain: .attachment)
+                    )
+                    let asDisplayPicture = try crypto.tryGenerate(
+                        .encryptAttachment(plaintext: plaintext, domain: .profilePicture)
+                    )
+                    
+                    expect(asAttachment.encryptionKey).toNot(equal(asDisplayPicture.encryptionKey))
+                    expect(asAttachment.ciphertext).toNot(equal(asDisplayPicture.ciphertext))
+                    
+                    expect {
+                        try crypto.tryGenerate(
+                            .decryptAttachment(
+                                ciphertext: asAttachment.ciphertext,
+                                key: asDisplayPicture.encryptionKey
+                            )
+                        )
+                    }.to(throwError(CryptoError.decryptionFailed))
+                }
+                
+                // MARK: ---- produces the same ciphertext for the same content
+                it("produces the same ciphertext for the same content") {
+                    /// Deduplication on the file server depends on this, and it is the reason display
+                    /// pictures can be re-uploaded without changing their URL
+                    let plaintext: Data = "repeatable".data(using: .utf8)!
+                    let first = try crypto.tryGenerate(
+                        .encryptAttachment(plaintext: plaintext, domain: .profilePicture)
+                    )
+                    let second = try crypto.tryGenerate(
+                        .encryptAttachment(plaintext: plaintext, domain: .profilePicture)
+                    )
+                    
+                    expect(first.ciphertext).to(equal(second.ciphertext))
+                    expect(first.encryptionKey).to(equal(second.encryptionKey))
+                }
+            }
+        }
+    }
+}

--- a/SessionMessagingKitTests/Sending & Receiving/MessageSenderGroupsSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageSenderGroupsSpec.swift
@@ -227,11 +227,14 @@ class MessageSenderGroupsSpec: AsyncSpec {
                 .when { $0.generate(.uuid()) }
                 .thenReturn(UUID(uuidString: "00000000-0000-0000-0000-000000000000")!)
             try await mockCrypto
-                .when { $0.generate(.legacyEncryptedDisplayPictureSize(plaintextSize: .any)) }
+                .when { try $0.tryGenerate(.expectedEncryptedAttachmentSize(plaintextSize: .any)) }
                 .thenReturn(1024)
             try await mockCrypto
-                .when { $0.generate(.legacyEncryptedDisplayPicture(data: .any, key: .any)) }
-                .thenReturn(TestConstants.validImageData)
+                .when { try $0.tryGenerate(.encryptAttachment(plaintext: .any, domain: .profilePicture)) }
+                .thenReturn((
+                    TestConstants.validImageData,
+                    Data((0..<DisplayPictureManager.encryptionKeySize).map { _ in 1 })
+                ))
             try await mockCrypto
                 .when {
                     try $0.generate(

--- a/SessionNetworkingKit/LibSession/LibSession+Networking.swift
+++ b/SessionNetworkingKit/LibSession/LibSession+Networking.swift
@@ -604,7 +604,7 @@ public actor LibSessionNetwork: NetworkType {
                 schemePtr,
                 hostPtr,
                 pubkeyPtr,
-                dependencies[feature: .useStreamEncryptionForAttachments],
+                true,
                 &url,
                 url.count
             )

--- a/SessionNetworkingKitTests/FileServer/FileServerParsedDownloadUrlSpec.swift
+++ b/SessionNetworkingKitTests/FileServer/FileServerParsedDownloadUrlSpec.swift
@@ -1,0 +1,82 @@
+// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+
+import Quick
+import Nimble
+
+@testable import SessionNetworkingKit
+
+/// The download url is the only thing that tells a reader which encryption a file used, so a client that writes
+/// the fragment in a spelling this parser does not recognise uploads content we silently treat as plaintext.
+class FileServerParsedDownloadUrlSpec: QuickSpec {
+    override class func spec() {
+        // MARK: - a FileServer ParsedDownloadUrl
+        describe("a FileServer ParsedDownloadUrl") {
+            // MARK: -- when detecting stream encryption
+            context("when detecting stream encryption") {
+                // MARK: ---- does not want stream decryption with no fragment
+                it("does not want stream decryption with no fragment") {
+                    let result = Network.FileServer.parsedDownloadUrl(
+                        for: "http://filev2.getsession.org/file/abc123"
+                    )
+                    
+                    expect(result?.fileId).to(equal("abc123"))
+                    expect(result?.wantsStreamDecryption).to(beFalse())
+                }
+                
+                // MARK: ---- wants stream decryption for a bare d fragment
+                it("wants stream decryption for a bare d fragment") {
+                    let result = Network.FileServer.parsedDownloadUrl(
+                        for: "http://filev2.getsession.org/file/abc123#d"
+                    )
+                    
+                    expect(result?.wantsStreamDecryption).to(beTrue())
+                }
+                
+                // MARK: ---- wants stream decryption alongside a custom pubkey in either order
+                it("wants stream decryption alongside a custom pubkey in either order") {
+                    let pubkey: String = "0123456789abcdef0123456789abcdef00000000000000000000000000000000"
+                    
+                    expect(
+                        Network.FileServer
+                            .parsedDownloadUrl(for: "http://example.com/file/abc123#d&p=\(pubkey)")?
+                            .wantsStreamDecryption
+                    ).to(beTrue())
+                    expect(
+                        Network.FileServer
+                            .parsedDownloadUrl(for: "http://example.com/file/abc123#p=\(pubkey)&d")?
+                            .wantsStreamDecryption
+                    ).to(beTrue())
+                }
+                
+                // MARK: ---- does not want stream decryption for a d= fragment
+                it("does not want stream decryption for a d= fragment") {
+                    /// Session Desktop builds this fragment with `URLSearchParams`, which serialises a valueless key
+                    /// as `d=`; libSession compares the fragment against `d` exactly, so we do not recognise it.
+                    ///
+                    /// This expectation is the divergence, not the intent — flip it when libSession accepts both
+                    /// spellings, and see `FileServerApis.parseAttachmentUrl` on Android for the shape of that fix.
+                    let result = Network.FileServer.parsedDownloadUrl(
+                        for: "http://filev2.getsession.org/file/abc123#d="
+                    )
+                    
+                    expect(result).toNot(beNil())
+                    expect(result?.fileId).to(equal("abc123"))
+                    expect(result?.wantsStreamDecryption).to(beFalse())
+                }
+                
+                // MARK: ---- does not want stream decryption for a d= fragment beside a custom pubkey
+                it("does not want stream decryption for a d= fragment beside a custom pubkey") {
+                    let result = Network.FileServer.parsedDownloadUrl(
+                        for: "http://example.com/file/abc123#p=0123456789abcdef0123456789abcdef00000000000000000000000000000000&d="
+                    )
+                    
+                    expect(result?.customPubkeyHex)
+                        .to(equal("0123456789abcdef0123456789abcdef00000000000000000000000000000000"))
+                    expect(result?.wantsStreamDecryption).to(beFalse())
+                }
+            }
+        }
+    }
+}

--- a/SessionResilienceTests/SessionResilienceTests.swift
+++ b/SessionResilienceTests/SessionResilienceTests.swift
@@ -593,7 +593,6 @@ class ResilienceTestFixture: FixtureBase {
         }
         
         var encryptionKey: Data?
-        var digest: Data?
         
         /// Need to ensure the `MockFileManager` returns the right amount of content for the upload/download tests
         switch config.variant {
@@ -602,10 +601,9 @@ class ResilienceTestFixture: FixtureBase {
                 .downloadAttachmentConcurrentDownloads:
                 let readFileHandle: TestFileHandle? = (try dependencies[singleton: .fileHandleFactory].create(forReadingFrom: .any) as? TestFileHandle)
                 let encryptionResult = try dependencies[singleton: .crypto].tryGenerate(
-                    .legacyEncryptedAttachment(plaintext: readFileHandle?.data ?? Data())
+                    .encryptAttachment(plaintext: readFileHandle?.data ?? Data(), domain: .attachment)
                 )
                 encryptionKey = encryptionResult.encryptionKey
-                digest = encryptionResult.digest
                 
                 await mockFileManager.removeMocksFor { try $0.contents(atPath: .any) }
                 try await mockFileManager
@@ -650,7 +648,7 @@ class ResilienceTestFixture: FixtureBase {
                     try Attachment.updateAll(
                         db,
                         Attachment.Columns.encryptionKey.set(to: encryptionKey),
-                        Attachment.Columns.digest.set(to: digest)
+                        Attachment.Columns.digest.set(to: Data?.none)
                     )
                 }
                 

--- a/SessionShareExtension/ShareNavController.swift
+++ b/SessionShareExtension/ShareNavController.swift
@@ -220,7 +220,6 @@ final class ShareNavController: UINavigationController {
                 try attachments.forEach { attachment in
                     try attachment.ensureExpectedEncryptedSize(
                         logCat: .media,
-                        domain: .attachment,
                         maxFileSize: Network.maxFileSize,
                         using: dependencies
                     )

--- a/SessionUtilitiesKit/General/Feature.swift
+++ b/SessionUtilitiesKit/General/Feature.swift
@@ -129,10 +129,6 @@ public extension FeatureStorage {
         identifier: "shortenFileTTL"
     )
     
-    static let useStreamEncryptionForAttachments: FeatureConfig<Bool> = Dependencies.create(
-        identifier: "useStreamEncryptionForAttachments"
-    )
-    
     static let simulateAppReviewLimit: FeatureConfig<Bool> = Dependencies.create(
         identifier: "simulateAppReviewLimit"
     )


### PR DESCRIPTION
Attachments and display pictures now always use libSession's stream encryption, and the generated download url always carries the stream fragment.

### What changed

- `useStreamEncryptionForAttachments` and its developer toggle are gone. Nothing selects an encryption format at write time any more, so `ensureExpectedEncryptedSize` no longer takes a domain.
- The legacy encrypt generators are deleted. **Legacy decryption stays** — content encrypted the old way sits on the file server indefinitely and there is no migration that removes it.
- The outgoing pointer no longer carries an empty `digest`. It only ever meant anything for the legacy format, and Android and Desktop both omit it.

### Two bugs found on the way

- **A keyed attachment whose download url did not describe its format was stored as plaintext, and the job reported success.** The ciphertext was written to the attachment's path and nothing surfaced. It now throws. The selection moved into `decryptionFormat(...)` so the case is testable — there is no `AttachmentDownloadJobSpec`, and the comparable `DisplayPictureDownloadJobSpec` is 1181 lines of mock setup.
- `Crypto.Generator.decryptAttachment` returned the whole `decrypted_max_size` buffer instead of truncating to the length libSession reports, so a 25-byte attachment came back as 4053 bytes of plaintext and zero fill. Unreachable today because both download jobs use the file-to-file variant.

### Testing

`SessionMessagingKitTests` + `SessionNetworkingKitTests`: **769 passed, 0 failed**, rebased on `dev`.

New coverage in `CryptoAttachmentsSpec`: legacy attachment decryption (padding kept vs trimmed, tampered ciphertext, mismatched digest), legacy display-picture decryption, stream round trip, domain separation, determinism, and the four `decryptionFormat` cases. Legacy vectors are generated externally rather than by round trip, deliberately — the encrypting half is gone, so a round-trip test would have had nothing to assert against.

Cross-client attachment sending was verified 6/6 by the Appium suite, including both iOS↔Android directions.

### Note for review

This touches `generateDownloadUrl` in `LibSession+Networking.swift`, which #754 also edits — the same call gains a `port` argument there. The two compose (the stream flag and the port are separate arguments) but will conflict textually; whichever lands second wants both changes kept.

Still uncovered: display pictures cross-client, group display pictures, and old content still opening after the change.
