### PR TITLE
Enforce the pin limit against pins that arrive from config, and tag the marker

### DIFF
--- a/Session/Home/HomeViewModel.swift
+++ b/Session/Home/HomeViewModel.swift
@@ -311,11 +311,19 @@ public class HomeViewModel: NavigatableStateHolder {
             /// pinned until the user pins or unpins something - and the pin limit, which reads this count, lets them
             /// past it. Pins made before the launch are invisible to it.
             ///
+            /// `conversationCreated` for the case the initial query cannot cover: a conversation arriving from config
+            /// already pinned. `SessionThread.upsert` creates it with the priority it read from `libSession`, so the
+            /// value never *changes* and no `anyConversationPinnedPriorityChanged` is emitted - and on a fresh install
+            /// the threads land after the initial query, so both of the other conditions miss them.
+            ///
             /// Kept behind the flag rather than queried unconditionally: the point of the flag is to avoid the count
-            /// on every pass, and this only adds the one pass that had no value to carry forward.
+            /// on every pass, and this only adds the passes which could have altered it.
             requiresPinnedConversationCountUpdate: (
                 isInitialQuery ||
-                changes.contains(.anyConversationPinnedPriorityChanged)
+                changes.containsAny(
+                    .anyConversationPinnedPriorityChanged,
+                    .conversationCreated
+                )
             )
         )
         

--- a/Session/Shared/FullConversationCell.swift
+++ b/Session/Shared/FullConversationCell.swift
@@ -138,8 +138,6 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         result.contentMode = .scaleAspectFit
         result.set(.width, to: FullConversationCell.unreadCountViewSize)
         result.set(.height, to: FullConversationCell.unreadCountViewSize)
-        result.isAccessibilityElement = true
-        result.accessibilityIdentifier = "Pinned icon"
         
         return result
     }()
@@ -397,9 +395,10 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         
         accentLineView.alpha = (unreadCount > 0 ? 1 : 0)
         isPinnedIcon.isHidden = (cellViewModel.pinnedPriority <= LibSession.visiblePriority)
-        /// Carries the conversation name, the same way the cell itself does, so a marker can be tied to the row
-        /// it belongs to - the icon is otherwise identical in every row
-        isPinnedIcon.accessibilityLabel = cellViewModel.displayName.deformatted()
+        /// The marker is identical in every row, so the identifier carries the conversation name to say which row
+        /// it belongs to. On the IDENTIFIER rather than the label deliberately: a label is read aloud, and the
+        /// screen reader has already announced this name from the cell a moment earlier.
+        isPinnedIcon.accessibilityIdentifier = "Pinned icon: \(cellViewModel.displayName.deformatted())"
         unreadCountView.isHidden = (unreadCount <= 0)
         unreadImageView.isHidden = (!unreadCountView.isHidden || !threadIsUnread)
         unreadCountLabel.text = (unreadCount <= 0 ?

--- a/Session/Shared/FullConversationCell.swift
+++ b/Session/Shared/FullConversationCell.swift
@@ -138,6 +138,8 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         result.contentMode = .scaleAspectFit
         result.set(.width, to: FullConversationCell.unreadCountViewSize)
         result.set(.height, to: FullConversationCell.unreadCountViewSize)
+        result.isAccessibilityElement = true
+        result.accessibilityIdentifier = "Pinned icon"
         
         return result
     }()
@@ -395,6 +397,9 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         
         accentLineView.alpha = (unreadCount > 0 ? 1 : 0)
         isPinnedIcon.isHidden = (cellViewModel.pinnedPriority <= LibSession.visiblePriority)
+        /// Carries the conversation name, the same way the cell itself does, so a marker can be tied to the row
+        /// it belongs to - the icon is otherwise identical in every row
+        isPinnedIcon.accessibilityLabel = cellViewModel.displayName.deformatted()
         unreadCountView.isHidden = (unreadCount <= 0)
         unreadImageView.isHidden = (!unreadCountView.isHidden || !threadIsUnread)
         unreadCountLabel.text = (unreadCount <= 0 ?


### PR DESCRIPTION
Two changes, both found by a seeded end-to-end spec that sets up a state no sequence of taps can reach.

## The bug

A standard account whose contacts config already holds **six** pinned conversations — one more than `SessionPro.PinnedConversationLimit` — could pin a seventh, with no CTA.

`HomeViewModel.State.currentPinnedConversationCount` is seeded at `0` and only refilled when `requiresPinnedConversationCountUpdate` is set. #762 widened that to the initial query, which fixes the relaunch case. It does not cover the case the initial query cannot see:

- on a fresh install the pinned conversations arrive from config **after** the initial query, and
- `SessionThread.upsert` creates a new thread with `pinnedPriority: targetPriority` read straight from `libSession`, so the subsequent `.setTo(data.priority)` finds the value **unchanged** and `SessionThread.update` emits no `.pinnedPriority` event — hence no `anyConversationPinnedPriorityChanged`.

The count therefore stayed at `0`, and the swipe action's `currentPinnedConversationCount >= SessionPro.PinnedConversationLimit` guard never tripped.

Reachable in production through a linked device or a restore, and the pins may well have been made while that account was Pro elsewhere.

The fix adds `.conversationCreated`, which `HomeViewModel` already observes.

### Verified

`pnpm test-mobile 'Pinned conversations above the limit arriving from config (non Pro) @ios'` in session-appium, which seeds six pins into the contacts config and then attempts a seventh.

- Before, on this branch's base: the seventh was **accepted** — the target moved from tenth place to seventh and gained a pin marker — and no CTA appeared.
- After: refused, CTA shown, unpin still works while over the limit, and the freed slot cannot be refilled.

Android already behaved correctly throughout; the same spec passes there unchanged.

### Related, not fixed here

Deleting a pinned conversation emits `.deleted`, not a priority change, so the count is left one too **high** until the next launch or pin toggle — the failure is over-restrictive rather than permissive, and `anyConversationDeleted` is not currently observed by `HomeViewModel`. Happy to fold it in if you would rather it went in one go.

## The tag

`isPinnedIcon` in `FullConversationCell` had no accessibility identifier, so a test could only reach it through the row's view hierarchy — which on iOS meant not at all, and the pin assertions in session-appium were skipped on this platform. They now run: the fix above was caught because the marker became readable.

The icon is identical in every row, so the identifier alone cannot say which conversation it belongs to. The label carries the display name for that, the same way `HomeVC` already sets `cell.accessibilityLabel = threadInfo.displayName.deformatted()` one line below the cell's own identifier.

One thing worth a second opinion: `isAccessibilityElement = true` is set so the view is guaranteed to appear in the XCUITest tree, which also makes VoiceOver announce it. If you would rather it stayed out of the VoiceOver order, dropping that line is worth trying — the identifier and label may well still surface — and I can re-run the specs against it.