### PR TITLE
Don't un-hide a conversation because of our own synced message

### DIFF
--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -365,6 +365,18 @@ public enum MessageReceiver {
         // When handling any message type which has related UI we want to make sure the thread becomes
         // visible (the only other spot this flag gets set is when sending messages)
         let shouldBecomeVisible: Bool = {
+            /// A message from ourselves is not someone getting in touch, so it should never bring a hidden conversation
+            /// back - the rule is "another person contacted you", and the sender is what says whether that happened.
+            ///
+            /// **Note:** Keyed on the sender rather than on the conversation. Note to Self is the case that made this
+            /// visible, since its incoming messages are all our own synced from another device, but the same is true of
+            /// any conversation we have hidden and then sent to elsewhere. The un-hide is written through
+            /// `updateAllAndConfig`, and `shouldBeVisible` is a config-synced column, so it does not stay local - it
+            /// pushes and reverts the hide on every device.
+            /// `sender` is populated for every received message on the way in (see `handle`), so this is the
+            /// same value the rest of the receive path keys on
+            guard message.sender != dependencies[cache: .general].sessionId.hexString else { return false }
+
             switch message {
                 case is ReadReceipt: return false
                 case is TypingIndicator: return false


### PR DESCRIPTION
A conversation the user has deliberately hidden is un-hidden by our **own** message syncing in from a
linked device — and the change is then written back to config, so every device follows.

Note to Self is the case that surfaces it, but the fix is not Note-to-Self-specific: hide any 1:1, send to
it from another of your devices, and it reappears everywhere.

## How it reaches the code

`MessageReceiver.handle()` has no sender-is-me filter between its start and the dispatch switch — only an
outdated-message check. `postHandleMessage` is then called unconditionally after the switch, and
`VisibleMessage` matches no case there, so it falls through to `default: return true`. A self-sent synced
message definitely gets that far: it is the same path that inserts it as `.standardOutgoing`.

## Why it spreads

`SessionThread.update` applies the change through `updateAllAndConfig`, and `shouldBeVisible` is in
`columnsRelatedToThreads`. So it is a `UserProfile` write that pushes. One device un-hides, the rest
follow.

## The detail that makes it worse

The guard immediately above only writes when the thread is **currently hidden**, commented as avoiding a
config update that is not needed. That optimisation narrows the config write to precisely the users who
deliberately hid the conversation: nobody else is affected, and everybody affected chose the state being
destroyed.

## The fix

A sender guard at the top of the `shouldBecomeVisible` closure, before the type switch:

```swift
guard message.sender != dependencies[cache: .general].sessionId.hexString else { return false }
```

`decodedMessage` is not in scope in `postHandleMessage`, but `message.sender` is populated on the way in,
so this keys on the same value the rest of the receive path uses. No signature change.

Keyed on the **sender** rather than the conversation, matching Android's existing
`senderAddress.address != ctx.currentUserPublicKey`. Desktop carries the same fix in
session-desktop#2000. Android already guarded, and was the reference for both.

## The `CallMessage` carve-out is left alone

The guard just above is conversation-keyed and covers one message type — the same intent, narrowed. The
sender guard subsumes it for the self-sent case, but it still covers a hypothetical `CallMessage` in the
Note to Self thread from another sender. Removing it is a separate judgement and is not made here.

## Verification

**Build only.** This needs two linked devices to exercise, which the Appium rig has and this branch's
author did not. Expected: hide Note to Self, send from the linked device, it stays hidden on both — and
the same for any 1:1, which is the case a conversation-keyed fix would miss.
