### PR TITLE
Count pinned conversations on launch, so the limit cannot be bypassed by relaunching

### DIFF
--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -293,11 +293,18 @@ public class HomeViewModel: NavigatableStateHolder {
                     .databaseLifecycle(.resumed)
                 )
             ),
-            requiresMessageRequestCountUpdate: changes.containsAny(
-                .messageRequestUnreadMessageReceived,
-                .messageRequestAccepted,
-                .messageRequestDeleted,
-                .messageRequestMessageRead
+            /// **Note:** Also on the initial query, for the same reason as the pinned count below - the value is seeded
+            /// at zero and only this flag fills it, so a fresh process showed no unread message requests until one of
+            /// the events below happened to arrive. Unlike the pinned count this one gates nothing, so it was a wrong
+            /// badge rather than a crossed limit, but it was wrong on every launch.
+            requiresMessageRequestCountUpdate: (
+                isInitialQuery ||
+                changes.containsAny(
+                    .messageRequestUnreadMessageReceived,
+                    .messageRequestAccepted,
+                    .messageRequestDeleted,
+                    .messageRequestMessageRead
+                )
             ),
             /// **Note:** Also on the initial query, not only on a change. The count is seeded at zero and the query
             /// behind this flag is the only thing that fills it, so without this a fresh process believes nothing is

--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -299,8 +299,16 @@ public class HomeViewModel: NavigatableStateHolder {
                 .messageRequestDeleted,
                 .messageRequestMessageRead
             ),
-            requiresPinnedConversationCountUpdate: changes.contains(
-                .anyConversationPinnedPriorityChanged
+            /// **Note:** Also on the initial query, not only on a change. The count is seeded at zero and the query
+            /// behind this flag is the only thing that fills it, so without this a fresh process believes nothing is
+            /// pinned until the user pins or unpins something - and the pin limit, which reads this count, lets them
+            /// past it. Pins made before the launch are invisible to it.
+            ///
+            /// Kept behind the flag rather than queried unconditionally: the point of the flag is to avoid the count
+            /// on every pass, and this only adds the one pass that had no value to carry forward.
+            requiresPinnedConversationCountUpdate: (
+                isInitialQuery ||
+                changes.contains(.anyConversationPinnedPriorityChanged)
             )
         )
         

--- a/Session/Utilities/UIContextualAction+Utilities.swift
+++ b/Session/Utilities/UIContextualAction+Utilities.swift
@@ -291,6 +291,9 @@ public extension UIContextualAction {
                                     }
                                 )
                                 
+                                /// The action was refused, so tell the table so - without this the row is left swiped
+                                /// open behind the modal, waiting on a handler which never gets called
+                                completionHandler(false)
                                 return
                             }
                             


### PR DESCRIPTION
### Description

**The pinned-conversation limit can be bypassed by relaunching the app, and no Pro is involved.**

Measured on a standard account that has never subscribed — one device, no backend, no revocation:

| step | result |
|---|---|
| pin 5 conversations | allowed — correct |
| pin a 6th, same session | **refused, CTA shown** ✓ |
| force-stop and relaunch | |
| pin the same 6th again | **allowed, no CTA** ✗ |

The control in the same run is what makes it attributable: the limit holds *within* a session, so this
is not an environment or a test problem. Repeating the relaunch pins arbitrarily many, so the free-tier
boundary is crossable by reopening the app.

### Cause

`currentPinnedConversationCount` is seeded at 0 and recomputed only when a pin priority changes **during
that process**:

    HomeViewModel.swift:186   initial state → currentPinnedConversationCount: 0
    HomeViewModel.swift:202   requiresPinnedConversationCountUpdate: false
    HomeViewModel.swift:302   set true ONLY by .anyConversationPinnedPriorityChanged
    HomeViewModel.swift:367   the count is queried ONLY behind that flag

On a fresh process with no pin change yet, the swipe action's gate evaluates `0 >= 5` and never fires.
That also explains the absent CTA: the gate did not refuse and then let the pin through — it never ran.

### The fix, and what it deliberately keeps

Not computing the count on every pass — that behaviour is an intentional optimisation and stays. The
change adds only the one pass that had no earlier value to carry:

    requiresPinnedConversationCountUpdate: (
        isInitialQuery ||
        changes.contains(.anyConversationPinnedPriorityChanged)
    )

This follows the local convention rather than inventing one: `requireFullRefresh`, two lines above in
the same `withContext` call, is already `(isInitialQuery || changes.containsAny(...))`.

**On cost:** the query is a `fetchCount` on the conversation table, and on the initial query
`requireFullRefresh` is already true on that same pass, in that same call — so the pass is already
fetching the whole conversation list from that table and this counts a subset of what is being read
anyway.

### The other two commits

**`08945f6958` — the swipe action never completes when it refuses.** When the gate fires it returns
without calling `completionHandler`, leaving UIKit waiting on the swipe. Separate from the bypass, same
function; kept as its own commit so the two can be reviewed apart.

**`fab6f82005` — `requiresMessageRequestCountUpdate` has the same shape**, so the unread
message-request count is also zero on a fresh launch. It drives a badge rather than a gate, so being
briefly wrong costs a wrong number rather than letting someone past a boundary, and the first relevant
event corrects it — but it is wrong on every launch until then.

Note the cost argument above does **not** carry over to this one, and the commit message says so: only
the first step is shared with the full refresh; what follows is a per-thread `isMessageRequest` under
the cache lock plus a second count query. Genuinely additional work, still cheap, and called out rather
than assumed.

One caveat worth recording: `isMessageRequest` returns `true` when a config is missing
(`LibSession+Shared.swift:531`, `:544`), so if configs were ever unloaded at that moment the badge would
read **inflated** rather than zero. Not expected — the cache is already in use on that path — but that
is the symptom to look for if it ever reads high on launch.

### Test approach

Builds clean.

The pin-limit fix is **verified behaviourally**, not just compiled: the probe above passes against this
branch, having failed identically on `dev`. A regression spec is being added in session-appium with the
assertion the existing pin specs structurally cannot make — pin to the limit, **relaunch**, then attempt
one more — because they pin and assert inside a single session, which is the case that already worked.

The message-request change is build-verified only.
