### PR TITLE
fix: confirm a device-only clear for every account, not just Pro

### DIFF
--- a/Session/Settings/NukeDataModal.swift
+++ b/Session/Settings/NukeDataModal.swift
@@ -204,28 +204,34 @@ final class NukeDataModal: Modal {
     }
     
     private func clearDeviceOnly() {
-        switch dependencies[singleton: .sessionProManager].currentUserCurrentProState.status {
-            case .active:
-                let confirmationModal: ConfirmationModal = ConfirmationModal(
-                    info: ConfirmationModal.Info(
-                        title: "clearDataAll".localized(),
-                        body: .attributedText(
-                            "proClearAllDataDevice"
-                                .localizedFormatted(),
-                            scrollMode: .never
-                        ),
-                        confirmTitle: "clear".localized(),
-                        confirmStyle: .danger,
-                        cancelStyle: .alert_text,
-                        dismissOnConfirm: false
-                    ) { [weak self] confirmationModal in
-                        self?.clearLocalAccount(presentedViewController: confirmationModal)
-                    }
-                )
-                present(confirmationModal, animated: true, completion: nil)
-            
-            default: self.clearLocalAccount(presentedViewController: self)
-        }
+        /// Confirmed for every account, as the network branch and every branch on Desktop already are.
+        /// A device wipe is irreversible whether or not the user holds Pro, so the confirmation is not the
+        /// Pro warning's to earn - Pro only changes which copy it carries.
+        let confirmationModal: ConfirmationModal = ConfirmationModal(
+            info: ConfirmationModal.Info(
+                title: "clearDataAll".localized(),
+                body: .attributedText(
+                    {
+                        switch dependencies[singleton: .sessionProManager].currentUserCurrentProState.status {
+                            case .active:
+                                "proClearAllDataDevice"
+                                    .localizedFormatted()
+                            default:
+                                "clearDeviceDescription"
+                                    .localizedFormatted(baseFont: Fonts.Body.baseRegular)
+                        }
+                    }(),
+                    scrollMode: .never
+                ),
+                confirmTitle: "clear".localized(),
+                confirmStyle: .danger,
+                cancelStyle: .alert_text,
+                dismissOnConfirm: false
+            ) { [weak self] confirmationModal in
+                self?.clearLocalAccount(presentedViewController: confirmationModal)
+            }
+        )
+        present(confirmationModal, animated: true, completion: nil)
     }
     
     private func clearLocalAccount(presentedViewController presented: UIViewController) {


### PR DESCRIPTION
A standard account pressing **Clear** with "device only" selected had its data deleted on that press,
with no confirmation.

Every other combination on every platform asks first — the network branch here, both branches on
Desktop, and this same branch for a Pro account. This was the one route where an irreversible action
happened on a single tap, and it is the odd one out rather than a deliberate shortcut.

| | device | network |
|---|---|---|
| Pro | confirmed | confirmed |
| standard | **not confirmed** ← this PR | confirmed |

## Verified on a device, both directions

Before: the app came back on the onboarding screen — the account was gone.
After: the confirmation shows, and Cancel leaves the account intact.

## Scope

Behaviour only where it was missing; nothing else moves. The confirmed state reuses the existing
handling, so the second press clears exactly as it did.

Stacked on the test-tag PR for the same flow, which is tags only.
