### PR TITLE
Keep the access expiry on a revoked proof, and confirm the account status at once

### DIFF
--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1063,11 +1063,17 @@ public actor SessionProManager: SessionProManagerType {
                     /// `get_pro_status` supplies the display horizon anyway.
                     case .subscriptionExpired:
                         await applyProofClear(
-                            accountExpiryTimestampSeconds: response.accountExpiryTimestampSeconds
+                            accountState: response.accountRenewalInfo.map { renewal in
+                                (
+                                    expirySeconds: response.accountExpiryTimestampSeconds,
+                                    gracePeriodSeconds: renewal.gracePeriodSeconds,
+                                    autoRenewing: renewal.autoRenewing
+                                )
+                            }
                         )
 
                     case .notSubscribed:
-                        await applyProofClear(accountExpiryTimestampSeconds: nil)
+                        await applyProofClear(accountState: nil)
 
                     /// Revocation from a proof response is terminal: clear regardless of validity, no `E`
                     /// write, off the transient/backoff path.
@@ -1155,10 +1161,13 @@ public actor SessionProManager: SessionProManagerType {
 
     /// subscription_expired / not_subscribed clear — downgrade-guarded: apply only if there is no currently
     /// valid (unexpired) proof, read inside the write.
-    /// - Parameter accountExpiryTimestampSeconds: the expiry to persist, or `nil` to clear it. `subscription_expired`
-    /// carries the account's real past expiry and the backend sends it so a client can keep it; `not_subscribed` has no
-    /// user row behind it, so there is genuinely nothing to record.
-    private func applyProofClear(accountExpiryTimestampSeconds: UInt64?) async {
+    /// - Parameter accountState: the expiry and its qualifiers to persist, or `nil` to clear all three.
+    /// `subscription_expired` carries the account's real past expiry along with the grace and renewal flags that
+    /// qualify it, and the backend sends them so a client can keep them; `not_subscribed` has no user row behind it,
+    /// so there is genuinely nothing to record.
+    private func applyProofClear(
+        accountState: (expirySeconds: UInt64, gracePeriodSeconds: UInt64, autoRenewing: Bool)?
+    ) async {
         let nowSeconds: Int64 = Int64(await dependencies.networkOffsetTimestampMs() / 1000)
 
         /// Whether the clear actually applied, which the display write at the end needs.
@@ -1191,20 +1200,14 @@ public actor SessionProManager: SessionProManagerType {
                     /// `E` reflects what the backend last said, so it is cleared only when the backend says there is
                     /// nothing to say. An expired subscription still has an expiry, and it is the value the display
                     /// needs to say "renew" rather than "you never subscribed".
-                    cache.updateProAccessExpiryTimestampSeconds(accountExpiryTimestampSeconds ?? 0)
-
-                    /// `G` and `A` qualify whichever `E` is written above, and the clear used to take them with it.
-                    /// Writing an expiry instead would leave them describing the subscription that just ended - a
-                    /// grace period silently moving where coverage ends, and a renewing flag the startup gate reads
-                    /// as "still renewing" - so they are written explicitly either way.
                     ///
-                    /// **Note:** Zeroed rather than taken from the response. libSession does parse the grace and
-                    /// renewal qualifiers for `subscription_expired`, but this type gates them behind
-                    /// `accountRenewalInfo`, which returns `nil` for any non-success outcome. Zero grace and not
-                    /// renewing is the truthful reading of a subscription the backend has just called expired; if the
-                    /// reported grace should be kept instead, that gate is what has to change.
-                    cache.updateProGracePeriodSeconds(0)
-                    cache.updateProAutoRenewing(false)
+                    /// All three are written together because `G` and `A` qualify whichever `E` is stored - writing an
+                    /// expiry while leaving them behind pairs it with the previous subscription's grace, silently
+                    /// moving where coverage ends, and leaves a renewing flag the startup gate reads as "still
+                    /// renewing". The clear used to take them with it, so nothing here may write `E` alone.
+                    cache.updateProAccessExpiryTimestampSeconds(accountState?.expirySeconds ?? 0)
+                    cache.updateProGracePeriodSeconds(accountState?.gracePeriodSeconds ?? 0)
+                    cache.updateProAutoRenewing(accountState?.autoRenewing ?? false)
                 }
 
                 return true
@@ -1218,6 +1221,12 @@ public actor SessionProManager: SessionProManagerType {
         }
 
         await updateWithLatestFromUserConfig()
+
+        /// Then ask, for the same reason as the revocation paths: the re-projection above reads config this function
+        /// has just written, so it can only repeat what was already decided locally. The response is the one thing
+        /// that can correct it - and on `not_subscribed`, where everything was cleared, it is the only way back to a
+        /// state that says anything at all.
+        try? await refreshProState(immediate: true)
     }
 
     /// `revoked` from a proof response is authoritative and terminal — clear regardless of validity. Clears
@@ -2188,7 +2197,12 @@ public actor SessionProManager: SessionProManagerType {
         ///
         /// This fetch is what makes leaving `E` safe — nothing else on this path reaches the network, so without it the
         /// account holds a stale future `E` with no proof and nothing scheduled to correct it.
-        try? await refreshProState()
+        ///
+        /// **Note:** Immediate, because that is only true if the fetch arrives. Floored, a status fetch at launch takes
+        /// the interval and this one is dropped - the revocation list is polled at launch too, so the two collide by
+        /// default rather than by chance. Exempt on the same terms as the other revocation path: a discrete event
+        /// which terminates itself once the response lands.
+        try? await refreshProState(immediate: true)
     }
 }
 

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1184,30 +1184,36 @@ public actor SessionProManager: SessionProManagerType {
 
                 try cache.performAndPushChange(db, for: .userProfile) { _ in
                     /// `remove_pro_config` clears ONLY the proof `s`. `E` does NOT self-age (unlike the proof
-                    /// `I`/`R`), so a stale future `E` left here would make `pro_renewal_target` fire on every
-                    /// eval and spin — clear it explicitly (`set_pro_access_expiry(nullopt)`, via `0`).
+                    /// `I`/`R`), so a stale future `E` left behind makes `pro_renewal_target` fire on every eval
+                    /// and spin — it is written here explicitly, never left to the proof clear.
                     ///
-                    /// This path must leave no `G` or `A` stranded beside the cleared `E`. They describe the
-                    /// subscription `E` denotes, so a surviving grace period pairs with whatever `E` is written next
-                    /// — silently changing where coverage ends — and a surviving renewing flag describes a
-                    /// subscription that no longer exists, which the startup gate then reads as "still renewing".
-                    ///
-                    /// Clearing `E` is expected to take both with it, so no explicit clears appear here. If you are
-                    /// reading this because they *are* being left behind, the obligation above is what has to hold —
-                    /// add the clears here rather than treating it as cosmetic.
+                    /// `G` and `A` describe the subscription `E` denotes, so they are written from the same
+                    /// response `E` is: a grace period surviving from a previous subscription pairs with the stored
+                    /// expiry and silently moves where coverage ends, and a stranded renewing flag describes a
+                    /// subscription that no longer exists, which the startup gate reads as "still renewing".
                     cache.removeProConfig()
 
                     /// `E` reflects what the backend last said, so it is cleared only when the backend says there is
                     /// nothing to say. An expired subscription still has an expiry, and it is the value the display
                     /// needs to say "renew" rather than "you never subscribed".
-                    ///
-                    /// All three are written together because `G` and `A` qualify whichever `E` is stored - writing an
-                    /// expiry while leaving them behind pairs it with the previous subscription's grace, silently
-                    /// moving where coverage ends, and leaves a renewing flag the startup gate reads as "still
-                    /// renewing". The clear used to take them with it, so nothing here may write `E` alone.
-                    cache.updateProAccessExpiryTimestampSeconds(accountState?.expirySeconds ?? 0)
-                    cache.updateProGracePeriodSeconds(accountState?.gracePeriodSeconds ?? 0)
-                    cache.updateProAutoRenewing(accountState?.autoRenewing ?? false)
+                    switch accountState {
+                        case .none:
+                            cache.updateProAccessExpiryTimestampSeconds(0)
+                            cache.updateProGracePeriodSeconds(0)
+                            cache.updateProAutoRenewing(false)
+                            
+                        case .some(let accountState):
+                            /// Only when the response carried one. `set_pro_access_expiry` maps `<= 0` to `nullopt`,
+                            /// so passing a missing `account_expiry_ts` straight through as `0` clears `E` on every
+                            /// device and erases the record that the account ever subscribed — the same guard
+                            /// `applyProofSuccess` puts on this field.
+                            if accountState.expirySeconds > 0 {
+                                cache.updateProAccessExpiryTimestampSeconds(accountState.expirySeconds)
+                            }
+                            
+                            cache.updateProGracePeriodSeconds(accountState.gracePeriodSeconds)
+                            cache.updateProAutoRenewing(accountState.autoRenewing)
+                    }
                 }
 
                 return true

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1061,8 +1061,13 @@ public actor SessionProManager: SessionProManagerType {
                     /// another device just landed). Both outcomes mean "not entitled", so `E` must not be
                     /// left future — clearing it (rather than re-setting a past value) is spin-safe and
                     /// `get_pro_status` supplies the display horizon anyway.
-                    case .subscriptionExpired, .notSubscribed:
-                        await applyProofClear()
+                    case .subscriptionExpired:
+                        await applyProofClear(
+                            accountExpiryTimestampSeconds: response.accountExpiryTimestampSeconds
+                        )
+
+                    case .notSubscribed:
+                        await applyProofClear(accountExpiryTimestampSeconds: nil)
 
                     /// Revocation from a proof response is terminal: clear regardless of validity, no `E`
                     /// write, off the transient/backoff path.
@@ -1150,7 +1155,10 @@ public actor SessionProManager: SessionProManagerType {
 
     /// subscription_expired / not_subscribed clear — downgrade-guarded: apply only if there is no currently
     /// valid (unexpired) proof, read inside the write.
-    private func applyProofClear() async {
+    /// - Parameter accountExpiryTimestampSeconds: the expiry to persist, or `nil` to clear it. `subscription_expired`
+    /// carries the account's real past expiry and the backend sends it so a client can keep it; `not_subscribed` has no
+    /// user row behind it, so there is genuinely nothing to record.
+    private func applyProofClear(accountExpiryTimestampSeconds: UInt64?) async {
         let nowSeconds: Int64 = Int64(await dependencies.networkOffsetTimestampMs() / 1000)
 
         /// Whether the clear actually applied, which the display write at the end needs.
@@ -1179,7 +1187,24 @@ public actor SessionProManager: SessionProManagerType {
                     /// reading this because they *are* being left behind, the obligation above is what has to hold —
                     /// add the clears here rather than treating it as cosmetic.
                     cache.removeProConfig()
-                    cache.updateProAccessExpiryTimestampSeconds(0)
+
+                    /// `E` reflects what the backend last said, so it is cleared only when the backend says there is
+                    /// nothing to say. An expired subscription still has an expiry, and it is the value the display
+                    /// needs to say "renew" rather than "you never subscribed".
+                    cache.updateProAccessExpiryTimestampSeconds(accountExpiryTimestampSeconds ?? 0)
+
+                    /// `G` and `A` qualify whichever `E` is written above, and the clear used to take them with it.
+                    /// Writing an expiry instead would leave them describing the subscription that just ended - a
+                    /// grace period silently moving where coverage ends, and a renewing flag the startup gate reads
+                    /// as "still renewing" - so they are written explicitly either way.
+                    ///
+                    /// **Note:** Zeroed rather than taken from the response. libSession does parse the grace and
+                    /// renewal qualifiers for `subscription_expired`, but this type gates them behind
+                    /// `accountRenewalInfo`, which returns `nil` for any non-success outcome. Zero grace and not
+                    /// renewing is the truthful reading of a subscription the backend has just called expired; if the
+                    /// reported grace should be kept instead, that gate is what has to change.
+                    cache.updateProGracePeriodSeconds(0)
+                    cache.updateProAutoRenewing(false)
                 }
 
                 return true

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1209,9 +1209,15 @@ public actor SessionProManager: SessionProManagerType {
     private func applyProofRevoked() async {
         try? await dependencies[singleton: .storage].write { [dependencies] db in
             try dependencies.mutate(cache: .libSession) { cache in
+                /// **Note:** The proof only. `E` is left alone, which is what the call site above already claims this
+                /// path does - a revocation says this proof is void, not what the subscription is. A revocation which
+                /// left the payments in place is a rotation: the account is still paid and re-provable, and nothing
+                /// local separates that from a refund.
+                ///
+                /// `E` is also synced config rather than device-local, so clearing it here pushed that clear to every
+                /// other device and erased the shared record that the user ever subscribed.
                 try cache.performAndPushChange(db, for: .userProfile) { _ in
                     cache.removeProConfig()
-                    cache.updateProAccessExpiryTimestampSeconds(0)
                 }
             }
         }
@@ -1222,17 +1228,18 @@ public actor SessionProManager: SessionProManagerType {
 
         await updateWithLatestFromUserConfig()
 
-        /// Then ask the server what the account actually is now. The re-projection above reads the config this
-        /// function has just emptied, so with no proof and `E` cleared it seeds `.never` - a positive claim that the
-        /// user never subscribed, which the settings screen acts on by offering "Recover" instead of "Renew".
+        /// Then ask the server what the account actually is now, because neither choice about `E` is right on its own:
+        /// after a refund the kept `E` is still the old FUTURE expiry, so the re-projection seeds `.active`, exactly as
+        /// clearing it seeded `.never`. Only the response fixes it - the backend keeps the user row and writes
+        /// `expiry_at = now`, so the status comes back expired with a real past expiry, which is mirrored into `E`.
         ///
-        /// A revocation says this proof is void; it does not say what the subscription is. The account may be gone, or
-        /// paid and re-provable after a rotation, and nothing local can tell those apart - so the only honest next step
-        /// is to ask. A refund leaves the user row with a past expiry, which reaches `.expired` in one fetch.
-        ///
-        /// **Note:** Floored rather than immediate. `immediate` is reserved for callers carrying their own cadence and
-        /// termination, and this is a routine trigger with nobody waiting on a screen.
-        try? await refreshProState()
+        /// **Note:** `immediate`, which the routine triggers are told not to pass. This one qualifies on the terms that
+        /// exemption is written for - it carries its own cadence and its own termination. A revocation is a discrete
+        /// event rather than a poll; re-entry is bounded by the proof loop's dark backoff; and this fetch is what ENDS
+        /// the loop, since the past expiry it writes stops the renewal target being acquired at all. Floored, the
+        /// terminator is the first thing dropped - a status fetch at launch takes the interval and this refresh, which
+        /// is the one that matters, is swallowed by it.
+        try? await refreshProState(immediate: true)
     }
 
     /// Clear the account triple in display state — a cleared outcome is a response too, and it says "you have

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1221,6 +1221,18 @@ public actor SessionProManager: SessionProManagerType {
         await clearProAccountDisplayState()
 
         await updateWithLatestFromUserConfig()
+
+        /// Then ask the server what the account actually is now. The re-projection above reads the config this
+        /// function has just emptied, so with no proof and `E` cleared it seeds `.never` - a positive claim that the
+        /// user never subscribed, which the settings screen acts on by offering "Recover" instead of "Renew".
+        ///
+        /// A revocation says this proof is void; it does not say what the subscription is. The account may be gone, or
+        /// paid and re-provable after a rotation, and nothing local can tell those apart - so the only honest next step
+        /// is to ask. A refund leaves the user row with a past expiry, which reaches `.expired` in one fetch.
+        ///
+        /// **Note:** Floored rather than immediate. `immediate` is reserved for callers carrying their own cadence and
+        /// termination, and this is a routine trigger with nobody waiting on a screen.
+        try? await refreshProState()
     }
 
     /// Clear the account triple in display state — a cleared outcome is a response too, and it says "you have

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1169,10 +1169,12 @@ public actor SessionProManager: SessionProManagerType {
 
     /// subscription_expired / not_subscribed clear — downgrade-guarded: apply only if there is no currently
     /// valid (unexpired) proof, read inside the write.
-    /// - Parameter accountState: the expiry and its qualifiers to persist, or `nil` to clear all three.
-    /// `subscription_expired` carries the account's real past expiry along with the grace and renewal flags that
-    /// qualify it, and the backend sends them so a client can keep them; `not_subscribed` has no user row behind it,
-    /// so there is genuinely nothing to record.
+    /// - Parameters:
+    ///   - accessExpirySeconds: the expiry to persist, or `.useExisting` where the outcome says nothing about it.
+    ///   `.set(to: 0)` is a clear, and so a claim that the account never subscribed — only `not_subscribed` may
+    ///   make it.
+    ///   - accountRenewal: the grace and renewal flags qualifying that expiry, or `nil` on the outcomes which do
+    ///   not carry them, where they would be struct defaults rather than answers.
     private func applyProofClear(
         accessExpirySeconds: Update<UInt64>,
         accountRenewal: (gracePeriodSeconds: UInt64, autoRenewing: Bool)?

--- a/SessionMessagingKit/SessionPro/SessionProManager.swift
+++ b/SessionMessagingKit/SessionPro/SessionProManager.swift
@@ -1056,24 +1056,31 @@ public actor SessionProManager: SessionProManagerType {
                     case .success:
                         await applyProofSuccess(response, rotatingKeyPair: rotatingKeyPair)
 
-                    /// Lapsed / no subscription → clear (proof `s` AND access-expiry `E`), but only if we
-                    /// don't currently hold a valid proof (never let a stale failure wipe a fresh proof
-                    /// another device just landed). Both outcomes mean "not entitled", so `E` must not be
-                    /// left future — clearing it (rather than re-setting a past value) is spin-safe and
-                    /// `get_pro_status` supplies the display horizon anyway.
+                    /// Lapsed / no subscription → clear the proof `s`, but only if we don't currently hold a
+                    /// valid proof (never let a stale failure wipe a fresh proof another device just landed).
+                    /// What each outcome may say about `E` differs, so they answer for it separately below.
                     case .subscriptionExpired:
                         await applyProofClear(
-                            accountState: response.accountRenewalInfo.map { renewal in
-                                (
-                                    expirySeconds: response.accountExpiryTimestampSeconds,
-                                    gracePeriodSeconds: renewal.gracePeriodSeconds,
-                                    autoRenewing: renewal.autoRenewing
-                                )
+                            /// The account exists and its plan lapsed. A response which omits the expiry is not
+                            /// claiming there never was one, so nothing is written for it.
+                            accessExpirySeconds: (
+                                response.accountExpiryTimestampSeconds > 0 ?
+                                    .set(to: response.accountExpiryTimestampSeconds) :
+                                    .useExisting
+                            ),
+                            accountRenewal: response.accountRenewalInfo.map { renewal in
+                                (gracePeriodSeconds: renewal.gracePeriodSeconds, autoRenewing: renewal.autoRenewing)
                             }
                         )
 
+                    /// The backend is asserting that no account row exists, so clearing `E` states what the
+                    /// response says rather than inventing it. `G` and `A` go with it because they qualify `E`:
+                    /// left behind they describe a subscription the cleared `E` no longer names.
                     case .notSubscribed:
-                        await applyProofClear(accountState: nil)
+                        await applyProofClear(
+                            accessExpirySeconds: .set(to: 0),
+                            accountRenewal: (gracePeriodSeconds: 0, autoRenewing: false)
+                        )
 
                     /// Revocation from a proof response is terminal: clear regardless of validity, no `E`
                     /// write, off the transient/backoff path.
@@ -1121,10 +1128,11 @@ public actor SessionProManager: SessionProManagerType {
                     /// Keep `G` and `A` coherent with the `E` just written: a grace period paired with the previous expiry makes
                     /// `E + G` meaningless.
                     ///
-                    /// `accountRenewalInfo` is `nil` unless the outcome was success, which is the protection: on a transport
-                    /// or protocol failure these are `0`/`false` parsed from nothing, and the config keys are presence-only, so
-                    /// writing that `false` erases what `get_pro_status` learned. The protection is the placement — reaching this
-                    /// line already implies success. A parsed `0`/`false` is a real answer and writing it is correct.
+                    /// `G` and `A` are presence-only config keys, so writing a value that was never parsed erases
+                    /// what `get_pro_status` learned. What prevents that is `accountRenewalInfo`'s own slug check,
+                    /// which answers `nil` for every outcome leaving these at their struct defaults — not the
+                    /// placement, since it is also non-nil for `subscription_expired`. A `0`/`false` reaching this
+                    /// line was parsed, and is a real answer.
                     if let renewalInfo: Network.SessionPro.GenerateProProofResponse.AccountRenewalInfo = response.accountRenewalInfo {
                         cache.updateProGracePeriodSeconds(renewalInfo.gracePeriodSeconds)
                         cache.updateProAutoRenewing(renewalInfo.autoRenewing)
@@ -1166,7 +1174,8 @@ public actor SessionProManager: SessionProManagerType {
     /// qualify it, and the backend sends them so a client can keep them; `not_subscribed` has no user row behind it,
     /// so there is genuinely nothing to record.
     private func applyProofClear(
-        accountState: (expirySeconds: UInt64, gracePeriodSeconds: UInt64, autoRenewing: Bool)?
+        accessExpirySeconds: Update<UInt64>,
+        accountRenewal: (gracePeriodSeconds: UInt64, autoRenewing: Bool)?
     ) async {
         let nowSeconds: Int64 = Int64(await dependencies.networkOffsetTimestampMs() / 1000)
 
@@ -1193,26 +1202,22 @@ public actor SessionProManager: SessionProManagerType {
                     /// subscription that no longer exists, which the startup gate reads as "still renewing".
                     cache.removeProConfig()
 
-                    /// `E` reflects what the backend last said, so it is cleared only when the backend says there is
-                    /// nothing to say. An expired subscription still has an expiry, and it is the value the display
-                    /// needs to say "renew" rather than "you never subscribed".
-                    switch accountState {
-                        case .none:
-                            cache.updateProAccessExpiryTimestampSeconds(0)
-                            cache.updateProGracePeriodSeconds(0)
-                            cache.updateProAutoRenewing(false)
-                            
-                        case .some(let accountState):
-                            /// Only when the response carried one. `set_pro_access_expiry` maps `<= 0` to `nullopt`,
-                            /// so passing a missing `account_expiry_ts` straight through as `0` clears `E` on every
-                            /// device and erases the record that the account ever subscribed — the same guard
-                            /// `applyProofSuccess` puts on this field.
-                            if accountState.expirySeconds > 0 {
-                                cache.updateProAccessExpiryTimestampSeconds(accountState.expirySeconds)
-                            }
-                            
-                            cache.updateProGracePeriodSeconds(accountState.gracePeriodSeconds)
-                            cache.updateProAutoRenewing(accountState.autoRenewing)
+                    /// The only writable form of "absent" for `E` is a clear — `set_pro_access_expiry` maps `<= 0`
+                    /// to `nullopt` — and a clear is a positive claim that the account never subscribed, synced to
+                    /// every device. So `E` is written when the caller has an expiry to state or is making that
+                    /// claim, and an outcome which simply supplies no expiry leaves the stored one alone rather than
+                    /// asserting something the response did not say.
+                    switch accessExpirySeconds {
+                        case .useExisting: break
+                        case .set(let expirySeconds): cache.updateProAccessExpiryTimestampSeconds(expirySeconds)
+                    }
+
+                    /// `G` and `A` are read only for the slugs which carry them, where libSession treats an absent
+                    /// field as not-applicable — so a parsed `0`/`false` is a faithful answer and is written. On every
+                    /// other outcome they are struct defaults carrying no information, which is what `nil` means here.
+                    if let accountRenewal: (gracePeriodSeconds: UInt64, autoRenewing: Bool) = accountRenewal {
+                        cache.updateProGracePeriodSeconds(accountRenewal.gracePeriodSeconds)
+                        cache.updateProAutoRenewing(accountRenewal.autoRenewing)
                     }
                 }
 

--- a/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
+++ b/SessionNetworkingKit/SessionPro/Requests/GenerateProProofResponse.swift
@@ -23,23 +23,31 @@ public extension Network.SessionPro {
 
         /// Not public — read them through `accountRenewalInfo`.
         ///
-        /// Trustworthy only when `outcome == .success`. On a transport or protocol failure nothing was parsed, so
-        /// these hold `0`/`false` — indistinguishable from an account that genuinely has no grace and is not
-        /// renewing. That is not inert: the config keys are presence-only, so writing that `false` erases a flag
-        /// `get_pro_status` had learned.
+        /// Trustworthy only on the outcomes libSession actually populates them for. On a transport or protocol
+        /// failure nothing was parsed, so these hold `0`/`false` — indistinguishable from an account that genuinely
+        /// has no grace and is not renewing. That is not inert: the config keys are presence-only, so writing that
+        /// `false` erases a flag `get_pro_status` had learned.
         ///
         /// The type cannot express "not parsed", so the scope does — hence private, behind a success-gated accessor.
         /// A `0`/`false` that *was* parsed is a real answer; the gate exists for the values that were not.
         private let rawAccountGracePeriodSeconds: UInt64
         private let rawAccountAutoRenewing: Bool
 
-        /// The account's grace period and renewal flag — `nil` unless this response carried a proof.
+        /// The account's grace period and renewal flag — `nil` on the outcomes which do not carry them.
         ///
-        /// They exist so a proof outcome can keep `E`, `G` and `A` coherent: this response writes `E`, and
-        /// without them a proof would move the access expiry while leaving a grace period and renewal flag paired
-        /// with the previous one, which makes `E + G` — the coverage end — silently meaningless.
+        /// They exist so an outcome can keep `E`, `G` and `A` coherent: a response which writes `E` and leaves these
+        /// alone pairs the new expiry with the previous subscription's qualifiers, which makes `E + G` — the coverage
+        /// end — silently meaningless.
+        ///
+        /// **Note:** `subscription_expired` carries them as well as `success`. libSession populates them only when the
+        /// envelope parsed *and* the failure slug is that one, so the case this gate exists for - a failure which
+        /// parsed nothing and left `0`/`false` behind - is already excluded before it gets here. Every other failure,
+        /// including an unrecognised slug, still answers `nil`.
         public var accountRenewalInfo: AccountRenewalInfo? {
-            guard outcome == .success else { return nil }
+            switch outcome {
+                case .success, .subscriptionExpired: break
+                case .notSubscribed, .revoked, .transient: return nil
+            }
 
             return AccountRenewalInfo(
                 gracePeriodSeconds: rawAccountGracePeriodSeconds,


### PR DESCRIPTION
One rule, applied to every `generate_pro_proof` failure, and a fetch afterwards.

| response | config | then |
|---|---|---|
| `revoked` | **keep `E`** (the response carries no expiry) | fetch status, **immediate** |
| `subscription_expired` | **set `E`, `G`, `A`** from the response | fetch status, **immediate** |
| `not_subscribed` | **clear `E`** (no user row exists) | fetch status, **immediate** |

The principle underneath: **`E` reflects what the backend last said. Clear it only when the backend says
there is nothing to say — never as a side effect of a local decision.**

## Why keeping `E` on `revoked` matters

A revocation says this proof is void; it does not say what the subscription is. A revocation with
`revoke_payments=false` is a **rotation** — the account stays paid and re-provable — and no client can tell
that apart from a refund locally. Android already said so in its own comment:

> "`E` is not cleared locally. A revocation says this proof is void, not what the subscription is now — the
> account may be fine and re-provable, or genuinely gone, and only the server knows which."

`E` is also **synced config**, not device-local: a client that clears it pushes that clear to every other
device, erasing the shared record that the user ever subscribed. Both mobile clients seed display status
from `E` plus the proof, so clearing it makes "lapsed subscriber" indistinguishable from "never subscribed".
That shipped on iOS as a refunded subscriber being offered "Recover Pro Access" and "Upgrade to" instead of
"Renew".

## Why the trio travels together

Verified in libsession's parser (`src/pro_backend.cpp`, `parse_pro_proof`) — all three fields are populated
inside the FAILURE branch when the slug is `subscription_expired`, with the comment:

> "They must travel together: coverage ends at `account_expiry + grace`, and an expiry has typically NOT
> changed on this failure (it is a lapse/cancellation) while the grace and flag have — refreshing only the
> expiry would leave a stale grace claiming coverage the backend has stopped honouring."

The backend sends all three unconditionally on that slug, so "absent" cannot arise from a current backend.

## Why immediate, not floored

Neither `E` choice gives a correct display on its own: after a refund `E` is still the OLD, FUTURE expiry, so
keeping it seeds "active" just as clearing it seeds "never". Only the status fetch fixes it — the backend
keeps the user row and writes `expiry_at = now`, returning `user_status: "expired"` with a real PAST
`expiry_ts`, which every client mirrors into `E`.

A floored fetch is dropped whenever a status fetch ran inside the floor, which is the normal case because
launch fetches. **Measured on iOS: adding a FLOORED fetch changed nothing — 5 runs out of 5 still wrong.**

That mirrored past `E` is also what TERMINATES the acquire loop: libsession's `pro_renewal_target` acquires
only while `access && *access > now`. Flooring the terminator is the wrong place to economise.


## What is iOS-specific here

`applyProofClear` serves both lapse slugs, and the expiry and the renewal qualifiers reach it as separate
arguments rather than as one optional. They have different presence conditions: `subscription_expired`
supplies an expiry only when the backend sends `account_expiry_ts`, while it always supplies the grace and
renewing flags. Deriving both from a single optional forces one answer onto two questions.

The expiry is therefore passed as `Update<UInt64>` — `.set(to:)` when the response states one,
`.useExisting` when it does not — so "write nothing" is stated rather than encoded as a `0` that
`set_pro_access_expiry` would read as `nullopt` and apply as a clear. `not_subscribed` passes
`.set(to: 0)`, because there the clear is the claim the backend is making.

**Worth calibrating: the guarded case is defensive, not observed.** A current backend sends all three on
that slug unconditionally, so an absent expiry cannot arise from one — libsession reads the field
optionally, and the other two clients guard it, and this makes iOS agree. It is not a fix for a failure
anyone has seen.

## Verification

Desktop 8/8 revocation specs. Android 15/15 revocation plus the wider `ProApi` surface, and 12/12 pin specs.
iOS pin 13/14 across two builds, refund 5/5, recipient 3/3.

`subscription_expired` has **no spec on any platform** — the slug only fires once
`expiry + grace + RENEWAL_LATENCY_ALLOWANCE` has passed, that allowance is a hard-coded hour, and
`/dev/add_payment` validates `duration` positive. Nothing can reach it in a test. Recorded as a blocked row
in the coverage table; a dev expire hook would make it reachable in seconds.
