### PR TITLE
Show our own Pro badge on a message in a community

### DIFF
--- a/Session/Media Viewing & Editing/MessageInfoScreen.swift
+++ b/Session/Media Viewing & Editing/MessageInfoScreen.swift
@@ -116,6 +116,12 @@ struct MessageInfoScreen: View {
         onStartThread: (@MainActor () -> Void)?,
         using dependencies: Dependencies
     ) {
+        /// One identity answer for the name and the badge both. In a community our own message carries the
+        /// blinded-id profile: it resolves as "You" through `currentUserSessionIds`, but it holds none of our
+        /// Pro features, so a badge read off that profile is missing on exactly the messages the label gets
+        /// right.
+        let isCurrentUser: Bool = messageViewModel.currentUserSessionIds.contains(messageViewModel.authorId)
+        
         self.viewModel = ViewModel(
             dependencies: dependencies,
             actions: actions.filter { $0.actionType != .emoji },    // Exclude emoji actions
@@ -125,7 +131,7 @@ struct MessageInfoScreen: View {
             openGroupPublicKey: openGroupPublicKey,
             onStartThread: onStartThread,
             isMessageFailed: [.failed, .failedToSync].contains(messageViewModel.state),
-            isCurrentUser: messageViewModel.currentUserSessionIds.contains(messageViewModel.authorId),
+            isCurrentUser: isCurrentUser,
             profileInfo: ProfilePictureView.Info.generateInfoFrom(
                 size: .message,
                 publicKey: messageViewModel.profile.id,
@@ -139,7 +145,18 @@ struct MessageInfoScreen: View {
                 messageFeatures: messageViewModel.proMessageFeatures,
                 profileFeatures: messageViewModel.proProfileFeatures
             ),
-            shouldShowProBadge: messageViewModel.profile.proFeatures.contains(.proBadge)
+            shouldShowProBadge: {
+                guard isCurrentUser else {
+                    return messageViewModel.profile.proFeatures.contains(.proBadge)
+                }
+                
+                /// Our own badge is what our own profile says, and `profileFeatures(for:)` applies the access
+                /// gate to it — so a badge we have hidden stays hidden, and one belonging to a lapsed
+                /// subscription stops showing.
+                return dependencies[singleton: .sessionProManager]
+                    .profileFeatures(for: dependencies.mutate(cache: .libSession) { $0.profile })
+                    .contains(.proBadge)
+            }()
         )
     }
     


### PR DESCRIPTION
Fixes the Pro badge missing from your **own** message in the message info "From" row when the conversation is a **community**. It shows correctly in a one-to-one, and correctly for other people in both.

### Cause

The row asked two different questions about identity, one line apart.

The name asked `currentUserSessionIds` — a set, plural precisely so it covers our blinded ids — so it resolved as "You" in a community. The badge did not consult identity at all: it read Pro features off the *message's attached profile*, and in a community our own message carries the **blinded-id** profile, which holds none of our Pro features. So the badge went missing on exactly the messages the label got right. A one-to-one attaches our real profile, which is why it only worked there.

### Fix

Both now come from one identity answer, hoisted into a local — two sources drifting apart is the bug, so leaving two expressions in place would let it recur.

For our own message the badge is read from our own profile via `profileFeatures(for:)`, which reads the profile's features **and** applies the access gate for the current user. The recipient and one-to-one paths are unchanged.

Worth noting why this is not `currentUserHasProAccess` on its own: `.proBadge` is a **user-toggleable** profile feature — the "Pro badge visible" switch in Pro settings writes it — so an access-only check would badge the message of a Pro user who had deliberately hidden theirs.

### Side effect worth confirming

An expired subscription can no longer badge its own message. The self path previously read raw `proFeatures` with no expiry check; it now runs through the access gate. This matches the "badge still showing after the account expired" behaviour observed during the manual purchase pass, and that should now be impossible to reproduce. **If it still reproduces, that is a separate bug** and worth reopening.

### Not changed

The recipient path also reads raw `proFeatures` rather than `profileFeatures(for:)`, so an expired *other* user may still show a badge. Deliberately left alone to keep this change narrow — flagged as a separate question.

### Testing

Builds clean. No unit run (CI covers it). The community self-badge case does not appear to be covered by the Appium suite, so this wants a look on device.
