### PR TITLE
Name the Pro badges so a test can tell them apart

### DIFF
--- a/Session/Shared/BaseVC.swift
+++ b/Session/Shared/BaseVC.swift
@@ -107,6 +107,9 @@ public class BaseVC: UIViewController {
         /// one read DISPLAY would take a subscriber's badge away during the overhang, which is the inverse of the bug
         /// that split them
         sessionProBadge.isHidden = !sessionProUIManager.currentUserHasProAccess
+        /// Replaces the generic identifier the badge carries by default, so an assertion aimed at this one cannot
+        /// match the composer's badge instead - they are the same widget in opposite roles
+        sessionProBadge.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.homeHeader
         
         let stackView: UIStackView = UIStackView(arrangedSubviews: [ headingImageView, sessionProBadge ])
         stackView.semanticContentAttribute = .forceLeftToRight

--- a/SessionUIKit/Components/Input View/InputView.swift
+++ b/SessionUIKit/Components/Input View/InputView.swift
@@ -315,6 +315,9 @@ public final class InputView: UIView, InputViewButtonDelegate, InputTextViewDele
         /// ACCESS it would offer Pro to someone whose plan is active but whose proof has not arrived yet, four pixels
         /// from a modal that (correctly) declines to make that same offer
         result.isHidden = (sessionProManager?.currentUserProPlanIsActive == true)
+        /// Replaces the generic identifier the badge carries by default, so a test aimed at this one cannot match the
+        /// home screen's badge instead - see `SessionProBadge.AccessibilityIdentifier.composer`
+        result.accessibilityIdentifier = SessionProBadge.AccessibilityIdentifier.composer
         
         return result
     }()

--- a/SessionUIKit/Components/SessionProBadge.swift
+++ b/SessionUIKit/Components/SessionProBadge.swift
@@ -29,6 +29,14 @@ public class SessionProBadge: UIView {
         /// conversation while the badge renders only for a Pro sender, so an assertion scoped to the name
         /// can never fail. Android made the same distinction after it caught a false positive
         public static let conversationHeader: String = "conversation-header-pro-badge"
+
+        /// The badge in the home screen's nav heading specifically
+        ///
+        /// **Note:** Scoped rather than relying on the generic `icon`, because the same widget class appears in the
+        /// composer in the opposite role - this one is an entitlement indicator reading ACCESS, that one an upsell
+        /// reading DISPLAY (see `BaseVC.setUpNavBarSessionHeading`). An unscoped locator could match either, so a test
+        /// aimed at one could pass against the other without anyone noticing
+        public static let homeHeader: String = "home-header-pro-badge"
     }
 
     public enum Size {

--- a/SessionUIKit/Components/SessionProBadge.swift
+++ b/SessionUIKit/Components/SessionProBadge.swift
@@ -37,6 +37,13 @@ public class SessionProBadge: UIView {
         /// reading DISPLAY (see `BaseVC.setUpNavBarSessionHeading`). An unscoped locator could match either, so a test
         /// aimed at one could pass against the other without anyone noticing
         public static let homeHeader: String = "home-header-pro-badge"
+
+        /// The badge in the message composer specifically
+        ///
+        /// **Note:** The counterpart to `homeHeader`, and the reason both are scoped. This one is an upsell and
+        /// follows the plan (DISPLAY); that one is an entitlement indicator and follows the proof (ACCESS). They are
+        /// visible in opposite circumstances, so an unscoped locator finding "a badge" proves nothing about which
+        public static let composer: String = "composer-pro-badge"
     }
 
     public enum Size {


### PR DESCRIPTION
### Description

`SessionProBadge` already carried an accessibility identifier, but a single generic one
(`pro-badge-icon`) shared by every instance. That is enough to find *a* badge and not enough to know
which one was found — and the two on screen are not interchangeable.

The home-screen badge is an **entitlement** indicator: it follows the proof, and a subscriber keeps it
through the overhang after their plan lapses. The composer badge is an **upsell**: it follows the plan.
The comment at `BaseVC.swift:102-108` already warns against reconciling the two, because making the
home one read DISPLAY would take a subscriber's badge away during the overhang.

They are therefore visible in *opposite* circumstances, which is what makes a generic identifier a
problem rather than an inconvenience: a test that asserts "the badge is shown" can pass against the
wrong widget in exactly the states where the distinction matters.

Both are now named through the existing `SessionProBadge.AccessibilityIdentifier` enum, alongside
`conversation-header-pro-badge`, rather than as literals at the call sites:

    homeHeader = "home-header-pro-badge"
    composer   = "composer-pro-badge"

### Test approach

Build only — no behaviour change; the identifiers are inert outside a UI test.

Checked before landing: the end-to-end suite has exactly one unscoped Pro-badge lookup
(`pro_unverifiable_proof.spec.ts`), and it runs on the Message Info screen, where neither of these two
badges is present. Nothing that matches today stops matching.

The names match the Android equivalents closely enough to keep the locators symmetric
(`sessionHeaderProBadge` there).
