### PR TITLE
Make the Fast Mode row title addressable

### DIFF
--- a/Session/Settings/NotificationSettingsViewModel.swift
+++ b/Session/Settings/NotificationSettingsViewModel.swift
@@ -169,8 +169,17 @@ class NotificationSettingsViewModel: SessionTableViewModel, NavigatableStateHold
                 elements: [
                     SessionCell.Info(
                         id: .strategyUseFastMode,
-                        title: "useFastMode".localized(),
-                        subtitle: "notificationsFastModeDescriptionIos".localized(),
+                        title: SessionCell.TextInfo(
+                            "useFastMode".localized(),
+                            font: .title,
+                            accessibility: Accessibility(
+                                identifier: "preferences-option-enable-push"
+                            )
+                        ),
+                        subtitle: SessionCell.TextInfo(
+                            "notificationsFastModeDescriptionIos".localized(),
+                            font: .subtitle
+                        ),
                         trailingAccessory: .toggle(
                             state.isUsingFullAPNs,
                             oldValue: previousState.isUsingFullAPNs,


### PR DESCRIPTION
Gives the Fast Mode row's title an accessibility identifier so a test can wait on it. No behaviour change.

## Why the suite needs it

`Check Notifications settings layout` screenshots this screen. The other four settings layout specs now wait for an element only their destination has, because a click returns before the push completes and a loaded host otherwise captures the screen behind — one was caught doing exactly that at SSIM 0.3825, 37% of the frame. Notifications is the last one still using `sleepFor(1_000)` instead, because this screen had nothing addressable to wait on.

The row's toggle already carries `Use Fast Mode - Switch`, but a toggle is a control the spec may later want to operate; the title is the stable "this screen is up" marker.

## Why the identifier is kebab-case

`preferences-option-enable-push` is the value Android's equivalent row already carries, so one Appium locator serves both platforms. That is the convention this repo already follows and writes down — `SessionUIKit/Components/Modals & Toast/ConfirmationModal.swift:18` says so, and `open-url-confirm-button` and `pro-badge-text` are existing examples.

Measured across the suite's 160 dual-platform locators: 65 share a single selector, and every recently added one of those is kebab-case. The Title Case ones are legacy iOS identifiers Android matched later.

## Why eleven lines and not one

The `title: String` convenience builds its `TextInfo` without an `Accessibility`, so a title cannot be tagged through it. This uses the designated initialiser and spells out both `TextInfo`s. The convenience applies `.title` and `.subtitle` fonts (`SessionCell+Info.swift:206`, `:271`) and those are passed explicitly here, so rendering is unchanged.

## Note for anyone reading the tree later

An accessibility identifier becomes Appium's `name` and pushes the displayed text to `label`. That is the intended shape — address this row by id, not by its text.

`SessionCell.swift:360` sets `isAccessibilityElement = (info.accessibility != nil)` for the cell. This row passes no cell-level `accessibility`, so the cell stays a container and its children remain individually addressable. Adding a cell-level identifier here would remove both the title and the toggle from the tree at once.

## Verification

Builds. `strings` on the built `Session.debug.dylib` finds the identifier once. **Not yet confirmed reachable at runtime** — that needs a page-source dump against a build carrying this change, which is the next step on the test side.
