### PR TITLE
fix(pro): drop the proof's version field

### DIFF
--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -169,7 +169,6 @@ public class Message: Codable {
         {
             let proMessageBuilder: SNProtoProMessage.SNProtoProMessageBuilder = SNProtoProMessage.builder()
             let proofBuilder: SNProtoProProof.SNProtoProProofBuilder = SNProtoProProof.builder()
-            proofBuilder.setVersion(UInt32(proProof.version))
             proofBuilder.setRevocationTag(Data(proProof.revocationTag))
             proofBuilder.setRotatingPublicKey(Data(proProof.rotatingPubkey))
             /// The proof expiry now travels as whole seconds on the wire (matches what libsession signs and

--- a/SessionMessagingKit/Messages/Visible Messages/VisibleMessage.swift
+++ b/SessionMessagingKit/Messages/Visible Messages/VisibleMessage.swift
@@ -132,8 +132,6 @@ public final class VisibleMessage: Message {
             .map { proMessage -> ProInfo? in
                 guard
                     let vmProof: SNProtoProProof = proMessage.proof,
-                    vmProof.hasVersion,
-                    vmProof.version <= UInt8.max,    /// Sanity check - Protobuf only supports `UInt32`/`UInt64`
                     vmProof.hasExpiryUnixTs,
                     let vmRevocationTag: Data = vmProof.revocationTag,
                     let vmRotatingPublicKey: Data = vmProof.rotatingPublicKey,
@@ -142,7 +140,6 @@ public final class VisibleMessage: Message {
                 
                 return (
                     Network.SessionPro.ProProof(
-                        version: UInt8(vmProof.version),
                         revocationTag: Array(vmRevocationTag),
                         rotatingPubkey: Array(vmRotatingPublicKey),
                         /// The wire carries whole seconds; convert to our millisecond domain

--- a/SessionMessagingKit/Protos/Generated/SNProto.swift
+++ b/SessionMessagingKit/Protos/Generated/SNProto.swift
@@ -4073,9 +4073,6 @@ extension SNProtoGroupUpdateDeleteMemberContentMessage.SNProtoGroupUpdateDeleteM
     // asBuilder() constructs a builder that reflects the proto's contents.
     @objc public func asBuilder() -> SNProtoProProofBuilder {
         let builder = SNProtoProProofBuilder()
-        if hasVersion {
-            builder.setVersion(version)
-        }
         if let _value = revocationTag {
             builder.setRevocationTag(_value)
         }
@@ -4096,10 +4093,6 @@ extension SNProtoGroupUpdateDeleteMemberContentMessage.SNProtoGroupUpdateDeleteM
         private var proto = SessionProtos_ProProof()
 
         @objc fileprivate override init() {}
-
-        @objc public func setVersion(_ valueParam: UInt32) {
-            proto.version = valueParam
-        }
 
         @objc public func setRevocationTag(_ valueParam: Data) {
             proto.revocationTag = valueParam
@@ -4127,13 +4120,6 @@ extension SNProtoGroupUpdateDeleteMemberContentMessage.SNProtoGroupUpdateDeleteM
     }
 
     fileprivate let proto: SessionProtos_ProProof
-
-    @objc public var version: UInt32 {
-        return proto.version
-    }
-    @objc public var hasVersion: Bool {
-        return proto.hasVersion
-    }
 
     @objc public var revocationTag: Data? {
         guard proto.hasRevocationTag else {

--- a/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
+++ b/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
@@ -1780,19 +1780,13 @@ struct SessionProtos_GroupUpdateDeleteMemberContentMessage {
   fileprivate var _adminSignature: Data? = nil
 }
 
+/// Numbering starts at 2: field 1 was `version`, dropped because a proof's format is its type
+/// rather than a value it carries -- the format is bound into the signature by the domain prefix
+/// it picks, and a future format arrives as its own message/field.
 struct SessionProtos_ProProof {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
-
-  var version: UInt32 {
-    get {return _version ?? 0}
-    set {_version = newValue}
-  }
-  /// Returns true if `version` has been explicitly set.
-  var hasVersion: Bool {return self._version != nil}
-  /// Clears the value of `version`. Subsequent reads from it will return its default value.
-  mutating func clearVersion() {self._version = nil}
 
   /// Opaque identifier of this proof produced by the Session Pro backend
   var revocationTag: Data {
@@ -1814,7 +1808,7 @@ struct SessionProtos_ProProof {
   /// Clears the value of `rotatingPublicKey`. Subsequent reads from it will return its default value.
   mutating func clearRotatingPublicKey() {self._rotatingPublicKey = nil}
 
-  /// Epoch timestamps in milliseconds
+  /// Proof expiry, unix epoch SECONDS (iOS domain keeps ms; boundary converts ×/÷1000)
   var expiryUnixTs: UInt64 {
     get {return _expiryUnixTs ?? 0}
     set {_expiryUnixTs = newValue}
@@ -1838,7 +1832,6 @@ struct SessionProtos_ProProof {
 
   init() {}
 
-  fileprivate var _version: UInt32? = nil
   fileprivate var _revocationTag: Data? = nil
   fileprivate var _rotatingPublicKey: Data? = nil
   fileprivate var _expiryUnixTs: UInt64? = nil
@@ -3728,7 +3721,6 @@ extension SessionProtos_GroupUpdateDeleteMemberContentMessage: SwiftProtobuf.Mes
 extension SessionProtos_ProProof: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ProProof"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "version"),
     2: .same(proto: "revocationTag"),
     3: .same(proto: "rotatingPublicKey"),
     4: .same(proto: "expiryUnixTs"),
@@ -3741,7 +3733,6 @@ extension SessionProtos_ProProof: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularUInt32Field(value: &self._version) }()
       case 2: try { try decoder.decodeSingularBytesField(value: &self._revocationTag) }()
       case 3: try { try decoder.decodeSingularBytesField(value: &self._rotatingPublicKey) }()
       case 4: try { try decoder.decodeSingularUInt64Field(value: &self._expiryUnixTs) }()
@@ -3756,9 +3747,6 @@ extension SessionProtos_ProProof: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    try { if let v = self._version {
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 1)
-    } }()
     try { if let v = self._revocationTag {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 2)
     } }()
@@ -3775,7 +3763,6 @@ extension SessionProtos_ProProof: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 
   static func ==(lhs: SessionProtos_ProProof, rhs: SessionProtos_ProProof) -> Bool {
-    if lhs._version != rhs._version {return false}
     if lhs._revocationTag != rhs._revocationTag {return false}
     if lhs._rotatingPublicKey != rhs._rotatingPublicKey {return false}
     if lhs._expiryUnixTs != rhs._expiryUnixTs {return false}

--- a/SessionMessagingKit/Protos/SessionProtos.proto
+++ b/SessionMessagingKit/Protos/SessionProtos.proto
@@ -369,7 +369,10 @@ message GroupUpdateDeleteMemberContentMessage {
 }
 
 message ProProof {
-  optional uint32 version           = 1;
+  // Numbering starts at 2: field 1 was `version`, dropped because a proof's format is its type
+  // rather than a value it carries -- the format is bound into the signature by the domain prefix
+  // it picks, and a future format arrives as its own message/field.
+
   optional bytes  revocationTag     = 2; // Opaque identifier of this proof produced by the Session Pro backend
   optional bytes  rotatingPublicKey = 3; // Public key whose signatures is authorised to entitle messages with Session Pro
   optional uint64 expiryUnixTs      = 4; // Proof expiry, unix epoch SECONDS (iOS domain keeps ms; boundary converts ×/÷1000)

--- a/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
+++ b/SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift
@@ -20,7 +20,7 @@ extension SessionPro.ProConfig: Mocked {
     public static var any: SessionPro.ProConfig {
         SessionPro.ProConfig(
             rotatingPrivateKey: [.any],
-            proProof: Network.SessionPro.ProProof(version: .any)
+            proProof: Network.SessionPro.ProProof(revocationTag: [.any])
         )
     }
 

--- a/SessionNetworkingKit/SessionPro/SessionPro.swift
+++ b/SessionNetworkingKit/SessionPro/SessionPro.swift
@@ -8,8 +8,6 @@ import SessionUtilitiesKit
 
 public extension Network {
     enum SessionPro {
-        public static let apiVersion: UInt8 = 0
-
         /// The production backend base URL + Ed25519 signing pubkey, which come from libsession (the single
         /// source of truth), replacing the previously hard-coded — and stale — client copies
         ///

--- a/SessionNetworkingKit/SessionPro/Types/ProProof.swift
+++ b/SessionNetworkingKit/SessionPro/Types/ProProof.swift
@@ -6,7 +6,6 @@ import SessionUtilitiesKit
 
 public extension Network.SessionPro {
     struct ProProof: Sendable, Codable, Equatable, Hashable {
-        public let version: UInt8
         public let revocationTag: [UInt8]
         public let rotatingPubkey: [UInt8]
         public let expiryUnixTimestampSeconds: UInt64
@@ -14,7 +13,6 @@ public extension Network.SessionPro {
         
         public var libSessionValue: session_protocol_pro_proof {
             var result: session_protocol_pro_proof = session_protocol_pro_proof()
-            result.version = version
             /// libsession renamed `gen_index_hash` -> `revocation_tag`. The proof expiry is whole
             /// unix seconds on both the C side (`expiry_ts`) and our domain, so this is a direct assign.
             result.set(\.revocation_tag, to: revocationTag)
@@ -28,13 +26,11 @@ public extension Network.SessionPro {
         // MARK: - Initialization
         
         public init(
-            version: UInt8 = Network.SessionPro.apiVersion,
             revocationTag: [UInt8] = [],
             rotatingPubkey: [UInt8] = [],
             expiryUnixTimestampSeconds: UInt64 = 0,
             signature: [UInt8] = []
         ) {
-            self.version = version
             self.revocationTag = revocationTag
             self.rotatingPubkey = rotatingPubkey
             self.expiryUnixTimestampSeconds = expiryUnixTimestampSeconds
@@ -42,7 +38,6 @@ public extension Network.SessionPro {
         }
         
         public init(_ libSessionValue: session_protocol_pro_proof) {
-            version = libSessionValue.version
             /// `revocation_tag` (renamed from `gen_index_hash`); expiry is whole unix seconds on the C side
             revocationTag = libSessionValue.get(\.revocation_tag)
             rotatingPubkey = libSessionValue.get(\.rotating_pubkey)


### PR DESCRIPTION
Propagates the already-merged libsession-util change ([#130](https://github.com/session-foundation/libsession-util/pull/130), `f0b9ab23`) that removes `ProProof::version`.

### Why the field goes

A proof's format is bound into its signature by the 16-byte domain prefix the signer selects (`ProProof_v0_____`). `version` was never part of the signed payload — carrying it alongside as a plain value proved nothing, and could disagree with the format the signature actually attests to.

Protobuf tag **1 is retired, not deleted**. Peers built before the removal still put a `uint32` there, so a new field on tag 1 would be fed their stale version numbers. libsession reports such a proof as `ProStatus::Invalid` and lets the message through *without* Pro content rather than dropping it — so an older peer degrades gracefully instead of the message vanishing.

### Changes

| file | change |
|---|---|
| `SessionMessagingKit/Protos/SessionProtos.proto` | tag 1 retired, with upstream's comment |
| `Protos/Generated/*.swift` | regenerated from the `.proto` — not hand-edited |
| `SessionNetworkingKit/SessionPro/Types/ProProof.swift` | `version` property and its uses removed |
| `SessionMessagingKit/Messages/Message.swift` | drops `proofBuilder.setVersion(...)` |
| `Visible Messages/VisibleMessage.swift` | drops the `hasVersion` guard and the `<= UInt8.max` sanity check |
| `SessionNetworkingKit/SessionPro/SessionPro.swift` | drops `apiVersion`, which existed only to default this field and had no other reader |
| `SessionMessagingKitTests/_TestUtilities/Mocked+SMK.swift` | mock updated |

`apiVersion` is worth calling out separately: it conflated the **transport's** API version with the **proof format**, which are different things. Zero remaining references.

### ⚠️ This cannot build green yet

iOS consumes libsession as the prebuilt `libsession-util-spm` xcframework, pinned at **1.8.0 — which predates this removal** (`git tag --contains f0b9ab23` is empty; the change is only on libsession's `dev`). This needs a libsession release *and* a matching SPM repackage before CI can pass. Expected; merge order is the maintainer's call.

### Verification

**No build was run.** A full Xcode build was not attempted — this box is down to ~18 GiB free and disk is its binding constraint. Review accordingly: the changes are mechanical removals plus regenerated protobuf, but they have not been compiled.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>