### PR TITLE
Let the typing indicator settle when animations are disabled

### DIFF
--- a/Session/Conversations/Message Cells/Content Views/TypingIndicatorView.swift
+++ b/Session/Conversations/Message Cells/Content Views/TypingIndicatorView.swift
@@ -87,22 +87,34 @@ import SessionUtilitiesKit
     }
 
     private var isAnimating = false
+    
+    /// Whether the dots may animate, captured from the caller's `Dependencies` each time the indicator is
+    /// shown.
+    ///
+    /// The restarts below — moving back on screen, returning to the foreground, a theme change — have no
+    /// `Dependencies` of their own, and CoreAnimation drops layer animations on each of those events. Without
+    /// a captured answer they would resurrect an animation the flag had disabled.
+    private var animationsEnabled: Bool = true
 
-    @objc
-    public func startAnimation() {
+    public func startAnimation(using dependencies: Dependencies) {
+        animationsEnabled = dependencies[feature: .animationsEnabled]
+        
+        startAnimation()
+    }
+
+    private func startAnimation() {
         isAnimating = true
 
         for dot in dots() {
-            dot.startAnimation()
+            dot.show(animated: animationsEnabled)
         }
     }
 
-    @objc
     public func stopAnimation() {
         isAnimating = false
 
         for dot in dots() {
-            dot.stopAnimation()
+            dot.hide()
         }
     }
 
@@ -116,6 +128,8 @@ import SessionUtilitiesKit
         private let dotType: DotType
         private let shapeLayer = CAShapeLayer()
         private var baseColor: UIColor = .white
+        private var isShowing: Bool = false
+        private var animated: Bool = true
 
         @available(*, unavailable, message:"use other constructor instead.")
         required init?(coder aDecoder: NSCoder) {
@@ -137,17 +151,22 @@ import SessionUtilitiesKit
 
             layer.addSublayer(shapeLayer)
             
+            /// Keyed off whether the dot is on show rather than whether a layer animation is attached: with
+            /// animation suppressed there are no animation keys, and the colour still has to follow the theme.
             ThemeManager.onThemeChange(observer: self) { [weak self] _, _, resolve in
-                guard self?.shapeLayer.animationKeys()?.isEmpty == false else { return }
+                guard self?.isShowing == true else { return }
                 
                 self?.baseColor = (resolve(.messageBubble_incomingText) ?? .white)
-                self?.startAnimation()
+                self?.show(animated: (self?.animated ?? true))
             }
         }
 
         // stringlint:ignore_contents
-        fileprivate func startAnimation() {
-            stopAnimation()
+        fileprivate func show(animated: Bool) {
+            hide()
+            
+            isShowing = true
+            self.animated = animated
 
             let timeIncrement: CFTimeInterval = 0.15
             var colorValues = [CGColor]()
@@ -202,6 +221,16 @@ import SessionUtilitiesKit
                 break
             }
 
+            /// The layer owns no path or fill of its own — both exist only as key frames — so suppressing the
+            /// animation without this would leave the dot drawing nothing at all, which is a different screen
+            /// rather than a still one. The first key frame is the resting state every dot starts and ends on,
+            /// and is the same for all three, so the row renders as three settled dots.
+            guard animated else {
+                shapeLayer.path = pathValues.first
+                shapeLayer.fillColor = colorValues.first
+                return
+            }
+            
             let makeAnimation: (String, [Any]) -> CAKeyframeAnimation = { (keyPath, values) in
                 let animation = CAKeyframeAnimation()
                 animation.keyPath = keyPath
@@ -221,8 +250,13 @@ import SessionUtilitiesKit
             shapeLayer.add(groupAnimation, forKey: UUID().uuidString)
         }
 
-        fileprivate func stopAnimation() {
+        fileprivate func hide() {
+            isShowing = false
             shapeLayer.removeAllAnimations()
+            /// Cleared explicitly: a suppressed dot leaves them set, and they would otherwise keep drawing a
+            /// dot the caller has just hidden.
+            shapeLayer.path = nil
+            shapeLayer.fillColor = nil
         }
     }
 }

--- a/Session/Conversations/Message Cells/TypingIndicatorCell.swift
+++ b/Session/Conversations/Message Cells/TypingIndicatorCell.swift
@@ -58,7 +58,7 @@ final class TypingIndicatorCell: MessageCell {
         updateBubbleViewCorners()
         
         // Typing indicator view
-        typingIndicatorView.startAnimation()
+        typingIndicatorView.startAnimation(using: dependencies)
     }
     
     override func dynamicUpdate(with cellViewModel: MessageViewModel, playbackInfo: ConversationViewModel.PlaybackInfo?) {

--- a/Session/Settings/PrivacySettingsViewModel.swift
+++ b/Session/Settings/PrivacySettingsViewModel.swift
@@ -622,7 +622,9 @@ class PrivacySettingsViewModel: SessionTableViewModel, NavigationItemSource, Nav
                             subtitle: SessionCell.TextInfo(
                                 "typingIndicatorsDescription".localized(),
                                 font: .subtitle,
-                                extraViewGenerator: { TypingIndicatorPreviewView() }
+                                extraViewGenerator: { [dependencies = viewModel.dependencies] in
+                                    TypingIndicatorPreviewView(using: dependencies)
+                                }
                             ),
                             trailingAccessory: .toggle(
                                 state.typingIndicatorsEnabled,
@@ -723,7 +725,11 @@ private final class TypingIndicatorPreviewView: UIView {
     
     // MARK: - Initialization
     
-    init() {
+    private let dependencies: Dependencies
+    
+    init(using dependencies: Dependencies) {
+        self.dependencies = dependencies
+        
         super.init(frame: .zero)
         
         setupLayout()
@@ -748,6 +754,6 @@ private final class TypingIndicatorPreviewView: UIView {
         // Use a transform scale to reduce the size of the typing indicator to the
         // desired size (this way the animation remains intact)
         typingIndicatorView.transform = CGAffineTransform(scaleX: 0.4, y: 0.4)
-        typingIndicatorView.startAnimation()
+        typingIndicatorView.startAnimation(using: dependencies)
     }
 }

--- a/Session/Shared/FullConversationCell.swift
+++ b/Session/Shared/FullConversationCell.swift
@@ -425,7 +425,7 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         if cellViewModel.isTyping {
             snippetLabel.text = ""
             typingIndicatorView.isHidden = false
-            typingIndicatorView.startAnimation()
+            typingIndicatorView.startAnimation(using: dependencies)
         }
         else {
             displayNameLabel.themeTextColor = {


### PR DESCRIPTION
The `...` beside "Typing Indicators" on the Privacy settings screen animates continuously, which made
`settings_privacy.png` the least deterministic of the Appium settings baselines — a screenshot caught the
wave at whatever phase the capture landed on. iOS already has an `animationsEnabled` feature flag, and the
Appium harness already passes `animationsEnabled: 'false'` on every session, so this makes the indicator
honour a flag that was already false during every test run.

### The dots have no static representation

Worth knowing before reading the diff, because it is what makes this more than a one-line change: the dots
are drawn *entirely* by the key frame animation — `shapeLayer` carries no `path` and no `fillColor` of its
own. So the obvious implementation ("skip `startAnimation()` when the flag is off") produces an **empty
bubble**: a perfectly stable screenshot of a screen that no longer shows the feature it illustrates.

Instead each dot renders its **first key frame** — the resting state every dot starts and ends on, identical
across all three, so the row settles rather than freezing mid-wave. Key frames map `progress` 0→1 onto
radius `lerp(6,8)` and alpha `lerp(0.4,1.0)`, so the still is r6 / α0.40.

### Two things the flag check had to be careful about

CoreAnimation drops layer animations when a view leaves the window and when the app backgrounds, so this
view restarts itself from `didMoveToWindow`, `didBecomeActive` and a theme observer — none of which have
`Dependencies`, and all three would otherwise have resurrected a disabled animation. The flag is captured
when the caller shows the indicator and reused by those restarts.

The theme observer also keyed off `animationKeys()?.isEmpty == false` ("am I animating"), which with
animation suppressed would have left a stale-coloured dot; it now keys off whether the dot is shown.

### Known limitation

With `animationsEnabled` off the indicator renders a still frame. Turning it back on in Developer Settings
does not resume the animation for an indicator that is already showing, nor after backgrounding or a theme
change — the flag is read when a caller shows the indicator, and the internal restarts reuse that answer so
they cannot revive an animation the flag disabled. Showing the indicator afresh picks up the new value.
Resuming live would mean observing `.feature(.animationsEnabled)` from the view, which nothing in the view
layer currently does.

### Testing

`SessionTests` 1279 passed / 0 failed / 7 suites. Validated visually on a simulator with the flag off: the
dots render and do not move.
