### PR TITLE
Truncate an incoming message by code point, not UTF-16 unit

### DIFF
--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -779,32 +779,28 @@ extension MessageReceiver {
             )
         else { return text }
         
-        // FIXME: Replace this with a libSession-based truncation solution
-        let utf16View = text.utf16
+        /// Cut on **code points**, which is the unit the limit is expressed in: `messageFeatures` above hands
+        /// `session_protocol_pro_features_for_message` a `unicodeScalars.count`, and both other platforms cut the
+        /// same way (`offsetByCodePoints` on Android, spreading the string on Desktop). Counting UTF-16 units here
+        /// halved the limit for anything outside the BMP - 10,000 emoji arrived as 5,000 - so the same message was
+        /// persisted at two different lengths depending on which client received it.
+        ///
+        /// A scalar view cannot be indexed into the middle of a surrogate pair, so this also replaces the
+        /// boundary-walking the UTF-16 version needed.
+        let scalars: String.UnicodeScalarView = text.unicodeScalars
         let characterLimit: Int = (
             proIsEntitled ?
                 SessionPro.ProCharacterLimit :
                 SessionPro.CharacterLimit
         )
         
-        guard utf16View.count > characterLimit else { return text }
+        guard scalars.count > characterLimit else { return text }
         
-        // Get the index at the maxUnits position in UTF16
-        let endUTF16Index = utf16View.index(utf16View.startIndex, offsetBy: characterLimit)
+        let endIndex: String.UnicodeScalarView.Index = scalars.index(
+            scalars.startIndex,
+            offsetBy: characterLimit
+        )
         
-        // Try converting that UTF16 index back to a String.Index
-        if let endIndex = String.Index(endUTF16Index, within: text) {
-            return String(text[..<endIndex])
-        } else {
-            // Fallback: safely step back until there is a valid boundary
-            var adjustedIndex = endUTF16Index
-            while adjustedIndex > utf16View.startIndex {
-                adjustedIndex = utf16View.index(before: adjustedIndex)
-                if let validIndex = String.Index(adjustedIndex, within: text) {
-                    return String(text[..<validIndex])
-                }
-            }
-            return text // If all else fails, return original string
-        }
+        return String(String.UnicodeScalarView(scalars[..<endIndex]))
     }
 }


### PR DESCRIPTION
## The divergence

The Pro character limit is expressed in **code points** everywhere it is decided, and in UTF-16 units in the one place it is applied.

| | counts | file |
|---|---|---|
| the gate | code points | `SessionProManager.messageFeatures` → `session_protocol_pro_features_for_message(message.unicodeScalars.count)` |
| libSession's API | code points | `session_protocol.hpp` takes a `codepoint_count` |
| Android | code points | `VisibleMessageHandler.kt` — `codePointCount` / `offsetByCodePoints` |
| Desktop | code points | `ts/receiver/queuedJob.ts` — `[...body].slice(0, maxChars)` |
| **here** | **UTF-16 units** | `MessageReceiver+VisibleMessages.swift`, three lines below the gate |

So the effective limit halved for anything outside the BMP. A 10,001-emoji body landed at **10,000** code points on Android and Desktop and at **5,000** here — the same message persisted at two different lengths depending on which client received it. The same 2:1 split applied at the standard limit, and truncation is destructive, so the surplus was not recoverable afterwards.

## The change

Cut on `text.unicodeScalars` instead of `text.utf16`. A scalar view cannot be indexed into the middle of a surrogate pair, so the boundary-walking fallback that the UTF-16 version needed goes with it, along with the `// FIXME: Replace this with a libSession-based truncation solution` that asked for exactly this.

`utf16_count_truncated_to_codepoints` in `session/util.h` would also do the job, but it exists for consumers indexing raw UTF-16 buffers; Swift already has a scalar view, so calling into C here would only add a bridge. The behaviour is what has to match across clients, and it now does.

## Verified

End-to-end, with a seeded 10,001-code-point body of non-BMP characters carrying a real backend-signed proof (session-appium, `sendProMessage`), asserting on a marker ending at code point 10,000 and the single character past it:

| build | marker at 10,000 | the 10,001st |
|---|---|---|
| `dev` | **absent** — cut at 5,000 | absent |
| this branch | present | absent |
| Android, same message | present | absent |

The existing suite's over-limit spec uses plain ASCII precisely because that was the only region where all three clients agreed. Once this lands, that constraint can be dropped and the non-BMP case becomes a normal cross-platform assertion.

Not related to #767, and the two do not touch the same files.