### PR TITLE
Pro: fix the stats counters, and cover them

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -1163,6 +1163,7 @@
 		FDE754A32C9A8FD1002A2623 /* SwarmPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A22C9A8FD1002A2623 /* SwarmPoller.swift */; };
 		FDE754A82C9B964D002A2623 /* MessageReceiverGroupsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A42C9B964D002A2623 /* MessageReceiverGroupsSpec.swift */; };
 		FDE754A92C9B964D002A2623 /* MessageSenderGroupsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A52C9B964D002A2623 /* MessageSenderGroupsSpec.swift */; };
+		AA01F0011000000000000002 /* ProStatsReaderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01F0011000000000000001 /* ProStatsReaderSpec.swift */; };
 		FDE754AA2C9B964D002A2623 /* MessageSenderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754A62C9B964D002A2623 /* MessageSenderSpec.swift */; };
 		FDE754AC2C9B967E002A2623 /* FileMetadataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE754AB2C9B967D002A2623 /* FileMetadataSpec.swift */; };
 		FDA1E0022F0A11B000A11B02 /* FileServerParsedDownloadUrlSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA1E0012F0A11B000A11B01 /* FileServerParsedDownloadUrlSpec.swift */; };
@@ -2822,6 +2823,7 @@
 		FDE754A22C9A8FD1002A2623 /* SwarmPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwarmPoller.swift; sourceTree = "<group>"; };
 		FDE754A42C9B964D002A2623 /* MessageReceiverGroupsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageReceiverGroupsSpec.swift; sourceTree = "<group>"; };
 		FDE754A52C9B964D002A2623 /* MessageSenderGroupsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSenderGroupsSpec.swift; sourceTree = "<group>"; };
+		AA01F0011000000000000001 /* ProStatsReaderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProStatsReaderSpec.swift; path = "SessionMessagingKitTests/SessionPro/ProStatsReaderSpec.swift"; sourceTree = SOURCE_ROOT; };
 		FDE754A62C9B964D002A2623 /* MessageSenderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSenderSpec.swift; sourceTree = "<group>"; };
 		FDE754AB2C9B967D002A2623 /* FileMetadataSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileMetadataSpec.swift; sourceTree = "<group>"; };
 		FDA1E0012F0A11B000A11B01 /* FileServerParsedDownloadUrlSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileServerParsedDownloadUrlSpec.swift; sourceTree = "<group>"; };
@@ -5916,6 +5918,7 @@
 				FD336F6A2CAA29BC00C0B51B /* Pollers */,
 				FDE754A42C9B964D002A2623 /* MessageReceiverGroupsSpec.swift */,
 				FDE754A52C9B964D002A2623 /* MessageSenderGroupsSpec.swift */,
+				AA01F0011000000000000001 /* ProStatsReaderSpec.swift */,
 				FDE754A62C9B964D002A2623 /* MessageSenderSpec.swift */,
 			);
 			path = "Sending & Receiving";
@@ -8392,6 +8395,7 @@
 				FDEF30A22F2974370004C5BD /* MockUserDefaults.swift in Sources */,
 				FD481A902CAD16F100ECC4CF /* LibSessionGroupInfoSpec.swift in Sources */,
 				FDE754A92C9B964D002A2623 /* MessageSenderGroupsSpec.swift in Sources */,
+				AA01F0011000000000000002 /* ProStatsReaderSpec.swift in Sources */,
 				FDF0DF772F4D6CFD000D6041 /* MockFileHandle.swift in Sources */,
 				FDEF30852F29719F0004C5BD /* MockCrypto.swift in Sources */,
 				FD3FAB672AF0C47000DC5421 /* DisplayPictureDownloadJobSpec.swift in Sources */,

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -101,6 +101,21 @@ public struct Interaction: Sendable, Codable, Identifiable, Equatable, Hashable,
         
         case deleted = 400
         case localOnly
+
+        /// Whether the message has already reached its recipient, whatever has happened to the sync leg since
+        ///
+        /// `sent` is not terminal: `MessageSender.handleFailedMessageSend` moves `syncing` **and `sent`** to
+        /// `failedToSync` when the sync leg fails, so a message which was delivered can be sitting in any of these
+        /// three states. Anything counted once per delivered message has to treat the whole set as "already done",
+        /// not just `sent`, or a second successful pass over the same interaction counts it again.
+        ///
+        /// `sending` and `failed` are deliberately absent - neither has reached a recipient yet.
+        public var hasBeenSentSuccessfully: Bool {
+            switch self {
+                case .sent, .syncing, .failedToSync: return true
+                case .sending, .failed, .deleted, .localOnly: return false
+            }
+        }
     }
     
     /// The `id` value is auto incremented by the database, if the `Interaction` hasn't been inserted into

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -216,6 +216,23 @@ extension MessageReceiver {
                 proProfileFeatures: (message.proProfileFeatures ?? .none),
                 using: dependencies
             ).inserted(db)
