### PR TITLE
qa: tag the first stage of the clear-data flow

### DIFF
--- a/Session/Settings/NukeDataModal.swift
+++ b/Session/Settings/NukeDataModal.swift
@@ -10,6 +10,25 @@ import SignalUtilitiesKit
 import SessionUtilitiesKit
 
 final class NukeDataModal: Modal {
+    /// Test identifiers for the first stage of the clear-data flow
+    ///
+    /// **Note:** The confirmation this modal presents is a `ConfirmationModal`, which already tags its own
+    /// title, body and buttons - these cover only what this modal itself owns
+    ///
+    /// **Note:** Deliberately DISTINCT from the `Modal heading`/`Modal description` and title-derived button
+    /// identifiers `ConfirmationModal` applies. The confirmation is presented OVER this modal rather than
+    /// replacing it, so both are in the accessibility tree at once - sharing a name would have a locator
+    /// match whichever came first, which is the one underneath
+    // stringlint:ignore_contents
+    enum AccessibilityIdentifier {
+        static let heading: String = "clear-data-heading"
+        static let description: String = "clear-data-description"
+        static let confirmButton: String = "clear-data-confirm-button"
+        static let cancelButton: String = "clear-data-cancel-button"
+        static let clearDeviceOnlyRadio: String = "clear-device-only-radio"
+        static let clearDeviceAndNetworkRadio: String = "clear-device-and-network-radio"
+    }
+
     private let dependencies: Dependencies
     
     // MARK: - Initialization
@@ -33,6 +52,9 @@ final class NukeDataModal: Modal {
         let result = UILabel()
         result.font = .boldSystemFont(ofSize: Values.mediumFontSize)
         result.text = "clearDataAll".localized()
+        result.isAccessibilityElement = true
+        result.accessibilityIdentifier = AccessibilityIdentifier.heading
+        result.accessibilityLabel = result.text
         result.themeTextColor = .textPrimary
         result.textAlignment = .center
         result.lineBreakMode = .byWordWrapping
@@ -45,6 +67,9 @@ final class NukeDataModal: Modal {
         let result = UILabel()
         result.font = .systemFont(ofSize: Values.smallFontSize)
         result.text = "clearDataAllDescription".localized()
+        result.isAccessibilityElement = true
+        result.accessibilityIdentifier = AccessibilityIdentifier.description
+        result.accessibilityLabel = result.text
         result.themeTextColor = .textPrimary
         result.textAlignment = .center
         result.lineBreakMode = .byWordWrapping
@@ -60,6 +85,9 @@ final class NukeDataModal: Modal {
         }
         result.font = .systemFont(ofSize: Values.smallFontSize)
         result.text = "clearDeviceOnly".localized()
+        result.isAccessibilityElement = true
+        result.accessibilityIdentifier = AccessibilityIdentifier.clearDeviceOnlyRadio
+        result.accessibilityLabel = result.text
         result.update(isSelected: true)
         
         return result
@@ -72,6 +100,9 @@ final class NukeDataModal: Modal {
         }
         result.font = .systemFont(ofSize: Values.smallFontSize)
         result.text = "clearDeviceAndNetwork".localized()
+        result.isAccessibilityElement = true
+        result.accessibilityIdentifier = AccessibilityIdentifier.clearDeviceAndNetworkRadio
+        result.accessibilityLabel = result.text
         
         return result
     }()
@@ -81,12 +112,18 @@ final class NukeDataModal: Modal {
             title: "clear".localized(),
             titleColor: .danger
         )
+        // Matches what `ConfirmationModal` derives from its own `confirmTitle`, so the same locator reads
+        // the action on both stages of the flow
+        result.accessibilityIdentifier = AccessibilityIdentifier.confirmButton
         result.addTarget(self, action: #selector(clearAllData), for: UIControl.Event.touchUpInside)
         
         return result
     }()
     
     private lazy var buttonStackView: UIStackView = {
+        // The base `Modal` gives its cancel button no identifier; `ConfirmationModal` sets one from its
+        // own `cancelTitle`, and this matches it
+        cancelButton.accessibilityIdentifier = AccessibilityIdentifier.cancelButton
         let result = UIStackView(arrangedSubviews: [ clearDataButton, cancelButton ])
         result.axis = .horizontal
         result.distribution = .fillEqually

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -811,6 +811,10 @@ class SettingsViewModel: SessionListScreenContent.ViewModelType, NavigationItemS
                         )
                     )
                 ),
+                accessibility: Accessibility(
+                    identifier: "Clear data",
+                    label: "sessionClearData".localized()
+                ),
                 onTap: { [weak viewModel, dependencies = viewModel.dependencies] in
                     viewModel?.transitionToScreen(NukeDataModal(using: dependencies), transitionType: .present)
                 }


### PR DESCRIPTION
The confirmation this flow presents is a `ConfirmationModal`, which already identifies its own title,
body and buttons. Nothing before it did — the settings row is a `ListItemInfo` built with no
`accessibility:`, and `NukeDataModal` set no identifier on its radios, its labels or its actions. So
a test could reach neither the row that opens the flow nor the radio that chooses its branch, and
iOS had no coverage of the Pro "cannot be transferred" warning at all.

Tags only. Nothing added to the UI, no behaviour changed, and no confirmation step introduced that
wasn't already there.

## The names are deliberately distinct from `ConfirmationModal`'s

Worth a look, because the obvious choice is wrong. The confirmation is presented **over**
`NukeDataModal` rather than replacing it, so both sit in the accessibility tree at once. My first
attempt reused `Modal heading` / `Modal description` and the title-derived button ids on the
assumption that one locator could then read both stages — and every iOS spec failed, asserting the
confirmation copy while reading the copy from the modal underneath.

So the first stage gets `clear-data-heading`, `clear-data-description`, `clear-data-confirm-button`
and `clear-data-cancel-button`. Android needs no equivalent: there the two stages are the same
dialog, whose text swaps.

The two radio ids (`clear-device-only-radio`, `clear-device-and-network-radio`) do match Android's,
since those controls exist once per platform — see session-android `qa/clear-data-radio-ids`.

## Verification

Built locally and run against session-appium `test/pro-clear-data-warning`: **3/3 iOS cases pass**
(31.5s / 31.7s / 31.1s), covering the device branch, the network branch, and a standard-account
control. The specs read the warning and cancel; the destructive action is never taken.
