### PR TITLE
Media: identify the attachment loading state

### DIFF
--- a/Session/Conversations/Message Cells/Content Views/MediaView.swift
+++ b/Session/Conversations/Message Cells/Content Views/MediaView.swift
@@ -144,6 +144,11 @@ public class MediaView: UIView {
     private let loadingIndicator: MediaLoaderView = {
         let result: MediaLoaderView = MediaLoaderView()
         result.isHidden = true
+        /// Identified so a test can tell a bubble that is still downloading from one that has drawn: the
+        /// bubble itself keeps the same identifier and reserves the eventual image's full size throughout,
+        /// so neither its presence nor its size separates the two states
+        result.isAccessibilityElement = true
+        result.accessibilityIdentifier = "Media loading"
         
         return result
     }()


### PR DESCRIPTION
A media bubble keeps the same accessibility identifier while its image is downloading as it does once
the image has drawn, and reserves the eventual image's full size throughout. From outside the app,
neither its presence nor its size separates the two states — so a check written against it passes on a
spinner.

`MediaView` already identifies its two failure states this way (`Media retry` for a failed download,
`Media invalid` for a file that arrived but would not decode). This adds the third: `Media loading` on
the loading indicator.

Five lines, setting `isAccessibilityElement` and `accessibilityIdentifier` on a view that is already
shown and hidden by the existing state machine. No behaviour change.

## Why

The cross-client attachment matrix in session-appium reported an attachment as rendered while the bubble
was still showing a spinner. The assertion was a screenshot-size floor, which a bubble-sized placeholder
clears — and there was nothing better to key on, because "the media message is present" is true in every
state.

The existing error identifiers are what make a wrong-format read detectable at all: a client reading a
stream-encrypted file as legacy produces bytes that will not decode, which is exactly `Media invalid`.
This closes the remaining gap, so "still downloading" stops being indistinguishable from "finished".

session-android#2186 adds the matching identifiers on that platform, so one cross-platform assertion means
the same thing on both.