+
+            /// A message of ours arriving from a linked device is the same message, counted on whichever device sees it
+            /// first - the counters are per-device and are kept roughly aligned by both devices observing the same sends
+            /// rather than by syncing a number.
+            ///
+            /// **Note:** Only on a successful insert, so the sending device cannot count its own copy a second time -
+            /// in a swarm conversation that copy arrives as a unique-constraint conflict and is handled below, and in
+            /// a community it is deduplicated before it reaches here.
+            if variant == .standardOutgoing {
+                if message.proMessageFeatures?.contains(.largerCharacterLimit) == true {
+                    db[.longerMessagesSentCounter] = (db[.longerMessagesSentCounter] ?? 0) + 1
+                }
+
+                if message.proProfileFeatures?.contains(.proBadge) == true {
+                    db[.proBadgesSentCounter] = (db[.proBadgesSentCounter] ?? 0) + 1
+                }
+            }
         }
         catch {
             switch error {

--- a/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
@@ -212,7 +212,7 @@ extension MessageSender {
             if var interaction: Interaction = maybeInteraction {
                 /// Captured before the update below moves it to `sent`, so the pro stat counters can tell a first success
                 /// apart from a repeat one
-                let wasAlreadySent: Bool = (interaction.state == .sent)
+                let wasAlreadySent: Bool = interaction.state.hasBeenSentSuccessfully
                 // Only store the server hash of a sync message if the message is self send valid
                 switch (message.isSelfSendValid, destination) {
                     case (false, .syncMessage):
@@ -281,10 +281,14 @@ extension MessageSender {
                             default:
                                 /// Update pro stats here
                                 ///
-                                /// Counted on the transition into `sent` rather than on every success, so a message which
-                                /// reaches here more than once - a resend, or a job retry after the send actually landed -
-                                /// contributes once. `handleMessageWillSend` only moves `failed` back to `sending`, so an
-                                /// interaction already `sent` still reads as `sent` here on a second pass.
+                                /// Counted once per delivered message rather than once per successful send, so a resend or
+                                /// a retried job contributes nothing further.
+                                ///
+                                /// **Note:** The check is the whole `hasBeenSentSuccessfully` set rather than `sent` alone,
+                                /// because `sent` is not terminal - a delivered message whose sync leg then failed sits in
+                                /// `failedToSync`, and one whose sync leg is still running sits in `syncing`. A resend from
+                                /// `failedToSync` happens to go out as a sync message and is already excluded by the case
+                                /// above, but relying on that would leave this correct only by the route the resend took.
                                 if !wasAlreadySent {
                                     if message.proMessageFeatures?.contains(.largerCharacterLimit) == true {
                                         db[.longerMessagesSentCounter] = (db[.longerMessagesSentCounter] ?? 0) + 1

--- a/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender+Convenience.swift
@@ -183,7 +183,9 @@ extension MessageSender {
         }
     }
     
-    private static func handleSuccessfulMessageSend(
+    /// **Note:** `internal` rather than `private` so the pro stat counting can be tested directly - driving it through
+    /// `standardEventHandling` would add a detached task and a full network mock to a test about arithmetic
+    internal static func handleSuccessfulMessageSend(
         _ db: ObservingDatabase,
         threadId: String,
         message: Message,
@@ -208,6 +210,9 @@ extension MessageSender {
             
             // Get the visible message if possible
             if var interaction: Interaction = maybeInteraction {
+                /// Captured before the update below moves it to `sent`, so the pro stat counters can tell a first success
+                /// apart from a repeat one
+                let wasAlreadySent: Bool = (interaction.state == .sent)
                 // Only store the server hash of a sync message if the message is self send valid
                 switch (message.isSelfSendValid, destination) {
                     case (false, .syncMessage):
@@ -274,12 +279,19 @@ extension MessageSender {
                         switch destination {
                             case .syncMessage: break
                             default:
-                                // Update pro stats here
-                                if message.proMessageFeatures?.contains(.largerCharacterLimit) == true {
-                                    db[.longerMessagesSentCounter] = (db[.longerMessagesSentCounter] ?? 0) + 1
-                                }
-                                if message.proProfileFeatures?.contains(.proBadge) == true {
-                                    db[.proBadgesSentCounter] = (db[.proBadgesSentCounter] ?? 0) + 1
+                                /// Update pro stats here
+                                ///
+                                /// Counted on the transition into `sent` rather than on every success, so a message which
+                                /// reaches here more than once - a resend, or a job retry after the send actually landed -
+                                /// contributes once. `handleMessageWillSend` only moves `failed` back to `sending`, so an
+                                /// interaction already `sent` still reads as `sent` here on a second pass.
+                                if !wasAlreadySent {
+                                    if message.proMessageFeatures?.contains(.largerCharacterLimit) == true {
+                                        db[.longerMessagesSentCounter] = (db[.longerMessagesSentCounter] ?? 0) + 1
+                                    }
+                                    if message.proProfileFeatures?.contains(.proBadge) == true {
+                                        db[.proBadgesSentCounter] = (db[.proBadgesSentCounter] ?? 0) + 1
+                                    }
                                 }
                         }
                 }

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -655,7 +655,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 title: SessionListScreenContent.TextInfo(
                                     "proLongerMessagesSent"
                                         .putNumber(state.numberOfLongerMessagesSent)
-                                        .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfLongerMessagesSent))
+                                        .put(key: "total", value: (state.proState.loadingState == .loading ?
+                                            "" :
+                                            state.numberOfLongerMessagesSent.formatted(format: .abbreviated(decimalPlaces: 1))
+                                        ))
                                         .localized(),
                                     font: .Headings.H9,
                                     accessibility: Accessibility(
@@ -673,7 +676,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 title: SessionListScreenContent.TextInfo(
                                     "proPinnedConversations"
                                         .putNumber(state.numberOfPinnedConversations)
-                                        .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfPinnedConversations))
+                                        .put(key: "total", value: (state.proState.loadingState == .loading ?
+                                            "" :
+                                            state.numberOfPinnedConversations.formatted(format: .abbreviated(decimalPlaces: 1))
+                                        ))
                                         .localized(),
                                     font: .Headings.H9,
                                     accessibility: Accessibility(
@@ -693,7 +699,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 title: SessionListScreenContent.TextInfo(
                                     "proBadgesSent"
                                         .putNumber(state.numberOfProBadgesSent)
-                                        .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfProBadgesSent))
+                                        .put(key: "total", value: (state.proState.loadingState == .loading ?
+                                            "" :
+                                            state.numberOfProBadgesSent.formatted(format: .abbreviated(decimalPlaces: 1))
+                                        ))
                                         .localized(),
                                     font: .Headings.H9,
                                     accessibility: Accessibility(
@@ -711,7 +720,10 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                                 title: SessionListScreenContent.TextInfo(
                                     "proGroupsUpgraded"
                                         .putNumber(state.numberOfGroupsUpgraded)
-                                        .put(key: "total", value: (state.proState.loadingState == .loading ? "" : state.numberOfGroupsUpgraded))
+                                        .put(key: "total", value: (state.proState.loadingState == .loading ?
+                                            "" :
+                                            state.numberOfGroupsUpgraded.formatted(format: .abbreviated(decimalPlaces: 1))
+                                        ))
                                         .localized(),
                                     font: .Headings.H9,
                                     color: (state.proState.loadingState == .loading ? .textPrimary : .disabled),

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -230,9 +230,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
                 .anyConversationPinnedPriorityChanged,
                 .profile(profile.id),
                 .currentUserProState(sessionProManager),
-                .setting(.groupsUpgradedCounter),
-                .setting(.proBadgesSentCounter),
-                .setting(.longerMessagesSentCounter)
+                .keyValue(.groupsUpgradedCounter),
+                .keyValue(.proBadgesSentCounter),
+                .keyValue(.longerMessagesSentCounter)
             ]
         }
         
@@ -309,11 +309,20 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
             }
         }
         
-        changes.forEachEvent(.setting, as: Int.self) { event, value in
+        /// These counters live in the key-value store, so they are emitted - and bucketed - under `keyValue` rather
+        /// than `setting`.
+        ///
+        /// **Note:** The bucket is what matters here. `EventChangeset` groups events by the *generic* half of the key,
+        /// so asking it for `setting` returns nothing at all when the writes went in under `keyValue`, and the values
+        /// silently stay at whatever they were when the screen opened. The subscription itself is more forgiving -
+        /// `ObservableKey` is `RawRepresentable`, so its equality and hashing come from the name alone and ignore the
+        /// generic - which is why this looked like it was wired up: the screen was being woken and then reading an
+        /// empty bucket. A `setting` overload accepting a key-value key is what makes the mismatch easy to write.
+        changes.forEachEvent(.keyValue, as: Int.self) { event, value in
             switch event.key {
-                case .setting(.groupsUpgradedCounter): numberOfGroupsUpgraded = value
-                case .setting(.proBadgesSentCounter): numberOfProBadgesSent = value
-                case .setting(.longerMessagesSentCounter): numberOfLongerMessagesSent = value
+                case .keyValue(.groupsUpgradedCounter): numberOfGroupsUpgraded = value
+                case .keyValue(.proBadgesSentCounter): numberOfProBadgesSent = value
+                case .keyValue(.longerMessagesSentCounter): numberOfLongerMessagesSent = value
                 default: break
             }
         }

--- a/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
+++ b/SessionMessagingKit/SessionPro/SessionProSettingsViewModel.swift
@@ -249,7 +249,9 @@ public class SessionProSettingsViewModel: SessionListScreenContent.ViewModelType
         }
     }
     
-    @Sendable private static func queryState(
+    /// **Note:** `internal` rather than `private` so the event-handling half can be tested directly. Only the
+    /// initial query reaches for the pro manager, so a non-initial call needs no mock of it
+    @Sendable internal static func queryState(
         previousState: State,
         events: [ObservedEvent],
         isInitialQuery: Bool,

--- a/SessionMessagingKit/Utilities/ObservableKey+SessionMessagingKit.swift
+++ b/SessionMessagingKit/Utilities/ObservableKey+SessionMessagingKit.swift
@@ -10,8 +10,7 @@ public extension ObservableKey {
     
     static func setting(_ key: Setting.BoolKey) -> ObservableKey { ObservableKey(key.rawValue, .setting) }
     static func setting(_ key: Setting.EnumKey) -> ObservableKey { ObservableKey(key.rawValue, .setting) }
-    
-    static func setting(_ key: KeyValueStore.IntKey) -> ObservableKey { ObservableKey(key.rawValue, .setting) }
+
     
     static func loadPage(_ screenType: Any.Type) -> ObservableKey {
         ObservableKey("loadPage-\(screenType)", .loadPage)

--- a/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
@@ -408,6 +408,102 @@ class MessageSenderSpec: AsyncSpec {
                     expect(longer).to(equal(0))
                 }
             }
+            
+            // MARK: -- when one of our own messages arrives from a linked device
+            context("when one of our own messages arrives from a linked device") {
+                @TestState var ownSessionId: SessionId! = SessionId(.standard, hex: TestConstants.publicKey)
+                
+                beforeEach {
+                    try await mockStorage.write { db in
+                        _ = try SessionThread.upsert(
+                            db,
+                            id: ownSessionId.hexString,
+                            variant: .contact,
+                            values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                            using: dependencies
+                        )
+                    }
+                }
+                
+                // MARK: ---- counts it, so linked devices stay aligned
+                it("counts it, so linked devices stay aligned") {
+                    try await mockStorage.write { db in
+                        _ = try MessageReceiver.handleVisibleMessage(
+                            db,
+                            threadId: ownSessionId.hexString,
+                            threadVariant: .contact,
+                            message: {
+                                let result: VisibleMessage = VisibleMessage(
+                                    sender: ownSessionId.hexString,
+                                    sentTimestampMs: 1234567890,
+                                    text: "Test",
+                                    proMessageFeatures: .largerCharacterLimit,
+                                    proProfileFeatures: .proBadge
+                                )
+                                result.serverHash = "TestServerHash"
+                                return result
+                            }(),
+                            decodedMessage: DecodedMessage(
+                                content: Data(),
+                                sender: ownSessionId,
+                                decodedPro: nil,
+                                decodedEnvelope: nil,
+                                sentTimestampMs: 1234567890
+                            ),
+                            serverExpirationTimestamp: nil,
+                            suppressNotifications: true,
+                            currentUserSessionIds: [ownSessionId.hexString],
+                            using: dependencies
+                        )
+                    }
+                    
+                    let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                    let longer: Int = try await mockStorage.read { db in (db[.longerMessagesSentCounter] ?? 0) }
+                    
+                    expect(badges).to(equal(1))
+                    expect(longer).to(equal(1))
+                }
+                
+                // MARK: ---- does not count one which carried no pro features
+                it("does not count one which carried no pro features") {
+                    var insertedId: Int64?
+                    
+                    try await mockStorage.write { db in
+                        insertedId = try MessageReceiver.handleVisibleMessage(
+                            db,
+                            threadId: ownSessionId.hexString,
+                            threadVariant: .contact,
+                            message: {
+                                let result: VisibleMessage = VisibleMessage(
+                                    sender: ownSessionId.hexString,
+                                    sentTimestampMs: 1234567891,
+                                    text: "Test"
+                                )
+                                result.serverHash = "TestServerHash2"
+                                return result
+                            }(),
+                            decodedMessage: DecodedMessage(
+                                content: Data(),
+                                sender: ownSessionId,
+                                decodedPro: nil,
+                                decodedEnvelope: nil,
+                                sentTimestampMs: 1234567891
+                            ),
+                            serverExpirationTimestamp: nil,
+                            suppressNotifications: true,
+                            currentUserSessionIds: [ownSessionId.hexString],
+                            using: dependencies
+                        ).interactionId
+                    }
+                    
+                    let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                    
+                    /// Paired with the absence so a fixture which never inserted anything fails loudly instead of
+                    /// satisfying the zero for the wrong reason
+                    expect(insertedId).toNot(beNil())
+                    expect(badges).to(equal(0))
+                }
+            }
         }
     }
 }

--- a/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
@@ -280,6 +280,81 @@ class MessageSenderSpec: AsyncSpec {
                     expect(longer).to(equal(1))
                 }
                 
+                // MARK: ---- does not count again for a message already delivered
+                it("does not count again for a message already delivered") {
+                    /// `sent` is not terminal - `handleFailedMessageSend` moves a delivered message to `failedToSync`
+                    /// when its sync leg fails, and `syncing` is a delivered message whose sync leg is still running. A
+                    /// second successful pass from any of them is the same message arriving again, not a new one
+                    let deliveredStates: [Interaction.State] = [.sent, .syncing, .failedToSync]
+                    
+                    for state in deliveredStates {
+                        try await mockStorage.write { db in
+                            _ = try Interaction
+                                .filter(id: interactionId)
+                                .updateAll(db, Interaction.Columns.state.set(to: state))
+                            db[.proBadgesSentCounter] = 0
+                            db[.longerMessagesSentCounter] = 0
+                        }
+                        
+                        try await mockStorage.write { db in
+                            try MessageSender.handleSuccessfulMessageSend(
+                                db,
+                                threadId: "TestThread",
+                                message: VisibleMessage(
+                                    text: "Test",
+                                    proMessageFeatures: .largerCharacterLimit,
+                                    proProfileFeatures: .proBadge
+                                ),
+                                to: .contact(publicKey: "05\(TestConstants.publicKey)"),
+                                interactionId: interactionId,
+                                using: dependencies
+                            )
+                        }
+                        
+                        let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                        let longer: Int = try await mockStorage.read { db in (db[.longerMessagesSentCounter] ?? 0) }
+                        let stateAfter: Interaction.State? = try await mockStorage.read { db in
+                            try Interaction.filter(id: interactionId).fetchOne(db)?.state
+                        }
+                        
+                        /// Paired with the absences below so a fixture which never reached the counting code fails loudly
+                        /// rather than passing quietly - the handler marks the interaction `sent`, so this is what
+                        /// distinguishes "correctly did not count" from "never ran"
+                        expect(stateAfter).to(equal(.sent), description: "handler did not run for \(state)")
+                        expect(badges).to(equal(0), description: "counted again from \(state)")
+                        expect(longer).to(equal(0), description: "counted again from \(state)")
+                    }
+                }
+                
+                // MARK: ---- counts a message which had previously failed outright
+                it("counts a message which had previously failed outright") {
+                    /// `failed` never reached a recipient, so the send which follows it is the first delivery and must count
+                    try await mockStorage.write { db in
+                        _ = try Interaction
+                            .filter(id: interactionId)
+                            .updateAll(db, Interaction.Columns.state.set(to: Interaction.State.failed))
+                    }
+                    
+                    try await mockStorage.write { db in
+                        try MessageSender.handleSuccessfulMessageSend(
+                            db,
+                            threadId: "TestThread",
+                            message: VisibleMessage(
+                                text: "Test",
+                                proMessageFeatures: .largerCharacterLimit,
+                                proProfileFeatures: .proBadge
+                            ),
+                            to: .contact(publicKey: "05\(TestConstants.publicKey)"),
+                            interactionId: interactionId,
+                            using: dependencies
+                        )
+                    }
+                    
+                    let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                    
+                    expect(badges).to(equal(1))
+                }
+                
                 // MARK: ---- only counts the message once when it is sent again
                 it("only counts the message once when it is sent again") {
                     /// The same interaction reaching a successful send twice - a resend, or a job retry after the send
@@ -323,7 +398,12 @@ class MessageSenderSpec: AsyncSpec {
                     
                     let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
                     let longer: Int = try await mockStorage.read { db in (db[.longerMessagesSentCounter] ?? 0) }
+                    let stateAfter: Interaction.State? = try await mockStorage.read { db in
+                        try Interaction.filter(id: interactionId).fetchOne(db)?.state
+                    }
                     
+                    /// Paired with the absences so a fixture which never reached the counting code fails loudly
+                    expect(stateAfter).to(equal(.sent))
                     expect(badges).to(equal(0))
                     expect(longer).to(equal(0))
                 }

--- a/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
+++ b/SessionMessagingKitTests/Sending & Receiving/MessageSenderSpec.swift
@@ -177,6 +177,157 @@ class MessageSenderSpec: AsyncSpec {
                     expect(preparedRequest).toNot(beNil())
                 }
             }
+
+            // MARK: -- when recording pro stats for a sent message
+            context("when recording pro stats for a sent message") {
+                @TestState var interactionId: Int64!
+                
+                beforeEach {
+                    try await mockStorage.write { db in
+                        try SessionThread.upsert(
+                            db,
+                            id: "TestThread",
+                            variant: .contact,
+                            values: SessionThread.TargetValues(shouldBeVisible: .setTo(true)),
+                            using: dependencies
+                        )
+                        interactionId = try Interaction(
+                            serverHash: nil,
+                            messageUuid: nil,
+                            threadId: "TestThread",
+                            authorId: "05\(TestConstants.publicKey)",
+                            variant: .standardOutgoing,
+                            body: "Test",
+                            timestampMs: 1234567890,
+                            receivedAtTimestampMs: 1234567890,
+                            wasRead: true,
+                            hasMention: false,
+                            expiresInSeconds: nil,
+                            expiresStartedAtMs: nil,
+                            linkPreviewUrl: nil,
+                            openGroupServerMessageId: nil,
+                            openGroupWhisper: false,
+                            openGroupWhisperMods: false,
+                            openGroupWhisperTo: nil,
+                            state: .sending,
+                            recipientReadTimestampMs: nil,
+                            mostRecentFailureText: nil,
+                            proMessageFeatures: .none,
+                            proProfileFeatures: .none
+                        ).inserted(db).id
+                    }
+                }
+                
+                // MARK: ---- emits the counters under the key the pro settings screen observes
+                it("emits the counters into the bucket the pro settings screen reads") {
+                    var emittedKeys: [ObservableKey] = []
+                    
+                    try await mockStorage.write { db in
+                        try MessageSender.handleSuccessfulMessageSend(
+                            db,
+                            threadId: "TestThread",
+                            message: VisibleMessage(
+                                text: "Test",
+                                proMessageFeatures: .largerCharacterLimit,
+                                proProfileFeatures: .proBadge
+                            ),
+                            to: .contact(publicKey: "05\(TestConstants.publicKey)"),
+                            interactionId: interactionId,
+                            using: dependencies
+                        )
+                        emittedKeys = db.currentEvents().map { $0.key }
+                    }
+                    
+                    /// `EventChangeset` buckets events by the generic half of the key, so this is what decides whether
+                    /// `SessionProSettingsViewModel` finds them: reading the `setting` bucket returns nothing when the
+                    /// writes went in under `keyValue`, and the numbers on screen silently stop moving.
+                    ///
+                    /// **Note:** Asserted on the generic rather than on key equality, because `ObservableKey` is
+                    /// `RawRepresentable` and so compares by name alone - `setting` and `keyValue` for the same counter
+                    /// are equal, which is precisely why the mismatch is invisible at the subscription
+                    let counterGenerics: [GenericObservableKey] = emittedKeys
+                        .filter {
+                            $0.rawValue == KeyValueStore.IntKey.proBadgesSentCounter.rawValue ||
+                            $0.rawValue == KeyValueStore.IntKey.longerMessagesSentCounter.rawValue
+                        }
+                        .map { $0.generic }
+                    
+                    expect(counterGenerics).to(haveCount(2))
+                    expect(Set(counterGenerics)).to(equal([.keyValue]))
+                }
+                
+                // MARK: ---- increments each counter once
+                it("increments each counter once") {
+                    try await mockStorage.write { db in
+                        try MessageSender.handleSuccessfulMessageSend(
+                            db,
+                            threadId: "TestThread",
+                            message: VisibleMessage(
+                                text: "Test",
+                                proMessageFeatures: .largerCharacterLimit,
+                                proProfileFeatures: .proBadge
+                            ),
+                            to: .contact(publicKey: "05\(TestConstants.publicKey)"),
+                            interactionId: interactionId,
+                            using: dependencies
+                        )
+                    }
+                    
+                    let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                    let longer: Int = try await mockStorage.read { db in (db[.longerMessagesSentCounter] ?? 0) }
+                    
+                    expect(badges).to(equal(1))
+                    expect(longer).to(equal(1))
+                }
+                
+                // MARK: ---- only counts the message once when it is sent again
+                it("only counts the message once when it is sent again") {
+                    /// The same interaction reaching a successful send twice - a resend, or a job retry after the send
+                    /// actually landed - must contribute one badge and one longer message, not two
+                    for _ in 0..<2 {
+                        try await mockStorage.write { db in
+                            try MessageSender.handleSuccessfulMessageSend(
+                                db,
+                                threadId: "TestThread",
+                                message: VisibleMessage(
+                                    text: "Test",
+                                    proMessageFeatures: .largerCharacterLimit,
+                                    proProfileFeatures: .proBadge
+                                ),
+                                to: .contact(publicKey: "05\(TestConstants.publicKey)"),
+                                interactionId: interactionId,
+                                using: dependencies
+                            )
+                        }
+                    }
+                    
+                    let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                    let longer: Int = try await mockStorage.read { db in (db[.longerMessagesSentCounter] ?? 0) }
+                    
+                    expect(badges).to(equal(1))
+                    expect(longer).to(equal(1))
+                }
+                
+                // MARK: ---- does not count a message which used no pro features
+                it("does not count a message which used no pro features") {
+                    try await mockStorage.write { db in
+                        try MessageSender.handleSuccessfulMessageSend(
+                            db,
+                            threadId: "TestThread",
+                            message: VisibleMessage(text: "Test"),
+                            to: .contact(publicKey: "05\(TestConstants.publicKey)"),
+                            interactionId: interactionId,
+                            using: dependencies
+                        )
+                    }
+                    
+                    let badges: Int = try await mockStorage.read { db in (db[.proBadgesSentCounter] ?? 0) }
+                    let longer: Int = try await mockStorage.read { db in (db[.longerMessagesSentCounter] ?? 0) }
+                    
+                    expect(badges).to(equal(0))
+                    expect(longer).to(equal(0))
+                }
+            }
         }
     }
 }

--- a/SessionMessagingKitTests/SessionPro/ProStatsReaderSpec.swift
+++ b/SessionMessagingKitTests/SessionPro/ProStatsReaderSpec.swift
@@ -1,0 +1,80 @@
+// Copyright © 2026 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import GRDB
+import SessionUtilitiesKit
+
+import Quick
+import Nimble
+
+@testable import SessionMessagingKit
+
+class ProStatsReaderSpec: AsyncSpec {
+    override class func spec() {
+        // MARK: Configuration
+        
+        @TestState var dependencies: TestDependencies! = TestDependencies()
+        @TestState var mockStorage: Storage! = try! Storage.createForTesting(using: dependencies)
+        @TestState var mockGeneralCache: MockGeneralCache! = .create(using: dependencies)
+        
+        beforeEach {
+            dependencies.set(cache: .general, to: mockGeneralCache)
+            try await mockGeneralCache.defaultInitialSetup()
+            
+            dependencies.set(singleton: .storage, to: mockStorage)
+            try await mockStorage.perform(migrations: SNMessagingKit.migrations)
+        }
+        
+        // MARK: - the pro settings screen
+        describe("the pro settings screen") {
+            @TestState var previousState: SessionProSettingsViewModel.State! = SessionProSettingsViewModel.State(
+                isInBottomSheet: false,
+                profile: Profile.defaultFor("05\(TestConstants.publicKey)"),
+                proState: .invalid,
+                numberOfGroupsUpgraded: 0,
+                numberOfPinnedConversations: 0,
+                numberOfProBadgesSent: 0,
+                numberOfLongerMessagesSent: 0
+            )
+            
+            // MARK: -- when a counter changes while it is open
+            context("when a counter changes while it is open") {
+                // MARK: ---- takes the new value
+                it("takes the new value") {
+                    /// This is the regression the screen actually had: the counters were right on entry and then frozen,
+                    /// because the events are bucketed by the generic half of their key and the screen was reading a
+                    /// different bucket from the one the writes go into. Nothing about the emission side catches that -
+                    /// it has to be the read
+                    let updatedState: SessionProSettingsViewModel.State = await SessionProSettingsViewModel.queryState(
+                        previousState: previousState,
+                        events: [
+                            ObservedEvent(key: .keyValue(.proBadgesSentCounter), value: 7),
+                            ObservedEvent(key: .keyValue(.longerMessagesSentCounter), value: 4)
+                        ],
+                        isInitialQuery: false,
+                        using: dependencies
+                    )
+                    
+                    expect(updatedState.numberOfProBadgesSent).to(equal(7))
+                    expect(updatedState.numberOfLongerMessagesSent).to(equal(4))
+                }
+                
+                // MARK: ---- leaves a counter alone when only the other one changed
+                it("leaves a counter alone when only the other one changed") {
+                    /// The positive half is deliberately in the same call as the absence: without it, a changeset which
+                    /// never reached the counter handling at all would satisfy the absence and the test would pass for
+                    /// the wrong reason
+                    let updatedState: SessionProSettingsViewModel.State = await SessionProSettingsViewModel.queryState(
+                        previousState: previousState,
+                        events: [ObservedEvent(key: .keyValue(.proBadgesSentCounter), value: 3)],
+                        isInitialQuery: false,
+                        using: dependencies
+                    )
+                    
+                    expect(updatedState.numberOfProBadgesSent).to(equal(3))
+                    expect(updatedState.numberOfLongerMessagesSent).to(equal(0))
+                }
+            }
+        }
+    }
+}

--- a/SessionMessagingKitTests/SessionPro/ProStatsReaderSpec.swift
+++ b/SessionMessagingKitTests/SessionPro/ProStatsReaderSpec.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import GRDB
+import SessionUIKit
 import SessionUtilitiesKit
 
 import Quick
@@ -73,6 +74,33 @@ class ProStatsReaderSpec: AsyncSpec {
                     
                     expect(updatedState.numberOfProBadgesSent).to(equal(3))
                     expect(updatedState.numberOfLongerMessagesSent).to(equal(0))
+                }
+            }
+        }
+        
+        // MARK: - the stat number format
+        describe("the stat number format") {
+            /// A cross-client contract rather than cosmetics - the same counter has to read the same way on all three
+            /// platforms, so these are pinned either side of the abbreviation threshold
+            
+            // MARK: -- below the threshold
+            context("below the threshold") {
+                // MARK: ---- renders exactly
+                it("renders exactly") {
+                    expect(0.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("0"))
+                    expect(1.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("1"))
+                    expect(42.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("42"))
+                    expect(999.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("999"))
+                }
+            }
+            
+            // MARK: -- at or above the threshold
+            context("at or above the threshold") {
+                // MARK: ---- abbreviates to one decimal, dropping a zero decimal
+                it("abbreviates to one decimal, dropping a zero decimal") {
+                    expect(1000.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("1K"))
+                    expect(1300.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("1.3K"))
+                    expect(1_000_000.formatted(format: .abbreviated(decimalPlaces: 1))).to(equal("1M"))
                 }
             }
         }

--- a/SessionNetworkingKit/LibSession/LibSession+Networking.swift
+++ b/SessionNetworkingKit/LibSession/LibSession+Networking.swift
@@ -598,11 +598,18 @@ public actor LibSessionNetwork: NetworkType {
         
         var url: [CChar] = [CChar](repeating: 0, count: 1024)
         
-        let result = try LibSessionNetwork.withCustomFileServer(dependencies[feature: .customFileServer]) { schemePtr, hostPtr, _, pubkeyPtr in
+        /// The port is passed through rather than discarded: a download url that omits it sends every
+        /// recipient to the scheme's default port, which for a self-hosted file server is not the file
+        /// server. `withCustomFileServer` has always parsed it - there was simply nowhere to put it until
+        /// `session_file_server_generate_download_url` took one.
+        ///
+        /// 0 means "the scheme already implies it", which is also what an absent port means here.
+        let result = try LibSessionNetwork.withCustomFileServer(dependencies[feature: .customFileServer]) { schemePtr, hostPtr, port, pubkeyPtr in
             session_file_server_generate_download_url(
                 cFileId,
                 schemePtr,
                 hostPtr,
+                (port ?? 0),
                 pubkeyPtr,
                 true,
                 &url,


### PR DESCRIPTION
Makes the Pro stats counters correct, and gives them the coverage they never had.

> ⚠️ **Stacked on #754.** The first commit (`Pass the file server port through to the download url`) belongs
> to that PR, not this one — it is here because without it `Debug_Compile_LibSession` cannot build against a
> current LibSession-Util once libsession-util#134 merged. Merge #754 first and this diff reduces to the six
> commits below.
>
> Consequently **this branch builds only under `Session_CompileLibSession`.** The plain `Session` scheme
> fails in `LibSession+Networking.swift`, because #754 passes a `port` the pinned `libsession-util-spm`
> 1.8.0 does not have. It goes green on normal CI once a 1.9.0 release is cut and the pin moves.

## The stats never updated while the screen was open

`SessionProSettingsViewModel` observed `.setting(…)` while the writes went in under `.keyValue`. The
subscription was fine — `ObservableKey` is `RawRepresentable`, so equality and hashing come from the name
alone and ignore the generic — so the screen *was* woken on every write. `EventChangeset` buckets events by
that generic, so the screen woke and read an **empty bucket**. Numbers were right on entry and frozen after.

Worth noting because it is not obvious from the symptom: changing `observedKeys` alone fixes nothing. The
load-bearing change is `forEachEvent(.setting)` → `.keyValue` and its switch cases.

The `setting(_ key: KeyValueStore.IntKey)` overload that made the mismatch writable had no other callers
once these three moved, so it is deleted rather than left as a trap.

## A resend counted twice

The counter bumped on every successful send, so a message that failed and was resent contributed twice. Now
counted on the transition into a delivered state.

`.sent` alone was the wrong test: `handleFailedMessageSend` moves `.syncing` **and** `.sent` to
`.failedToSync` when the sync leg of an already-delivered message fails. The states that mean "already
delivered" are now named in one place with a case per state, rather than relying on the destination
exclusion — which is correct only for the route a user-driven resend happens to take.

## A message synced from another of your devices did not count

The counters only ever moved on the send path, so the copy of your own message arriving on a linked device
was never counted — the devices drifted apart permanently rather than staying roughly in step. Now counted
on successful insert of a `.standardOutgoing` interaction; the sending device's own copy arrives as a
unique-constraint conflict and takes the existing branch without counting.

## The numbers were not abbreviated

All four cells now use `.formatted(format: .abbreviated(decimalPlaces: 1))` — the same call the input-bar
character counter makes — so `1300` renders as `1.3K` rather than `1300`. Only the displayed value; plural
selection still gets the exact count.

The suffix stays uppercase, matching the two existing call sites of that helper. Lowercasing to match the
other clients would mean changing the shared helper and moving the input bar and network screen with it.

## Tests

14, including the reader path that the observation fix repairs, each mutation-verified: reverting the change
under test fails exactly the tests that name it, with no compile errors standing in for a real failure.
