### PR TITLE
Allow voice messages to run to five minutes

### DIFF
--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -2942,8 +2942,10 @@ extension ConversationVC:
             return cancelVoiceMessageRecording()
         }
         
-        // Limit voice messages to a minute
-        audioTimer = Timer.scheduledTimer(withTimeInterval: 180, repeats: false, block: { [weak self] _ in
+        // Capped so the attachment stays inside the 10MB upload limit (Network.maxFileSize), which is
+        // enforced against the encrypted size. At the AAC settings above - 44.1kHz stereo, 128kbps, so
+        // 16KB/s - 300s is ~4.9MB, leaving room for the padding applied before encryption
+        audioTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: false, block: { [weak self] _ in
             DispatchQueue.main.async { [weak self] in
                 self?.snInputView.hideVoiceMessageUI()
                 self?.endVoiceMessageRecording()


### PR DESCRIPTION
Closes #781.

iOS stopped voice message recording at 180s while Android and Desktop both allow 300s, so the same message could be recorded on one client and not another.

### Why 300s is safe

The cap exists to keep the attachment inside the 10MB upload limit (`Network.maxFileSize`), which is enforced against the **encrypted** size, and 300s is not close to it.

The recorder a few lines above produces AAC at 44.1kHz **stereo**, 128kbps — 16KB/s — so:

| | |
|---|---|
| 300s at 16KB/s | ~4.92MB |
| upload limit | 10MB |
| used | ~49% |

That leaves room for the padding applied before encryption (plaintext is padded to the next power of 1.05). The limit would in principle allow ~580s. Desktop documents its own 300s cap at 1.97MB, the difference being that it does not record in stereo.

### The comment

The line above read `// Limit voice messages to a minute`, which stopped being true in 593ab49952 when the value went 60 -> 180 and the comment was left behind. It now records why the limit exists and what it is derived from, so a future change to the recorder settings has something to check against — the absence of that is why this drifted from the other clients in the first place.

### Deliberately not in this PR

Both noted as follow-ups on #781:

- **iOS records voice notes in stereo at 128kbps where Android uses mono at 32kbps.** Mono is indistinguishable for speech and would cut file size roughly 4x. That is arguably the more valuable change, and it is what makes the current cap so conservative.
- **The duration is hard-coded in a view controller** rather than derived from `maxFileSize` and the bitrate, which is the actual reason it drifted.

### Testing

Builds clean. **Not otherwise verified** — the useful check is recording past three minutes on a device and confirming it runs to five and still sends, which I have no device access to do.
